### PR TITLE
fix:  initStorage 传递 nil esStore 到 SetTaskStore 防止错误

### DIFF
--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -232,6 +232,7 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 	if esStore != nil {
 		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
 	}
+
 	return nil
 }
 

--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -229,8 +229,9 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 			},
 		)
 	}
-	tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
-
+	if esStore != nil {
+		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
+	}
 	return nil
 }
 


### PR DESCRIPTION
fix: initStorage 传递 nil esStore 到 SetTaskStore 防止错误

文件: cmd/huatuo-bamai/main.go:232                                                 
                                                                                     
tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})                                                
                                                                                     
当 ES 未配置时（cfg.Storage.ES.Address == ""），第195-209行的初始化跳过了，esStore 保持零值 nil。这里创建了一个包含 nil 元素的切片 []*storage.Store[*tracing.Document]{nil} 传递给 SetTaskStore，后续在 SetTaskStore 内部解引用该 nil 元素将导致 panic。

修复：加个判断，如果 esStore != nil 才执行。