### PR TITLE
iotracing: refactor file path handling to support multiple directories

### DIFF
--- a/cmd/iotracing/iotracing.go
+++ b/cmd/iotracing/iotracing.go
@@ -113,10 +113,7 @@ type IOData struct {
 	Blkcg           uint64
 	Latency         LatencyInfo
 	Comm            [16]byte
-	FileName        [64]byte
-	Dentry1Name     [64]byte
-	Dentry2Name     [64]byte
-	Dentry3Name     [64]byte
+	FilePath        [8][32]byte
 }
 
 // IODelayData contains IO schedule info from iodelay_perf_events.
@@ -132,12 +129,15 @@ type IODelayData struct {
 }
 
 func (data *IOData) FilePathName() string {
-	fileName := strings.TrimLeft(fmt.Sprintf("%s/%s/%s/%s",
-		bytesutil.ToString(data.Dentry3Name[:]),
-		bytesutil.ToString(data.Dentry2Name[:]),
-		bytesutil.ToString(data.Dentry1Name[:]),
-		bytesutil.ToString(data.FileName[:])),
-		"/")
+	names := make([]string, 0, len(data.FilePath))
+	for i := len(data.FilePath) - 1; i >= 0; i-- {
+		s := strings.TrimSpace(bytesutil.ToString(data.FilePath[i][:]))
+		if s == "" || s == "/" {
+			continue
+		}
+		names = append(names, s)
+	}
+	fileName := "/" + strings.Join(names, "/")
 
 	if data.InodeNum == 0 {
 		fileName = "[direct IO]"


### PR DESCRIPTION
This pull request refactors how file path information is captured and represented in the I/O tracing code, both in the eBPF program (`iotracing.c`) and in the Go code that consumes its data (`iotracing.go`). Instead of storing only a few individual directory names, the code now captures a configurable depth of the file path in a more flexible array structure, and reconstructs the full path accordingly.

Before:
```shell
➜  huatuo git:(main) ./_output/bin/iotracing
===========================================================================
PID: 478     TOTAL_IO: R=14KB W=284KB  FILES: 1
COMMAND: /usr/lib/systemd/systemd-journald 
-----------------------------------
DEVICE  FS_READ FS_WRITE DISK_READ DISK_WRITE   LATENCY(μs)      FILE/INODE
[8:2]    13824B  291328B        0B   235520B   q2c=410  d2c=384  log/journal/f55d0c7bde9c471882841ea73d3ccb84/system.journal

===========================================================================
PID: 1297780 TOTAL_IO: R=14KB W=200KB  FILES: 3
COMMAND: /usr/bin/containerd 
-----------------------------------
DEVICE  FS_READ FS_WRITE DISK_READ DISK_WRITE   LATENCY(μs)      FILE/INODE
[8:2]        0B  204288B        0B   203776B   q2c=106  d2c=106  lib/containerd/io.containerd.metadata.v1.bolt/meta.db
[8:2]     8897B       0B        0B        0B   q2c=0    d2c=0    io.containerd.content.v1.content/blobs/sha256/ff2ba8901a2244acdc607a32e04361bb7b00f9e0c450de2667bcdc4d5e67897
[8:2]     5197B       0B        0B        0B   q2c=0    d2c=0    io.containerd.content.v1.content/blobs/sha256/0955a05f4f65837cb38c6d810b380e10a329d23bcd791630d2448511f538a43
```

After:
```shell
➜  huatuo git:(dir_resolution) ✗ ./_output/bin/iotracing
...
===========================================================================
PID: 478     TOTAL_IO: R=12KB W=146KB  FILES: 1
COMMAND: /usr/lib/systemd/systemd-journald 
-----------------------------------
DEVICE  FS_READ FS_WRITE DISK_READ DISK_WRITE   LATENCY(μs)      FILE/INODE
[8:2]    11776B  150016B        0B   153088B   q2c=469  d2c=444  /var/log/journal/f55d0c7bde9c471882841ea73d3c.../system.journal

===========================================================================
PID: 1297780 TOTAL_IO: R=6.9KB W=103KB  FILES: 3
COMMAND: /usr/bin/containerd 
-----------------------------------
DEVICE  FS_READ FS_WRITE DISK_READ DISK_WRITE   LATENCY(μs)      FILE/INODE
[8:2]        0B  105472B        0B   102912B   q2c=110  d2c=110  /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db
[8:2]     4448B       0B        0B        0B   q2c=0    d2c=0    /var/lib/containerd/io.containerd.content.v1.con.../blobs/sha256/ff2ba8901a2244acdc607a32e043...
[8:2]     2598B       0B        0B        0B   q2c=0    d2c=0    /var/lib/containerd/io.containerd.content.v1.con.../blobs/sha256/0955a05f4f65837cb38c6d810b38...
```

The next step could be to further refactor the parsing and storage of file paths in an ebpf map to prevent kernel stack limits