### PR TITLE
feat: add BPF debug/print utility with perf event export

### DIFF
--- a/bpf/include/bpf_dbg.h
+++ b/bpf/include/bpf_dbg.h
@@ -1,0 +1,50 @@
+#ifndef __BPF_DBG_H__
+#define __BPF_DBG_H__
+
+#include <bpf/bpf_helpers.h>
+
+#include "bpf_common.h"
+
+#define BPF_DBG_MSG_LEN 64
+
+struct bpf_dbg_event {
+	u64 timestamp;
+	u32 file_id;
+	u32 line;
+	u64 args[4];
+	char msg[BPF_DBG_MSG_LEN];
+};
+
+#define BPF_DBG_MAP(prog_name)                                          \
+	struct {                                                          \
+		__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);              \
+		__uint(key_size, sizeof(int));                            \
+		__uint(value_size, sizeof(u32));                          \
+	} dbg_##prog_name##_events SEC(".maps")
+
+#ifndef BPF_DBG_FILE_ID
+#define BPF_DBG_FILE_ID 0
+#endif
+
+volatile const u32 bpf_dbg_enabled = 0;
+
+#define bpf_dbg(ctx, map_name, msg, a1, a2, a3)                               \
+	do {                                                                    \
+		if (bpf_dbg_enabled) {                                          \
+			struct bpf_dbg_event __event = {                        \
+				.timestamp = bpf_ktime_get_ns(),               \
+				.file_id   = BPF_DBG_FILE_ID,                  \
+				.line      = __LINE__,                        \
+				.args      = {a1, a2, a3, 0},                 \
+			};                                                      \
+			bpf_probe_read_kernel_str(__event.msg,                  \
+						  BPF_DBG_MSG_LEN, msg);         \
+			bpf_perf_event_output(ctx, &dbg_##map_name##_events,  \
+					      COMPAT_BPF_F_CURRENT_CPU,          \
+					      &__event, sizeof(__event));         \
+		}                                                               \
+	} while (0)
+
+#define bpf_dbg_msg(ctx, map_name, msg)  bpf_dbg(ctx, map_name, msg, 0, 0, 0)
+
+#endif /* __BPF_DBG_H__ */

--- a/bpf/include/bpf_dbg.h
+++ b/bpf/include/bpf_dbg.h
@@ -37,8 +37,8 @@ volatile const u32 bpf_dbg_enabled = 0;
 				.line      = __LINE__,                        \
 				.args      = {a1, a2, a3, 0},                 \
 			};                                                      \
-			bpf_probe_read_kernel_str(__event.msg,                  \
-						  BPF_DBG_MSG_LEN, msg);         \
+			bpf_probe_read_str(__event.msg,                        \
+						   sizeof(__event.msg), msg);          \
 			bpf_perf_event_output(ctx, &dbg_##map_name##_events,  \
 					      COMPAT_BPF_F_CURRENT_CPU,          \
 					      &__event, sizeof(__event));         \

--- a/internal/bpf/bpf_dbg.go
+++ b/internal/bpf/bpf_dbg.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"context"
+	"fmt"
+
+	"huatuo-bamai/internal/log"
+)
+
+const BpfDbgMsgLen = 64
+
+// BpfDbgEvent mirrors struct bpf_dbg_event in bpf_dbg.h.
+// The binary layout must match exactly (112 bytes, no padding).
+type BpfDbgEvent struct {
+	Timestamp uint64
+	FileID    uint32
+	Line      uint32
+	Args      [4]uint64
+	Msg       [BpfDbgMsgLen]byte
+}
+
+// ReadDbgEvent reads a single debug event from the perf event reader.
+func ReadDbgEvent(reader PerfEventReader) (*BpfDbgEvent, error) {
+	var event BpfDbgEvent
+	if err := reader.ReadInto(&event); err != nil {
+		return nil, fmt.Errorf("read debug event: %w", err)
+	}
+	return &event, nil
+}
+
+// DebugEventLoop reads debug events in a loop and logs each at Debug level.
+// Blocks until ctx is cancelled or the reader encounters a fatal error.
+func DebugEventLoop(ctx context.Context, reader PerfEventReader) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		event, err := ReadDbgEvent(reader)
+		if err != nil {
+			return err
+		}
+
+		log.Debugf("bpf_dbg: file=%#x line=%d ts=%d msg=%s args=[%#x %#x %#x %#x]",
+			event.FileID, event.Line, event.Timestamp,
+			nullTerminatedString(event.Msg[:]),
+			event.Args[0], event.Args[1], event.Args[2], event.Args[3],
+		)
+	}
+}
+
+func nullTerminatedString(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}

--- a/internal/bpf/bpf_dbg_test.go
+++ b/internal/bpf/bpf_dbg_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"huatuo-bamai/internal/bpf"
+)
+
+func TestBpfDbgEventSize(t *testing.T) {
+	var e bpf.BpfDbgEvent
+	// struct bpf_dbg_event: u64(8) + u32(4) + u32(4) + u64[4](32) + char[64](64) = 112
+	if s := unsafe.Sizeof(e); s != 112 {
+		t.Fatalf("BpfDbgEvent size mismatch: got %d, expected 112", s)
+	}
+}
+
+func TestBpfDbgEventRoundTrip(t *testing.T) {
+	e := bpf.BpfDbgEvent{
+		Timestamp: 123456789,
+		FileID:    0x0001,
+		Line:      42,
+		Args:      [4]uint64{1, 2, 3, 4},
+	}
+	copy(e.Msg[:], "hello world\x00")
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.NativeEndian, e); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 112 {
+		t.Fatalf("serialized size: got %d, expected 112", buf.Len())
+	}
+
+	var decoded bpf.BpfDbgEvent
+	if err := binary.Read(bytes.NewReader(buf.Bytes()), binary.NativeEndian, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Timestamp != e.Timestamp || decoded.FileID != e.FileID ||
+		decoded.Line != e.Line || decoded.Args != e.Args {
+		t.Fatalf("round-trip mismatch: %+v != %+v", decoded, e)
+	}
+	if nullTerminated(string(decoded.Msg[:])) != "hello world" {
+		t.Fatalf("msg mismatch: %q", string(decoded.Msg[:]))
+	}
+}
+
+func nullTerminated(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}


### PR DESCRIPTION
Add bpf_dbg.h header and Go helper to send structured debug events from BPF programs to userspace via a dedicated perf event array map, instead of relying on bpf_printk(). The utility is opt-in and disabled by default (zero overhead when bpf_dbg_enabled=0).