### PR TITLE
feat(server): add healthz endpoint

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,9 +102,17 @@ func NewServer(cfg *Config) *server {
 	s.engine.Use(middleWares...)
 	s.rootGroup = NewRoot(s.engine, cfg.Group)
 	s.MustRegisterRoutes("", []Handle{
+		{Typ: HttpGet, Uri: "/healthz", Handle: s.healthzHandler()},
 		{Typ: HttpGet, Uri: "/metrics", Handle: s.promServerHandler()},
 	})
 	return s
+}
+
+func (s *server) healthzHandler() ErrHandlerContextFunc {
+	return func(ctx *Context) error {
+		ctx.Status(http.StatusNoContent)
+		return nil
+	}
 }
 
 func (s *server) promServerHandler() ErrHandlerContextFunc {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -42,6 +42,22 @@ func TestNewServerRegistersMetricsRouteWithoutRegistry(t *testing.T) {
 	}
 }
 
+func TestNewServerRegistersHealthzRoute(t *testing.T) {
+	s := NewServer(nil)
+
+	request := httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody)
+	recorder := httptest.NewRecorder()
+
+	s.engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("response status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	if recorder.Body.Len() != 0 {
+		t.Errorf("response body = %q, want empty body", recorder.Body.String())
+	}
+}
+
 func TestPromServerHandlerWithRegistry(t *testing.T) {
 	s := &server{promRegistry: prometheus.NewRegistry()}
 


### PR DESCRIPTION
## Summary

- register a lightweight GET /healthz route on the default HTTP server
- return 204 No Content for successful health checks
- add server coverage for the new healthz route

## Testing

- gofmt -w internal/server/server.go internal/server/server_test.go
- GOOS=linux GOARCH=amd64 go test -c ./internal/server
- Not run: go test ./internal/server on Windows is blocked by existing syscall.SetsockoptInt platform differences in server.go.

Fixes #211