### PR TITLE
fix(flamegraph): use root name index

### DIFF
--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -67,7 +67,7 @@ func LevelsToTree(levels []*Level, names []string) *ProfileTree {
 		Value: levels[0].Values[ValueOffest],
 		Self:  levels[0].Values[SelfOffest],
 		Level: 0,
-		Name:  names[levels[0].Values[0]],
+		Name:  names[levels[0].Values[NameOffest]],
 	}
 
 	parentsStack := []*ProfileTree{tree}

--- a/internal/flamegraph/flamegraph_test.go
+++ b/internal/flamegraph/flamegraph_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import "testing"
+
+func TestLevelsToTreeUsesRootNameIndex(t *testing.T) {
+	levels := []*Level{
+		{Values: []int64{0, 10, 1, 2}},
+	}
+	names := []string{"offset-zero", "other", "root"}
+
+	tree := LevelsToTree(levels, names)
+	if tree == nil {
+		t.Fatalf("LevelsToTree returned nil")
+	}
+	if tree.Name != "root" {
+		t.Fatalf("root name = %q, want %q", tree.Name, "root")
+	}
+}


### PR DESCRIPTION
`LevelsToTree` was reading the root label from `Values[0]`, but that slot is the start offset. Child nodes already read names from `NameOffest`; the root should do the same, otherwise a root whose name index is not zero gets labeled incorrectly.

Testing:
- `gofmt -w internal/flamegraph/flamegraph.go internal/flamegraph/flamegraph_test.go`
- `GOCACHE=.gocache-flamegraph go test ./internal/flamegraph`