### PR TITLE
feat(profiling): add capabilities endpoint

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -54,6 +54,24 @@ type ProfilingResults struct {
 	URL string `json:"url"` // URL to view the results
 }
 
+// ProfilingCapabilityDefaults represents default profiling runtime settings.
+type ProfilingCapabilityDefaults struct {
+	CPUProfilingInterval     int `json:"cpu_profiling_interval"`
+	MemoryProfilingInterval  int `json:"memory_profiling_interval"`
+	CPUSingleTraceTimeout    int `json:"cpu_single_trace_timeout"`
+	MemorySingleTraceTimeout int `json:"memory_single_trace_timeout"`
+	ThirdPartyToolLimit      int `json:"third_party_tool_limit"`
+}
+
+// ProfilingCapabilitiesResponse represents profiling capabilities supported by the API server.
+type ProfilingCapabilitiesResponse struct {
+	Types           []string                    `json:"types"`
+	CPULanguages    []string                    `json:"cpu_languages"`
+	MemoryLanguages []string                    `json:"memory_languages"`
+	MemoryModes     []string                    `json:"memory_modes"`
+	Defaults        ProfilingCapabilityDefaults `json:"defaults"`
+}
+
 // RawDataResponse represents raw profiling data response
 type RawDataResponse struct {
 	Data any `json:"data"` // raw profiling data

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -39,19 +39,34 @@ const (
 	ProfilingCPU    = "profiling_cpu"
 )
 
+type memoryModeCapability struct {
+	name      string
+	tracerArg string
+}
+
 var (
-	supportedLanguages = map[string]bool{
+	supportedProfilingTypes  = []string{"cpu", "memory"}
+	supportedCPULanguages    = []string{"c", "c++", "go", "java", "python"}
+	supportedMemoryLanguages = []string{
+		"c",
+		"c++",
+		"go",
+		"java",
+	}
+	supportedMemoryModeCapabilities = []memoryModeCapability{
+		{name: "NATIVE_PHYSICAL_ALLOC", tracerArg: "native_physical_alloc"},
+		{name: "NATIVE_PHYSICAL_USAGE", tracerArg: "native_physical_usage"},
+		{name: "NATIVE_VIRTUAL_ALLOC", tracerArg: "native_virtual_alloc"},
+		{name: "OBJECT_ALLOC", tracerArg: "object_alloc"},
+		{name: "OBJECT_USAGE", tracerArg: "object_usage"},
+	}
+	supportedMemoryModeNames = memoryModeNames(supportedMemoryModeCapabilities)
+	supportedMemoryModes     = memoryModeMap(supportedMemoryModeCapabilities)
+	supportedLanguages       = map[string]bool{
 		"c++":  true,
 		"c":    true,
 		"go":   true,
 		"java": true,
-	}
-	supportedMemoryModes = map[string]string{
-		"NATIVE_PHYSICAL_ALLOC": "native_physical_alloc",
-		"NATIVE_PHYSICAL_USAGE": "native_physical_usage",
-		"NATIVE_VIRTUAL_ALLOC":  "native_virtual_alloc",
-		"OBJECT_ALLOC":          "object_alloc",
-		"OBJECT_USAGE":          "object_usage",
 	}
 )
 
@@ -68,6 +83,7 @@ func NewHandler(jm *job.Manager) *Handler {
 	h.Handlers = []server.Handle{
 		{Typ: server.HttpPost, Uri: "", Handle: h.start},
 		{Typ: server.HttpGet, Uri: "", Handle: h.list},
+		{Typ: server.HttpGet, Uri: "/capabilities", Handle: h.capabilities},
 		{Typ: server.HttpGet, Uri: "/:id", Handle: h.get},
 		{Typ: server.HttpGet, Uri: "/:id/raw", Handle: h.getRawData},
 		{Typ: server.HttpPatch, Uri: "/:id", Handle: h.patchOne},
@@ -82,8 +98,44 @@ func NewHandler(jm *job.Manager) *Handler {
 	return h
 }
 
+// capabilities returns the profiling modes and defaults supported by this API server.
+func (h *Handler) capabilities(ctx *server.Context) error {
+	cfg := config.Get().Profiling
+
+	response.Success(ctx, v1.ProfilingCapabilitiesResponse{
+		Types:           append([]string(nil), supportedProfilingTypes...),
+		CPULanguages:    append([]string(nil), supportedCPULanguages...),
+		MemoryLanguages: append([]string(nil), supportedMemoryLanguages...),
+		MemoryModes:     append([]string(nil), supportedMemoryModeNames...),
+		Defaults: v1.ProfilingCapabilityDefaults{
+			CPUProfilingInterval:     cfg.CPUProfilingInterval,
+			MemoryProfilingInterval:  cfg.MemoryProfilingInterval,
+			CPUSingleTraceTimeout:    cfg.CPUSingleTraceTimeout,
+			MemorySingleTraceTimeout: cfg.MemorySingleTraceTimeout,
+			ThirdPartyToolLimit:      cfg.ThirdPartyToolLimit,
+		},
+	})
+	return nil
+}
+
 func isLanguageSupported(lang string) bool {
 	return supportedLanguages[lang]
+}
+
+func memoryModeNames(modes []memoryModeCapability) []string {
+	names := make([]string, 0, len(modes))
+	for _, mode := range modes {
+		names = append(names, mode.name)
+	}
+	return names
+}
+
+func memoryModeMap(modes []memoryModeCapability) map[string]string {
+	result := make(map[string]string, len(modes))
+	for _, mode := range modes {
+		result[mode.name] = mode.tracerArg
+	}
+	return result
 }
 
 func isMemoryModeSupported(mode string) (string, bool) {

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	v1 "huatuo-bamai/apis/v1"
+	"huatuo-bamai/cmd/huatuo-apiserver/config"
+	"huatuo-bamai/internal/server"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHandlerRegistersCapabilitiesRouteBeforeIDRoute(t *testing.T) {
+	h := NewHandler(nil)
+
+	capabilitiesIdx := -1
+	idIdx := -1
+	for i, route := range h.Handlers {
+		if route.Typ == server.HttpGet && route.Uri == "/capabilities" {
+			capabilitiesIdx = i
+		}
+		if route.Typ == server.HttpGet && route.Uri == "/:id" {
+			idIdx = i
+		}
+	}
+
+	if capabilitiesIdx == -1 {
+		t.Fatalf("GET /capabilities route was not registered")
+	}
+	if idIdx == -1 {
+		t.Fatalf("GET /:id route was not registered")
+	}
+	if capabilitiesIdx > idIdx {
+		t.Fatalf("GET /capabilities route index=%d, want before GET /:id index=%d", capabilitiesIdx, idIdx)
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	cfg := config.Get()
+	oldProfilingConfig := cfg.Profiling
+	cfg.Profiling.CPUProfilingInterval = 11
+	cfg.Profiling.MemoryProfilingInterval = 12
+	cfg.Profiling.CPUSingleTraceTimeout = 21
+	cfg.Profiling.MemorySingleTraceTimeout = 22
+	cfg.Profiling.ThirdPartyToolLimit = 7
+	defer func() {
+		cfg.Profiling = oldProfilingConfig
+	}()
+
+	engine := newProfilingTestEngine(t)
+	request := httptest.NewRequest(http.MethodGet, "/v1/profiles/capabilities", http.NoBody)
+	recorder := httptest.NewRecorder()
+
+	engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("response status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var got struct {
+		Code    int                              `json:"code"`
+		Message string                           `json:"message"`
+		Data    v1.ProfilingCapabilitiesResponse `json:"data"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+
+	if got.Code != 0 {
+		t.Errorf("response code = %d, want 0", got.Code)
+	}
+	if got.Message != "success" {
+		t.Errorf("response message = %q, want %q", got.Message, "success")
+	}
+
+	want := v1.ProfilingCapabilitiesResponse{
+		Types:           []string{"cpu", "memory"},
+		CPULanguages:    []string{"c", "c++", "go", "java", "python"},
+		MemoryLanguages: []string{"c", "c++", "go", "java"},
+		MemoryModes: []string{
+			"NATIVE_PHYSICAL_ALLOC",
+			"NATIVE_PHYSICAL_USAGE",
+			"NATIVE_VIRTUAL_ALLOC",
+			"OBJECT_ALLOC",
+			"OBJECT_USAGE",
+		},
+		Defaults: v1.ProfilingCapabilityDefaults{
+			CPUProfilingInterval:     11,
+			MemoryProfilingInterval:  12,
+			CPUSingleTraceTimeout:    21,
+			MemorySingleTraceTimeout: 22,
+			ThirdPartyToolLimit:      7,
+		},
+	}
+
+	if !reflect.DeepEqual(got.Data, want) {
+		t.Errorf("capabilities response = %+v, want %+v", got.Data, want)
+	}
+}
+
+func newProfilingTestEngine(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	group := server.NewRoot(engine, "").Group("/v1/profiles")
+	for _, route := range NewHandler(nil).Handlers {
+		method, ok := testHTTPMethod(route.Typ)
+		if !ok {
+			t.Fatalf("unknown route type: %d", route.Typ)
+		}
+		group.Handle(method, route.Uri, route.Handle)
+	}
+
+	return engine
+}
+
+func testHTTPMethod(typ int) (string, bool) {
+	switch typ {
+	case server.HttpPost:
+		return http.MethodPost, true
+	case server.HttpDelete:
+		return http.MethodDelete, true
+	case server.HttpGet:
+		return http.MethodGet, true
+	case server.HttpPut:
+		return http.MethodPut, true
+	case server.HttpPatch:
+		return http.MethodPatch, true
+	default:
+		return "", false
+	}
+}


### PR DESCRIPTION
 ### 修改内容

  为 huatuo-apiserver 的 profiling API 增加 capabilities 接口：

      GET /v1/profiles/capabilities

  该接口返回当前服务端支持的 profiling 能力和默认配置，包括：

  - 支持的 profiling 类型
  - CPU profiling 支持的目标语言
  - Memory profiling 支持的目标语言
  - Memory profiling 支持的 memory mode
  - 默认 profiling interval
  - 默认 third-party tool limit

  ### 变更说明

  新增 ProfilingCapabilitiesResponse 和 ProfilingCapabilityDefaults 响应结构，用于描述 capabilities 接口返回内容。

  同时在 profiling handler 中注册 GET /capabilities 路由，并确保该静态路由位于 /:id 之前，避免被任务 ID 路由误匹配。

  Memory mode 的对外名称和传给 tracer 的内部参数使用同一份能力定义生成，避免 capabilities 返回内容和实际创建 profiling 任务时的参数映射不一致。

  Fixes #275

  ### 测试

      GOFLAGS=-mod=mod go test -count=1 -v ./cmd/huatuo-apiserver/handlers/profiling -run 'TestHandlerRegistersCapabilitiesRouteBeforeIDRoute|TestCapabilities'
      GOFLAGS=-mod=mod go test -count=1 ./cmd/huatuo-apiserver/handlers/profiling ./cmd/huatuo-apiserver/handlers/trace ./internal/server
      GOFLAGS=-mod=mod go test -count=1 ./cmd/huatuo-apiserver/...