### PR TITLE
fix(events): reserve watch clients atomically

### DIFF
--- a/cmd/huatuo-bamai/handlers/events.go
+++ b/cmd/huatuo-bamai/handlers/events.go
@@ -66,6 +66,22 @@ func NewEventsHandler(maxClients, keepAliveIntervalSecs int) *EventsHandler {
 	return h
 }
 
+func (h *EventsHandler) acquireClient() bool {
+	for {
+		active := h.activeClients.Load()
+		if int(active) >= h.maxClients {
+			return false
+		}
+		if h.activeClients.CompareAndSwap(active, active+1) {
+			return true
+		}
+	}
+}
+
+func (h *EventsHandler) releaseClient() {
+	h.activeClients.Add(-1)
+}
+
 // WatchRequest is the POST body sent by a client to register an event watch.
 // All filter fields are optional regex patterns; omitting a field matches all values.
 // Additional filter fields can be added to WatchFilters without breaking existing clients.
@@ -126,12 +142,11 @@ func (wf *WatchFilters) matcher() (*matcher.FieldMatcher[*tracing.Document], err
 // the client disconnects, the server shuts down, or keepalive probes fail
 // maxKeepAliveFailures consecutive times.
 func (h *EventsHandler) watch(ctx *server.Context) error {
-	if int(h.activeClients.Load()) >= h.maxClients {
+	if !h.acquireClient() {
 		log.Infof("[eventwatch] rejected: max clients reached (%d/%d)", h.activeClients.Load(), h.maxClients)
 		return response.ErrTooManyRequests.WithMessage("max watch clients reached")
 	}
-	h.activeClients.Add(1)
-	defer h.activeClients.Add(-1)
+	defer h.releaseClient()
 
 	var req WatchRequest
 	if err := ctx.ShouldBindJSON(&req); err != nil {

--- a/cmd/huatuo-bamai/handlers/events_test.go
+++ b/cmd/huatuo-bamai/handlers/events_test.go
@@ -15,12 +15,41 @@
 package handlers
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"huatuo-bamai/pkg/tracing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestEventsHandler_AcquireClientConcurrent(t *testing.T) {
+	h := NewEventsHandler(1, 0)
+	start := make(chan struct{})
+	var acquired atomic.Int32
+	var wg sync.WaitGroup
+
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if h.acquireClient() {
+				acquired.Add(1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int32(1), acquired.Load())
+	require.Equal(t, int32(1), h.activeClients.Load())
+
+	h.releaseClient()
+	require.Equal(t, int32(0), h.activeClients.Load())
+}
 
 // --- WatchFilters.matcher() ---
 


### PR DESCRIPTION
Two `/v1/events/watch` requests can both pass the active-client check before either increments the counter, so `max_clients` is not a hard cap under concurrency.

This reserves the slot with CAS and releases the same counter on exit. I added a small concurrent test around that path.

Testing:
- `gofmt -w cmd/huatuo-bamai/handlers/events.go cmd/huatuo-bamai/handlers/events_test.go`
- Not run: `go test ./cmd/huatuo-bamai/handlers` on Windows is blocked by Linux-only `github.com/prometheus/procfs/sysfs` build constraints.
- Not run: `GOOS=linux GOARCH=amd64 go test -c ./cmd/huatuo-bamai/handlers` is blocked locally by missing generated `internal/toolstream/transport` capnp types on main.