### PR TITLE
fix(iolatency): attach freeze_queue probe on renamed kernel symbol

### DIFF
--- a/cmd/iotracing/bpf_attach.go
+++ b/cmd/iotracing/bpf_attach.go
@@ -68,7 +68,7 @@ func attachAndEventPipe(ctx context.Context, b bpf.BPF) (reader bpf.PerfEventRea
 // stack capture in the kprobe sees a populated return-side context.
 func buildAttachOptions(programs []bpf.ProgramInfo) ([]bpf.AttachOption, error) {
 	requestQosIssue, requestQosDone := "__rq_qos_issue", "__rq_qos_done"
-	if hasKprobeFunction("rq_qos_issue") {
+	if bpf.HasKprobeFunction("rq_qos_issue") {
 		requestQosIssue, requestQosDone = "rq_qos_issue", "rq_qos_done"
 	}
 
@@ -108,30 +108,6 @@ func buildAttachOptions(programs []bpf.ProgramInfo) ([]bpf.AttachOption, error) 
 	options = append(options, anyfsAttachOptions()...)
 
 	return options, nil
-}
-
-// hasKprobeFunction returns whether the given symbol is reported as
-// attachable in the kernel's available_filter_functions list.
-func hasKprobeFunction(name string) bool {
-	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
-	if err != nil {
-		return false
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-
-		if strings.Fields(line)[0] == name {
-			return true
-		}
-	}
-
-	return false
 }
 
 // isAnyfsProgram is true for filesystem-agnostic stub programs that

--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -81,7 +81,20 @@ func (c *iolatencyTracing) Start(ctx context.Context) error {
 	}
 	defer b.Close()
 
-	if err := b.Attach(); err != nil {
+	// commit 1e1a9cecfab3 ("block: force noio scope in blk_mq_freeze_queue")
+	// made blk_mq_freeze_queue a static inline wrapper in v6.15; the
+	// attachable symbol is blk_mq_freeze_queue_nomemsave. The first arg
+	// (struct request_queue *) is unchanged, so BPF logic stays the same.
+	freezeQueueSym := "blk_mq_freeze_queue"
+	if !bpf.HasKprobeFunction(freezeQueueSym) {
+		freezeQueueSym = "blk_mq_freeze_queue_nomemsave"
+	}
+
+	if err := b.AttachWithOptions([]bpf.AttachOption{
+		{ProgramName: "kprobe_start_request", Symbol: "blk_mq_start_request"},
+		{ProgramName: "kprobe_done_bio", Symbol: "__rq_qos_done_bio"},
+		{ProgramName: "kprobe_freeze_queue", Symbol: freezeQueueSym},
+	}); err != nil {
 		return err
 	}
 

--- a/internal/bpf/bpf_kprobe.go
+++ b/internal/bpf/bpf_kprobe.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// HasKprobeFunction returns whether the given symbol is reported as
+// attachable in the kernel's available_filter_functions list.
+func HasKprobeFunction(name string) bool {
+	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		if strings.Fields(line)[0] == name {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Fix error below:
https://github.com/ccfos/huatuo/actions/runs/27772719794/job/82176711814?pr=248#step:6:3131

error message:
time="2026-06-18T16:18:23.194547490Z" level="error" msg="start tracing iolatency: attach kprobe: can't attach kprobe blk_mq_freeze_queue in Kprobe(kprobe_freeze_queue)#220: creating perf_kprobe PMU (arch-specific fallback for \"blk_mq_freeze_queue\"): token __x64_blk_mq_freeze_queue: not found: no such file or directory" file="tracing.go:88" func="huatuo-bamai/pkg/tracing.(*EventTracing).doStart"