### PR TITLE
fix(cpusys): skip zero cpu stat deltas

### DIFF
--- a/core/autotracing/cpusys.go
+++ b/core/autotracing/cpusys.go
@@ -108,6 +108,11 @@ func (c *cpuSysTracing) updateCpuSysUsage() error {
 
 	sysUsageDelta := usage.system - c.usage.system
 	sysTotalDelta := usage.total - c.usage.total
+	if sysTotalDelta == 0 {
+		c.usage = usage
+		return nil
+	}
+
 	sysPercentage := int64(100 * sysUsageDelta / sysTotalDelta)
 
 	c.sysPercentDelta = sysPercentage - c.sysPercent


### PR DESCRIPTION
CPUSys divides by the total `/proc/stat` delta. If the sampler runs again before total ticks move forward, that delta is 0 and the tracer can panic.

This just skips that interval and keeps the latest sample as the next baseline. The next tick will calculate from a real delta.

Testing: gofmt -w core/autotracing/cpusys.go

Not run locally: `go test ./core/autotracing` on Windows hits Linux-only syscall/cgroup/BPF types; `GOOS=linux GOARCH=amd64 go test -c ./core/autotracing` is blocked by missing generated capnp transport types in my local snapshot.