### PR TITLE
fix(kubelet): check io.ReadAll error in httpDoRequest

### DIFF
--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -353,7 +353,10 @@ func httpDoRequest(client *http.Client, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("http: %s, read body: %w", url, err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("http: %s, status: %d, body: %s", url, resp.StatusCode, string(body))
 	}

--- a/internal/pod/container_kubelet_sync_test.go
+++ b/internal/pod/container_kubelet_sync_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReader) Close() error             { return nil }
+
+func TestHTTPDoRequestReadBodyError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       errReader{},
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	_, err := httpDoRequest(client, "http://127.0.0.1/pods")
+	if err == nil {
+		t.Fatal("httpDoRequest() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "read body") {
+		t.Fatalf("httpDoRequest() error = %q, want read body context", err)
+	}
+}
+
+func TestHTTPDoRequestSuccess(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+
+	body, err := httpDoRequest(client, "http://127.0.0.1/pods")
+	if err != nil {
+		t.Fatalf("httpDoRequest() error = %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("httpDoRequest() body = %q, want %q", string(body), "ok")
+	}
+}


### PR DESCRIPTION
httpDoRequest silently ignored io.ReadAll errors via '_'. When the kubelet returns a response with a broken body, callers saw an empty body instead of the actual read error, making it hard to diagnose kubelet communication issues.

Return the read error wrapped with the request URL so callers can distinguish body read failures from normal non-OK responses.

Closes #258