### PR TITLE
fix: dload.go ctx 取消响应延迟

### DIFF
--- a/core/autotracing/dload.go
+++ b/core/autotracing/dload.go
@@ -372,13 +372,14 @@ func (c *dloadTracing) Start(ctx context.Context) error {
 		debug:           cfg.Dload.EnableDebug,
 	}
 
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return types.ErrExitByCancelCtx
-		default:
-			time.Sleep(time.Duration(interval) * time.Second)
-
+		case <-ticker.C:
 			if err := updateContainersDload(); err != nil {
 				return err
 			}


### PR DESCRIPTION
文件: core/autotracing/dload.go:375-392                                            
    for {                                                                            
        select {                                                                     
        case <-ctx.Done():                                                           
            return types.ErrExitByCancelCtx                                          
        default:                                                                     
            time.Sleep(time.Duration(interval) * time.Second)  // ↑ 可能休眠很久     
                                                                                     
time.Sleep 在 default 分支中执行，期间完全没有监听 ctx.Done()。如果 interval 配置 为较大值（如60秒），shutdown 延迟可达60秒。而且在 updateContainersDload() 内如果发生阻塞，同样无法响应取消。 