### PR TITLE
fix: updateContainerBlkDisk 吞掉 pod.Containers() 的 error

### DIFF
--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -156,7 +156,7 @@ func (c *iolatencyTracing) dumpContainerLatency() ([]BlkgqEntry, error) {
 func (c *iolatencyTracing) updateContainerBlkDisk(b bpf.BPF) error {
 	containers, err := pod.Containers()
 	if err != nil {
-		return err
+		return err 
 	}
 
 	var newContainers []*pod.Container

--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -156,7 +156,7 @@ func (c *iolatencyTracing) dumpContainerLatency() ([]BlkgqEntry, error) {
 func (c *iolatencyTracing) updateContainerBlkDisk(b bpf.BPF) error {
 	containers, err := pod.Containers()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var newContainers []*pod.Container


### PR DESCRIPTION
fix: updateContainerBlkDisk 吞掉 pod.Containers() 的 error

 文件: core/metrics/iolatency_tracing.go:158-159                                    
                                                                                     
    func (c *iolatencyTracing) updateContainerBlkDisk(b bpf.BPF) error {             
        containers, err := pod.Containers()                                          
        if err != nil {                                                              
            return nil  // ← 返回 nil 而不是 err                                     
        }                                                                            
当获取容器列表失败时，错误被丢弃，函数返回 nil，调用方以为一切正常。这会静默导致 BPF map 中的容器数据不一致——老的容器 key 没清理，新的容器 key 没添加。