### PR TITLE
fix: FsSupported substring matching issue

### DIFF
--- a/internal/utils/procfsutil/procfsutil.go
+++ b/internal/utils/procfsutil/procfsutil.go
@@ -39,7 +39,8 @@ func FsSupported(filesystem string) bool {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, filesystem) {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[len(fields)-1] == filesystem {
 			return true
 		}
 	}


### PR DESCRIPTION
Fix bug where FsSupported would incorrectly match filesystem names as substrings. For example, searching for "xfs" would incorrectly match "selinuxfs". Changed to use exact field matching instead of substring contains.
fixes #108