### PR TITLE
fix(iotracing): skip reset diskstat samples

### DIFF
--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -183,6 +183,10 @@ func ReadDiskStats() ([]blockdevice.Diskstats, error) {
 
 // blockdevice.Diskstats is heavy (168 bytes); consider passing it by pointer
 func buildDiskMetric(prev, curr *blockdevice.Diskstats, intervalSeconds uint64) DiskStatus {
+	if diskStatsWentBack(prev, curr) {
+		return DiskStatus{}
+	}
+
 	deltaReadIOs := curr.ReadIOs - prev.ReadIOs
 	deltaWriteIOs := curr.WriteIOs - prev.WriteIOs
 
@@ -204,6 +208,17 @@ func buildDiskMetric(prev, curr *blockdevice.Diskstats, intervalSeconds uint64) 
 	}
 
 	return metrics
+}
+
+func diskStatsWentBack(prev, curr *blockdevice.Diskstats) bool {
+	return curr.ReadIOs < prev.ReadIOs ||
+		curr.WriteIOs < prev.WriteIOs ||
+		curr.ReadSectors < prev.ReadSectors ||
+		curr.WriteSectors < prev.WriteSectors ||
+		curr.ReadTicks < prev.ReadTicks ||
+		curr.WriteTicks < prev.WriteTicks ||
+		curr.IOsTotalTicks < prev.IOsTotalTicks ||
+		curr.WeightedIOTicks < prev.WeightedIOTicks
 }
 
 func waitingDiskEvents(ctx context.Context, intervalSeconds uint64, thresholds IoThresholds) (*ReasonSnapshot, error) {


### PR DESCRIPTION
Diskstats counters can go backwards after a device reset/recreate. My first patch clamped each field separately, but that can still mix two counter epochs in one sample.

This version treats any backwards field as a reset and drops that interval by returning zero metrics. The next sample is then compared against the new counter epoch, so we avoid both uint64 underflow and misleading partial deltas.

Testing: gofmt -w core/autotracing/iotracing.go

Not run locally: GOOS=linux GOARCH=amd64 go test -c ./core/autotracing is blocked by missing generated capnp files in my local snapshot.