### PR TITLE
fix(profiler): escape container_id query value

### DIFF
--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	v1 "huatuo-bamai/apis/v1"
@@ -458,7 +459,14 @@ func getFlameGraphURL(jobResult *job.Job) string {
 		labelVal = jobResult.Host
 	}
 
-	return fmt.Sprintf("%s/%s/%s?orgId=1&from=%s&to=%s&timezone=browser&%s=%s", base, dashboardUid, dashboardSlug, from, to, labelKey, labelVal)
+	query := url.Values{}
+	query.Set("orgId", "1")
+	query.Set("from", from)
+	query.Set("to", to)
+	query.Set("timezone", "browser")
+	query.Set(labelKey, labelVal)
+
+	return fmt.Sprintf("%s/%s/%s?%s", base, dashboardUid, dashboardSlug, query.Encode())
 }
 
 // delete deletes a profiling job record by ID.

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/cmd/huatuo-apiserver/config"
+	"huatuo-bamai/internal/job"
+)
+
+func TestGetFlameGraphURLEscapesLabelValue(t *testing.T) {
+	cfg := config.Get()
+	oldBase := cfg.Profiling.FlameGraphBaseURL
+	cfg.Profiling.FlameGraphBaseURL = "http://grafana.example/d"
+	defer func() { cfg.Profiling.FlameGraphBaseURL = oldBase }()
+
+	url := getFlameGraphURL(&job.Job{
+		Type:      ProfilingCPU,
+		Container: "container+2026&debug",
+		StartTime: time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC),
+		EndTime:   time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC),
+	})
+
+	if !strings.Contains(url, "var-container_hostname=container%2B2026%26debug") {
+		t.Fatalf("url = %q, want escaped container label value", url)
+	}
+}

--- a/internal/profiler/document.go
+++ b/internal/profiler/document.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -206,10 +207,12 @@ func fetchProfilingMetadataContainer(serverAddress, containerID string) (*profil
 		return nil, fmt.Errorf("container lookup requires server address and container id")
 	}
 
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/containers/json?container_id=%s", serverAddress, containerID), http.NoBody)
+	endpoint := fmt.Sprintf("http://%s/containers/json", serverAddress)
+	request, err := http.NewRequest(http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
+	request.URL.RawQuery = url.Values{"container_id": {containerID}}.Encode()
 
 	client := &http.Client{Timeout: 3 * time.Second}
 	response, err := client.Do(request)

--- a/internal/profiler/document_test.go
+++ b/internal/profiler/document_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchProfilingMetadataContainerEscapesContainerID(t *testing.T) {
+	var requestURI string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"data":[{"id":"container-2026","hostname":"huatuo-dev","type":"normal","qos":"besteffort","labels":{"app":"demo"}}]}`)
+	}))
+	defer server.Close()
+
+	serverAddr := strings.TrimPrefix(server.URL, "http://")
+
+	container, err := fetchProfilingMetadataContainer(serverAddr, "container+2026&debug")
+	if err != nil {
+		t.Fatalf("fetchProfilingMetadataContainer() error = %v", err)
+	}
+	if container == nil || container.ID != "container-2026" {
+		t.Fatalf("container = %+v, want container-2026", container)
+	}
+	if !strings.Contains(requestURI, "container_id=container%2B2026%26debug") {
+		t.Fatalf("requestURI = %q, want escaped container_id", requestURI)
+	}
+}


### PR DESCRIPTION
fetchProfilingMetadataContainer manually embedded containerID in the query string. Special characters such as '+' and '&' could be interpreted as query syntax instead of being preserved as a single container_id value.

Use url.Values.Encode to build the query string safely.