### PR TITLE
fix(bpf): restore pre-7.0 kernel compat broken by 85e6aedb

### DIFF
--- a/bpf/hungtask.c
+++ b/bpf/hungtask.c
@@ -27,15 +27,23 @@ int tracepoint_sched_process_hang(struct trace_event_raw_sched_process_hang *ctx
 	struct hungtask_info info = {};
 
 	info.pid = ctx->pid;
-	{
-		struct trace_event_raw_sched_process_hang___7_0 *ctx7 = (void *)ctx;
-		if (bpf_core_field_exists(ctx7->__data_loc_comm)) {
-			bpf_probe_read_str(info.comm, sizeof(info.comm),
-					   (void *)ctx7 + (ctx7->__data_loc_comm & 0xffff));
-		} else {
-			BPF_CORE_READ_STR_INTO(&info.comm, ctx, comm);
-		}
+
+	/*
+	 * trace_event_raw_sched_process_hang::comm changed across kernels:
+	 *   pre-7.0: fixed-size __array(char, comm, TASK_COMM_LEN)
+	 *   7.0+:    __string(comm, ...) -> u32 __data_loc_comm offset/length
+	 */
+	if (bpf_core_field_exists(ctx->comm)) {
+		BPF_CORE_READ_STR_INTO(&info.comm, ctx, comm);
+	} else {
+		struct trace_event_raw_sched_process_hang___7_0 *ctx7 =
+			(struct trace_event_raw_sched_process_hang___7_0 *)ctx;
+		u32 dl = BPF_CORE_READ(ctx7, __data_loc_comm);
+
+		bpf_probe_read_str(info.comm, sizeof(info.comm),
+				   (void *)ctx + (dl & 0xffff));
 	}
+
 	bpf_perf_event_output(ctx, &hungtask_perf_events,
 			      COMPAT_BPF_F_CURRENT_CPU, &info, sizeof(info));
 	return 0;

--- a/bpf/include/bpf_blkio.h
+++ b/bpf/include/bpf_blkio.h
@@ -18,12 +18,12 @@ static __always_inline u64 ktime_ns_mask()
  * These local structs with preserve_access_index enable BPF CO-RE to
  * correctly relocate field offsets at load time.
  */
-struct block_device___compat {
+struct block_device___5_12 {
 	struct gendisk *bd_disk;
 	u32 bd_dev;
 } __attribute__((preserve_access_index));
 
-struct bio___compat {
+struct bio___5_12 {
 	struct block_device *bi_bdev;
 } __attribute__((preserve_access_index));
 
@@ -35,7 +35,7 @@ static __always_inline struct gendisk *bio_disk(struct bio *bio)
 		BPF_CORE_READ_INTO(&disk, bio, bi_disk);
 	} else {
 		/* Kernel 5.12+: bio->bi_disk moved to bio->bi_bdev->bd_disk */
-		struct bio___compat *bio_new = (struct bio___compat *)bio;
+		struct bio___5_12 *bio_new = (struct bio___5_12 *)bio;
 		struct block_device *bdev;
 
 		BPF_CORE_READ_INTO(&bdev, bio_new, bi_bdev);
@@ -55,8 +55,8 @@ static __always_inline u8 bio_partno(struct bio *bio)
 		BPF_CORE_READ_INTO(&partno, bio, bi_partno);
 	} else {
 		/* Kernel 5.12+: bi_partno moved to bio->bi_bdev->bd_dev */
-		struct bio___compat *bio_new = (struct bio___compat *)bio;
-		struct block_device___compat *bdev;
+		struct bio___5_12 *bio_new = (struct bio___5_12 *)bio;
+		struct block_device___5_12 *bdev;
 
 		BPF_CORE_READ_INTO(&bdev, bio_new, bi_bdev);
 		if (bdev) {

--- a/bpf/include/bpf_compat_7_0.h
+++ b/bpf/include/bpf_compat_7_0.h
@@ -4,42 +4,50 @@
 #include "vmlinux.h"
 #include <bpf/bpf_core_read.h>
 
-/* Compat structs for kernel 7.0+ API changes */
+/*
+ * CO-RE compat structs for kernel 7.0+ field renames/relocations that
+ * cannot be expressed by accessing the field directly on the original
+ * kernel type. Each struct only contains the field(s) that the
+ * corresponding BPF program needs to read on a 7.0+ kernel; the older
+ * field paths are still accessed through the original kernel types
+ * (or the existing per-file ___X_Y compat structs).
+ */
 
+/*
+ * iotracing: rq_disk was removed; gendisk is now reached via
+ * request->part->bd_disk on 7.0+.
+ */
 struct request___7_0 {
-	struct request_queue *q;
 	struct block_device *part;
 } __attribute__((preserve_access_index));
 
 struct block_device___7_0 {
 	struct gendisk *bd_disk;
-	dev_t bd_dev;
 } __attribute__((preserve_access_index));
 
+/*
+ * iotracing: iov_iter::data_source was renamed to ::iter_type on 7.0+.
+ */
 struct iov_iter___7_0 {
 	u8 iter_type;
-	bool data_source;
 } __attribute__((preserve_access_index));
 
-struct task_struct___7_0 {
-	unsigned int __state;
+/*
+ * iolatency_tracing: bio::bi_issue (struct bio_issue with packed
+ * timestamp) was replaced by a plain bio::issue_time_ns on 7.0+.
+ */
+struct bio___7_0 {
+	u64 issue_time_ns;
 } __attribute__((preserve_access_index));
 
-struct sock___7_0 {
-	u32 sk_protocol;
-	u16 sk_type;
-} __attribute__((preserve_access_index));
-
+/*
+ * hungtask: trace_event_raw_sched_process_hang::comm changed from a
+ * fixed-size __array to a __data_loc string on 7.0+.
+ */
 struct trace_event_raw_sched_process_hang___7_0 {
 	struct trace_entry ent;
 	u32 __data_loc_comm;
 	pid_t pid;
-	char __data[0];
-} __attribute__((preserve_access_index));
-
-struct bio___7_0 {
-	struct block_device *bi_bdev;
-	u64 issue_time_ns;
 } __attribute__((preserve_access_index));
 
 #endif /* __BPF_COMPAT_7_0_H__ */

--- a/bpf/iolatency_tracing.c
+++ b/bpf/iolatency_tracing.c
@@ -4,8 +4,8 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
-#include "bpf_blkio.h"
 #include "bpf_common.h"
+#include "bpf_blkio.h"
 #include "bpf_compat_7_0.h"
 
 #define LATENCY_20MS_NS 20000000
@@ -114,17 +114,19 @@ static __always_inline int q2c_latency_index(struct bio *bio, u64 now)
 {
 	u64 bi_issue, val;
 
-	{
-		struct bio___7_0 *bio7 = (struct bio___7_0 *)bio;
-		if (bpf_core_field_exists(bio7->issue_time_ns)) {
-			if (bpf_probe_read(&val, sizeof(val), &bio7->issue_time_ns))
-				return -1;
-		} else if (bpf_probe_read(&val, sizeof(val), &bio->bi_issue)) {
+	/*
+	 * pre-7.0: bio::bi_issue (struct bio_issue, low bits packed timestamp)
+	 * 7.0+:    bio::issue_time_ns (plain u64 nanosecond timestamp)
+	 */
+	if (bpf_core_field_exists(bio->bi_issue)) {
+		if (bpf_probe_read(&val, sizeof(val), &bio->bi_issue))
 			return -1;
-		}
+	} else {
+		struct bio___7_0 *bio7 = (struct bio___7_0 *)bio;
+
+		if (bpf_probe_read(&val, sizeof(val), &bio7->issue_time_ns))
+			return -1;
 	}
-	if (0)
-		return -1;
 
 	bi_issue = val & TIMESTAMP_MASK;
 

--- a/bpf/iotracing.c
+++ b/bpf/iotracing.c
@@ -109,51 +109,72 @@ static __always_inline int is_write_request(u32 cmd_flags)
 	return (cmd_flags & REQ_OP_MASK) == REQ_OP_WRITE;
 }
 
-struct request_queue___new {
+struct request_queue___5_14 {
 	struct gendisk *disk;
-};
+} __attribute__((preserve_access_index));
 
-struct block_device___new {
+struct block_device___5_11 {
 	dev_t bd_dev;
 };
 
 /*
- * compatible with different kernel versions of disk device acquisition
+ * compatible with different kernel versions of disk device acquisition.
+ *
+ *   pre-5.17:   request->rq_disk
+ *   5.17 ~ 6.x: request->q->disk (rq_disk removed, request_queue gained
+ *               the disk field in 5.14)
+ *   7.0+:       request->part->bd_disk (request_queue->disk no longer
+ *               reflects the real disk on 7.0+)
+ *
+ * Discriminating 5.17~6.x from 7.0+ relies on whether the kernel's
+ * struct request_queue still carries the `disk` field. request->part
+ * cannot be used for this purpose: it exists since 5.11 (just with a
+ * different type) and is therefore always present on every kernel that
+ * reaches the second branch below.
  */
 static __always_inline struct gendisk *get_request_disk(struct request *req)
 {
-	struct request___7_0 *req7 = (struct request___7_0 *)req;
-	
-	if (bpf_core_field_exists(req7->part)) {
-		struct block_device *bdev = BPF_CORE_READ(req7, part);
-		if (bdev) {
-			struct block_device___7_0 *bdev7 = (struct block_device___7_0 *)bdev;
-			return BPF_CORE_READ(bdev7, bd_disk);
-		}
-	}
-	{
-		struct request_queue___new *q;
-		q = (struct request_queue___new *)BPF_CORE_READ(req, q);
+	struct request_queue___5_14 *q = NULL;
+
+	if (bpf_core_field_exists(req->rq_disk))
+		return BPF_CORE_READ(req, rq_disk);
+
+	if (bpf_core_field_exists(q->disk)) {
+		q = (struct request_queue___5_14 *)BPF_CORE_READ(req, q);
 		return BPF_CORE_READ(q, disk);
+	}
+
+	{
+		struct request___7_0 *req7 = (struct request___7_0 *)req;
+		struct block_device___7_0 *bdev7;
+
+		bdev7 = (struct block_device___7_0 *)BPF_CORE_READ(req7, part);
+		return BPF_CORE_READ(bdev7, bd_disk);
 	}
 }
 
 /*
- * compatible with different kernel versions of partition number acquisition
+ * compatible with different kernel versions of partition number acquisition.
+ *
+ *   pre-5.11: request->part is struct hd_struct*, partno is the
+ *             partition index directly
+ *   5.11+:    request->part is struct block_device*, the low byte of
+ *             bd_dev encodes the partition index
+ *
+ * 7.0+ keeps using struct block_device, so the 5.11+ path covers both.
  */
 static __always_inline int get_partition_number(struct request *req)
 {
 	void *part = BPF_CORE_READ(req, part);
-	struct block_device___7_0 *bdev7 = (struct block_device___7_0 *)part;
 
-	if (bpf_core_field_exists(bdev7->bd_dev)) {
-		dev_t dev = BPF_CORE_READ(bdev7, bd_dev);
-		return dev & 0xff;
-	}
+	if (bpf_core_field_exists(((struct hd_struct *)part)->partno))
+		return BPF_CORE_READ((struct hd_struct *)part, partno);
+
 	{
-		struct block_device___new *new_part;
+		struct block_device___5_11 *new_part;
 		int partno;
-		new_part = (struct block_device___new *)part;
+
+		new_part = (struct block_device___5_11 *)part;
 		partno	 = BPF_CORE_READ(new_part, bd_dev);
 		return partno & 0xff;
 	}
@@ -305,7 +326,7 @@ init_io_data(struct io_data *entry, struct dentry *root_dentry,
 	}
 }
 
-struct iov_iter___new {
+struct iov_iter___5_14 {
 	bool data_source;
 } __attribute__((preserve_access_index));
 
@@ -344,15 +365,23 @@ static __always_inline int bpf_file_read_write(struct pt_regs *ctx)
 	from  = (struct iov_iter *)PT_REGS_PARM2(ctx);
 	count = BPF_CORE_READ(from, count);
 
-	{
+	/*
+	 * iov_iter direction across kernel versions:
+	 *   pre-5.14: iov_iter::type        (low bit: 0=read, 1=write)
+	 *   5.14~6.x: iov_iter::data_source (bool: 0=read, 1=write)
+	 *   7.0+:     iov_iter::iter_type   (low bit: 0=read, 1=write)
+	 */
+	if (bpf_core_field_exists(from->type)) {
+		type = BPF_CORE_READ(from, type);
+	} else if (bpf_core_field_exists(((struct iov_iter___7_0 *)0)->iter_type)) {
 		struct iov_iter___7_0 *from7 = (struct iov_iter___7_0 *)from;
-		if (bpf_core_field_exists(from7->iter_type)) {
-			type = BPF_CORE_READ(from7, iter_type);
-		} else {
-			struct iov_iter___new *from_new;
-			from_new = (struct iov_iter___new *)from;
-			type	 = BPF_CORE_READ(from_new, data_source);
-		}
+
+		type = BPF_CORE_READ(from7, iter_type);
+	} else {
+		struct iov_iter___5_14 *from_new;
+
+		from_new = (struct iov_iter___5_14 *)from;
+		type	 = BPF_CORE_READ(from_new, data_source);
 	}
 
 	type = type & 0x1;

--- a/cmd/iotracing/trace.go
+++ b/cmd/iotracing/trace.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -42,7 +43,7 @@ func runTrace(ctx context.Context, bpfPath string, cfg ioConfig, filters map[str
 		return nil, fmt.Errorf("read bpf object: %w", err)
 	}
 
-	b, err := bpf.LoadBpfFromBytes(bpfPath, bpfBytes, filters)
+	b, err := bpf.LoadBpfFromBytes(filepath.Base(bpfPath), bpfBytes, filters)
 	if err != nil {
 		return nil, fmt.Errorf("load bpf: %w", err)
 	}


### PR DESCRIPTION
85e6aedb intended to add 7.0+ kernel support but overwrote the existing pre-7.0 compat paths. Reinstate the BPF CO-RE discriminators so the programs cover both old and new kernels:

- iotracing: three-tier paths for request->disk, partition number from request->part, and iov_iter direction
- iolatency_tracing: read bio->bi_issue on pre-7.0, fall back to bio->issue_time_ns on 7.0+; drop dead `if (0) return -1`
- hungtask: check ctx->comm first, fall back to __data_loc_comm on 7.0+
- bpf_compat_7_0.h: drop unused 7.0 flavor structs

Unify flavor struct suffixes to ___X_Y (the kernel version where the field was introduced) instead of the previous mixed ___new / ___compat / ___7_0 convention, which did not extend cleanly past 7.0+.

Fix iolatency_tracing.c include order: bpf_common.h must precede bpf_blkio.h because the latter relies on NULL.

While here, pass only the basename of bpf-path to
LoadBpfFromBytes in cmd/iotracing so labels do not embed directories.