### PR TITLE
fix(pod): return kubelet body read errors

### DIFF
--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -351,7 +351,10 @@ func httpDoRequest(client *http.Client, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("http: %s, read body: %w", url, err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("http: %s, status: %d, body: %s", url, resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
## Summary

  Fix `httpDoRequest` in `internal/pod` to return errors from `io.ReadAll(resp.Body)` instead of ignoring them.

  This preserves the original response body read failure and keeps the request URL in the error context.

  Fixes #258

  ## Testing

  - `go test -v ./internal/pod`
  - `go test ./internal/pod`
  - `go test ./internal/pod ./internal/command/container ./internal/job`