### PR TITLE
docs(apiserver): clean up huatuo-apiserver.conf

### DIFF
--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -1,56 +1,151 @@
-# log-level: Debug, Info, Warn, Error, Panic
-LogLevel = "Info"
+# Log level for huatuo-apiserver.
+# Supported: Debug, Info, Warn, Error, Panic.
+# Default: Info
+#
+# LogLevel = "Info"
 
+# Runtime resource limit for the huatuo-apiserver process itself.
+#
+# - LimitCPU
+# CPU resource limit in cores.
+# Default: 20
+#
+# - LimitMem
+# Memory resource limit in MB.
+# Default: 4096
+#
 [RuntimeCgroup]
-# CfsInitQuota, CfsRuntimeQuota: run-time replenishegitd
-# within a period (in microseconds)
-  # LimitCPU: cpu limit in cores
-  LimitCPU = 20
-  # LimitMem: memory limit in MB
-  LimitMem = 4096
+    # LimitCPU = 20
+    # LimitMem = 4096
 
+# APIServer listening configuration.
+#
+# - TCPAddr
+# The TCP listen address of the huatuo-apiserver, in "host:port" form.
+# Leaving host empty means listening on all interfaces.
+# Default: ":12740"
+#
 [APIServer]
-  # TCPAddr is the tcp monitoring information of the HUATUO server
-  TCPAddr = ":12740"
+    # TCPAddr = ":12740"
 
+# Task scheduling limits.
+#
+# - MaxProfilingTasksPerHost
+# Maximum number of profiling tasks allowed per host.
+# Default: 3
+#
+# - MaxTracingTasksPerHost
+# Maximum number of tracing tasks allowed per host.
+# Default: 5
+#
+# - MaxTotalProfilingTasks
+# Maximum number of profiling tasks allowed across the whole cluster.
+# Default: 500
+#
+# - MaxTotalTracingTasks
+# Maximum number of tracing tasks allowed across the whole cluster.
+# Default: 1000
+#
 [TaskConfig]
-  # MaxProfilingTasksPerHost is the maximum number of profiling tasks allowed per host
-  MaxProfilingTasksPerHost = 3
-  # MaxTracingTasksPerHost is the maximum number of tracing tasks allowed per host
-  MaxTracingTasksPerHost = 5
-  # MaxTotalProfilingTasks is the maximum number of total profiling tasks allowed
-  MaxTotalProfilingTasks = 500
-  # MaxTotalTracingTasks is the maximum number of total tracing tasks allowed
-  MaxTotalTracingTasks = 1000
+    # MaxProfilingTasksPerHost = 3
+    # MaxTracingTasksPerHost   = 5
+    # MaxTotalProfilingTasks   = 500
+    # MaxTotalTracingTasks     = 1000
 
+# Elasticsearch / OpenSearch backend used by the apiserver to query
+# tracing and event data produced by huatuo-bamai.
+#
+# Storage is disabled if any of Address, Username or Password is empty.
+#
+# - Address
+# Full URL of the ES/OS endpoint, e.g.
+#   http://127.0.0.1:9200
+#   https://127.0.0.1:9200
+#
+# - Username / Password
+# Credentials used to authenticate against ES/OS. No default.
+#
+# - Index
+# Logical index name that holds huatuo-bamai documents.
+# Typically matches the Index configured in huatuo-bamai.conf
+# (default there is "huatuo_bamai").
+#
+# - Debug
+# Enable verbose request/response logging from the ES client.
+# Default: false
+#
 [ElasticSearch]
-  Debug = false
-  Address = ""
-  Username = ""
-  Password = ""
-  Index = ""
+    # Address  = "http://127.0.0.1:9200"
+    # Username = "elastic"
+    # Password = "huatuo-bamai"
+    # Index    = "huatuo_bamai"
+    # Debug    = false
 
-[Auth]
-  # User authentication configurations
-  [[Auth.users]]
-    ID = "a800ed4b075ecacd2dfc246a9a1ae87a"
-    Name = "Administrator"
-    IsAdmin = true
+# Authentication configuration.
+#
+# Each user is declared with a [[Auth.users]] block.
+#
+# Supported fields:
+# - ID
+#   Unique identifier for the user, presented by the client on each request.
+#   Treat this as a secret; generate a sufficiently random value
+#   (e.g. `openssl rand -hex 16`).
+# - Name
+#   Human-readable display name. Not used for authorization.
+# - IsAdmin
+#   When true, the user has full access and Permissions is ignored.
+#   Default: false
+# - Permissions
+#   List of URL path patterns this user is allowed to access.
+#   Only consulted when IsAdmin is false.
+#   "**" matches any suffix, e.g. "/v1/traces/**".
+#
+# Examples:
+#
+# # Administrator: full access, Permissions ignored.
+# [[Auth.users]]
+#     ID      = "REPLACE_WITH_RANDOM_HEX"
+#     Name    = "Administrator"
+#     IsAdmin = true
+#
+# # Restricted user: read-only access to traces and profiles.
+# [[Auth.users]]
+#     ID          = "REPLACE_WITH_RANDOM_HEX"
+#     Name        = "huatuo-front"
+#     IsAdmin     = false
+#     Permissions = ["/v1/traces", "/v1/traces/**", "/v1/profiles", "/v1/profiles/**"]
 
-  [[Auth.users]]
-    ID = "2649c74e8baac5a727ea862756c8299b"
-    Name = "huatuo-front"
-    Permissions = ["/v1/traces/**", "/v1/traces", "/v1/profiles", "/v1/profiles/**"]
-    IsAdmin = false
-
+# Profiling configuration.
+#
+# - CPUProfilingInterval
+# Default sampling interval (seconds) for CPU profiling.
+# Default: 10
+#
+# - MemoryProfilingInterval
+# Default sampling interval (seconds) for memory profiling.
+# Default: 10
+#
+# - CPUSingleTraceTimeout
+# Timeout (seconds) for a single CPU trace run.
+# Default: 20
+#
+# - MemorySingleTraceTimeout
+# Timeout (seconds) for a single memory trace run.
+# Default: 20
+#
+# - ThirdPartyToolLimit
+# Maximum concurrent invocations of third-party profiling tools.
+# Default: 10
+#
+# - FlameGraphBaseURL
+# Base URL of the flame graph dashboard. The apiserver builds per-trace
+# links by appending dashboard identifiers to this URL.
+# Default: "http://localhost:8006/d"
+#
 [Profiling]
-  # CPUProfilingInterval is the interval for CPU profiling
-  CPUProfilingInterval = 10
-  # MemoryProfilingInterval is the interval for Memory profiling
-  MemoryProfilingInterval = 10
-  # CPUSingleTraceTimeout is the timeout for CPU single trace
-  CPUSingleTraceTimeout = 20
-  # MemorySingleTraceTimeout is the timeout for Memory single trace
-  MemorySingleTraceTimeout = 20
-  # ThirdPartyToolLimit is the limit for third party tool
-  ThirdPartyToolLimit = 10
+    # CPUProfilingInterval     = 10
+    # MemoryProfilingInterval  = 10
+    # CPUSingleTraceTimeout    = 20
+    # MemorySingleTraceTimeout = 20
+    # ThirdPartyToolLimit      = 10
+    # FlameGraphBaseURL        = "http://localhost:8006/d"


### PR DESCRIPTION
Align the default config with huatuo-bamai.conf style: comment out all fields that carry built-in defaults and keep only the documentation and examples. Replace the hard-coded Auth users with annotated examples so operators must supply their own IDs. Add the previously missing Profiling.FlameGraphBaseURL entry as a commented example.