### PR TITLE
feat: add iolatency metrics feature

### DIFF
--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -18,5 +18,5 @@ ENV PATH="${GOPATH}/bin:${GOROOT}/bin:/usr/lib/llvm15/bin:${PATH}"
 RUN go install mvdan.cc/gofumpt@v0.9.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.41.0 && \
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.4 && \
-    go install github.com/vektra/mockery/v2@latest && \
-    go install mvdan.cc/sh/v3/cmd/shfmt@latest
+    go install github.com/vektra/mockery/v2@v2.53.6 && \
+    go install mvdan.cc/sh/v3/cmd/shfmt@v3.11.0

--- a/bpf/iolatency_tracing.c
+++ b/bpf/iolatency_tracing.c
@@ -1,0 +1,253 @@
+#include "vmlinux.h"
+#include "bpf_common.h"
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#define LATENCY_20MS_NS  20000000
+#define LATENCY_30MS_NS  30000000
+#define LATENCY_50MS_NS  50000000
+#define LATENCY_100MS_NS 100000000
+#define LATENCY_200MS_NS 200000000
+#define LATENCY_400MS_NS 400000000
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+struct disk_entry {
+	u64 disk;
+	u32 major;
+	u32 minor;
+	u64 freeze_nr;
+	u64 q2c_zone[6];
+	u64 d2c_zone[6];
+};
+
+struct blkgq_entry {
+	u64 blkgq;
+	u64 cgroup;
+	u64 disk;
+	u64 q2c_zone[6];
+	u64 d2c_zone[6];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, struct disk_entry);
+	__uint(max_entries, 128);
+} disk_info SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, struct blkgq_entry);
+	__uint(max_entries, 2048);
+} blkgq_info SEC(".maps");
+
+/*
+ * key: bio address
+ * value: start timestamp
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, u64);
+	__uint(max_entries, 10240);
+} bio_start_time SEC(".maps");
+
+static int zone_index(u64 delta)
+{
+	if (delta < LATENCY_20MS_NS)
+		return -1;
+
+	if (delta <= LATENCY_30MS_NS)
+		return 0;
+
+	if (delta <= LATENCY_50MS_NS)
+		return 1;
+
+	if (delta <= LATENCY_100MS_NS)
+		return 2;
+
+	if (delta <= LATENCY_200MS_NS)
+		return 3;
+
+	if (delta <= LATENCY_400MS_NS)
+		return 4;
+
+	return 5;
+}
+
+#define TIMESTAMP_MASK (((u64)1 << 51) - 1)
+
+/* Local struct definitions for kernel 5.12+ compatibility.
+ * In newer kernels, bio->bi_disk was moved to bio->bi_bdev->bd_disk.
+ * These local structs with preserve_access_index enable BPF CO-RE to
+ * correctly relocate field offsets at load time.
+ */
+struct block_device___compat {
+	struct gendisk *bd_disk;
+	u32 bd_dev;
+} __attribute__((preserve_access_index));
+
+struct bio___compat {
+	struct block_device *bi_bdev;
+} __attribute__((preserve_access_index));
+
+static __always_inline struct gendisk *get_bio_disk(struct bio *bio)
+{
+	struct gendisk *disk = NULL;
+
+	if (bpf_core_field_exists(bio->bi_disk)) {
+		BPF_CORE_READ_INTO(&disk, bio, bi_disk);
+	} else {
+		/* Kernel 5.12+: bio->bi_disk moved to bio->bi_bdev->bd_disk */
+		struct bio___compat *bio_new = (struct bio___compat *)bio;
+		struct block_device *bdev;
+
+		BPF_CORE_READ_INTO(&bdev, bio_new, bi_bdev);
+		if (bdev) {
+			BPF_CORE_READ_INTO(&disk, bdev, bd_disk);
+		}
+	}
+
+	return disk;
+}
+
+static __always_inline u8 get_bio_partno(struct bio *bio)
+{
+	u8 partno = 0;
+
+	if (bpf_core_field_exists(bio->bi_partno)) {
+		BPF_CORE_READ_INTO(&partno, bio, bi_partno);
+	} else {
+		/* Kernel 5.12+: bi_partno moved to bio->bi_bdev->bd_dev */
+		struct bio___compat *bio_new = (struct bio___compat *)bio;
+		struct block_device___compat *bdev;
+
+		BPF_CORE_READ_INTO(&bdev, bio_new, bi_bdev);
+		if (bdev) {
+			BPF_CORE_READ_INTO(&partno, bdev, bd_dev);
+		}
+	}
+
+	return partno;
+}
+
+SEC("kprobe/blk_mq_start_request")
+int kprobe_start_request(struct pt_regs *ctx)
+{
+	struct request *req = (struct request *)PT_REGS_PARM1(ctx);
+	struct bio *bio;
+	u64 now = bpf_ktime_get_ns() & TIMESTAMP_MASK;
+
+	bio = BPF_CORE_READ(req, bio);
+	for (int i = 0; i < 64 && bio; i++) {
+		u64 bio_addr = (u64)bio;
+
+		bpf_map_update_elem(&bio_start_time, &bio_addr, &now, COMPAT_BPF_ANY);
+		bio = BPF_CORE_READ(bio, bi_next);
+	}
+
+	return 0;
+}
+
+SEC("kprobe/__rq_qos_done_bio")
+int kprobe_done_bio(struct pt_regs *ctx)
+{
+	struct bio *bio = (struct bio *)PT_REGS_PARM2(ctx);
+	u64 now = bpf_ktime_get_ns();
+	u64 q2c, d2c;
+	struct gendisk *disk = NULL;
+	int q2c_index, d2c_index;
+	u64 val, bi_issue, bi_start;
+	u64 bio_addr = (u64)bio;
+
+	/* val=&bio.bi_issue */
+	if (bpf_probe_read(&val, sizeof(val), &bio->bi_issue))
+		return 0;
+
+	now = now & TIMESTAMP_MASK;
+	bi_issue = val & TIMESTAMP_MASK;
+	u64 *start_time = bpf_map_lookup_elem(&bio_start_time, &bio_addr);
+	if (!start_time)
+		return 0;
+
+	bi_start = *start_time & TIMESTAMP_MASK;
+	bpf_map_delete_elem(&bio_start_time, &bio_addr);
+
+	if (!bi_issue || (now < bi_issue))
+		q2c = 0;
+	else
+		q2c = now - bi_issue;
+	q2c_index = zone_index(q2c);
+
+	if (!bi_start || (now < bi_start) || (bi_start < bi_issue))
+		d2c = 0;
+	else
+		d2c = now - bi_start;
+	d2c_index = zone_index(d2c);
+
+	if ((q2c_index < 0) && (d2c_index < 0))
+		return 0;
+
+	struct blkgq_entry *blkgq_entry;
+	u64 css;
+
+	css = (u64)BPF_CORE_READ(bio, bi_blkg, blkcg);
+	blkgq_entry = bpf_map_lookup_elem(&blkgq_info, &css);
+	if (blkgq_entry) {
+		if (q2c_index >= 0)
+			__sync_fetch_and_add(&blkgq_entry->q2c_zone[q2c_index], 1);
+		if (d2c_index >= 0)
+			__sync_fetch_and_add(&blkgq_entry->d2c_zone[d2c_index], 1);
+	}
+
+	struct disk_entry *disk_entry;
+
+	disk = get_bio_disk(bio);
+	disk_entry = bpf_map_lookup_elem(&disk_info, &disk);
+	if (disk_entry) {
+		if (q2c_index >= 0)
+			__sync_fetch_and_add(&disk_entry->q2c_zone[q2c_index], 1);
+		if (d2c_index >= 0)
+			__sync_fetch_and_add(&disk_entry->d2c_zone[d2c_index], 1);
+	} else {
+		struct disk_entry new_entry = {.disk = (u64)disk};
+		u32 disk_dev[2];
+		u8 partno;
+
+		/* gendisk.major, gendisk.first_minor */
+		bpf_probe_read(disk_dev, sizeof(disk_dev), disk);
+		partno = get_bio_partno(bio);
+		new_entry.major = disk_dev[0];
+		new_entry.minor = disk_dev[1] + partno;
+
+		if (q2c_index >= 0)
+			new_entry.q2c_zone[q2c_index] = 1;
+		if (d2c_index >= 0)
+			new_entry.d2c_zone[d2c_index] = 1;
+		bpf_map_update_elem(&disk_info, &disk, &new_entry, COMPAT_BPF_ANY);
+	}
+
+	return 0;
+}
+
+SEC("kprobe/blk_mq_freeze_queue")
+int kprobe_freeze_queue(struct pt_regs *regs)
+{
+	struct request_queue *q = (void *)regs->di;
+	struct blkcg_gq *blkg;
+	struct blkgq_entry *blkgq_entry;
+	struct disk_entry *disk_entry;
+
+	blkg = BPF_CORE_READ(q, root_blkg);
+	blkgq_entry = bpf_map_lookup_elem(&blkgq_info, &blkg);
+	if (blkgq_entry) {
+		disk_entry = bpf_map_lookup_elem(&disk_info, &blkgq_entry->disk);
+		if (disk_entry)
+			__sync_fetch_and_add(&disk_entry->freeze_nr, 1);
+	}
+
+	return 0;
+}

--- a/build/docker/grafana/dashboards/metrics-container.json
+++ b/build/docker/grafana/dashboards/metrics-container.json
@@ -235,7 +235,7 @@
               "exemplar": true,
               "expr": "increase(huatuo_bamai_iolatency_container_q2c{container_host=~\"$container_host\",region=\"$region\"}[5m])",
               "interval": "",
-              "legendFormat": "{{container_host}} [{{latency}}]",
+              "legendFormat": "{{container_host}} [zone={{zone}}]",
               "refId": "A"
             }
           ],
@@ -338,7 +338,7 @@
               "exemplar": true,
               "expr": "increase(huatuo_bamai_iolatency_container_d2c{container_host=~\"$container_host\",region=\"$region\"}[5m])",
               "interval": "",
-              "legendFormat": "{{container_host}} [{{latency}}]",
+              "legendFormat": "{{container_host}} [zone={{zone}}]",
               "range": true,
               "refId": "A"
             }

--- a/build/docker/grafana/dashboards/metrics-host.json
+++ b/build/docker/grafana/dashboards/metrics-host.json
@@ -378,7 +378,7 @@
               "exemplar": true,
               "expr": "increase(huatuo_bamai_iolatency_disk_q2c{host=~\"$host\",region=\"$region\"}[5m])",
               "interval": "",
-              "legendFormat": "{{host}},disk={{disk}} [{{latency}}]",
+              "legendFormat": "{{host}},disk={{disk}} [zone={{zone}}]",
               "refId": "A"
             }
           ],
@@ -476,7 +476,7 @@
               "exemplar": true,
               "expr": "increase(huatuo_bamai_iolatency_disk_d2c{host=~\"$host\",region=\"$region\"}[5m])",
               "interval": "",
-              "legendFormat": "{{host}},disk={{disk}} [{{latency}}]",
+              "legendFormat": "{{host}},disk={{disk}} [zone={{zone}}]",
               "refId": "A"
             }
           ],

--- a/core/metrics/iolatency_collector.go
+++ b/core/metrics/iolatency_collector.go
@@ -1,0 +1,174 @@
+// Copyright 2025 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/pkg/metric"
+)
+
+var latencyLabels = []string{
+	"20ms - 30ms",
+	"30ms - 50ms",
+	"50ms - 100ms",
+	"100ms - 200ms",
+	"200ms - 400ms",
+	"400ms - ",
+}
+
+// DiskEntry stores disk latency histogram buckets and freeze counts.
+type DiskEntry struct {
+	Disk     uint64
+	Major    uint32
+	Minor    uint32
+	FreezeNr uint64
+	Q2CZone  [6]uint64
+	D2CZone  [6]uint64
+}
+
+// BlkgqEntry stores latency histogram buckets for a block cgroup queue.
+type BlkgqEntry struct {
+	Blkgq   uint64
+	Cgroup  uint64
+	Disk    uint64
+	Q2CZone [6]uint64
+	D2CZone [6]uint64
+}
+
+func (c *iolatencyTracing) Update() ([]*metric.Data, error) {
+	if !c.running.Load() {
+		return nil, nil
+	}
+
+	diskMetrics, err := c.getDiskIOLatencyMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	containerMetrics, err := c.getContainerIOLatencyMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(diskMetrics, containerMetrics...), nil
+}
+
+func (c *iolatencyTracing) getContainerIOLatencyMetrics() ([]*metric.Data, error) {
+	c.dataLock.RLock()
+
+	currentContainerLatencyData := make([]BlkgqEntry, len(c.containerLatencyData))
+	copy(currentContainerLatencyData, c.containerLatencyData)
+
+	currentBlkgqContainerMap := make(map[uint64]*pod.Container, len(c.blkcgContainerMap))
+	for blkgq, container := range c.blkcgContainerMap {
+		currentBlkgqContainerMap[blkgq] = container
+	}
+
+	c.dataLock.RUnlock()
+
+	var containerMetrics []*metric.Data
+
+	for i := range currentContainerLatencyData {
+		blkcg := &currentContainerLatencyData[i]
+		container, ok := currentBlkgqContainerMap[blkcg.Blkgq]
+		if !ok {
+			continue
+		}
+
+		for zone, cnt := range blkcg.Q2CZone {
+			if cnt == 0 {
+				continue
+			}
+
+			containerMetrics = append(containerMetrics, metric.NewContainerGaugeData(
+				container,
+				"q2c",
+				float64(cnt),
+				"container q2c latency",
+				map[string]string{"latency": latencyLabels[zone]},
+			))
+		}
+
+		for zone, cnt := range blkcg.D2CZone {
+			if cnt == 0 {
+				continue
+			}
+
+			containerMetrics = append(containerMetrics, metric.NewContainerGaugeData(
+				container,
+				"d2c",
+				float64(cnt),
+				"container d2c latency",
+				map[string]string{"latency": latencyLabels[zone]},
+			))
+		}
+
+	}
+
+	return containerMetrics, nil
+}
+
+func (c *iolatencyTracing) getDiskIOLatencyMetrics() ([]*metric.Data, error) {
+	c.dataLock.RLock()
+	currentDiskLatencyData := make([]DiskEntry, len(c.diskLatencyData))
+	copy(currentDiskLatencyData, c.diskLatencyData)
+	c.dataLock.RUnlock()
+
+	var diskMetrics []*metric.Data
+
+	for i := range currentDiskLatencyData {
+		diskInfo := &currentDiskLatencyData[i]
+		diskDev := fmt.Sprintf("%d:%d", diskInfo.Major, diskInfo.Minor)
+
+		for zone, cnt := range diskInfo.Q2CZone {
+			if cnt == 0 {
+				continue
+			}
+
+			diskMetrics = append(diskMetrics, metric.NewGaugeData(
+				"disk_q2c",
+				float64(cnt),
+				"disk q2c latency",
+				map[string]string{"disk": diskDev, "latency": latencyLabels[zone]},
+			))
+		}
+
+		for zone, cnt := range diskInfo.D2CZone {
+			if cnt == 0 {
+				continue
+			}
+
+			diskMetrics = append(diskMetrics, metric.NewGaugeData(
+				"disk_d2c",
+				float64(cnt),
+				"disk d2c latency",
+				map[string]string{"disk": diskDev, "latency": latencyLabels[zone]},
+			))
+		}
+
+		if diskInfo.FreezeNr > 0 {
+			diskMetrics = append(diskMetrics, metric.NewGaugeData(
+				"disk_freeze",
+				float64(diskInfo.FreezeNr),
+				"disk freeze count",
+				map[string]string{"disk": diskDev},
+			))
+		}
+	}
+
+	return diskMetrics, nil
+}

--- a/core/metrics/iolatency_collector.go
+++ b/core/metrics/iolatency_collector.go
@@ -116,7 +116,6 @@ func (c *iolatencyTracing) getContainerIOLatencyMetrics() ([]*metric.Data, error
 				map[string]string{"latency": latencyLabels[zone]},
 			))
 		}
-
 	}
 
 	return containerMetrics, nil

--- a/core/metrics/iolatency_collector.go
+++ b/core/metrics/iolatency_collector.go
@@ -16,19 +16,11 @@ package collector
 
 import (
 	"fmt"
+	"strconv"
 
 	"huatuo-bamai/internal/pod"
 	"huatuo-bamai/pkg/metric"
 )
-
-var latencyLabels = []string{
-	"20ms - 30ms",
-	"30ms - 50ms",
-	"50ms - 100ms",
-	"100ms - 200ms",
-	"200ms - 400ms",
-	"400ms - ",
-}
 
 // DiskEntry stores disk latency histogram buckets and freeze counts.
 type DiskEntry struct {
@@ -99,7 +91,7 @@ func (c *iolatencyTracing) getContainerIOLatencyMetrics() ([]*metric.Data, error
 				"q2c",
 				float64(cnt),
 				"container q2c latency",
-				map[string]string{"latency": latencyLabels[zone]},
+				map[string]string{"zone": strconv.Itoa(zone)},
 			))
 		}
 
@@ -113,7 +105,7 @@ func (c *iolatencyTracing) getContainerIOLatencyMetrics() ([]*metric.Data, error
 				"d2c",
 				float64(cnt),
 				"container d2c latency",
-				map[string]string{"latency": latencyLabels[zone]},
+				map[string]string{"zone": strconv.Itoa(zone)},
 			))
 		}
 	}
@@ -142,7 +134,7 @@ func (c *iolatencyTracing) getDiskIOLatencyMetrics() ([]*metric.Data, error) {
 				"disk_q2c",
 				float64(cnt),
 				"disk q2c latency",
-				map[string]string{"disk": diskDev, "latency": latencyLabels[zone]},
+				map[string]string{"disk": diskDev, "zone": strconv.Itoa(zone)},
 			))
 		}
 
@@ -155,7 +147,7 @@ func (c *iolatencyTracing) getDiskIOLatencyMetrics() ([]*metric.Data, error) {
 				"disk_d2c",
 				float64(cnt),
 				"disk d2c latency",
-				map[string]string{"disk": diskDev, "latency": latencyLabels[zone]},
+				map[string]string{"disk": diskDev, "zone": strconv.Itoa(zone)},
 			))
 		}
 

--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -1,0 +1,252 @@
+// Copyright 2025 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/pkg/tracing"
+)
+
+func init() {
+	tracing.RegisterEventTracing("iolatency", newIolatency)
+}
+
+func newIolatency() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &iolatencyTracing{},
+		Interval:    10,
+		Flag:        tracing.FlagTracing | tracing.FlagMetric,
+	}, nil
+}
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/iolatency_tracing.c -o $BPF_DIR/iolatency_tracing.o
+
+type iolatencyTracing struct {
+	running atomic.Bool
+
+	dataLock             sync.RWMutex
+	diskLatencyData      []DiskEntry
+	containerLatencyData []BlkgqEntry
+	blkcgContainerMap    map[uint64]*pod.Container
+
+	oldContainerMap map[string]*pod.Container
+}
+
+func (e *BlkgqEntry) structToSlice() []byte {
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.LittleEndian, e)
+	return buf.Bytes()
+}
+
+// Start loads the iolatency BPF object and refreshes the histogram snapshots.
+func (c *iolatencyTracing) Start(ctx context.Context) error {
+	b, err := bpf.LoadBpf(bpf.ThisBpfOBJ(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to load bpf: %w", err)
+	}
+	defer b.Close()
+
+	if err := attachIOLatencyPrograms(b); err != nil {
+		return err
+	}
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	b.WaitDetachByBreaker(childCtx, cancel)
+
+	c.oldContainerMap = make(map[string]*pod.Container)
+	c.blkcgContainerMap = make(map[uint64]*pod.Container)
+
+	log.Infof("start iolatency")
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	c.running.Store(true)
+	defer c.running.Store(false)
+
+	for {
+		select {
+		case <-childCtx.Done():
+			return nil
+		case <-ticker.C:
+			if err := c.updateBlkgqInfo(b); err != nil {
+				return err
+			}
+			if err := c.readDiskLatencyData(b); err != nil {
+				return err
+			}
+			if err := c.readContainerLatencyData(b); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func attachIOLatencyPrograms(b bpf.BPF) error {
+	info, err := b.Info()
+	if err != nil {
+		return err
+	}
+
+	attachOptions := make([]bpf.AttachOption, 0, len(info.ProgramsInfo))
+	for _, progInfo := range info.ProgramsInfo {
+		parts := strings.SplitN(progInfo.SectionName, "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid section name: %s", progInfo.SectionName)
+		}
+
+		attachOptions = append(attachOptions, bpf.AttachOption{
+			ProgramName: progInfo.Name,
+			Symbol:      parts[1],
+		})
+	}
+
+	return b.AttachWithOptions(attachOptions)
+}
+
+func (c *iolatencyTracing) readDiskLatencyData(b bpf.BPF) error {
+	data, err := b.DumpMapByName("disk_info")
+	if err != nil {
+		return err
+	}
+
+	newDiskLatencyData := make([]DiskEntry, 0, len(data))
+	for _, ioData := range data {
+		var diskInfo DiskEntry
+
+		buf := bytes.NewReader(ioData.Value)
+		if err := binary.Read(buf, binary.LittleEndian, &diskInfo); err != nil {
+			return err
+		}
+
+		newDiskLatencyData = append(newDiskLatencyData, diskInfo)
+	}
+
+	c.dataLock.Lock()
+	c.diskLatencyData = newDiskLatencyData
+	c.dataLock.Unlock()
+
+	return nil
+}
+
+func (c *iolatencyTracing) readContainerLatencyData(b bpf.BPF) error {
+	data, err := b.DumpMapByName("blkgq_info")
+	if err != nil {
+		return err
+	}
+
+	newContainerLatencyData := make([]BlkgqEntry, 0, len(data))
+	for _, ioData := range data {
+		var blkcg BlkgqEntry
+
+		buf := bytes.NewReader(ioData.Value)
+		if err := binary.Read(buf, binary.LittleEndian, &blkcg); err != nil {
+			return err
+		}
+
+		newContainerLatencyData = append(newContainerLatencyData, blkcg)
+	}
+
+	c.dataLock.Lock()
+	c.containerLatencyData = newContainerLatencyData
+	c.dataLock.Unlock()
+
+	return nil
+}
+
+func (c *iolatencyTracing) updateBlkgqInfo(b bpf.BPF) error {
+	mapID := b.MapIDByName("blkgq_info")
+
+	currContainers, err := pod.Containers()
+	if err != nil {
+		log.Warnf("get all containers error: %v", err)
+		return nil
+	}
+
+	newBlkcgContainerMap := make(map[uint64]*pod.Container, len(currContainers))
+	newPods := make([]*pod.Container, 0)
+
+	for containerID, container := range currContainers {
+		if _, exists := c.oldContainerMap[containerID]; !exists {
+			newPods = append(newPods, container)
+		} else {
+			delete(c.oldContainerMap, containerID)
+		}
+
+		if blkcg, ok := container.CgroupCss[pod.SubSysBlkIO]; ok {
+			newBlkcgContainerMap[blkcg] = container
+		}
+	}
+
+	deletedPods := make([][]byte, 0, len(c.oldContainerMap))
+	for _, container := range c.oldContainerMap {
+		if blkcg, ok := container.CgroupCss[pod.SubSysBlkIO]; ok {
+			deletedPods = append(deletedPods, uint64ToBytes(blkcg))
+		}
+	}
+	if len(deletedPods) > 0 {
+		if err := b.DeleteMapItems(mapID, deletedPods); err != nil {
+			return err
+		}
+	}
+
+	items := make([]bpf.MapItem, 0, len(newPods))
+	for _, container := range newPods {
+		blkcg, ok := container.CgroupCss[pod.SubSysBlkIO]
+		if !ok {
+			continue
+		}
+
+		entry := &BlkgqEntry{Blkgq: blkcg}
+		items = append(items, bpf.MapItem{
+			Key:   uint64ToBytes(blkcg),
+			Value: entry.structToSlice(),
+		})
+	}
+	if len(items) > 0 {
+		if err := b.WriteMapItems(mapID, items); err != nil {
+			return err
+		}
+	}
+
+	c.dataLock.Lock()
+	c.blkcgContainerMap = newBlkcgContainerMap
+	c.dataLock.Unlock()
+
+	c.oldContainerMap = currContainers
+	return nil
+}
+
+func uint64ToBytes(n uint64) []byte {
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, n); err != nil {
+		log.Warnf("binary.Write failed: %v", err)
+		return nil
+	}
+	return buf.Bytes()
+}

--- a/docs/key-feature/metrics_en.md
+++ b/docs/key-feature/metrics_en.md
@@ -1125,33 +1125,24 @@ metrics also always include `container_host`, `container_name`,
 ```bash
 # HELP huatuo_bamai_iolatency_disk_q2c disk q2c latency
 # TYPE huatuo_bamai_iolatency_disk_q2c gauge
-huatuo_bamai_iolatency_disk_q2c{disk="8:0",host="hostname",latency="20ms - 30ms",region="dev"} 12
+huatuo_bamai_iolatency_disk_q2c{disk="8:0",host="hostname",region="dev",zone="0"} 12
 # HELP huatuo_bamai_iolatency_disk_d2c disk d2c latency
 # TYPE huatuo_bamai_iolatency_disk_d2c gauge
-huatuo_bamai_iolatency_disk_d2c{disk="8:0",host="hostname",latency="30ms - 50ms",region="dev"} 3
+huatuo_bamai_iolatency_disk_d2c{disk="8:0",host="hostname",region="dev",zone="1"} 3
 # HELP huatuo_bamai_iolatency_container_q2c container q2c latency
 # TYPE huatuo_bamai_iolatency_container_q2c gauge
-huatuo_bamai_iolatency_container_q2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="20ms - 30ms",region="dev"} 7
+huatuo_bamai_iolatency_container_q2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",region="dev",zone="0"} 7
 # HELP huatuo_bamai_iolatency_container_d2c container d2c latency
 # TYPE huatuo_bamai_iolatency_container_d2c gauge
-huatuo_bamai_iolatency_container_d2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="30ms - 50ms",region="dev"} 2
+huatuo_bamai_iolatency_container_d2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",region="dev",zone="1"} 2
 ```
 
 |Metric|Description|Unit|Scope|Labels|
 |---|---|---|---|---|
-|iolatency_disk_q2c|Host disk latency statistics for the full I/O lifecycle, from queueing to completion|count|Host|host, region, disk, latency|
-|iolatency_disk_d2c|Host disk latency statistics from driver dispatch to completion, closer to device processing time|count|Host|host, region, disk, latency|
-|iolatency_container_q2c|Container-caused latency statistics for the full I/O lifecycle, from queueing to completion|count|Container|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
-|iolatency_container_d2c|Container-caused latency statistics from driver dispatch to completion|count|Container|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
-
-The `latency` label currently uses 6 buckets:
-
-- `20ms - 30ms`
-- `30ms - 50ms`
-- `50ms - 100ms`
-- `100ms - 200ms`
-- `200ms - 400ms`
-- `400ms - `
+|iolatency_disk_q2c|Host disk latency statistics for the full I/O lifecycle, from queueing to completion. Buckets: zone0 20-30ms, zone1 30-50ms, zone2 50-100ms, zone3 100-200ms, zone4 200-400ms, zone5 400ms+|count|Host|host, region, disk, zone|
+|iolatency_disk_d2c|Host disk latency statistics from driver dispatch to completion, closer to device processing time. Buckets: zone0 20-30ms, zone1 30-50ms, zone2 50-100ms, zone3 100-200ms, zone4 200-400ms, zone5 400ms+|count|Host|host, region, disk, zone|
+|iolatency_container_q2c|Container-caused latency statistics for the full I/O lifecycle, from queueing to completion. Buckets: zone0 20-30ms, zone1 30-50ms, zone2 50-100ms, zone3 100-200ms, zone4 200-400ms, zone5 400ms+|count|Container|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, zone|
+|iolatency_container_d2c|Container-caused latency statistics from driver dispatch to completion. Buckets: zone0 20-30ms, zone1 30-50ms, zone2 50-100ms, zone3 100-200ms, zone4 200-400ms, zone5 400ms+|count|Container|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, zone|
 
 ### Hardware
 

--- a/docs/key-feature/metrics_en.md
+++ b/docs/key-feature/metrics_en.md
@@ -1108,9 +1108,62 @@ huatuo_bamai_sockstat_sockets_used{host="hostname",region="dev"} 409
 
 ## IO
 
+`iolatency` tracks disk I/O latency distribution. A simple way to read it is: break one disk request into stages, then count how many requests fall into each latency bucket.
+
+- `q2c`: from entering the queue to completion, covering the full I/O lifecycle
+- `d2c`: from driver dispatch to completion, closer to device-side latency
+- `freeze`: number of disk freeze events
+
+The current version exposes both host-level and container-level metrics.
+
 ### Queue
 
+These metrics always include the common labels `host` and `region`. Container
+metrics also always include `container_host`, `container_name`,
+`container_type`, `container_level`, and `container_hostnamespace`.
+
+```bash
+# HELP huatuo_bamai_iolatency_disk_q2c disk q2c latency
+# TYPE huatuo_bamai_iolatency_disk_q2c gauge
+huatuo_bamai_iolatency_disk_q2c{disk="8:0",host="hostname",latency="20ms - 30ms",region="dev"} 12
+# HELP huatuo_bamai_iolatency_disk_d2c disk d2c latency
+# TYPE huatuo_bamai_iolatency_disk_d2c gauge
+huatuo_bamai_iolatency_disk_d2c{disk="8:0",host="hostname",latency="30ms - 50ms",region="dev"} 3
+# HELP huatuo_bamai_iolatency_container_q2c container q2c latency
+# TYPE huatuo_bamai_iolatency_container_q2c gauge
+huatuo_bamai_iolatency_container_q2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="20ms - 30ms",region="dev"} 7
+# HELP huatuo_bamai_iolatency_container_d2c container d2c latency
+# TYPE huatuo_bamai_iolatency_container_d2c gauge
+huatuo_bamai_iolatency_container_d2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="30ms - 50ms",region="dev"} 2
+```
+
+|Metric|Description|Unit|Scope|Labels|
+|---|---|---|---|---|
+|iolatency_disk_q2c|Host disk latency statistics for the full I/O lifecycle, from queueing to completion|count|Host|host, region, disk, latency|
+|iolatency_disk_d2c|Host disk latency statistics from driver dispatch to completion, closer to device processing time|count|Host|host, region, disk, latency|
+|iolatency_container_q2c|Container-caused latency statistics for the full I/O lifecycle, from queueing to completion|count|Container|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
+|iolatency_container_d2c|Container-caused latency statistics from driver dispatch to completion|count|Container|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
+
+The `latency` label currently uses 6 buckets:
+
+- `20ms - 30ms`
+- `30ms - 50ms`
+- `50ms - 100ms`
+- `100ms - 200ms`
+- `200ms - 400ms`
+- `400ms - `
+
 ### Hardware
+
+```bash
+# HELP huatuo_bamai_iolatency_disk_freeze disk freeze count
+# TYPE huatuo_bamai_iolatency_disk_freeze gauge
+huatuo_bamai_iolatency_disk_freeze{disk="8:0",host="hostname",region="dev"} 4
+```
+
+|Metric|Description|Unit|Scope|Labels|
+|---|---|---|---|---|
+|iolatency_disk_freeze|Host disk freeze event count|count|Host|host, region, disk|
 
 ## General System
 

--- a/docs/key-feature/metrics_zh.md
+++ b/docs/key-feature/metrics_zh.md
@@ -1191,11 +1191,63 @@ huatuo_bamai_sockstat_sockets_used{host="hostname",region="dev"} 409
 
 ## IO
 
-即将开源。
+`iolatency` 用来统计磁盘 I/O 延迟分布。可以把它理解成“把一次磁盘请求拆成几个阶段，再分别看每个阶段卡了多久”。
+
+- `q2c`：从请求进入队列到完成，反映整个 I/O 生命周期延迟
+- `d2c`：从驱动层下发到完成，更接近磁盘和驱动本身的耗时
+- `freeze`：磁盘冻结事件次数
+
+当前版本同时提供宿主机维度和容器维度指标。
 
 ### 队列
 
+这些指标都会自动带上公共标签 `host` 和 `region`。其中容器维度指标还会固定带上
+`container_host`、`container_name`、`container_type`、`container_level`、
+`container_hostnamespace` 这几个容器标签。
+
+```bash
+# HELP huatuo_bamai_iolatency_disk_q2c disk q2c latency
+# TYPE huatuo_bamai_iolatency_disk_q2c gauge
+huatuo_bamai_iolatency_disk_q2c{disk="8:0",host="hostname",latency="20ms - 30ms",region="dev"} 12
+# HELP huatuo_bamai_iolatency_disk_d2c disk d2c latency
+# TYPE huatuo_bamai_iolatency_disk_d2c gauge
+huatuo_bamai_iolatency_disk_d2c{disk="8:0",host="hostname",latency="30ms - 50ms",region="dev"} 3
+# HELP huatuo_bamai_iolatency_container_q2c container q2c latency
+# TYPE huatuo_bamai_iolatency_container_q2c gauge
+huatuo_bamai_iolatency_container_q2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="20ms - 30ms",region="dev"} 7
+# HELP huatuo_bamai_iolatency_container_d2c container d2c latency
+# TYPE huatuo_bamai_iolatency_container_d2c gauge
+huatuo_bamai_iolatency_container_d2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="30ms - 50ms",region="dev"} 2
+```
+
+|指标|意义|单位|对象|标签|
+|---|---|---|---|---|
+|iolatency_disk_q2c|宿主机磁盘整体 I/O 生命周期延迟统计，从入队到完成|计数|宿主|host, region, disk, latency|
+|iolatency_disk_d2c|宿主机磁盘驱动到完成阶段的延迟统计，更接近设备处理耗时|计数|宿主|host, region, disk, latency|
+|iolatency_container_q2c|容器触发的整体 I/O 生命周期延迟统计，从入队到完成|计数|容器|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
+|iolatency_container_d2c|容器触发的驱动到完成阶段延迟统计|计数|容器|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
+
+`latency` 标签当前分为 6 个桶：
+
+- `20ms - 30ms`
+- `30ms - 50ms`
+- `50ms - 100ms`
+- `100ms - 200ms`
+- `200ms - 400ms`
+- `400ms - `
+
 ### 硬件
+
+```bash
+# HELP huatuo_bamai_iolatency_disk_freeze disk freeze count
+# TYPE huatuo_bamai_iolatency_disk_freeze gauge
+huatuo_bamai_iolatency_disk_freeze{disk="8:0",host="hostname",region="dev"} 4
+```
+
+|指标|意义|单位|对象|标签|
+|---|---|---|---|---|
+|iolatency_disk_freeze|宿主机磁盘 freeze 事件次数|计数|宿主|host, region, disk|
+
 
 ## 通用系统
 
@@ -1255,4 +1307,3 @@ huatuo_bamai_hungtask_total{host="hostname",region="dev"} 0
 |metax_gpu_dpm_performance_level|GPU DPM 性能等级|-|gpu, die, ip|sml.GetDieDPMPerformanceLevel|
 |metax_gpu_ecc_memory_errors_total|GPU ECC 内存错误次数|计数|gpu, die, memory_type, error_type|sml.GetDieECCMemoryInfo|
 |metax_gpu_ecc_memory_retired_pages_total|GPU ECC 内存退役页数|计数|gpu, die|sml.GetDieECCMemoryInfo|
-

--- a/docs/key-feature/metrics_zh.md
+++ b/docs/key-feature/metrics_zh.md
@@ -1208,33 +1208,24 @@ huatuo_bamai_sockstat_sockets_used{host="hostname",region="dev"} 409
 ```bash
 # HELP huatuo_bamai_iolatency_disk_q2c disk q2c latency
 # TYPE huatuo_bamai_iolatency_disk_q2c gauge
-huatuo_bamai_iolatency_disk_q2c{disk="8:0",host="hostname",latency="20ms - 30ms",region="dev"} 12
+huatuo_bamai_iolatency_disk_q2c{disk="8:0",host="hostname",region="dev",zone="0"} 12
 # HELP huatuo_bamai_iolatency_disk_d2c disk d2c latency
 # TYPE huatuo_bamai_iolatency_disk_d2c gauge
-huatuo_bamai_iolatency_disk_d2c{disk="8:0",host="hostname",latency="30ms - 50ms",region="dev"} 3
+huatuo_bamai_iolatency_disk_d2c{disk="8:0",host="hostname",region="dev",zone="1"} 3
 # HELP huatuo_bamai_iolatency_container_q2c container q2c latency
 # TYPE huatuo_bamai_iolatency_container_q2c gauge
-huatuo_bamai_iolatency_container_q2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="20ms - 30ms",region="dev"} 7
+huatuo_bamai_iolatency_container_q2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",region="dev",zone="0"} 7
 # HELP huatuo_bamai_iolatency_container_d2c container d2c latency
 # TYPE huatuo_bamai_iolatency_container_d2c gauge
-huatuo_bamai_iolatency_container_d2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",latency="30ms - 50ms",region="dev"} 2
+huatuo_bamai_iolatency_container_d2c{container_host="coredns-855c4dd65d-8v5kg",container_hostnamespace="kube-system",container_level="burstable",container_name="coredns",container_type="normal",host="hostname",region="dev",zone="1"} 2
 ```
 
 |指标|意义|单位|对象|标签|
 |---|---|---|---|---|
-|iolatency_disk_q2c|宿主机磁盘整体 I/O 生命周期延迟统计，从入队到完成|计数|宿主|host, region, disk, latency|
-|iolatency_disk_d2c|宿主机磁盘驱动到完成阶段的延迟统计，更接近设备处理耗时|计数|宿主|host, region, disk, latency|
-|iolatency_container_q2c|容器触发的整体 I/O 生命周期延迟统计，从入队到完成|计数|容器|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
-|iolatency_container_d2c|容器触发的驱动到完成阶段延迟统计|计数|容器|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, latency|
-
-`latency` 标签当前分为 6 个桶：
-
-- `20ms - 30ms`
-- `30ms - 50ms`
-- `50ms - 100ms`
-- `100ms - 200ms`
-- `200ms - 400ms`
-- `400ms - `
+|iolatency_disk_q2c|宿主机磁盘整体 I/O 生命周期延迟统计，从入队到完成。分桶为：zone0 20-30ms，zone1 30-50ms，zone2 50-100ms，zone3 100-200ms，zone4 200-400ms，zone5 400ms+|计数|宿主|host, region, disk, zone|
+|iolatency_disk_d2c|宿主机磁盘驱动到完成阶段的延迟统计，更接近设备处理耗时。分桶为：zone0 20-30ms，zone1 30-50ms，zone2 50-100ms，zone3 100-200ms，zone4 200-400ms，zone5 400ms+|计数|宿主|host, region, disk, zone|
+|iolatency_container_q2c|容器触发的整体 I/O 生命周期延迟统计，从入队到完成。分桶为：zone0 20-30ms，zone1 30-50ms，zone2 50-100ms，zone3 100-200ms，zone4 200-400ms，zone5 400ms+|计数|容器|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, zone|
+|iolatency_container_d2c|容器触发的驱动到完成阶段延迟统计。分桶为：zone0 20-30ms，zone1 30-50ms，zone2 50-100ms，zone3 100-200ms，zone4 200-400ms，zone5 400ms+|计数|容器|host, region, container_host, container_name, container_type, container_level, container_hostnamespace, zone|
 
 ### 硬件
 


### PR DESCRIPTION
Introduce iolatency tracing based on eBPF for host and container IO latency metrics. This change adds the iolatency BPF program, integrates Go-side tracing and metric collection, and updates the Chinese and English metrics documentation to cover the new IO latency metrics and labels.