### PR TITLE
fix: avoid nil store in SetTaskStore and propagate Close error

### DIFF
--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -229,7 +229,9 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 			},
 		)
 	}
-	tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
+	if esStore != nil {
+		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
+	}
 
 	return nil
 }

--- a/internal/bpf/perf_event_reader_default.go
+++ b/internal/bpf/perf_event_reader_default.go
@@ -55,9 +55,7 @@ func newPerfEventReader(ctx context.Context, array *ebpf.Map, perCPUBuffer int) 
 // Close the perfEventReader.
 func (r *perfEventReader) Close() error {
 	r.cancelCtx()
-	r.rd.Close()
-
-	return nil
+	return r.rd.Close()
 }
 
 // ReadInto reads the eBPF perf_event into pdata.


### PR DESCRIPTION
## Summary

Two small fixes for correctness and error propagation.

### 1. Avoid passing nil store to `SetTaskStore` (`cmd/huatuo-bamai/main.go`)

When Elasticsearch storage is not configured, `esStore` remains `nil`. Previously it was unconditionally passed to `SetTaskStore()`, resulting in a slice containing a nil element. Although `saveDocument()` has a nil guard, it's cleaner to skip the call entirely.

### 2. Propagate `Close()` error in `perfEventReader` (`internal/bpf/perf_event_reader_default.go`)

`perfEventReader.Close()` discarded the error from `r.rd.Close()` and always returned nil. This could hide resource cleanup failures. Now the error is properly returned to the caller.

## Changes
- `cmd/huatuo-bamai/main.go`: Guard `SetTaskStore` call with nil check
- `internal/bpf/perf_event_reader_default.go`: Return `rd.Close()` error