### PR TITLE
fix(config): return errors for invalid config updates

### DIFF
--- a/cmd/huatuo-bamai/cli.go
+++ b/cmd/huatuo-bamai/cli.go
@@ -236,7 +236,9 @@ func configureRuntime(opts *Options) error {
 		merged := make([]string, 0, len(bl)+len(opts.DisableTracing))
 		merged = append(merged, bl...)
 		merged = append(merged, opts.DisableTracing...)
-		config.Set("BlackList", merged)
+		if err := config.Set("BlackList", merged); err != nil {
+			return err
+		}
 		log.Infof("merged tracer blacklist from CLI: %v", config.Get().BlackList)
 	}
 

--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -100,9 +100,12 @@ func Get() *BamaiConfig {
 }
 
 // Set updates a config field by dot-separated key.
-func Set(key string, val any) {
-	internalconfig.Set(cfg, key, val)
+func Set(key string, val any) error {
+	if err := internalconfig.Set(cfg, key, val); err != nil {
+		return err
+	}
 	setCoreModuleConfig()
+	return nil
 }
 
 // Sync writes the config back to the current config file.

--- a/cmd/huatuo-bamai/handlers/config.go
+++ b/cmd/huatuo-bamai/handlers/config.go
@@ -50,7 +50,9 @@ func (h *ConfigHandler) update(ctx *server.Context) error {
 		if reflect.ValueOf(v).Kind() == reflect.Float64 {
 			v = int(v.(float64))
 		}
-		config.Set(k, v)
+		if err := config.Set(k, v); err != nil {
+			return response.ErrInvalidRequest.WithMessage(err.Error())
+		}
 	}
 
 	if err := config.Sync(); err != nil {

--- a/cmd/huatuo-bamai/handlers/config_test.go
+++ b/cmd/huatuo-bamai/handlers/config_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/cmd/huatuo-bamai/config"
+	"huatuo-bamai/internal/server"
+
+	httpGin "github.com/gin-gonic/gin"
+)
+
+func TestConfigHandlerRejectsInvalidConfigKey(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	if err := config.Load(writeConfig(t, `
+Log = { Level = "Info" }
+`)); err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	engine := httpGin.New()
+	server.NewRoot(engine, "").PUT("/config", NewConfigHandler().update)
+
+	req := httptest.NewRequest(http.MethodPut, "/config", bytes.NewBufferString(`{"config":{"NotExist":1}}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid elem") {
+		t.Fatalf("body = %q, want invalid elem error", rec.Body.String())
+	}
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	path := t.TempDir() + "/huatuo-bamai.conf"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,8 +67,7 @@ func Sync(path string, src any) error {
 }
 
 // Set modifies a field in cfg (a pointer to a struct) by dot-separated key.
-// Panics if the key is invalid or the value type doesn't match.
-func Set(cfg any, key string, val any) {
+func Set(cfg any, key string, val any) error {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -76,7 +75,7 @@ func Set(cfg any, key string, val any) {
 	for _, k := range strings.Split(key, ".") {
 		elem := c.Elem().FieldByName(k)
 		if !elem.IsValid() || !elem.CanAddr() {
-			panic(fmt.Errorf("invalid elem %s: %v", key, elem))
+			return fmt.Errorf("invalid elem %s: %v", key, elem)
 		}
 		c = elem.Addr()
 	}
@@ -84,8 +83,9 @@ func Set(cfg any, key string, val any) {
 	rc := reflect.Indirect(c)
 	rval := reflect.ValueOf(val)
 	if rc.Kind() != rval.Kind() {
-		panic(fmt.Errorf("%s type %s is not assignable to type %s", key, rc.Kind(), rval.Kind()))
+		return fmt.Errorf("%s type %s is not assignable to type %s", key, rc.Kind(), rval.Kind())
 	}
 
 	rc.Set(rval)
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,8 +155,12 @@ func TestSyncAndSet(t *testing.T) {
 		t.Fatalf("Sync returned error: %v", err)
 	}
 
-	Set(cfg, "Name", "huatuo-region")
-	Set(cfg, "Nested.Value", "kernel_sched_tick")
+	if err := Set(cfg, "Name", "huatuo-region"); err != nil {
+		t.Fatalf("Set Name returned error: %v", err)
+	}
+	if err := Set(cfg, "Nested.Value", "kernel_sched_tick"); err != nil {
+		t.Fatalf("Set Nested.Value returned error: %v", err)
+	}
 
 	if err := Sync(path, cfg); err != nil {
 		t.Fatalf("Sync after Set returned error: %v", err)


### PR DESCRIPTION
Config updates used to panic on invalid dot-separated keys or type mismatches. The /config handler called config.Set directly, so malformed requests could trigger a process panic instead of a controlled invalid-request response.

Return errors from config.Set, propagate them through huatuo-bamai config, and make the /config handler report invalid updates as bad requests.

Tested with:
GOPROXY=https://goproxy.cn,direct go test -mod=mod -count=1   huatuo-bamai/internal/config   huatuo-bamai/cmd/huatuo-bamai/config   huatuo-bamai/cmd/huatuo-bamai/handlers