### PR TITLE
fix: checkAndRecordMemoryUsage 吞掉 readMemInfo 的 error

### DIFF
--- a/core/autotracing/memburst.go
+++ b/core/autotracing/memburst.go
@@ -87,7 +87,7 @@ func checkAndRecordMemoryUsage(currentIndex *int, isHistoryFull *bool,
 	})
 	if err != nil {
 		log.Errorf("Error reading memory info: %v\n", err)
-		return []*processMemInfo{}, nil
+		return []*processMemInfo{}, err
 	}
 	currentSum := memInfo["Active(anon)"] + memInfo["Inactive(anon)"]
 	history[*currentIndex] = currentSum

--- a/core/autotracing/memburst.go
+++ b/core/autotracing/memburst.go
@@ -87,7 +87,7 @@ func checkAndRecordMemoryUsage(currentIndex *int, isHistoryFull *bool,
 	})
 	if err != nil {
 		log.Errorf("Error reading memory info: %v\n", err)
-		return []*processMemInfo{}, err
+		return []*processMemInfo{}, err 
 	}
 	currentSum := memInfo["Active(anon)"] + memInfo["Inactive(anon)"]
 	history[*currentIndex] = currentSum


### PR DESCRIPTION
fix: checkAndRecordMemoryUsage 吞掉 readMemInfo 的 error
文件: core/autotracing/memburst.go:88-91
    memInfo, err := readMemInfo(...) 
    if err != nil {
        log.Errorf("Error reading memory info: %v\n", err)
        return []*processMemInfo{}, nil  // ← 返回 nil error!
    }

当 /proc/meminfo 读取失败时，函数记录日志但返回 nil 错误。调用方（第144行）检查 err != nil 会认为调用成功，从而静默跳过故障。这可能导致内存突发检测完全失效而不报错。