### PR TITLE
bpf/cgroup_css: support containerd

### DIFF
--- a/bpf/cgroup_css_events.c
+++ b/bpf/cgroup_css_events.c
@@ -6,7 +6,8 @@
 
 #include "bpf_common.h"
 
-#define CGROUP_KNODE_NAME_MAXLEN 64
+#define CGROUP_KNODE_NAME_MAXLEN 85
+#define CGROUP_KNODE_NAME_MINLEN 64
 
 struct cgroup_perf_event_t {
 	u64 cgroup;
@@ -37,7 +38,7 @@ bpf_cgroup_event_class_prog(struct bpf_raw_tracepoint_args *ctx, u64 type)
 	knode_len =
 	    bpf_probe_read_str(&data.knode_name, sizeof(data.knode_name),
 			       BPF_CORE_READ(cgrp, kn, name));
-	if (knode_len != CGROUP_KNODE_NAME_MAXLEN + 1)
+	if (knode_len < CGROUP_KNODE_NAME_MINLEN + 1)
 		return 0;
 
 	data.ops_type	  = type;

--- a/bpf/cgroup_css_gather.c
+++ b/bpf/cgroup_css_gather.c
@@ -6,7 +6,8 @@
 
 #include "bpf_common.h"
 
-#define CGROUP_KNODE_NAME_MAXLEN 64
+#define CGROUP_KNODE_NAME_MAXLEN 85
+#define CGROUP_KNODE_NAME_MINLEN 64
 
 struct cgroup_perf_event_t {
 	u64 cgroup;
@@ -37,7 +38,7 @@ int bpf_cgroup_subsys_state_prog(struct pt_regs *ctx)
 	knode_len =
 	    bpf_probe_read_str(&data.knode_name, sizeof(data.knode_name),
 			       BPF_CORE_READ(cgrp, kn, name));
-	if (knode_len != CGROUP_KNODE_NAME_MAXLEN + 1)
+	if (knode_len < CGROUP_KNODE_NAME_MINLEN + 1)
 		return 0;
 
 	data.cgroup	  = (u64)cgrp;

--- a/internal/pod/container_css_default.go
+++ b/internal/pod/container_css_default.go
@@ -55,12 +55,14 @@ func parseContainerCSS(containerID string) (map[string]uint64, error) {
 }
 
 const (
-	cgroupSubsysCount             = 13
-	kubeletContainerIDKnodeMaxlen = 64
+	cgroupSubsysCount                 = 13
+	kubeletContainerIDKnodeNameMaxlen = 85
+	kubeletContainerIDKnodeNameMinlen = 64
 )
 
 var (
-	kubeletContainerIDRegexp  = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+	// used to extract container id from cgroup name
+	kubeletContainerIDRegexp  = regexp.MustCompile(`(?:cri-containerd-)?([0-9a-f]{64})(?:\.scope)?`)
 	cgroupv1SubSysName        = []string{"cpu", "cpuacct", "cpuset", "memory", "blkio"}
 	cgroupv1NotifyFile        = "cgroup.clone_children"
 	cgroupv2NotifyFile        = "memory.current"
@@ -70,10 +72,6 @@ var (
 	// avoid GC
 	_cgroupCssBpfInternal *bpf.BPF
 )
-
-func isValidKnodeName(name string) bool {
-	return !kubeletContainerIDRegexp.MatchString(name)
-}
 
 type containerCssMetaData struct {
 	CSS         uint64
@@ -90,7 +88,7 @@ type containerCssPerfEvent struct {
 	CgroupRoot  int32
 	CgroupLevel int32
 	CSS         [cgroupSubsysCount]uint64
-	KnodeName   [kubeletContainerIDKnodeMaxlen + 2]byte
+	KnodeName   [kubeletContainerIDKnodeNameMaxlen + 2]byte
 }
 
 func cgroupListCssDataByKnode(containerID string) []*containerCssMetaData {
@@ -108,7 +106,8 @@ func cgroupListCssDataByKnode(containerID string) []*containerCssMetaData {
 
 func cgroupUpdateOrCreateCssData(data *containerCssPerfEvent) error {
 	knodeName := strings.TrimRight(string(data.KnodeName[:]), "\x00")
-	if !isValidKnodeName(knodeName) {
+	containerID := extractContainerID(knodeName)
+	if containerID == "" {
 		return fmt.Errorf("knode name is not containterID")
 	}
 
@@ -123,7 +122,7 @@ func cgroupUpdateOrCreateCssData(data *containerCssPerfEvent) error {
 				Cgroup:      data.Cgroup,
 				CgroupRoot:  data.CgroupRoot,
 				CgroupLevel: data.CgroupLevel,
-				ContainerID: knodeName,
+				ContainerID: containerID,
 				SubSys:      sysName,
 			}
 			log.Debugf("update container css data: %+v", m)
@@ -136,7 +135,8 @@ func cgroupUpdateOrCreateCssData(data *containerCssPerfEvent) error {
 
 func cgroupDeleteCssData(data *containerCssPerfEvent) error {
 	knodeName := strings.TrimRight(string(data.KnodeName[:]), "\x00")
-	if !isValidKnodeName(knodeName) {
+	containerID := extractContainerID(knodeName)
+	if containerID == "" {
 		return fmt.Errorf("knode name is not containterID")
 	}
 
@@ -191,8 +191,9 @@ func cgroupRootNotify(realRoot, name string) error {
 		if err != nil {
 			return err
 		}
-
-		if !d.IsDir() || len(d.Name()) != kubeletContainerIDKnodeMaxlen {
+		// for containerd, the length of cgroup name is 85
+		// for docker, it is 64
+		if !d.IsDir() || len(d.Name()) < kubeletContainerIDKnodeNameMinlen {
 			return nil
 		}
 
@@ -329,4 +330,12 @@ func containerCgroupCssInit() error {
 	}
 
 	return nil
+}
+
+func extractContainerID(fileName string) string {
+	got := kubeletContainerIDRegexp.FindStringSubmatch(fileName)
+	if len(got) > 0 {
+		return got[1]
+	}
+	return ""
 }

--- a/internal/pod/container_css_default_test.go
+++ b/internal/pod/container_css_default_test.go
@@ -1,0 +1,32 @@
+package pod
+
+import "testing"
+
+func TestExtractContainerID(t *testing.T) {
+	for _, tc := range []struct {
+		input    string
+		expected string
+	}{
+		{ // docker container cgroup name
+			input:    "c2b95e61271060bef9a8b832e50c81f5eed60b788ff8a42b173c4a694c284a77",
+			expected: "c2b95e61271060bef9a8b832e50c81f5eed60b788ff8a42b173c4a694c284a77",
+		},
+		{ // docker pod cgroup name
+			input:    "pod66384b12-8f16-45f5-b520-f378e0f491fe",
+			expected: "",
+		},
+		{ // containerd pod cgroup name
+			input:    "kubepods-burstable-pod44e9d203_d0d2_4d44_a5da_702190080eb4.slice",
+			expected: "",
+		},
+		{ // containerd container cgroup name
+			input:    "cri-containerd-bd23762346b2af6261d285e8c2bdf82f9abeb427338c086cca27da98fee4dfa5.scope",
+			expected: "bd23762346b2af6261d285e8c2bdf82f9abeb427338c086cca27da98fee4dfa5",
+		},
+	} {
+		actual := extractContainerID(tc.input)
+		if actual != tc.expected {
+			t.Errorf("parseContainerID input %s want %s  actual %s", tc.input, tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
# 环境
kubernetes: 1.28.3 
container-runtime: containerd  1.7.27 

# 现象
采集不了这个环境下容器的 css 数据

# 原因

原因是这个环境下 容器对应的 cgroup 的目录名 如 cri-containerd-bd23762346b2af6261d285e8c2bdf82f9abeb427338c086cca27da98fee4dfa5.scope  的长度是 85  ,代码里面限制是 64 

# 修复方式
最大长度改到 85 

# 验证
可以正常采集到 containerd 和 docker 的数据了
<img width="1266" height="593" alt="image" src="https://github.com/user-attachments/assets/286aa8fc-ca2a-438b-ab15-c762fb1944d5" />



