### PR TITLE
feat: add filter(containers) for autotracing CPUIdle

### DIFF
--- a/core/autotracing/config.go
+++ b/core/autotracing/config.go
@@ -26,6 +26,7 @@ type Config struct {
 		Interval              int64 `default:"10"`
 		IntervalTracing       int64 `default:"1800"`
 		RunTracingToolTimeout int64 `default:"10"`
+		Filter                filter
 	}
 
 	CPUSys struct {
@@ -61,6 +62,17 @@ type Config struct {
 	}
 
 	PatternList [][]string
+}
+
+type filter struct {
+	Exclude []filterRule
+	Include []filterRule
+}
+
+type filterRule struct {
+	Field     string
+	Pattern   string
+	MatchType string
 }
 
 var cfg = &Config{}

--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -93,6 +93,10 @@ func updateContainersCPUIdle() error {
 	}
 
 	for _, container := range containers {
+		if ignoreContainer(container, cfg.CPUIdle.Filter) {
+			continue
+		}
+
 		if _, ok := containersCPUIdle[container.ID]; ok {
 			containersCPUIdle[container.ID].path = container.CgroupPath
 			containersCPUIdle[container.ID].alive = true

--- a/core/autotracing/filter.go
+++ b/core/autotracing/filter.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"regexp"
+
+	"huatuo-bamai/internal/pod"
+)
+
+func ignoreContainer(container *pod.Container, filter filter) bool {
+	if len(filter.Include) > 0 {
+		included := matchfilterRules(container, filter.Include)
+		if !included {
+			return true
+		}
+	}
+
+	if len(filter.Exclude) > 0 {
+		excluded := matchfilterRules(container, filter.Exclude)
+		if excluded {
+			return true
+		}
+	}
+
+	return false
+}
+
+func matchfilterRules(container *pod.Container, rules []filterRule) bool {
+	for _, rule := range rules {
+		value := getContainerFieldValue(container, rule.Field)
+		if value == "" {
+			continue
+		}
+
+		matched := matchValue(value, rule.Pattern, rule.MatchType)
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func getContainerFieldValue(container *pod.Container, field string) string {
+	switch field {
+	case "container_host_namespace":
+		return container.LabelHostNamespace()
+	case "container_hostname":
+		return container.Hostname
+	case "container_qos":
+		return container.Qos.String()
+	default:
+		return ""
+	}
+}
+
+func matchValue(value, pattern, matchType string) bool {
+	if pattern == "" {
+		return false
+	}
+
+	switch matchType {
+	case "regex":
+		re := regexp.MustCompile(pattern)
+		return re.MatchString(value)
+	case "exact":
+		return value == pattern
+	default:
+		re := regexp.MustCompile(pattern)
+		return re.MatchString(value)
+	}
+}

--- a/core/autotracing/filter_test.go
+++ b/core/autotracing/filter_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/pod"
+)
+
+func TestIgnoreContainer_Exclude(t *testing.T) {
+	tests := []struct {
+		name      string
+		container *pod.Container
+		filter    filter
+		want      bool
+	}{
+		{
+			name: "exclude by namespace regex",
+			container: &pod.Container{
+				Hostname: "test-host",
+				Labels:   map[string]any{"HostNamespace": "kube-system"},
+			},
+			filter: filter{
+				Exclude: []filterRule{
+					{Field: "container_host_namespace", Pattern: "^kube-", MatchType: "regex"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "exclude by hostname exact",
+			container: &pod.Container{
+				Hostname: "legacy-host-001",
+				Labels:   map[string]any{"HostNamespace": "default"},
+			},
+			filter: filter{
+				Exclude: []filterRule{
+					{Field: "container_hostname", Pattern: "legacy-host-001", MatchType: "exact"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "exclude by qos exact",
+			container: &pod.Container{
+				Hostname: "test-host",
+				Labels:   map[string]any{"HostNamespace": "default"},
+				Qos:      pod.ContainerQos(3),
+			},
+			filter: filter{
+				Exclude: []filterRule{
+					{Field: "container_qos", Pattern: "besteffort", MatchType: "exact"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no exclude rule",
+			container: &pod.Container{
+				Hostname: "test-host",
+				Labels:   map[string]any{"HostNamespace": "default"},
+			},
+			filter: filter{
+				Exclude: []filterRule{
+					{Field: "container_host_namespace", Pattern: "^kube-", MatchType: "regex"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ignoreContainer(tt.container, tt.filter)
+			if got != tt.want {
+				t.Errorf("ignoreContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIgnoreContainer_Include(t *testing.T) {
+	tests := []struct {
+		name      string
+		container *pod.Container
+		filter    filter
+		want      bool
+	}{
+		{
+			name: "include by namespace regex",
+			container: &pod.Container{
+				Hostname: "test-host",
+				Labels:   map[string]any{"HostNamespace": "application-prod"},
+			},
+			filter: filter{
+				Include: []filterRule{
+					{Field: "container_host_namespace", Pattern: "^application-", MatchType: "regex"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "include but not match",
+			container: &pod.Container{
+				Hostname: "test-host",
+				Labels:   map[string]any{"HostNamespace": "kube-system"},
+			},
+			filter: filter{
+				Include: []filterRule{
+					{Field: "container_host_namespace", Pattern: "^application-", MatchType: "regex"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "include by qos exact",
+			container: &pod.Container{
+				Hostname: "test-host",
+				Labels:   map[string]any{"HostNamespace": "default"},
+				Qos:      pod.ContainerQos(1),
+			},
+			filter: filter{
+				Include: []filterRule{
+					{Field: "container_qos", Pattern: "guaranteed", MatchType: "exact"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ignoreContainer(tt.container, tt.filter)
+			if got != tt.want {
+				t.Errorf("ignoreContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIgnoreContainer_EmptyFilter(t *testing.T) {
+	container := &pod.Container{
+		Hostname: "test-host",
+		Labels:   map[string]any{"HostNamespace": "default"},
+	}
+
+	filter := filter{}
+
+	got := ignoreContainer(container, filter)
+	if got != false {
+		t.Errorf("ignoreContainer() = %v, want false", got)
+	}
+}

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -150,6 +150,34 @@ BlackList = ["netdev_hw", "metax_gpu"]
         # IntervalTracing = 1800
         # RunTracingToolTimeout = 10
 
+        # CPUIdle-specific filtering rules
+        # Filter rules to include or exclude containers from CPUIdle detection
+        #
+        # Supported fields:
+        # - container_host_namespace: namespace label of the container
+        # - container_hostname: hostname of the container
+        # - container_qos: qos level (guaranteed, burstable, besteffort)
+        #
+        # Supported match types:
+        # - regex: regular expression matching (default)
+        # - exact: exact string matching
+        #
+        # Logic:
+        # - Include rules take priority: only containers matching Include rules will be monitored
+        # - Exclude rules: containers matching Exclude rules will be skipped
+        # - If no rules are configured, all containers will be monitored
+        #
+        # Example:
+        # [[AutoTracing.CPUIdle.Filter.Exclude]]
+        #     Field = "container_qos"
+        #     Pattern = "besteffort"
+        #     MatchType = "exact"
+        #
+        # [[AutoTracing.CPUIdle.Filter.Include]]
+        #     Field = "container_host_namespace"
+        #     Pattern = "application-.*"
+        #     MatchType = "regex"
+
     # cpusys
     #
     # For a high system cpu usage all of a sudden on host machine.


### PR DESCRIPTION
Add filter configuration to exclude/include containers from CPUIdle detection based on
  - container_host_namespace
  - container_hostname
  - container_qos fields using regex or exact match.

Add filterRule and filter config structs in config.go Add filter.go with match logic
Add unit tests for filter functionality
Add filter documentation in huatuo-bamai.conf

Change-Id: Ia1115d9cd0ec560cae26e612c4bb3df2779ef4d3