### PR TITLE
feat(netdev): support regex DeviceList matching

### DIFF
--- a/core/events/netdev_events.go
+++ b/core/events/netdev_events.go
@@ -17,12 +17,12 @@ package events
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
 	"huatuo-bamai/internal/linkstatus"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 
@@ -142,6 +142,11 @@ func (netdev *netdevTracing) checkAndInitLinkStatus() error {
 		return err
 	}
 
+	devices, err := matcher.NewListMatcher(cfg.Netdev.DeviceList)
+	if err != nil {
+		return err
+	}
+
 	eth, err := ethtool.NewEthtool()
 	if err != nil {
 		return err
@@ -150,8 +155,7 @@ func (netdev *netdevTracing) checkAndInitLinkStatus() error {
 
 	for _, link := range links {
 		ifname := link.Attrs().Name
-		if !slices.Contains(cfg.Netdev.DeviceList,
-			ifname) {
+		if !devices.Match(ifname) {
 			continue
 		}
 

--- a/core/metrics/netdev_dcb.go
+++ b/core/metrics/netdev_dcb.go
@@ -21,6 +21,8 @@ import (
 	"syscall"
 	"unsafe"
 
+	"huatuo-bamai/internal/matcher"
+	"huatuo-bamai/internal/procfs/sysfs"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 
@@ -124,7 +126,25 @@ func parseAttributes(attrs []syscall.NetlinkRouteAttr) (*ieeePfc, error) {
 func (dcb *dcbCollector) Update() ([]*metric.Data, error) {
 	data := []*metric.Data{}
 
-	for _, ifname := range cfg.NetdevDCB.DeviceList {
+	if len(cfg.NetdevDCB.DeviceList) == 0 {
+		return data, nil
+	}
+
+	ifaces, err := sysfs.DefaultNetClassDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	devices, err := matcher.NewListMatcher(cfg.NetdevDCB.DeviceList)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ifname := range ifaces {
+		if !devices.Match(ifname) {
+			continue
+		}
+
 		msgs, err := doDcbRequest(ifname)
 		if err != nil {
 			if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENODEV) {

--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -27,6 +27,7 @@ import (
 
 	"huatuo-bamai/internal/bpf"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/procfs/sysfs"
 	"huatuo-bamai/internal/utils/parseutil"
 	"huatuo-bamai/pkg/metric"
@@ -65,6 +66,10 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 
 	ifaceList := make(map[string]*ethtool.DrvInfo)
 	ifaceSwCounter := make(map[string]uint64)
+	devices, err := matcher.NewListMatcher(cfg.NetdevHW.DeviceList)
+	if err != nil {
+		return nil, err
+	}
 
 	log.Infof("processing interfaces: %v", ifaces)
 	for _, iface := range ifaces {
@@ -74,7 +79,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 		}
 
 		// skip processing if the interface is not in the whitelist or the driver is not allowed
-		if !slices.Contains(cfg.NetdevHW.DeviceList, iface) ||
+		if !devices.Match(iface) ||
 			!slices.Contains(deviceDriverList, drv.Driver) {
 			log.Debugf("%s is skipped (not in whitelist or driver not allowed)", iface)
 			continue

--- a/docs/configuration_en.md
+++ b/docs/configuration_en.md
@@ -710,13 +710,15 @@ This section is responsible for capturing key kernel events and monitoring laten
 #
 # - DeviceList
 # The net devices we monitor.
+# Entries without explicit regex operators are matched exactly. Entries
+# containing regex operators are matched as full regular expressions.
 # Default: [] (empty, meaning no devices).
 #
 [EventTracing.Netdev]
 	DeviceList = ["eth0", "eth1", "bond4", "lo"]
 ```
 
-- **DeviceList**: List of network devices to monitor.
+- **DeviceList**: List of network devices to monitor. Plain names such as `eth0` are matched exactly, while regex patterns such as `eth[0-9]+` match multiple devices.
 
   Default example includes "eth0", "eth1", "bond4", "lo". An empty list means no devices are monitored.
 
@@ -834,13 +836,15 @@ This section defines collection rules for various system and network metrics. Al
 #
 # - DeviceList
 # The net devices we monitor.
+# Entries without explicit regex operators are matched exactly. Entries
+# containing regex operators are matched as full regular expressions.
 # Default: [] (empty, meaning no devices).
 #
 [MetricCollector.NetdevDCB]
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**: List of network devices for which DCB (Data Center Bridging) PFC information is collected.
+- **DeviceList**: List of network devices for which DCB (Data Center Bridging) PFC information is collected. Plain names are matched exactly, and regex patterns can be used to match multiple devices.
 
   Default: empty.
 
@@ -853,13 +857,15 @@ This section defines collection rules for various system and network metrics. Al
 #
 # - DeviceList
 # The net devices we monitor.
+# Entries without explicit regex operators are matched exactly. Entries
+# containing regex operators are matched as full regular expressions.
 # Default: [] (empty, meaning no devices).
 #
 [MetricCollector.NetdevHW]
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**: List of network devices for hardware-level statistics (e.g., rx_dropped).
+- **DeviceList**: List of network devices for hardware-level statistics (e.g., rx_dropped). Plain names are matched exactly, and regex patterns can be used to match multiple devices.
 
   Default: empty.
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -709,13 +709,15 @@ IssuesList = []
 #
 # - DeviceList
 # The net devices we take care of.
+# Entries without explicit regex operators are matched exactly. Entries
+# containing regex operators are matched as full regular expressions.
 # Default: [] is empty, meaning no devices.
 #
 [EventTracing.Netdev]
 	DeviceList = ["eth0", "eth1", "bond4", "lo"]
 ```
 
-- **DeviceList**：需要监控的网卡设备列表。
+- **DeviceList**：需要监控的网卡设备列表。不包含显式正则操作符的条目按精确名称匹配，包含正则操作符的条目按完整正则表达式匹配。
 
   默认示例包含 "eth0", "eth1", "bond4", "lo"。 为空列表时表示不监控任何设备。 监控网络设备的物理链路状态事件等。
 
@@ -835,13 +837,15 @@ IssuesList = []
 #
 # - DeviceList
 # The net devices we take care of.
+# Entries without explicit regex operators are matched exactly. Entries
+# containing regex operators are matched as full regular expressions.
 # Default: [] is empty, meaning no devices.
 #
 [MetricCollector.NetdevDCB]
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**：需要采集 DCB（优先流控 PFC）信息的网卡列表。
+- **DeviceList**：需要采集 DCB（优先流控 PFC）信息的网卡列表。不包含显式正则操作符的条目按精确名称匹配，包含正则操作符的条目按完整正则表达式匹配。
 
   默认空。 
 
@@ -856,13 +860,15 @@ IssuesList = []
 #
 # - DeviceList
 # The net devices we take care of.
+# Entries without explicit regex operators are matched exactly. Entries
+# containing regex operators are matched as full regular expressions.
 # Default: [] is empty, meaning no devices.
 #
 [MetricCollector.NetdevHW]
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**：需要采集硬件层统计（如 rx_dropped）的网卡列表。
+- **DeviceList**：需要采集硬件层统计（如 rx_dropped）的网卡列表。不包含显式正则操作符的条目按精确名称匹配，包含正则操作符的条目按完整正则表达式匹配。
 
   默认空。 
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -392,6 +392,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     #
     # - DeviceList
     # The net devices we take care of.
+    # Entries without explicit regex operators are matched exactly. Entries
+    # containing regex operators are matched as full regular expressions.
     # Default: [] is empty, meaning no devices.
     #
     [EventTracing.Netdev]
@@ -476,6 +478,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     #
     # - DeviceList
     # The net devices we take care of.
+    # Entries without explicit regex operators are matched exactly. Entries
+    # containing regex operators are matched as full regular expressions.
     # Default: [] is empty, meaning no devices.
     #
     [MetricCollector.NetdevDCB]
@@ -487,6 +491,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     #
     # - DeviceList
     # The net devices we take care of.
+    # Entries without explicit regex operators are matched exactly. Entries
+    # containing regex operators are matched as full regular expressions.
     # Default: [] is empty, meaning no devices.
     #
     [MetricCollector.NetdevHW]

--- a/internal/matcher/list_matcher.go
+++ b/internal/matcher/list_matcher.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ListMatcher matches a value when any configured list entry matches it.
+// Entries without explicit regex operators are matched exactly. Entries
+// containing regex operators are treated as full regular expressions.
+type ListMatcher struct {
+	exact map[string]struct{}
+	rules []*regexp.Regexp
+}
+
+// NewListMatcher compiles list entries into a ListMatcher.
+// An empty list matches nothing.
+func NewListMatcher(patterns []string) (*ListMatcher, error) {
+	lm := &ListMatcher{
+		exact: make(map[string]struct{}),
+		rules: make([]*regexp.Regexp, 0, len(patterns)),
+	}
+	for _, pattern := range patterns {
+		if !hasRegexOperator(pattern) {
+			lm.exact[pattern] = struct{}{}
+			continue
+		}
+
+		re, err := regexp.Compile("^(?:" + pattern + ")$")
+		if err != nil {
+			return nil, fmt.Errorf("invalid list pattern %q: %w", pattern, err)
+		}
+		lm.rules = append(lm.rules, re)
+	}
+	return lm, nil
+}
+
+func hasRegexOperator(pattern string) bool {
+	// Treat a plain dot as a literal interface-name character so legacy VLAN
+	// names such as "eth0.100" keep exact-match behavior.
+	return strings.ContainsAny(pattern, `\+*?()|[]{}^$`)
+}
+
+// Match reports whether value matches any compiled list entry.
+func (lm *ListMatcher) Match(value string) bool {
+	if lm == nil {
+		return false
+	}
+	if _, ok := lm.exact[value]; ok {
+		return true
+	}
+	for _, rule := range lm.rules {
+		if rule.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/matcher/list_matcher_test.go
+++ b/internal/matcher/list_matcher_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListMatcher_Match_EmptyListMatchesNothing(t *testing.T) {
+	lm, err := NewListMatcher(nil)
+	require.NoError(t, err)
+
+	require.False(t, lm.Match("eth0"))
+}
+
+func TestListMatcher_Match_ExactName(t *testing.T) {
+	lm, err := NewListMatcher([]string{"eth0", "eth1", "eth0.100"})
+	require.NoError(t, err)
+
+	require.True(t, lm.Match("eth0"))
+	require.True(t, lm.Match("eth0.100"))
+	require.False(t, lm.Match("veth0"))
+	require.False(t, lm.Match("eth0x100"))
+}
+
+func TestListMatcher_Match_RegexName(t *testing.T) {
+	lm, err := NewListMatcher([]string{"eth[0-9]+"})
+	require.NoError(t, err)
+
+	require.True(t, lm.Match("eth0"))
+	require.True(t, lm.Match("eth10"))
+	require.False(t, lm.Match("veth0"))
+}
+
+func TestNewListMatcher_InvalidPattern(t *testing.T) {
+	_, err := NewListMatcher([]string{"[bad"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "[bad")
+}


### PR DESCRIPTION
 ## 问题背景

  DeviceList 用于配置需要关注的网卡设备列表，但当前多个 netdev 相关实现只支持精确字符串匹配。

  例如配置 DeviceList = ["eth[0-9]+"] 在修改前无法匹配 eth0，因为旧逻辑等价于 slices.Contains([]string{"eth[0-9]+"}, "eth0")。

  这会导致用户很难一次性配置一组同类网卡，例如 eth0、eth1、bond0 等。

  ## 修改内容

  本 PR 在 internal/matcher 中新增通用的 ListMatcher，并应用到以下配置项：

  - EventTracing.Netdev
  - MetricCollector.NetdevDCB
  - MetricCollector.NetdevHW

  匹配规则如下：

  - 不包含显式正则操作符的条目按精确名称匹配。
  - 包含正则操作符的条目按完整正则表达式匹配。
  - 普通配置项如 eth0 仍然保持精确匹配。
  - VLAN 风格接口名如 eth0.100 仍然保持精确匹配。
  - 正则配置项如 eth[0-9]+ 可以匹配 eth0、eth1 等设备。
  - 空 DeviceList 保持原有行为，即不匹配任何设备。

  同时更新了示例配置和中英文配置文档，说明 DeviceList 的匹配行为。

  ## 测试

  - gofmt -w internal/matcher/list_matcher.go internal/matcher/list_matcher_test.go
  - GOFLAGS=-mod=mod go test -count=1 -v ./internal/matcher -run TestListMatcher
  - GOFLAGS=-mod=mod go test -count=1 ./internal/matcher ./core/events ./core/metrics