### PR TITLE
fix(iotracing): export max block latencies

### DIFF
--- a/bpf/iotracing.c
+++ b/bpf/iotracing.c
@@ -220,6 +220,8 @@ int bpf_rq_qos_done(struct pt_regs *ctx)
 	int partno;
 	int devn[2];
 	u64 now;
+	u64 q2c;
+	u64 d2c;
 
 	disk = get_request_disk(req);
 	/* gendisk.major, gendisk.first_minor */
@@ -258,8 +260,15 @@ int bpf_rq_qos_done(struct pt_regs *ctx)
 	}
 
 	now = bpf_ktime_get_ns();
-	entry->latency.sum_q2c += now - BPF_CORE_READ(req, start_time_ns);
-	entry->latency.sum_d2c += now - BPF_CORE_READ(req, io_start_time_ns);
+	q2c = now - BPF_CORE_READ(req, start_time_ns);
+	d2c = now - BPF_CORE_READ(req, io_start_time_ns);
+
+	entry->latency.sum_q2c += q2c;
+	entry->latency.sum_d2c += d2c;
+	if (q2c > entry->latency.max_q2c)
+		entry->latency.max_q2c = q2c;
+	if (d2c > entry->latency.max_d2c)
+		entry->latency.max_d2c = d2c;
 	entry->latency.cnt++;
 
 	if (entry == &data) {

--- a/cmd/iotracing/aggregate.go
+++ b/cmd/iotracing/aggregate.go
@@ -53,10 +53,12 @@ func buildProcessFileIOStats(g *pidGroup, cfg ioConfig) types.ProcessFileIOStats
 			continue
 		}
 
-		var q2c, d2c uint64
+		var q2c, d2c, maxQ2C, maxD2C uint64
 		if record.Latency.Count > 0 {
 			q2c = record.Latency.SumQ2CNs / (record.Latency.Count * 1000)
 			d2c = record.Latency.SumD2CNs / (record.Latency.Count * 1000)
+			maxQ2C = record.Latency.MaxQ2CNs / 1000
+			maxD2C = record.Latency.MaxD2CNs / 1000
 		}
 
 		fileStats = append(fileStats, types.FileIOStats{
@@ -71,6 +73,8 @@ func buildProcessFileIOStats(g *pidGroup, cfg ioConfig) types.ProcessFileIOStats
 			DiskWriteBps: dwbps,
 			Q2CUs:        q2c,
 			D2CUs:        d2c,
+			MaxQ2CUs:     maxQ2C,
+			MaxD2CUs:     maxD2C,
 		})
 	}
 

--- a/cmd/iotracing/format.go
+++ b/cmd/iotracing/format.go
@@ -103,7 +103,7 @@ func printIOTracingReport(w io.Writer, report *types.IOTracingReport) {
 		fmt.Fprintf(w, "COMMAND: %-20s\n", p.Comm)
 
 		fmt.Fprintln(w, "-----------------------------------")
-		fmt.Fprintln(w, "DEVICE  FS_READ FS_WRITE DISK_READ DISK_WRITE   LATENCY(μs)      FILE/INODE")
+		fmt.Fprintln(w, "DEVICE  FS_READ FS_WRITE DISK_READ DISK_WRITE   LATENCY(us)                         FILE/INODE")
 
 		for _, f := range p.TotalFiles {
 			path := f.Path
@@ -122,13 +122,13 @@ func printIOTracingReport(w io.Writer, report *types.IOTracingReport) {
 			diskWrite := fmt.Sprintf("%dB", f.DiskWriteBps)
 
 			if f.Inode == 0 {
-				fmt.Fprintf(w, "%-7s %7s %8s %9s %9s   q2c=%-4d d2c=%-4d %s\n",
+				fmt.Fprintf(w, "%-7s %7s %8s %9s %9s   q2c=%-4d max_q2c=%-4d d2c=%-4d max_d2c=%-4d %s\n",
 					device, fsRead, fsWrite, diskRead, diskWrite,
-					f.Q2CUs, f.D2CUs, path)
+					f.Q2CUs, f.MaxQ2CUs, f.D2CUs, f.MaxD2CUs, path)
 			} else {
-				fmt.Fprintf(w, "%-7s %7s %8s %9s %9s   q2c=%-4d d2c=%-4d %s (%d)\n",
+				fmt.Fprintf(w, "%-7s %7s %8s %9s %9s   q2c=%-4d max_q2c=%-4d d2c=%-4d max_d2c=%-4d %s (%d)\n",
 					device, fsRead, fsWrite, diskRead, diskWrite,
-					f.Q2CUs, f.D2CUs, path, f.Inode)
+					f.Q2CUs, f.MaxQ2CUs, f.D2CUs, f.MaxD2CUs, path, f.Inode)
 			}
 		}
 		fmt.Fprintln(w)

--- a/pkg/types/iotracing.go
+++ b/pkg/types/iotracing.go
@@ -63,4 +63,6 @@ type FileIOStats struct {
 	DiskWriteBps uint64 `json:"disk_write_bps"`
 	Q2CUs        uint64 `json:"q2c_us"`
 	D2CUs        uint64 `json:"d2c_us"`
+	MaxQ2CUs     uint64 `json:"max_q2c_us"`
+	MaxD2CUs     uint64 `json:"max_d2c_us"`
 }


### PR DESCRIPTION
Summary
- update iotracing BPF to maintain max q2c/d2c latency counters
- expose max_q2c_us and max_d2c_us in JSON output
- include max latency values in the text table output

Testing
- gofmt -w cmd/iotracing/aggregate.go cmd/iotracing/format.go pkg/types/iotracing.go
- go test ./pkg/types
- Not run: GOOS=linux GOARCH=amd64 go test -c ./cmd/iotracing is blocked on a clean upstream snapshot by missing generated internal/toolstream/transport capnp types.
- Not run: BPF build / clang-format because clang is not available on this Windows machine.