### PR TITLE
fix(container): escape container_id query value

### DIFF
--- a/internal/command/container/container.go
+++ b/internal/command/container/container.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"huatuo-bamai/internal/pod"
@@ -34,7 +35,7 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 	}
 
 	if containerID != "" {
-		req.URL.RawQuery = fmt.Sprintf("container_id=%s", containerID)
+		req.URL.RawQuery = url.Values{"container_id": {containerID}}.Encode()
 	}
 
 	resp, err := client.Do(req)

--- a/internal/command/container/container_test.go
+++ b/internal/command/container/container_test.go
@@ -34,15 +34,15 @@ func TestGetContainersCompatibility(t *testing.T) {
 
 	serverAddr := strings.TrimPrefix(server.URL, "http://")
 
-	containers, err := getContainers(serverAddr, "container-20250226")
+	containers, err := getContainers(serverAddr, "container+2025&0226")
 	if err != nil {
 		t.Errorf("getContainers() error = %v", err)
 	}
 	if !strings.Contains(requestedPath, "/containers/json") {
 		t.Errorf("requested path = %q, want /containers/json", requestedPath)
 	}
-	if !strings.Contains(requestedPath, "container_id=container-20250226") {
-		t.Errorf("requested path = %q, want container_id query", requestedPath)
+	if !strings.Contains(requestedPath, "container_id=container%2B2025%260226") {
+		t.Errorf("requested path = %q, want escaped container_id query", requestedPath)
 	}
 	if len(containers) != 2 {
 		t.Errorf("len(containers) = %d, want %d", len(containers), 2)


### PR DESCRIPTION
  ## Problem

  `internal/command/container.getContainers` manually builds the query string with
  `fmt.Sprintf`:

  ```go
  req.URL.RawQuery = fmt.Sprintf("container_id=%s", containerID)

  If containerID contains URL query special characters such as +, &, =, or
  %, the value may be parsed incorrectly as query syntax instead of a single
  container_id value.

  Fix

  Use url.Values.Encode() to build the query string safely:

  req.URL.RawQuery = url.Values{"container_id": {containerID}}.Encode()

  Testing

  go test -count=1 huatuo-bamai/internal/command/container -timeout=60s

  Result:

  ok  huatuo-bamai/internal/command/container  0.015s

  Closes #286
  ```