### PR TITLE
feat(task): add task list endpoint

### DIFF
--- a/cmd/huatuo-bamai/handlers/task.go
+++ b/cmd/huatuo-bamai/handlers/task.go
@@ -35,6 +35,7 @@ func NewTaskHandler() *TaskHandler {
 	h := &TaskHandler{}
 	h.Handlers = []server.Handle{
 		{Typ: server.HttpPost, Uri: "", Handle: h.create},
+		{Typ: server.HttpGet, Uri: "", Handle: h.list},
 		{Typ: server.HttpGet, Uri: "/:id", Handle: h.get},
 		{Typ: server.HttpDelete, Uri: "/:id", Handle: h.stop},
 	}
@@ -75,6 +76,11 @@ func (h *TaskHandler) create(ctx *server.Context) error {
 
 	id := tracing.NewTask(req.TracerName, time.Duration(req.Timeout)*time.Second, storageDefault, req.TracerArgs)
 	response.Success(ctx, map[string]any{"task_id": id})
+	return nil
+}
+
+func (h *TaskHandler) list(ctx *server.Context) error {
+	response.Success(ctx, map[string]any{"tasks": tracing.ListTasks()})
 	return nil
 }
 

--- a/cmd/huatuo-bamai/handlers/task_test.go
+++ b/cmd/huatuo-bamai/handlers/task_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/server"
+)
+
+func TestTaskHandlerRegistersListRoute(t *testing.T) {
+	h := NewTaskHandler()
+
+	for _, route := range h.Handlers {
+		if route.Typ == server.HttpGet && route.Uri == "" {
+			return
+		}
+	}
+
+	t.Fatal("NewTaskHandler() should register GET /tasks list route")
+}

--- a/pkg/tracing/task.go
+++ b/pkg/tracing/task.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"os/exec"
 	"path"
+	"sort"
 	"sync"
 	"time"
 
@@ -59,6 +60,13 @@ type TaskResult struct {
 	TaskStatus Status
 	TaskData   []byte
 	TaskErr    error
+}
+
+// TaskInfo is a lightweight task summary returned by list APIs.
+type TaskInfo struct {
+	TaskID     string `json:"task_id"`
+	TracerName string `json:"tracer_name"`
+	Status     Status `json:"status"`
 }
 
 // task represents a unit of work to be executed.
@@ -218,6 +226,31 @@ func RunningTaskCount() int {
 		return true
 	})
 	return count
+}
+
+// ListTasks returns summaries for all tasks currently kept in memory.
+func ListTasks() []TaskInfo {
+	tasks := make([]TaskInfo, 0)
+	taskLifeTmpCache.Range(func(key, value any) bool {
+		task := value.(*task)
+		taskID := task.id
+		if taskID == "" {
+			if keyID, ok := key.(string); ok {
+				taskID = keyID
+			}
+		}
+		tasks = append(tasks, TaskInfo{
+			TaskID:     taskID,
+			TracerName: task.execBinary,
+			Status:     task.status,
+		})
+		return true
+	})
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].TaskID < tasks[j].TaskID
+	})
+	return tasks
 }
 
 // Result returns the result of a task given its ID.

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -234,6 +234,37 @@ func TestRunningTaskCount(t *testing.T) {
 	}
 }
 
+func TestListTasks(t *testing.T) {
+	clearTaskCache()
+	t.Cleanup(clearTaskCache)
+
+	taskLifeTmpCache.Store("task-z", &task{
+		id:         "task-z",
+		execBinary: "mem",
+		status:     StatusFailed,
+	})
+	taskLifeTmpCache.Store("task-a", &task{
+		id:         "task-a",
+		execBinary: "cpu",
+		status:     StatusRunning,
+	})
+
+	got := ListTasks()
+	if len(got) != 2 {
+		t.Fatalf("ListTasks() len=%d, want 2", len(got))
+	}
+
+	want := []TaskInfo{
+		{TaskID: "task-a", TracerName: "cpu", Status: StatusRunning},
+		{TaskID: "task-z", TracerName: "mem", Status: StatusFailed},
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ListTasks()[%d]=%+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestSetDeadlineDefault(t *testing.T) {
 	task := &task{}
 	before := time.Now()


### PR DESCRIPTION
 ## 变更说明

  Closes #271

  为 `huatuo-bamai` 增加 `GET /tasks` 列表接口，用于查看当前内存中仍保留的 task 摘要信息。

  本次新增：

  - `pkg/tracing.ListTasks()`：返回当前 task 的 `task_id`、`tracer_name` 和 `status`
  - `TaskInfo`：定义 task 列表接口的轻量返回结构
  - `GET /tasks`：复用现有 task handler，返回当前 task 列表
  - 单元测试覆盖 task 列表排序和路由注册

  返回内容只包含 task 摘要，不暴露 trace 参数、执行输出、错误详情或本地路径。

  ## 测试

  已在 Docker 环境验证：

  - `GOFLAGS=-mod=mod go test -count=1 -v ./pkg/tracing -run TestListTasks`
  - `GOFLAGS=-mod=mod go test -count=1 -v ./cmd/huatuo-bamai/handlers -run TestTaskHandlerRegistersListRoute`
  - `GOFLAGS=-mod=mod go test -count=1 ./pkg/tracing ./cmd/huatuo-bamai/handlers ./internal/server`
  - `GOFLAGS=-mod=mod go test -count=1 ./cmd/huatuo-bamai/...`

  说明：当前 `upstream/main` 的 vendor 目录缺少 `capnproto.org/go/capnp/v3/internal/schema`，默认 vendor 模式会阻塞 `cmd/huatuo-bamai/handlers` 编译；以上测试使用 `GOFLAGS=-mod=mod` 验证功能相关包。