### PR TITLE
docs: add Linux 7.0 kernel support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The project supports kernel version 4.18 and later. The following kernel and OS 
 | 1.0.0  | 6.6.x          | OpenEuler 24.03/Anolis OS 23.3/OpenCloudOS V9 |
 | 1.0.0  | 6.8.x          | Ubuntu 24.04                                  |
 | 1.0.0  | 6.14.x         | Fedora 42                                     |
+| 2.3.0  | 7.0.x          | Ubuntu 26.04                                  |
 
 # Documentation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -102,6 +102,7 @@ HUATUO 已进入 [CNCF Landscape](https://landscape.cncf.io/?item=observability-
 | 1.0      | 6.6.x       | OpenEuler 24.03/Anolis OS 23.3/OpenCloudOS V9 |
 | 1.0      | 6.8.x       | Ubuntu 24.04                                  |
 | 1.0      | 6.14.x      | Fedora 42                                     |
+| 2.3.0    | 7.0.x       | Ubuntu 26.04                                  |
 
 
 # 文档


### PR DESCRIPTION
  Update the kernel version support matrix in README.md and README_CN.md to mention Linux 7.0.x
  compatibility on main after v2.2.0.

  The current BPF code already contains kernel 7.0 compatibility helpers under bpf/include/
  bpf_compat_7_0.h.