### PR TITLE
feat(storage): support ES TLS certificates

### DIFF
--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -45,6 +45,10 @@ type BamaiConfig struct {
 			Address            string `default:"http://127.0.0.1:9200"`
 			Username, Password string
 			Index              string `default:"huatuo_bamai"`
+			CAFile             string
+			CertFile           string
+			KeyFile            string
+			InsecureSkipVerify *bool
 		}
 
 		LocalFile struct {

--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -213,11 +213,15 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 		cfg.Storage.ES.Username != "" &&
 		cfg.Storage.ES.Password != "" {
 		esStore, err = storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
-			Driver:      "elasticsearch",
-			ESAddresses: splitStorageAddresses(cfg.Storage.ES.Address),
-			ESUsername:  cfg.Storage.ES.Username,
-			ESPassword:  cfg.Storage.ES.Password,
-			ESIndex:     cfg.Storage.ES.Index,
+			Driver:               "elasticsearch",
+			ESAddresses:          splitStorageAddresses(cfg.Storage.ES.Address),
+			ESUsername:           cfg.Storage.ES.Username,
+			ESPassword:           cfg.Storage.ES.Password,
+			ESIndex:              cfg.Storage.ES.Index,
+			ESCAFile:             cfg.Storage.ES.CAFile,
+			ESCertFile:           cfg.Storage.ES.CertFile,
+			ESKeyFile:            cfg.Storage.ES.KeyFile,
+			ESInsecureSkipVerify: cfg.Storage.ES.InsecureSkipVerify,
 		}, tracing.DocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("storage.NewStore(tracing documents): %w", err)

--- a/docs/configuration_en.md
+++ b/docs/configuration_en.md
@@ -133,9 +133,26 @@ BlackList = ["netdev_hw", "metax_gpu"]
     # - Password
     # There is no default username and password.
     #
+    # - CAFile
+    # Optional CA certificate path used to verify HTTPS ES/OS servers.
+    #
+    # - CertFile
+    # - KeyFile
+    # Optional client certificate and key paths used for mutual TLS. CertFile and
+    # KeyFile must be configured together.
+    #
+    # - InsecureSkipVerify
+    # Skip HTTPS server certificate verification. Default is true for backward
+    # compatibility with existing self-signed deployments. Set it to false when
+    # CAFile or system root CAs should verify the server certificate.
+    #
     [Storage.ES]
         # Address = "http://127.0.0.1:9200"
         # Index = "huatuo_bamai"
+        # CAFile = "/etc/huatuo/certs/es-ca.crt"
+        # CertFile = "/etc/huatuo/certs/es-client.crt"
+        # KeyFile = "/etc/huatuo/certs/es-client.key"
+        # InsecureSkipVerify = true
         Username = "elastic"
         Password = "huatuo-bamai"
 ```
@@ -163,6 +180,24 @@ BlackList = ["netdev_hw", "metax_gpu"]
   No default value (example uses huatuo-bamai).
 
   **Description**: Used together with the username. In production, use a strong password and enable TLS encryption.
+
+- **CAFile**: CA certificate file path.
+
+  No default value.
+
+  **Description**: When ES/OS is exposed over HTTPS, use this field to trust a private CA or self-signed server certificate. Set `InsecureSkipVerify` to `false` to verify the server certificate with this CA file or system root CAs.
+
+- **CertFile** and **KeyFile**: Client certificate and private key file paths.
+
+  No default value.
+
+  **Description**: Used for mutual TLS authentication. These two fields must be configured together.
+
+- **InsecureSkipVerify**: Whether to skip HTTPS server certificate verification.
+
+  Default: true.
+
+  **Description**: The default preserves compatibility with existing self-signed deployments. In production, set it to `false` and configure `CAFile` or rely on system root CAs.
 
 **Overall**: ES/OS storage persists kernel tracing and event data for later search and analysis.
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -132,9 +132,26 @@ BlackList = ["netdev_hw", "metax_gpu"]
     # - Password
     # There is no default username and password.
     #
+    # - CAFile
+    # Optional CA certificate path used to verify HTTPS ES/OS servers.
+    #
+    # - CertFile
+    # - KeyFile
+    # Optional client certificate and key paths used for mutual TLS. CertFile and
+    # KeyFile must be configured together.
+    #
+    # - InsecureSkipVerify
+    # Skip HTTPS server certificate verification. Default is true for backward
+    # compatibility with existing self-signed deployments. Set it to false when
+    # CAFile or system root CAs should verify the server certificate.
+    #
     [Storage.ES]
         # Address = "http://127.0.0.1:9200"
         # Index = "huatuo_bamai"
+        # CAFile = "/etc/huatuo/certs/es-ca.crt"
+        # CertFile = "/etc/huatuo/certs/es-client.crt"
+        # KeyFile = "/etc/huatuo/certs/es-client.key"
+        # InsecureSkipVerify = true
         Username = "elastic"
         Password = "huatuo-bamai"
 ```
@@ -162,6 +179,24 @@ BlackList = ["netdev_hw", "metax_gpu"]
   无默认值（示例中使用 huatuo-bamai）。
 
   **说明**：配合用户名进行安全认证。生产环境强烈建议使用强密码并结合 TLS 加密传输。
+
+- **CAFile**：CA 证书文件路径。
+
+  无默认值。
+
+  **说明**：当 ES/OS 使用 HTTPS 暴露服务时，可通过该字段信任私有 CA 或自签名服务端证书。将 `InsecureSkipVerify` 设置为 `false` 后，会使用该 CA 文件或系统根证书校验服务端证书。
+
+- **CertFile** 和 **KeyFile**：客户端证书和私钥文件路径。
+
+  无默认值。
+
+  **说明**：用于双向 TLS 认证，两个字段必须同时配置。
+
+- **InsecureSkipVerify**：是否跳过 HTTPS 服务端证书校验。
+
+  默认值为 true。
+
+  **说明**：默认值用于兼容已有自签名部署。生产环境建议设置为 `false`，并配置 `CAFile` 或使用系统根证书完成校验。
 
 **整体说明**：ES/OS 存储用于持久化内核追踪和事件数据，便于后续检索与分析。如果用户不关心 Linux 内核事件、Autotracing 数据则可以关闭该配置。
 

--- a/docs/quick-start_en.md
+++ b/docs/quick-start_en.md
@@ -94,6 +94,10 @@ $ docker build --network host -t huatuo/huatuo-bamai:latest .
             Username = "elastic"
             Password = "huatuo-bamai"
             Index = "huatuo_bamai"
+            # CAFile = "/etc/huatuo/certs/es-ca.crt"
+            # CertFile = "/etc/huatuo/certs/es-client.crt"
+            # KeyFile = "/etc/huatuo/certs/es-client.key"
+            # InsecureSkipVerify = true
         ```
 
         Local storage configuration is as follows:

--- a/docs/quick-start_zh.md
+++ b/docs/quick-start_zh.md
@@ -97,6 +97,10 @@ $ ./huatuo-bamai --region example --config huatuo-bamai.conf
             Username = "elastic"
             Password = "huatuo-bamai"
             Index = "huatuo_bamai"
+            # CAFile = "/etc/huatuo/certs/es-ca.crt"
+            # CertFile = "/etc/huatuo/certs/es-client.crt"
+            # KeyFile = "/etc/huatuo/certs/es-client.key"
+            # InsecureSkipVerify = true
         ```
 
         本地存储配置如下：

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -62,9 +62,26 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # - Password
     # There is no default username and password.
     #
+    # - CAFile
+    # Optional CA certificate path used to verify HTTPS ES/OS servers.
+    #
+    # - CertFile
+    # - KeyFile
+    # Optional client certificate and key paths used for mutual TLS. CertFile and
+    # KeyFile must be configured together.
+    #
+    # - InsecureSkipVerify
+    # Skip HTTPS server certificate verification. Default is true for backward
+    # compatibility with existing self-signed deployments. Set it to false when
+    # CAFile or system root CAs should verify the server certificate.
+    #
     [Storage.ES]
         # Address = "http://127.0.0.1:9200"
         # Index = "huatuo_bamai"
+        # CAFile = "/etc/huatuo/certs/es-ca.crt"
+        # CertFile = "/etc/huatuo/certs/es-client.crt"
+        # KeyFile = "/etc/huatuo/certs/es-client.key"
+        # InsecureSkipVerify = true
         Username = "elastic"
         Password = "huatuo-bamai"
 

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -56,6 +56,12 @@ type Config struct {
 	ESUsername  string
 	ESPassword  string
 	ESIndex     string
+	ESCAFile    string
+	ESCertFile  string
+	ESKeyFile   string
+	// ESInsecureSkipVerify defaults to true when nil to preserve legacy ES/OS
+	// HTTPS behavior for deployments that use self-signed certificates.
+	ESInsecureSkipVerify *bool
 }
 
 // Op is a storage query operator.

--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -16,9 +16,11 @@ package elasticsearch
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -88,13 +90,21 @@ func (t *productHeaderTransport) RoundTrip(req *http.Request) (*http.Response, e
 //   - ES v7 ≥ 7.14: CompatibilityMode headers + native product header.
 //   - ES v7 < 7.14: CompatibilityMode headers + injected product header.
 //   - OpenSearch:    returns X-Elastic-Product natively; no separate client needed.
-func newCompatClient(addresses []string, username, password string) (*elasticsearch.Client, error) {
+func newCompatClient(cfg *Config) (*elasticsearch.Client, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	tlsConfig, err := buildTLSConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses:               addresses,
-		Username:                username,
-		Password:                password,
+		Addresses:               cfg.Addresses,
+		Username:                cfg.Username,
+		Password:                cfg.Password,
 		EnableCompatibilityMode: true,
-		Transport:               &productHeaderTransport{inner: defaultTransport},
+		Transport:               &productHeaderTransport{inner: newTransport(tlsConfig)},
 		// Whole-batch retry: covers transport failures and 429/5xx returned for
 		// the entire bulk request. Per-item failures inside a 200 response are
 		// surfaced through BulkIndexerItem.OnFailure instead.
@@ -118,4 +128,69 @@ func newCompatClient(addresses []string, username, password string) (*elasticsea
 		return nil, fmt.Errorf("elasticsearch client info: status %d", res.StatusCode)
 	}
 	return client, nil
+}
+
+func newTransport(tlsConfig *tls.Config) http.RoundTripper {
+	transport, ok := defaultTransport.(*http.Transport)
+	if !ok {
+		return defaultTransport
+	}
+	clone := transport.Clone()
+	clone.TLSClientConfig = tlsConfig
+	return clone
+}
+
+func buildTLSConfig(cfg *Config) (*tls.Config, error) {
+	insecureSkipVerify := true
+	if cfg != nil && cfg.InsecureSkipVerify != nil {
+		insecureSkipVerify = *cfg.InsecureSkipVerify
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify, // #nosec G402 -- legacy default is preserved unless explicitly disabled.
+		ClientSessionCache: tls.NewLRUClientSessionCache(64),
+	}
+	if cfg == nil {
+		return tlsConfig, nil
+	}
+
+	if cfg.CAFile != "" {
+		rootCAs, err := loadRootCAs(cfg.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.RootCAs = rootCAs
+	}
+
+	if cfg.CertFile != "" || cfg.KeyFile != "" {
+		if cfg.CertFile == "" || cfg.KeyFile == "" {
+			return nil, fmt.Errorf("elasticsearch tls client certificate requires both cert file and key file")
+		}
+		certificate, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("elasticsearch tls load client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
+	}
+
+	return tlsConfig, nil
+}
+
+func loadRootCAs(path string) (*x509.CertPool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("elasticsearch tls read ca file: %w", err)
+	}
+
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if !rootCAs.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf("elasticsearch tls ca file contains no PEM certificates: %s", path)
+	}
+	return rootCAs, nil
 }

--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -183,10 +183,7 @@ func loadRootCAs(path string) (*x509.CertPool, error) {
 	}
 
 	rootCAs, err := x509.SystemCertPool()
-	if err != nil {
-		rootCAs = x509.NewCertPool()
-	}
-	if rootCAs == nil {
+	if err != nil || rootCAs == nil {
 		rootCAs = x509.NewCertPool()
 	}
 	if !rootCAs.AppendCertsFromPEM(data) {

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -50,10 +50,14 @@ const (
 
 // Config contains Elasticsearch backend settings.
 type Config struct {
-	Addresses []string
-	Username  string
-	Password  string
-	Index     string
+	Addresses          []string
+	Username           string
+	Password           string
+	Index              string
+	CAFile             string
+	CertFile           string
+	KeyFile            string
+	InsecureSkipVerify *bool
 }
 
 // Storage stores records in Elasticsearch, OpenSearch, or any compatible backend.
@@ -74,10 +78,14 @@ var _ driver.Backend = (*Storage)(nil)
 func init() {
 	factory := func(cfg *driver.Config) (driver.Backend, error) {
 		return NewBackend(&Config{
-			Addresses: cfg.ESAddresses,
-			Username:  cfg.ESUsername,
-			Password:  cfg.ESPassword,
-			Index:     cfg.ESIndex,
+			Addresses:          cfg.ESAddresses,
+			Username:           cfg.ESUsername,
+			Password:           cfg.ESPassword,
+			Index:              cfg.ESIndex,
+			CAFile:             cfg.ESCAFile,
+			CertFile:           cfg.ESCertFile,
+			KeyFile:            cfg.ESKeyFile,
+			InsecureSkipVerify: cfg.ESInsecureSkipVerify,
 		})
 	}
 	driver.RegisterBackend("elasticsearch", factory)
@@ -86,11 +94,14 @@ func init() {
 
 // NewBackend creates a backend that connects to Elasticsearch v7/v8 or OpenSearch.
 func NewBackend(cfg *Config) (*Storage, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
 	prefix := cfg.Index
 	if prefix == "" {
 		prefix = defaultIndex
 	}
-	client, err := newCompatClient(cfg.Addresses, cfg.Username, cfg.Password)
+	client, err := newCompatClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -16,11 +16,14 @@ package elasticsearch
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -1064,4 +1067,84 @@ func TestNewBackend_ServerError(t *testing.T) {
 	if !strings.Contains(err.Error(), "elasticsearch client info") {
 		t.Errorf("error = %q, want to contain \"elasticsearch client info\"", err.Error())
 	}
+}
+
+func TestNewBackend_WithCAFile(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"mock-es","version":{"number":"8.13.0"}}`))
+	}))
+	defer server.Close()
+
+	caFile := writeCertificateFile(t, server.Certificate().Raw)
+	insecureSkipVerify := false
+	backend, err := NewBackend(&Config{
+		Addresses:          []string{server.URL},
+		CAFile:             caFile,
+		InsecureSkipVerify: &insecureSkipVerify,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() returned error: %v", err)
+	}
+	if backend == nil {
+		t.Fatal("NewBackend() returned nil backend")
+	}
+}
+
+func TestBuildTLSConfig_LoadsClientCertificate(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	certificate := server.TLS.Certificates[0]
+	certFile := writeCertificateFile(t, certificate.Certificate[0])
+	keyData, err := x509.MarshalPKCS8PrivateKey(certificate.PrivateKey)
+	if err != nil {
+		t.Fatalf("x509.MarshalPKCS8PrivateKey() returned error: %v", err)
+	}
+	keyFile := writePEMFile(t, "PRIVATE KEY", keyData)
+
+	insecureSkipVerify := false
+	tlsConfig, err := buildTLSConfig(&Config{
+		CertFile:           certFile,
+		KeyFile:            keyFile,
+		InsecureSkipVerify: &insecureSkipVerify,
+	})
+	if err != nil {
+		t.Fatalf("buildTLSConfig() returned error: %v", err)
+	}
+	if tlsConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify = true, want false")
+	}
+	if len(tlsConfig.Certificates) != 1 {
+		t.Fatalf("Certificates length = %d, want 1", len(tlsConfig.Certificates))
+	}
+}
+
+func TestBuildTLSConfig_ClientCertificateRequiresKeyPair(t *testing.T) {
+	_, err := buildTLSConfig(&Config{CertFile: "client.crt"})
+	if err == nil {
+		t.Fatal("buildTLSConfig() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires both cert file and key file") {
+		t.Errorf("error = %q, want missing key pair message", err.Error())
+	}
+}
+
+func writeCertificateFile(t *testing.T, derBytes []byte) string {
+	t.Helper()
+	return writePEMFile(t, "CERTIFICATE", derBytes)
+}
+
+func writePEMFile(t *testing.T, blockType string, derBytes []byte) string {
+	t.Helper()
+
+	path := t.TempDir() + "/tls.pem"
+	data := pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: derBytes})
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("os.WriteFile() returned error: %v", err)
+	}
+	return path
 }


### PR DESCRIPTION
## Summary

- add ES/OpenSearch TLS options for CA file, client certificate, client key, and server certificate verification
- pass TLS settings through huatuo-bamai config, storage driver config, and the Elasticsearch backend
- document the new Storage.ES TLS fields in the sample config and English/Chinese docs
- add coverage for HTTPS CA verification, client certificate loading, and incomplete cert/key config

## Testing

- gofmt -w cmd/huatuo-bamai/main.go cmd/huatuo-bamai/config/config.go internal/storage/driver/types.go internal/storage/elasticsearch/client.go internal/storage/elasticsearch/elasticsearch.go internal/storage/elasticsearch/elasticsearch_test.go
- go test ./internal/storage/elasticsearch
