### PR TITLE
fix(job): return node agent body read errors

### DIFF
--- a/internal/job/node_agent.go
+++ b/internal/job/node_agent.go
@@ -61,7 +61,10 @@ func (c *HTTPNodeAgent) StartTask(host, container string, args *NewAgentTaskReq)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("agent returned non-OK status: %d, read body: %w", resp.StatusCode, err)
+		}
 		return "", fmt.Errorf("agent returned non-OK status: %d, body: %s", resp.StatusCode, body)
 	}
 
@@ -95,7 +98,10 @@ func (c *HTTPNodeAgent) StopTask(host, taskID string, force bool) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to stop job: %s, read body: %w", resp.Status, err)
+		}
 		return fmt.Errorf("failed to stop job: %s, body: %s", resp.Status, string(body))
 	}
 
@@ -126,7 +132,10 @@ func (c *HTTPNodeAgent) GetTaskStatus(host, taskID string) (string, *Result, err
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return "", nil, fmt.Errorf("agent returned non-OK status: %d, read body: %w", resp.StatusCode, err)
+			}
 			return "", nil, fmt.Errorf("agent returned non-OK status: %d, body: %s", resp.StatusCode, string(body))
 		}
 

--- a/internal/job/node_agent_test.go
+++ b/internal/job/node_agent_test.go
@@ -54,6 +54,66 @@ func newHTTPResponse(statusCode int, body string) *http.Response {
 	}
 }
 
+var errNodeAgentBodyRead = errors.New("node agent response body read failed")
+
+type failingReadCloser struct{}
+
+func (failingReadCloser) Read(_ []byte) (int, error) {
+	return 0, errNodeAgentBodyRead
+}
+
+func (failingReadCloser) Close() error {
+	return nil
+}
+
+func newHTTPResponseWithBody(statusCode int, body io.ReadCloser) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Header:     make(http.Header),
+		Body:       body,
+	}
+}
+
+func TestHTTPNodeAgentReturnsBodyReadError(t *testing.T) {
+	t.Run("start task", func(t *testing.T) {
+		agent := newHTTPNodeAgentWithTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return newHTTPResponseWithBody(http.StatusInternalServerError, failingReadCloser{}), nil
+		}))
+
+		_, err := agent.StartTask("huatuo-dev", "payment-worker", &NewAgentTaskReq{
+			TracerName:   "oncpu",
+			TraceTimeout: 60,
+			DataType:     "flamegraph",
+		})
+		if !errors.Is(err, errNodeAgentBodyRead) {
+			t.Errorf("StartTask() error=%v, want body read error", err)
+		}
+	})
+
+	t.Run("stop task", func(t *testing.T) {
+		agent := newHTTPNodeAgentWithTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return newHTTPResponseWithBody(http.StatusConflict, failingReadCloser{}), nil
+		}))
+
+		err := agent.StopTask("huatuo-dev", "agent-task-2026", true)
+		if !errors.Is(err, errNodeAgentBodyRead) {
+			t.Errorf("StopTask() error=%v, want body read error", err)
+		}
+	})
+
+	t.Run("get task status", func(t *testing.T) {
+		agent := newHTTPNodeAgentWithTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return newHTTPResponseWithBody(http.StatusInternalServerError, failingReadCloser{}), nil
+		}))
+
+		_, _, err := agent.GetTaskStatus("huatuo-dev", "agent-task-2026")
+		if !errors.Is(err, errNodeAgentBodyRead) {
+			t.Errorf("GetTaskStatus() error=%v, want body read error", err)
+		}
+	})
+}
+
 // TestHTTPNodeAgentStartTask tests HTTPNodeAgent.StartTask request and response handling, including successful task dispatch, writing container name to request body, agent returning non-200, and error handling for unparseable response body.
 func TestHTTPNodeAgentStartTask(t *testing.T) {
 	t.Run("success", func(t *testing.T) {


### PR DESCRIPTION
## 变更说明

  修复 `HTTPNodeAgent` 在读取 agent 非成功响应 body 时忽略 `io.ReadAll(resp.Body)` 错误的问题。

  此前 `StartTask`、`StopTask` 和 `GetTaskStatus` 在处理非 2xx 响应时会忽略 body 读取错误，导致调用方可能只看到空 body 的错误信息，而不是实际的 response body 读取失败原因。

  Fixes #264

  ## 测试

  - `go test -count=1 -v ./internal/job -run TestHTTPNodeAgentReturnsBodyReadError`
  - `go test -count=1 ./internal/job`
  - `go test -count=1 ./internal/job ./cmd/huatuo-apiserver/handlers/trace ./cmd/huatuo-apiserver/handlers/profiling`