### PR TITLE
fix(iotracing): validate device filter bounds

### DIFF
--- a/cmd/iotracing/cli.go
+++ b/cmd/iotracing/cli.go
@@ -42,6 +42,11 @@ const (
 	outputJSON = "json"
 )
 
+const (
+	devMajorMax = 0xfff
+	devMinorMax = 0xfffff
+)
+
 func appFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{
@@ -169,13 +174,23 @@ func parseDeviceNumbers(deviceStr string) ([]uint32, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid major number %q: %w", parts[0], err)
 		}
+		if major > devMajorMax {
+			return nil, fmt.Errorf("major number %d exceeds max %d", major, devMajorMax)
+		}
 
 		minor, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("invalid minor number %q: %w", parts[1], err)
 		}
+		if minor > devMinorMax {
+			return nil, fmt.Errorf("minor number %d exceeds max %d", minor, devMinorMax)
+		}
 
 		deviceNums = append(deviceNums, (uint32(major)&0xfff)<<20|uint32(minor))
+	}
+
+	if len(deviceNums) == 0 {
+		return nil, errors.New("no devices specified")
 	}
 
 	if len(deviceNums) > bpfFilterDevMaxNums {

--- a/cmd/iotracing/cli_device_test.go
+++ b/cmd/iotracing/cli_device_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestParseDeviceNumbersRejectsInvalidSpecs(t *testing.T) {
+	cases := []string{
+		"",
+		" ",
+		",",
+		"4096:0",
+		"8:1048576",
+		"8",
+		"8:0:1",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			if _, err := parseDeviceNumbers(tc); err == nil {
+				t.Fatalf("parseDeviceNumbers(%q) error = nil, want error", tc)
+			}
+		})
+	}
+}
+
+func TestParseDeviceNumbersAcceptsBoundaryValues(t *testing.T) {
+	got, err := parseDeviceNumbers("8:0,4095:1048575")
+	if err != nil {
+		t.Fatalf("parseDeviceNumbers() error = %v", err)
+	}
+
+	want := []uint32{
+		8 << 20,
+		4095<<20 | 1048575,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("device[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Summary
- reject empty --device values instead of silently disabling the filter
- reject major/minor values outside Linux device-number encoding bounds
- add unit coverage for invalid specs and boundary values

Testing
- gofmt -w cmd/iotracing/cli.go cmd/iotracing/cli_device_test.go
- Not run: GOOS=linux GOARCH=amd64 go test -c ./cmd/iotracing is blocked on a clean upstream snapshot by missing generated internal/toolstream/transport capnp types.