### PR TITLE
fix(memburst): validate sampling config

### DIFF
--- a/core/autotracing/memburst.go
+++ b/core/autotracing/memburst.go
@@ -110,6 +110,19 @@ func checkAndRecordMemoryUsage(currentIndex *int, isHistoryFull *bool,
 	return []*processMemInfo{}, nil
 }
 
+func validateMemBurstConfig(historyWindowLength, sampleInterval, topNProcesses int) error {
+	if historyWindowLength <= 0 {
+		return fmt.Errorf("memory burst sliding window length must be greater than zero, got %d", historyWindowLength)
+	}
+	if sampleInterval <= 0 {
+		return fmt.Errorf("memory burst interval must be greater than zero, got %d", sampleInterval)
+	}
+	if topNProcesses <= 0 {
+		return fmt.Errorf("memory burst dump process max num must be greater than zero, got %d", topNProcesses)
+	}
+	return nil
+}
+
 // Core function
 func (c *memBurstTracing) Start(ctx context.Context) error {
 	var err error
@@ -120,6 +133,10 @@ func (c *memBurstTracing) Start(ctx context.Context) error {
 	topNProcesses := cfg.MemoryBurst.DumpProcessMaxNum
 	burstRatio := (float64(cfg.MemoryBurst.DeltaMemoryBurst)/100.0 + 1)
 	anonThreshold := cfg.MemoryBurst.DeltaAnonThreshold
+
+	if err := validateMemBurstConfig(historyWindowLength, sampleInterval, topNProcesses); err != nil {
+		return err
+	}
 
 	memInfo, err := readMemInfo(map[string]bool{"MemTotal": true})
 	if err != nil {

--- a/core/autotracing/memburst_config_test.go
+++ b/core/autotracing/memburst_config_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import "testing"
+
+func TestValidateMemBurstConfig(t *testing.T) {
+	cases := []struct {
+		name                string
+		historyWindowLength int
+		sampleInterval      int
+		topNProcesses       int
+		wantErr             bool
+	}{
+		{
+			name:                "valid",
+			historyWindowLength: 60,
+			sampleInterval:      10,
+			topNProcesses:       10,
+		},
+		{
+			name:                "zero history",
+			historyWindowLength: 0,
+			sampleInterval:      10,
+			topNProcesses:       10,
+			wantErr:             true,
+		},
+		{
+			name:                "zero interval",
+			historyWindowLength: 60,
+			sampleInterval:      0,
+			topNProcesses:       10,
+			wantErr:             true,
+		},
+		{
+			name:                "zero top processes",
+			historyWindowLength: 60,
+			sampleInterval:      10,
+			topNProcesses:       0,
+			wantErr:             true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMemBurstConfig(tc.historyWindowLength, tc.sampleInterval, tc.topNProcesses)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateMemBurstConfig() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary
- validate MemoryBurst sliding window, interval, and process dump limits before starting
- return a clear error instead of panicking on zero or negative user config
- add table-driven coverage for the validation helper

Testing
- gofmt -w core/autotracing/memburst.go core/autotracing/memburst_config_test.go
- Not run: GOOS=linux GOARCH=amd64 go test -c ./core/autotracing is blocked on a clean upstream snapshot by missing generated internal/toolstream/transport capnp types.