### PR TITLE
fix(request): keep response body readable

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -89,8 +89,13 @@ func doRequest(req *http.Request) (*ServerResponse, error) {
 	}
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return serverResp, err
+	}
+
 	serverResp.StatusCode = resp.StatusCode
-	serverResp.Body = resp.Body
+	serverResp.Body = io.NopCloser(bytes.NewReader(body))
 	serverResp.Header = resp.Header
 
 	return serverResp, nil

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -17,6 +17,7 @@ package request
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -104,6 +105,32 @@ func TestCheckResponseErrTextBody(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "backend down") {
 		t.Fatalf("error = %q, want backend down", err.Error())
+	}
+}
+
+func TestDoRequestKeepsSuccessBodyReadable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	resp, err := doRequest(req)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	defer resp.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", string(body))
 	}
 }
 


### PR DESCRIPTION
 ## Summary

  Fix `doRequest` so successful HTTP response bodies remain readable after the helper returns.

  Previously, `doRequest` deferred `resp.Body.Close()` before assigning the body to `ServerResponse.Body`, so callers received a closed body.

  ## Testing

  - `go test -v ./internal/request`
  - `go test ./internal/request ./internal/command/container ./internal/job`