### PR TITLE
fix: guard unsafe type assertions to prevent runtime panics

### DIFF
--- a/internal/request/rawhttp.go
+++ b/internal/request/rawhttp.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -82,10 +83,16 @@ func connectUnix(sock string) (*net.UnixConn, error) {
 		return nil, err
 	}
 
-	// auto clean
-	runtime.SetFinalizer(c, (*net.UnixConn).Close)
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		_ = c.Close()
+		return nil, fmt.Errorf("expected *net.UnixConn, got %T", c)
+	}
 
-	return c.(*net.UnixConn), nil
+	// auto clean
+	runtime.SetFinalizer(uc, (*net.UnixConn).Close)
+
+	return uc, nil
 }
 
 // SendRequest Provide a standard interface for sending http to the security agent

--- a/internal/storage/localfile/localfile.go
+++ b/internal/storage/localfile/localfile.go
@@ -112,8 +112,12 @@ func (s *Storage) newFileWriter(filename string) io.Writer {
 		s.writerCache.Store(fp, fileWriter)
 	}
 
-	s.files[filename] = fileWriter.(io.Writer)
-	return s.files[filename]
+	w, ok := fileWriter.(io.Writer)
+	if !ok {
+		return nil
+	}
+	s.files[filename] = w
+	return w
 }
 
 func (s *Storage) writerByName(name string) io.Writer {


### PR DESCRIPTION
## Summary

Two unchecked type assertions in the codebase could trigger a runtime panic if the underlying value type ever changes (e.g. due to refactoring of dependencies or unexpected cache contents). Replace them with the comma-ok pattern.

### 1. `internal/request/rawhttp.go` - `connectUnix`

`net.Dial(\"unix\", ...)` typically returns a `*net.UnixConn`, but the code asserts this without checking. If the assertion ever fails, the program panics and the dialed connection leaks.

**Fix**: verify the assertion, close the connection on mismatch, and return a descriptive error.

### 2. `internal/storage/localfile/localfile.go` - `newFileWriter`

The value loaded from `sync.Map` is asserted to `io.Writer` without checking. Although today the only writer added is a `*filerotate.FileRotator` (which implements `io.Writer`), an unchecked assertion is fragile.

**Fix**: use the comma-ok pattern and return `nil` on mismatch.

## Why this matters

Both sites are on hot paths: `connectUnix` is called for every security-agent request, and `newFileWriter` is called for every record written to local file storage. A panic here would crash the whole process. The fix is small and defensive.

## Testing

No behavioral change for the success path. Builds cleanly.