### PR TITLE
fix(cpuidle): handle cgroup manager init errors

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -43,7 +43,14 @@ func init() {
 var cgroupMgr cgroups.Cgroup
 
 func newCPUIdle() (*tracing.EventTracingAttr, error) {
-	cgroupMgr, _ = cgroups.NewManager()
+	cgroup, err := cgroups.NewManager()
+	if err != nil {
+		return nil, err
+	}
+	if cgroup == nil {
+		return nil, fmt.Errorf("cgroup manager is nil")
+	}
+	cgroupMgr = cgroup
 
 	return &tracing.EventTracingAttr{
 		TracingData: &cpuIdleTracing{},


### PR DESCRIPTION
## Summary

- return initialization errors from cgroups.NewManager() in cpuidle tracing
- guard against a nil cgroup manager before it is used by container CPU sampling

## Testing

- gofmt -w core/autotracing/cpuidle.go
- GOOS=linux GOARCH=amd64 go test -exec=echo ./core/autotracing

Fixes #209