### PR TITLE
fix(tracing): fix typo and improve lock scope in Dump()

### DIFF
--- a/pkg/tracing/manager.go
+++ b/pkg/tracing/manager.go
@@ -101,11 +101,12 @@ func (mgr *TracingManager) StopByName(name string) error {
 
 // Dump gets all tracer info
 func (mgr *TracingManager) Dump() map[string]*EventTracingInfo {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
 	dump := make(map[string]*EventTracingInfo)
 	for name, c := range mgr.tracingEvents {
-		mgr.mu.Lock()
 		dump[name] = c.Info()
-		mgr.mu.Unlock()
 	}
 	return dump
 }

--- a/pkg/tracing/task.go
+++ b/pkg/tracing/task.go
@@ -251,6 +251,6 @@ func StopTask(taskID string) error {
 		task.cancelFunc()
 	}
 	taskLifeTmpCache.Delete(taskID)
-	log.Infof("task %s stoped", task.id)
+	log.Infof("task %s stopped", task.id)
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR fixes two minor issues in `pkg/tracing/`:

### 1. Typo fix in `task.go`
- Fixed "stoped" → "stopped" in log message (line 254)

### 2. Lock scope improvement in `manager.go`
- `TracingManager.Dump()` previously locked/unlocked the mutex per iteration entry, which could yield an inconsistent snapshot if tracers are started or stopped concurrently during the dump.
- Changed to hold the lock for the entire iteration to ensure a consistent view.

## Changes
- `pkg/tracing/task.go`: Fix typo in log message
- `pkg/tracing/manager.go`: Hold mutex for entire `Dump()` loop

## Testing
- No behavioral change; existing tests pass.