### PR TITLE
docs(pkg): add package-level godoc comments

### DIFF
--- a/pkg/metric/collector.go
+++ b/pkg/metric/collector.go
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package metric provides the metrics collection framework used by HuaTuo
+// to expose runtime observability data via Prometheus.
+//
+// Tracers implement the Collector interface and register with a
+// CollectorManager, which adapts them to prometheus.Collector and
+// publishes scrape duration and success metrics for each registered
+// collector.
 package metric
 
 import (

--- a/pkg/metric/runtime/runtime.go
+++ b/pkg/metric/runtime/runtime.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package runtime registers Go runtime and process-level Prometheus
+// collectors (memory, GC, file descriptors, CPU time, etc.) under the
+// HuaTuo metrics namespace.
 package runtime
 
 import (
@@ -19,6 +22,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 )
 
+// RegisterCollector registers the standard process and Go runtime
+// collectors with reg, prefixing their metric names with namespace so
+// they share a consistent prefix with the rest of the HuaTuo metrics.
 func RegisterCollector(reg *prometheus.Registry, namespace string) {
 	reg.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
 		Namespace: namespace,

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tracing is the core scheduling and lifecycle layer for HuaTuo
+// tracers and event sources.
+//
+// It defines the ITracingEvent and ITracingMetric interfaces, manages
+// per-tracer goroutines through EventTracing, and exposes a global
+// manager for registering, starting, and stopping tracing tasks.
+// The package also provides the document model and watch-event publish/
+// subscribe mechanism used to deliver tracer output to consumers.
 package tracing
 
 import (

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package types defines the public data types and sentinel errors shared
+// across HuaTuo components and exposed to external consumers.
+//
+// It includes the CloudEvents-based WatchEvent envelope, tracer report
+// payloads (such as IOTracingReport and DropWatch events) and common
+// error values used to signal cancellation, disconnection, and
+// unsupported operations.
 package types
 
 import "errors"


### PR DESCRIPTION
### What

Add package-level godoc comments to four `pkg/` packages that previously had none:

- `pkg/metric`         — collector framework and Prometheus integration
- `pkg/metric/runtime` — process and Go runtime collector registration
- `pkg/tracing`        — tracer scheduling and watch-event delivery
- `pkg/types`          — shared public types and sentinel errors

### Why

These are the public-facing packages of the project. A short package overview is what `go doc <pkg>` and pkg.go.dev display first, so adding it improves discoverability for new contributors and external users without changing any code or behavior.

### Notes

- Documentation only; no code or behavior changes.
- DCO signed off.