### PR TITLE
fix(request): keep response body readable

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -87,7 +87,6 @@ func doRequest(req *http.Request) (*ServerResponse, error) {
 	if err != nil {
 		return serverResp, err
 	}
-	defer resp.Body.Close()
 
 	serverResp.StatusCode = resp.StatusCode
 	serverResp.Body = resp.Body

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -17,6 +17,7 @@ package request
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -70,6 +71,32 @@ func TestEncodeBodySetsJSONContentType(t *testing.T) {
 	}
 	if strings.TrimSpace(string(raw)) != `{"name":"cpu"}` {
 		t.Fatalf("body = %q, want JSON object", string(raw))
+	}
+}
+
+func TestDoRequestReturnsReadableBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	resp, err := doRequest(req)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	defer resp.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll(response body) error = %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", string(body))
 	}
 }
 


### PR DESCRIPTION
  ## Problem

  `internal/request.doRequest` returns `resp.Body` through `ServerResponse.Body`,
  but it also defers `resp.Body.Close()` before returning:

  ```go
  defer resp.Body.Close()
  serverResp.Body = resp.Body

  As a result, callers may receive a closed response body on successful responses,
  making it impossible to read the body after doRequest returns.

  Fix

  Remove the premature defer resp.Body.Close() from doRequest.

  ServerResponse already provides a Close() method, so the response body
  lifetime should be owned by the returned ServerResponse.

  Testing

  go test -count=1 huatuo-bamai/internal/request -timeout=60s

  Result:

  ok  huatuo-bamai/internal/request

  Closes #282 