### PR TITLE
fix(container): include response body for non-OK errors

### DIFF
--- a/internal/command/container/container.go
+++ b/internal/command/container/container.go
@@ -17,7 +17,9 @@ package container
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"huatuo-bamai/internal/pod"
@@ -44,7 +46,11 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("get container failed, status code: %d", resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("get container failed, status code: %d, read body: %w", resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("get container failed, status code: %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	type containersResp struct {

--- a/internal/command/container/container_test.go
+++ b/internal/command/container/container_test.go
@@ -23,6 +23,23 @@ import (
 )
 
 // TestGetContainersCompatibility covers the compatibility of container query callers. It verifies that the request path is unchanged when the container_id query parameter is present, that the unified response wrapper can be correctly decoded, and that both GetContainerByID and GetAllContainers continue to work.
+func TestGetContainersIncludesErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	serverAddr := strings.TrimPrefix(server.URL, "http://")
+
+	_, err := getContainers(serverAddr, "container-20250226")
+	if err == nil {
+		t.Fatal("getContainers() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "backend unavailable") {
+		t.Fatalf("getContainers() error = %q, want response body", err)
+	}
+}
+
 func TestGetContainersCompatibility(t *testing.T) {
 	var requestedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
  ## Problem

  `internal/command/container.getContainers` only returned the HTTP status code
  when the container API returned a non-OK response:

  ```go
  return nil, fmt.Errorf("get container failed, status code: %d", resp.StatusCode)
```
  This drops the response body returned by the API, so callers cannot see the actual error message from the backend.

  Fix

  Read the response body on non-OK responses and include it in the returned error.

  Also handle body read errors explicitly.

  Testing

  go test -count=1 huatuo-bamai/internal/command/container -timeout=60s

  Result:

  ok  huatuo-bamai/internal/command/container  0.019s

  Closes #284 