### PR TITLE
fix(request): keep response body readable

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -87,7 +87,6 @@ func doRequest(req *http.Request) (*ServerResponse, error) {
 	if err != nil {
 		return serverResp, err
 	}
-	defer resp.Body.Close()
 
 	serverResp.StatusCode = resp.StatusCode
 	serverResp.Body = resp.Body

--- a/internal/request/response_body_test.go
+++ b/internal/request/response_body_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package request
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDoRequestKeepsSuccessBodyReadable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	resp, err := doRequest(req)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	defer resp.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if strings.TrimSpace(string(body)) != "ok" {
+		t.Fatalf("body = %q, want ok", string(body))
+	}
+}


### PR DESCRIPTION
Summary
- stop closing http.Response.Body before returning ServerResponse
- add a regression test that reads the returned response body

Testing
- gofmt -w internal/request/request.go internal/request/response_body_test.go
- GOOS=linux GOARCH=amd64 go test -c ./internal/request
- Not run: go test ./internal/request on Windows is blocked by Unix-only rawhttp syscall usage.