### PR TITLE
feat(server): add HTTP version endpoint

### DIFF
--- a/cmd/huatuo-apiserver/handlers/server.go
+++ b/cmd/huatuo-apiserver/handlers/server.go
@@ -22,17 +22,19 @@ import (
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers/trace"
 	"huatuo-bamai/internal/job"
 	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/version"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ServerStart starts the API service with the given configuration.
-func ServerStart(addr string, promReg *prometheus.Registry, profilingManager, tracingManager *job.Manager) error {
+func ServerStart(addr string, promReg *prometheus.Registry, profilingManager, tracingManager *job.Manager, versionInfo version.Info) error {
 	httpServer := server.NewServer(&server.Config{
 		EnablePProf:     false,
 		EnableRateLimit: false,
 		AuthUsers:       getUserConfigs(),
 		PromReg:         promReg,
+		VersionInfo:     &versionInfo,
 	})
 
 	// Register trace routes

--- a/cmd/huatuo-apiserver/main.go
+++ b/cmd/huatuo-apiserver/main.go
@@ -50,6 +50,7 @@ var (
 	AppVersion   string
 	AppGitCommit string
 	AppBuildTime string
+	versionInfo  version.Info
 )
 
 type fatalWriter struct {
@@ -126,7 +127,7 @@ func main() {
 
 	app.Action = mainAction
 
-	version.Wire(app, version.Seed{
+	versionInfo = version.Wire(app, version.Seed{
 		Name:      apiServerToolName,
 		Version:   AppVersion,
 		GitCommit: AppGitCommit,
@@ -214,7 +215,7 @@ func mainAction(ctx *cli.Context) error {
 		return fmt.Errorf("initialize metrics collector: %w", err)
 	}
 
-	if err := handlers.ServerStart(config.Get().APIServer.TCPAddr, promRegistry, profilingManager, tracingManager); err != nil {
+	if err := handlers.ServerStart(config.Get().APIServer.TCPAddr, promRegistry, profilingManager, tracingManager, versionInfo); err != nil {
 		return fmt.Errorf("handlers.APIServer: %w", err)
 	}
 

--- a/cmd/huatuo-bamai/cli.go
+++ b/cmd/huatuo-bamai/cli.go
@@ -61,6 +61,7 @@ type Options struct {
 	LogDebug       bool
 	DryRun         bool
 	ProcfsPrefix   string
+	VersionInfo    version.Info
 }
 
 func buildCommand(seed version.Seed) *cli.App {
@@ -69,7 +70,7 @@ func buildCommand(seed version.Seed) *cli.App {
 	app.Name = appName
 	app.Usage = appUsage
 	opts.AddFlags(app)
-	version.Wire(app, seed)
+	opts.VersionInfo = version.Wire(app, seed)
 
 	app.Before = func(ctx *cli.Context) error {
 		if err := opts.FromContext(ctx); err != nil {

--- a/cmd/huatuo-bamai/handlers/server.go
+++ b/cmd/huatuo-bamai/handlers/server.go
@@ -19,13 +19,14 @@ import (
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
 	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/version"
 	"huatuo-bamai/pkg/tracing"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Start starts the HTTP server with all handlers registered.
-func Start(addr string, mgrTracing *tracing.TracingManager, promReg *prometheus.Registry) {
+func Start(addr string, mgrTracing *tracing.TracingManager, promReg *prometheus.Registry, versionInfo version.Info) {
 	s := server.NewServer(&server.Config{
 		EnablePProf:     true,
 		EnableRateLimit: true,
@@ -33,6 +34,7 @@ func Start(addr string, mgrTracing *tracing.TracingManager, promReg *prometheus.
 		RateBurst:       200,
 		EnableRetry:     true,
 		PromReg:         promReg,
+		VersionInfo:     &versionInfo,
 	})
 
 	SetTracingManager(mgrTracing)

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -73,6 +73,6 @@ func startTracing(d *Daemon) (func(context.Context) error, error) {
 }
 
 func startHandlers(d *Daemon) (func(context.Context) error, error) {
-	handlers.Start(config.Get().APIServer.TCPAddr, d.tracer, d.metrics)
+	handlers.Start(config.Get().APIServer.TCPAddr, d.tracer, d.metrics, d.opts.VersionInfo)
 	return nil, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/version"
 
 	"github.com/cloudflare/backoff"
 	"github.com/gin-contrib/pprof"
@@ -42,6 +43,7 @@ type Config struct {
 	AuthUsers       []UserConfig
 	PromReg         *prometheus.Registry
 	Group           string
+	VersionInfo     *version.Info
 }
 
 var defaultConfig = &Config{
@@ -105,6 +107,11 @@ func NewServer(cfg *Config) *server {
 		{Typ: HttpGet, Uri: "/healthz", Handle: s.healthzHandler()},
 		{Typ: HttpGet, Uri: "/metrics", Handle: s.promServerHandler()},
 	})
+	if cfg.VersionInfo != nil {
+		s.MustRegisterRoutes("", []Handle{
+			{Typ: HttpGet, Uri: "/version", Handle: newVersionHandler(*cfg.VersionInfo)},
+		})
+	}
 	return s
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,11 +15,14 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"huatuo-bamai/internal/version"
 
 	httpGin "github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,6 +58,44 @@ func TestNewServerRegistersHealthzRoute(t *testing.T) {
 	}
 	if recorder.Body.Len() != 0 {
 		t.Errorf("response body = %q, want empty body", recorder.Body.String())
+	}
+}
+
+func TestNewServerRegistersVersionRoute(t *testing.T) {
+	info := version.Info{
+		Name:         "huatuo-apiserver",
+		Version:      "1.2.3",
+		GitCommit:    "abcdef123456",
+		GitTreeState: "clean",
+		BuildTime:    "2026-06-24T00:00:00Z",
+		GoVersion:    "go1.24.0",
+		Compiler:     "gc",
+		Platform:     "linux/amd64",
+	}
+	s := NewServer(&Config{VersionInfo: &info})
+
+	request := httptest.NewRequest(http.MethodGet, "/version", http.NoBody)
+	recorder := httptest.NewRecorder()
+
+	s.engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("response status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var got struct {
+		Code    int          `json:"code"`
+		Message string       `json:"message"`
+		Data    version.Info `json:"data"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, recorder.Body.String())
+	}
+	if got.Code != 0 || got.Message != "success" {
+		t.Fatalf("response code/message = %d/%q, want 0/success", got.Code, got.Message)
+	}
+	if got.Data != info {
+		t.Errorf("version response = %+v, want %+v", got.Data, info)
 	}
 }
 

--- a/internal/server/version.go
+++ b/internal/server/version.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"huatuo-bamai/internal/server/response"
+	"huatuo-bamai/internal/version"
+)
+
+func newVersionHandler(info version.Info) ErrHandlerContextFunc {
+	return func(ctx *Context) error {
+		response.Success(ctx, info)
+		return nil
+	}
+}


### PR DESCRIPTION
Fixes #277
### 修改内容

  为公共 HTTP server 增加 `GET /version` 接口，并在 `huatuo-apiserver` 和 `huatuo-bamai` 中接入该接口。

  返回内容复用现有 `internal/version.Info`，包括：

  - name
  - version
  - git_commit
  - git_tree_state
  - build_time
  - go_version
  - compiler
  - platform

  这样 HTTP 服务暴露的版本信息可以和 CLI `--version` 输出保持一致，便于线上排查运行实例对应的构建版本和 commit。

  ### 实现说明

  - 在 `internal/server` 中新增 `/version` handler。
  - 通过 `server.Config.VersionInfo` 注入版本信息。
  - `huatuo-apiserver` 复用 `version.Wire` 返回的 `version.Info` 并传入 HTTP server。
  - `huatuo-bamai` 在 CLI options 中保存 `version.Info`，启动 HTTP server 时传入。
  - 新增单测覆盖 `/version` 路由注册和响应结构。
  ### 测试

  ```sh
  GOFLAGS=-mod=mod go test -count=1 ./internal/server
  GOFLAGS=-mod=mod go test -count=1 ./cmd/huatuo-apiserver/... ./cmd/huatuo-bamai/...
  GOFLAGS=-mod=mod go test -count=1 -v ./internal/server -run TestNewServerRegistersVersionRoute

  运行时验证 huatuo-bamai：

  /tmp/huatuo-bamai --region dev --config-dir /workspace/huatuo --disable-kubelet --disable-storage --disable-cgroup >/tmp/bamai.log 2>&1 &
  wget -qO- http://127.0.0.1:19704/version

  返回示例：

  {
    "code": 0,
    "message": "success",
    "data": {
      "name": "huatuo-bamai",
      "version": "(devel)",
      "git_commit": "(devel)",
      "git_tree_state": "unknown",
      "build_time": "(devel)",
      "go_version": "go1.24.13",
      "compiler": "gc",
      "platform": "linux/amd64"
    }
  }

  说明：huatuo-apiserver runtime verification was not run in the current Docker environment because its startup path requires systemd cgroup support. The shared /version handler is covered by internal/server
  tests, and cmd/huatuo-apiserver packages compile successfully.
