### PR TITLE
fix(cpu): avoid cpu stat hierarchy wait sum underflow

### DIFF
--- a/core/metrics/cpu_stat.go
+++ b/core/metrics/cpu_stat.go
@@ -106,13 +106,13 @@ func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Containe
 		lastUpdate:       now,
 	}
 
-	deltaHierarchyWaitSum = stat.hierarchyWaitSum - cpu.hierarchyWaitSum
-	if deltaHierarchyWaitSum <= 0 {
+	if stat.hierarchyWaitSum <= cpu.hierarchyWaitSum {
 		deltaThrottledSum = 0
 		deltaHierarchyWaitSum = 0
 		deltaInnerWaitSum = 0
 		deltaExterWaitSum = 0
 	} else {
+		deltaHierarchyWaitSum = stat.hierarchyWaitSum - cpu.hierarchyWaitSum
 		deltaThrottledSum = stat.throttledTime - cpu.throttledTime
 		deltaInnerWaitSum = stat.innerWaitSum - cpu.innerWaitSum
 


### PR DESCRIPTION
## Summary

- compare hierarchy_wait_sum before subtracting to avoid uint64 underflow when the counter resets

## Testing

- gofmt -w core/metrics/cpu_stat.go
- GOOS=linux GOARCH=amd64 go test -exec=echo ./core/metrics
- Not run: go test ./core/metrics ... on Windows is blocked by Linux-only github.com/prometheus/procfs/sysfs build constraints.

Fixes #204