### PR TITLE
fix: systemd cgroup driver with V2 should use dbus connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cloudflare/backoff v0.0.0-20240920015135-e46b80a3a7d0
 	github.com/cloudflare/cbpfc v0.0.0-20250612101420-369091e6a9e1
 	github.com/containerd/cgroups/v3 v3.0.3
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/deckarep/golang-set v1.8.0
 	github.com/docker/docker v27.4.1+incompatible
 	github.com/ebitengine/purego v0.9.1
@@ -16,6 +17,7 @@ require (
 	github.com/gin-contrib/pprof v1.5.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-playground/validator/v10 v10.22.1
+	github.com/godbus/dbus/v5 v5.0.6
 	github.com/google/cadvisor v0.50.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -69,7 +71,6 @@ require (
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
-	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
@@ -91,7 +92,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gogo/status v1.1.1 // indirect

--- a/internal/cgroups/v2/cgroups.go
+++ b/internal/cgroups/v2/cgroups.go
@@ -15,6 +15,7 @@
 package v2
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -25,12 +26,15 @@ import (
 	"huatuo-bamai/internal/utils/parseutil"
 
 	extv2 "github.com/containerd/cgroups/v3/cgroup2"
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type CgroupV2 struct {
-	name   string
-	cgroup *extv2.Manager
+	name     string
+	cgroup   *extv2.Manager
+	unitName string
 }
 
 func New() (*CgroupV2, error) {
@@ -58,6 +62,7 @@ func (c *CgroupV2) NewRuntime(path string, spec *specs.LinuxResources) error {
 	}
 
 	c.cgroup = m
+	c.unitName = path + Postfix
 	return nil
 }
 
@@ -78,8 +83,52 @@ func (c *CgroupV2) DeleteRuntime() error {
 	return c.cgroup.DeleteSystemd()
 }
 
+// convert OCI resource spec to dbus properties for cgroup v2 systemd
+func specToSystemdProperties(spec *specs.LinuxResources) []systemdDbus.Property {
+	var properties []systemdDbus.Property
+
+	if spec.CPU != nil && spec.CPU.Quota != nil && *spec.CPU.Quota > 0 &&
+		spec.CPU.Period != nil && *spec.CPU.Period != 0 {
+		quota := uint64(*spec.CPU.Quota)
+		period := *spec.CPU.Period
+		cpuQuotaPerSecUSec := quota * 1000000 / period
+		if cpuQuotaPerSecUSec%10000 != 0 {
+			cpuQuotaPerSecUSec = ((cpuQuotaPerSecUSec / 10000) + 1) * 10000
+		}
+		properties = append(properties, systemdDbus.Property{
+			Name:  "CPUQuotaPerSecUSec",
+			Value: dbus.MakeVariant(cpuQuotaPerSecUSec),
+		})
+	}
+
+	if spec.Memory != nil && spec.Memory.Limit != nil {
+		properties = append(properties, systemdDbus.Property{
+			Name:  "MemoryMax",
+			Value: dbus.MakeVariant(uint64(*spec.Memory.Limit)),
+		})
+	}
+
+	return properties
+}
+
+func (c *CgroupV2) updateSystemd(properties []systemdDbus.Property) error {
+	ctx := context.TODO()
+	conn, err := systemdDbus.NewWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("cgroup2 connect to systemd dbus: %w", err)
+	}
+	defer conn.Close()
+
+	return conn.SetUnitPropertiesContext(ctx, c.unitName, true, properties...)
+}
+
 func (c *CgroupV2) UpdateRuntime(spec *specs.LinuxResources) error {
-	return c.cgroup.Update(extv2.ToResources(spec))
+	properties := specToSystemdProperties(spec)
+	if len(properties) == 0 {
+		return nil
+	}
+
+	return c.updateSystemd(properties)
 }
 
 func (c *CgroupV2) AddProc(pid uint64) error {


### PR DESCRIPTION
Closes #203

  ## 问题

  cgroup v2 + systemd driver 环境下，UpdateRuntime 直接调用 Update 会被 systemd service 覆盖，导致配置冲突。

  ## 修复方案

  通过 dbus 连接来更新 runtime 资源。