### PR TITLE
fix/feat: address io counter race, device list regex and ES TLS config

### DIFF
--- a/bpf/iotracing.c
+++ b/bpf/iotracing.c
@@ -108,6 +108,15 @@ struct {
 	__uint(value_size, sizeof(u64));
 } request_struct_map SEC(".maps");
 
+static __always_inline void add_u64_counter(u64 *counter, u64 value,
+					    int is_map_entry)
+{
+	if (is_map_entry)
+		__sync_fetch_and_add(counter, value);
+	else
+		*counter += value;
+}
+
 #define REQ_OP_BITS 8
 #define REQ_OP_MASK ((1 << REQ_OP_BITS) - 1)
 #define REQ_META (1ULL << __REQ_META)
@@ -248,6 +257,7 @@ int bpf_rq_qos_done(struct pt_regs *ctx)
 	u32 cmd_flags;
 	int partno;
 	int devn[2];
+	int is_map_entry;
 	u64 now;
 	u64 q2c;
 	u64 d2c;
@@ -275,14 +285,17 @@ int bpf_rq_qos_done(struct pt_regs *ctx)
 		io_key.pid = info->pid;
 
 	entry = bpf_map_lookup_elem(&io_source_map, &io_key);
+	is_map_entry = entry != NULL;
 	if (!entry)
 		entry = &data;
 
 	cmd_flags = BPF_CORE_READ(req, cmd_flags);
 	if (is_write_request(cmd_flags)) {
-		entry->block_write_bytes += info->data_len;
+		add_u64_counter(&entry->block_write_bytes, info->data_len,
+				is_map_entry);
 	} else if ((cmd_flags & REQ_OP_MASK) == REQ_OP_READ) {
-		entry->block_read_bytes += info->data_len;
+		add_u64_counter(&entry->block_read_bytes, info->data_len,
+				is_map_entry);
 	} else {
 		bpf_map_delete_elem(&start_info_map, &info_key);
 		return 0;
@@ -292,13 +305,13 @@ int bpf_rq_qos_done(struct pt_regs *ctx)
 	q2c = now - BPF_CORE_READ(req, start_time_ns);
 	d2c = now - BPF_CORE_READ(req, io_start_time_ns);
 
-	entry->latency.sum_q2c += q2c;
-	entry->latency.sum_d2c += d2c;
+	add_u64_counter(&entry->latency.sum_q2c, q2c, is_map_entry);
+	add_u64_counter(&entry->latency.sum_d2c, d2c, is_map_entry);
 	if (q2c > entry->latency.max_q2c)
 		entry->latency.max_q2c = q2c;
 	if (d2c > entry->latency.max_d2c)
 		entry->latency.max_d2c = d2c;
-	entry->latency.cnt++;
+	add_u64_counter(&entry->latency.cnt, 1, is_map_entry);
 
 	if (entry == &data) {
 		entry->blkcg_gq = (u64)info->bi_blkg;
@@ -359,6 +372,7 @@ static __always_inline int bpf_file_read_write(struct pt_regs *ctx)
 	struct iov_iter *from;
 	size_t count;
 	unsigned int type;
+	int is_map_entry;
 
 	inode	  = BPF_CORE_READ(iocb, ki_filp, f_inode);
 	key.inode = BPF_CORE_READ(inode, i_ino);
@@ -368,6 +382,7 @@ static __always_inline int bpf_file_read_write(struct pt_regs *ctx)
 		return 0;
 
 	entry = bpf_map_lookup_elem(&io_source_map, &key);
+	is_map_entry = entry != NULL;
 	if (!entry)
 		entry = &data;
 
@@ -403,9 +418,9 @@ static __always_inline int bpf_file_read_write(struct pt_regs *ctx)
 
 	type = type & 0x1;
 	if (type) /* 0: read, 1: write */
-		entry->fs_write_bytes += count;
+		add_u64_counter(&entry->fs_write_bytes, count, is_map_entry);
 	else
-		entry->fs_read_bytes += count;
+		add_u64_counter(&entry->fs_read_bytes, count, is_map_entry);
 
 	entry->flag = BPF_CORE_READ(iocb, ki_flags);
 	if (entry == &data)
@@ -435,6 +450,7 @@ static __always_inline int bpf_filemap_page_mkwrite(struct pt_regs *ctx)
 	struct io_data data	   = {};
 	struct io_key key	   = {};
 	struct inode *inode;
+	int is_map_entry;
 
 	inode	  = BPF_CORE_READ(vma, vm_file, f_inode);
 	key.inode = BPF_CORE_READ(inode, i_ino);
@@ -444,6 +460,7 @@ static __always_inline int bpf_filemap_page_mkwrite(struct pt_regs *ctx)
 		return 0;
 
 	entry = bpf_map_lookup_elem(&io_source_map, &key);
+	is_map_entry = entry != NULL;
 	if (!entry)
 		entry = &data;
 
@@ -458,7 +475,7 @@ static __always_inline int bpf_filemap_page_mkwrite(struct pt_regs *ctx)
 		entry->inode = key.inode;
 	}
 
-	entry->fs_write_bytes += PAGE_SIZE;
+	add_u64_counter(&entry->fs_write_bytes, PAGE_SIZE, is_map_entry);
 	if (entry == &data)
 		bpf_map_update_elem(&io_source_map, &key, &data,
 				    COMPAT_BPF_ANY);
@@ -480,6 +497,7 @@ int bpf_filemap_fault(struct pt_regs *ctx)
 	struct io_data data	   = {};
 	struct io_key key	   = {};
 	struct inode *inode;
+	int is_map_entry;
 
 	inode	  = BPF_CORE_READ(vma, vm_file, f_inode);
 	key.inode = BPF_CORE_READ(inode, i_ino);
@@ -489,6 +507,7 @@ int bpf_filemap_fault(struct pt_regs *ctx)
 		return 0;
 
 	entry = bpf_map_lookup_elem(&io_source_map, &key);
+	is_map_entry = entry != NULL;
 	if (!entry)
 		entry = &data;
 
@@ -502,7 +521,7 @@ int bpf_filemap_fault(struct pt_regs *ctx)
 		entry->dev   = key.dev;
 		entry->inode = key.inode;
 	}
-	entry->fs_read_bytes += PAGE_SIZE;
+	add_u64_counter(&entry->fs_read_bytes, PAGE_SIZE, is_map_entry);
 
 	if (entry == &data)
 		bpf_map_update_elem(&io_source_map, &key, &data,

--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -45,6 +45,10 @@ type BamaiConfig struct {
 			Address            string `default:"http://127.0.0.1:9200"`
 			Username, Password string
 			Index              string `default:"huatuo_bamai"`
+			CAFile             string
+			CertFile           string
+			KeyFile            string
+			InsecureSkipVerify bool `default:"true"`
 		}
 
 		LocalFile struct {

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -49,6 +49,12 @@ IssuesList = [["net_rx_latency", "kernel_sched_tick"]]
 [EventTracing.NetRxLatency]
 ExcludedContainerQos = ["bestEffort"]
 
+[Storage.ES]
+CAFile = "/etc/huatuo/es-ca.crt"
+CertFile = "/etc/huatuo/es-client.crt"
+KeyFile = "/etc/huatuo/es-client.key"
+InsecureSkipVerify = false
+
 [MetricCollector.Vmstat]
 IncludedOnHost = "pgscan_direct"
 ExcludedOnHost = "total"
@@ -83,6 +89,18 @@ ExcludedOnContainer = "writeback"
 	}
 	if len(Get().EventTracing.NetRxLatency.ExcludedContainerQos) != 1 {
 		t.Errorf("unexpected ExcludedContainerQos length: %d", len(Get().EventTracing.NetRxLatency.ExcludedContainerQos))
+	}
+	if Get().Storage.ES.CAFile != "/etc/huatuo/es-ca.crt" {
+		t.Errorf("unexpected Storage.ES.CAFile: %q", Get().Storage.ES.CAFile)
+	}
+	if Get().Storage.ES.CertFile != "/etc/huatuo/es-client.crt" {
+		t.Errorf("unexpected Storage.ES.CertFile: %q", Get().Storage.ES.CertFile)
+	}
+	if Get().Storage.ES.KeyFile != "/etc/huatuo/es-client.key" {
+		t.Errorf("unexpected Storage.ES.KeyFile: %q", Get().Storage.ES.KeyFile)
+	}
+	if Get().Storage.ES.InsecureSkipVerify {
+		t.Error("Storage.ES.InsecureSkipVerify should be false")
 	}
 }
 

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -43,11 +43,15 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 		cfg.Storage.ES.Username != "" &&
 		cfg.Storage.ES.Password != "" {
 		store, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
-			Driver:      "elasticsearch",
-			ESAddresses: splitStorageAddresses(cfg.Storage.ES.Address),
-			ESUsername:  cfg.Storage.ES.Username,
-			ESPassword:  cfg.Storage.ES.Password,
-			ESIndex:     cfg.Storage.ES.Index,
+			Driver:               "elasticsearch",
+			ESAddresses:          splitStorageAddresses(cfg.Storage.ES.Address),
+			ESUsername:           cfg.Storage.ES.Username,
+			ESPassword:           cfg.Storage.ES.Password,
+			ESIndex:              cfg.Storage.ES.Index,
+			ESCAFile:             cfg.Storage.ES.CAFile,
+			ESCertFile:           cfg.Storage.ES.CertFile,
+			ESKeyFile:            cfg.Storage.ES.KeyFile,
+			ESInsecureSkipVerify: &cfg.Storage.ES.InsecureSkipVerify,
 		}, tracing.DocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("new tracing document store (elasticsearch): %w", err)

--- a/core/events/netdev_events.go
+++ b/core/events/netdev_events.go
@@ -17,12 +17,12 @@ package events
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
 	"huatuo-bamai/internal/linkstatus"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 
@@ -148,10 +148,14 @@ func (netdev *netdevTracing) checkAndInitLinkStatus() error {
 	}
 	defer eth.Close()
 
+	deviceMatcher, err := matcher.NewValueListMatcher(cfg.Netdev.DeviceList)
+	if err != nil {
+		return err
+	}
+
 	for _, link := range links {
 		ifname := link.Attrs().Name
-		if !slices.Contains(cfg.Netdev.DeviceList,
-			ifname) {
+		if !deviceMatcher.Match(ifname) {
 			continue
 		}
 

--- a/core/metrics/netdev_dcb.go
+++ b/core/metrics/netdev_dcb.go
@@ -17,10 +17,12 @@ package collector
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"syscall"
 	"unsafe"
 
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 
@@ -124,7 +126,22 @@ func parseAttributes(attrs []syscall.NetlinkRouteAttr) (*ieeePfc, error) {
 func (dcb *dcbCollector) Update() ([]*metric.Data, error) {
 	data := []*metric.Data{}
 
-	for _, ifname := range cfg.NetdevDCB.DeviceList {
+	deviceMatcher, err := matcher.NewValueListMatcher(cfg.NetdevDCB.DeviceList)
+	if err != nil {
+		return nil, err
+	}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, iface := range ifaces {
+		ifname := iface.Name
+		if !deviceMatcher.Match(ifname) {
+			continue
+		}
+
 		msgs, err := doDcbRequest(ifname)
 		if err != nil {
 			if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENODEV) {

--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -27,6 +27,7 @@ import (
 
 	"huatuo-bamai/internal/bpf"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/procfs/sysfs"
 	"huatuo-bamai/internal/utils/parseutil"
 	"huatuo-bamai/pkg/metric"
@@ -63,6 +64,11 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 		return nil, err
 	}
 
+	deviceMatcher, err := matcher.NewValueListMatcher(cfg.NetdevHW.DeviceList)
+	if err != nil {
+		return nil, err
+	}
+
 	ifaceList := make(map[string]*ethtool.DrvInfo)
 	ifaceSwCounter := make(map[string]uint64)
 
@@ -74,7 +80,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 		}
 
 		// skip processing if the interface is not in the whitelist or the driver is not allowed
-		if !slices.Contains(cfg.NetdevHW.DeviceList, iface) ||
+		if !deviceMatcher.Match(iface) ||
 			!slices.Contains(deviceDriverList, drv.Driver) {
 			log.Debugf("%s is skipped (not in whitelist or driver not allowed)", iface)
 			continue

--- a/docs/best-practice/storage_en.md
+++ b/docs/best-practice/storage_en.md
@@ -110,6 +110,10 @@ Add the following configuration to `huatuo-bamai.conf`. The default username and
 [Storage.ES]
     Address = "https://127.0.0.1:9200"
     Index = "huatuo_bamai"
+    # CAFile = "/path/to/ca.crt"
+    # CertFile = "/path/to/client.crt"
+    # KeyFile = "/path/to/client.key"
+    # InsecureSkipVerify = false
     Username = "admin"
     Password = "admin"
 ```
@@ -234,6 +238,10 @@ Add the following configuration to `huatuo-bamai.conf`. The default username for
 [Storage.ES]
     Address = "https://127.0.0.1:9200"
     Index = "huatuo_bamai"
+    # CAFile = "/path/to/ca.crt"
+    # CertFile = "/path/to/client.crt"
+    # KeyFile = "/path/to/client.key"
+    # InsecureSkipVerify = false
     Username = "elastic"
     Password = "123456"
 ```

--- a/docs/best-practice/storage_zh.md
+++ b/docs/best-practice/storage_zh.md
@@ -110,6 +110,10 @@ docker logs opensearch
 [Storage.ES]
     Address = "https://127.0.0.1:9200"
     Index = "huatuo_bamai"
+    # CAFile = "/path/to/ca.crt"
+    # CertFile = "/path/to/client.crt"
+    # KeyFile = "/path/to/client.key"
+    # InsecureSkipVerify = false
     Username = "admin"
     Password = "admin"
 ```
@@ -233,6 +237,10 @@ curl -k -u elastic:123456 https://localhost:9200
 [Storage.ES]
     Address = "https://127.0.0.1:9200"
     Index = "huatuo_bamai"
+    # CAFile = "/path/to/ca.crt"
+    # CertFile = "/path/to/client.crt"
+    # KeyFile = "/path/to/client.key"
+    # InsecureSkipVerify = false
     Username = "elastic"
     Password = "123456"
 ```

--- a/docs/configuration_en.md
+++ b/docs/configuration_en.md
@@ -133,9 +133,27 @@ BlackList = ["netdev_hw", "metax_gpu"]
     # - Password
     # There is no default username and password.
     #
+    # - CAFile
+    # CA certificate file for verifying HTTPS Elasticsearch/OpenSearch servers.
+    # Empty means using system roots only.
+    #
+    # - CertFile
+    # - KeyFile
+    # Client certificate and private key files for mutual TLS.
+    # Configure them together or leave both empty.
+    #
+    # - InsecureSkipVerify
+    # Keep true to preserve the historical behavior with self-signed servers.
+    # Set false when CAFile or system roots can verify the server certificate.
+    # Default: true
+    #
     [Storage.ES]
         # Address = "http://127.0.0.1:9200"
         # Index = "huatuo_bamai"
+        # CAFile = ""
+        # CertFile = ""
+        # KeyFile = ""
+        # InsecureSkipVerify = true
         Username = "elastic"
         Password = "huatuo-bamai"
 ```
@@ -163,6 +181,18 @@ BlackList = ["netdev_hw", "metax_gpu"]
   No default value (example uses huatuo-bamai).
 
   **Description**: Used together with the username. In production, use a strong password and enable TLS encryption.
+
+- **CAFile**: CA certificate file used to verify HTTPS Elasticsearch/OpenSearch servers.
+
+  Default: empty, which means the client uses system root certificates only.
+
+- **CertFile** and **KeyFile**: Client certificate and private key files for mutual TLS.
+
+  Configure both fields together, or leave both empty.
+
+- **InsecureSkipVerify**: Whether to skip server certificate verification.
+
+  Default: true, preserving the previous behavior for existing self-signed deployments. Set it to false when CAFile or system roots can verify the server certificate.
 
 **Overall**: ES/OS storage persists kernel tracing and event data for later search and analysis.
 

--- a/docs/configuration_en.md
+++ b/docs/configuration_en.md
@@ -739,16 +739,16 @@ This section is responsible for capturing key kernel events and monitoring laten
 # Monitor network device events.
 #
 # - DeviceList
-# The net devices we monitor.
+# Regex list of net devices we monitor. Each pattern must match the full device name.
 # Default: [] (empty, meaning no devices).
 #
 [EventTracing.Netdev]
-	DeviceList = ["eth0", "eth1", "bond4", "lo"]
+	DeviceList = ["eth[0-9]+", "bond[0-9]+", "lo"]
 ```
 
-- **DeviceList**: List of network devices to monitor.
+- **DeviceList**: Regex list of network devices to monitor.
 
-  Default example includes "eth0", "eth1", "bond4", "lo". An empty list means no devices are monitored.
+  Each item must match the full device name. Exact names such as "eth0" still work; patterns such as "eth[0-9]+" can match a group of devices. An empty list means no devices are monitored.
 
   **Description**: Monitors physical link status events for specified network interfaces.
 
@@ -863,16 +863,16 @@ This section defines collection rules for various system and network metrics. Al
 # Collecting the DCB PFC (Priority-based Flow Control).
 #
 # - DeviceList
-# The net devices we monitor.
+# Regex list of net devices we monitor. Each pattern must match the full device name.
 # Default: [] (empty, meaning no devices).
 #
 [MetricCollector.NetdevDCB]
-	DeviceList = ["eth0", "eth1"]
+	DeviceList = ["eth[0-9]+"]
 ```
 
-- **DeviceList**: List of network devices for which DCB (Data Center Bridging) PFC information is collected.
+- **DeviceList**: Regex list of network devices for which DCB (Data Center Bridging) PFC information is collected.
 
-  Default: empty.
+  Each item must match the full device name. Exact names such as "eth0" still work; patterns such as "eth[0-9]+" can match a group of devices. Default: empty.
 
 #### 8.3 Netdev Hardware Statistics
 
@@ -882,16 +882,16 @@ This section defines collection rules for various system and network metrics. Al
 # Collecting the hardware statistic of net devices, e.g, rx_dropped.
 #
 # - DeviceList
-# The net devices we monitor.
+# Regex list of net devices we monitor. Each pattern must match the full device name.
 # Default: [] (empty, meaning no devices).
 #
 [MetricCollector.NetdevHW]
-	DeviceList = ["eth0", "eth1"]
+	DeviceList = ["eth[0-9]+"]
 ```
 
-- **DeviceList**: List of network devices for hardware-level statistics (e.g., rx_dropped).
+- **DeviceList**: Regex list of network devices for hardware-level statistics (e.g., rx_dropped).
 
-  Default: empty.
+  Each item must match the full device name. Exact names such as "eth0" still work; patterns such as "eth[0-9]+" can match a group of devices. Default: empty.
 
 #### 8.4 Qdisc Collection
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -738,16 +738,16 @@ IssuesList = []
 # monitor the net device events.
 #
 # - DeviceList
-# The net devices we take care of.
+# Regex list of net devices we take care of. Each pattern must match the full device name.
 # Default: [] is empty, meaning no devices.
 #
 [EventTracing.Netdev]
-	DeviceList = ["eth0", "eth1", "bond4", "lo"]
+	DeviceList = ["eth[0-9]+", "bond[0-9]+", "lo"]
 ```
 
-- **DeviceList**：需要监控的网卡设备列表。
+- **DeviceList**：需要监控的网卡设备正则列表。
 
-  默认示例包含 "eth0", "eth1", "bond4", "lo"。 为空列表时表示不监控任何设备。 监控网络设备的物理链路状态事件等。
+  每一项都需要完整匹配网卡名。写成 "eth0" 时仍然只匹配 eth0，写成 "eth[0-9]+" 时可以匹配一组 eth 网卡。为空列表时表示不监控任何设备。
 
   **说明**：精确指定感兴趣的网络接口，支持 bond、lo 等。
 
@@ -864,16 +864,16 @@ IssuesList = []
 # Collecting the DCB PFC (Priority-based Flow Control).
 #
 # - DeviceList
-# The net devices we take care of.
+# Regex list of net devices we take care of. Each pattern must match the full device name.
 # Default: [] is empty, meaning no devices.
 #
 [MetricCollector.NetdevDCB]
-	DeviceList = ["eth0", "eth1"]
+	DeviceList = ["eth[0-9]+"]
 ```
 
-- **DeviceList**：需要采集 DCB（优先流控 PFC）信息的网卡列表。
+- **DeviceList**：需要采集 DCB（优先流控 PFC）信息的网卡正则列表。
 
-  默认空。 
+  每一项都需要完整匹配网卡名。写成 "eth0" 时仍然只匹配 eth0，写成 "eth[0-9]+" 时可以匹配一组 eth 网卡。默认空。
 
   **说明**：主要用于数据中心网络环境下的优先级流控监控。
 
@@ -885,16 +885,16 @@ IssuesList = []
 # Collecting the hardware statistic of net devices, e.g, rx_dropped.
 #
 # - DeviceList
-# The net devices we take care of.
+# Regex list of net devices we take care of. Each pattern must match the full device name.
 # Default: [] is empty, meaning no devices.
 #
 [MetricCollector.NetdevHW]
-	DeviceList = ["eth0", "eth1"]
+	DeviceList = ["eth[0-9]+"]
 ```
 
-- **DeviceList**：需要采集硬件层统计（如 rx_dropped）的网卡列表。
+- **DeviceList**：需要采集硬件层统计（如 rx_dropped）的网卡正则列表。
 
-  默认空。 
+  每一项都需要完整匹配网卡名。写成 "eth0" 时仍然只匹配 eth0，写成 "eth[0-9]+" 时可以匹配一组 eth 网卡。默认空。
 
   **说明**：聚焦硬件丢包、错误等底层指标。
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -132,9 +132,27 @@ BlackList = ["netdev_hw", "metax_gpu"]
     # - Password
     # There is no default username and password.
     #
+    # - CAFile
+    # CA certificate file for verifying HTTPS Elasticsearch/OpenSearch servers.
+    # Empty means using system roots only.
+    #
+    # - CertFile
+    # - KeyFile
+    # Client certificate and private key files for mutual TLS.
+    # Configure them together or leave both empty.
+    #
+    # - InsecureSkipVerify
+    # Keep true to preserve the historical behavior with self-signed servers.
+    # Set false when CAFile or system roots can verify the server certificate.
+    # Default: true
+    #
     [Storage.ES]
         # Address = "http://127.0.0.1:9200"
         # Index = "huatuo_bamai"
+        # CAFile = ""
+        # CertFile = ""
+        # KeyFile = ""
+        # InsecureSkipVerify = true
         Username = "elastic"
         Password = "huatuo-bamai"
 ```
@@ -162,6 +180,18 @@ BlackList = ["netdev_hw", "metax_gpu"]
   无默认值（示例中使用 huatuo-bamai）。
 
   **说明**：配合用户名进行安全认证。生产环境强烈建议使用强密码并结合 TLS 加密传输。
+
+- **CAFile**：用于校验 HTTPS ElasticSearch/OpenSearch 服务端证书的 CA 证书文件。
+
+  默认空，表示只使用系统根证书。
+
+- **CertFile** 和 **KeyFile**：用于双向 TLS 的客户端证书和私钥文件。
+
+  两个字段需要同时配置，或者都保持为空。
+
+- **InsecureSkipVerify**：是否跳过服务端证书校验。
+
+  默认 true，用于兼容以前自签名证书也能连接的行为。当 `CAFile` 或系统根证书可以校验服务端证书时，建议设置为 false。
 
 **整体说明**：ES/OS 存储用于持久化内核追踪和事件数据，便于后续检索与分析。如果用户不关心 Linux 内核事件、Autotracing 数据则可以关闭该配置。
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -62,9 +62,27 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # - Password
     # There is no default username and password.
     #
+    # - CAFile
+    # CA certificate file for verifying HTTPS Elasticsearch/OpenSearch servers.
+    # Empty means using system roots only.
+    #
+    # - CertFile
+    # - KeyFile
+    # Client certificate and private key files for mutual TLS.
+    # Configure them together or leave both empty.
+    #
+    # - InsecureSkipVerify
+    # Keep true to preserve the historical behavior with self-signed servers.
+    # Set false when CAFile or system roots can verify the server certificate.
+    # Default: true
+    #
     [Storage.ES]
         # Address = "http://127.0.0.1:9200"
         # Index = "huatuo_bamai"
+        # CAFile = ""
+        # CertFile = ""
+        # KeyFile = ""
+        # InsecureSkipVerify = true
         Username = "elastic"
         Password = "huatuo-bamai"
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -409,11 +409,11 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # monitor the net device events.
     #
     # - DeviceList
-    # The net devices we take care of.
+    # Regex list of net devices we take care of. Each pattern must match the full device name.
     # Default: [] is empty, meaning no devices.
     #
     [EventTracing.Netdev]
-        DeviceList = ["eth0", "eth1", "bond4", "lo"]
+        DeviceList = ["eth[0-9]+", "bond[0-9]+", "lo"]
 
     # dropwatch
     #
@@ -493,22 +493,22 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # Collecting the DCB PFC (Priority-based Flow Control).
     #
     # - DeviceList
-    # The net devices we take care of.
+    # Regex list of net devices we take care of. Each pattern must match the full device name.
     # Default: [] is empty, meaning no devices.
     #
     [MetricCollector.NetdevDCB]
-        DeviceList = ["eth0", "eth1"]
+        DeviceList = ["eth[0-9]+"]
 
     # netdev hardware statistic
     #
     # Collecting the hardware statistic of net devices, e.g, rx_dropped.
     #
     # - DeviceList
-    # The net devices we take care of.
+    # Regex list of net devices we take care of. Each pattern must match the full device name.
     # Default: [] is empty, meaning no devices.
     #
     [MetricCollector.NetdevHW]
-        DeviceList = ["eth0", "eth1"]
+        DeviceList = ["eth[0-9]+"]
 
     # Qdisc
     #

--- a/internal/bpf/bpf_default_test.go
+++ b/internal/bpf/bpf_default_test.go
@@ -46,9 +46,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestManager_InitAndClose(t *testing.T) {
+	requireBPFPermission(t)
+
 	// Just verify they don't panic.
 	if err := NewManager(nil); err != nil {
-		// It might fail on non-Linux or without permissions.
 		t.Fatalf("InitBpfManager returned: %v", err)
 	} else {
 		Close()

--- a/internal/matcher/value_list_matcher.go
+++ b/internal/matcher/value_list_matcher.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type valueListRule struct {
+	re *regexp.Regexp
+}
+
+// ValueListMatcher matches a string against any configured regex pattern.
+// A pattern must match the complete value, so "eth0" keeps exact-list behavior
+// while "eth.*" can be used to match multiple device names.
+type ValueListMatcher struct {
+	rules []valueListRule
+}
+
+func NewValueListMatcher(patterns []string) (*ValueListMatcher, error) {
+	rules := make([]valueListRule, 0, len(patterns))
+	for i, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pattern at index %d %q: %w", i, pattern, err)
+		}
+
+		rules = append(rules, valueListRule{re: re})
+	}
+
+	return &ValueListMatcher{rules: rules}, nil
+}
+
+func (m *ValueListMatcher) Match(value string) bool {
+	if m == nil {
+		return false
+	}
+
+	for _, rule := range m.rules {
+		match := rule.re.FindStringIndex(value)
+		if match != nil && match[0] == 0 && match[1] == len(value) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/matcher/value_list_matcher_test.go
+++ b/internal/matcher/value_list_matcher_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueListMatcher_EmptyListMatchesNothing(t *testing.T) {
+	m, err := NewValueListMatcher(nil)
+	require.NoError(t, err)
+
+	require.False(t, m.Match("eth0"))
+}
+
+func TestValueListMatcher_ExactDeviceName(t *testing.T) {
+	m, err := NewValueListMatcher([]string{"eth0"})
+	require.NoError(t, err)
+
+	require.True(t, m.Match("eth0"))
+	require.False(t, m.Match("veth0"))
+}
+
+func TestValueListMatcher_RegexDeviceName(t *testing.T) {
+	m, err := NewValueListMatcher([]string{"eth[0-9]+", "bond.*"})
+	require.NoError(t, err)
+
+	require.True(t, m.Match("eth0"))
+	require.True(t, m.Match("eth12"))
+	require.True(t, m.Match("bond4"))
+	require.False(t, m.Match("ens3"))
+}
+
+func TestValueListMatcher_RegexMustMatchWholeValue(t *testing.T) {
+	m, err := NewValueListMatcher([]string{"eth"})
+	require.NoError(t, err)
+
+	require.True(t, m.Match("eth"))
+	require.False(t, m.Match("eth0"))
+}
+
+func TestValueListMatcher_InvalidPattern(t *testing.T) {
+	_, err := NewValueListMatcher([]string{"eth0", "[bad"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "index 1")
+	require.Contains(t, err.Error(), "[bad")
+}

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -56,6 +56,11 @@ type Config struct {
 	ESUsername  string
 	ESPassword  string
 	ESIndex     string
+	ESCAFile    string
+	ESCertFile  string
+	ESKeyFile   string
+	// Nil keeps the backend's historical default; non-nil makes the choice explicit.
+	ESInsecureSkipVerify *bool
 }
 
 // Op is a storage query operator.

--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -16,16 +16,25 @@ package elasticsearch
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v8"
 )
 
-// defaultTransport is sized to keep TLS handshake cost off the hot path.
+type tlsOptions struct {
+	CAFile             string
+	CertFile           string
+	KeyFile            string
+	InsecureSkipVerify *bool
+}
+
+// newDefaultTransport is sized to keep TLS handshake cost off the hot path.
 // Under FIPS, each fresh handshake spends several ms on RSA-PSS verification;
 // a small idle pool turned bursty writes into per-request handshakes and
 // dominated CPU. The idle/total caps below let concurrent writers reuse
@@ -34,23 +43,64 @@ import (
 // ClientSessionCache enables TLS 1.3 PSK resumption: when the server (or an
 // intermediate proxy) silently closes an idle connection, the next handshake
 // reuses a ticket instead of doing full RSA-PSS verification.
-var defaultTransport http.RoundTripper = &http.Transport{
-	MaxIdleConns:        200,
-	MaxIdleConnsPerHost: 100,
-	MaxConnsPerHost:     200,
-	// Keep below typical server-side idle timeouts (ES/nginx/LB ~60s) so the
-	// client closes first. If the server closes a connection we still hold,
-	// the next request races into a stale conn and triggers a fresh handshake.
-	IdleConnTimeout:       50 * time.Second,
-	ResponseHeaderTimeout: 10 * time.Second,
-	DialContext: (&net.Dialer{
-		Timeout:   10 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	TLSClientConfig: &tls.Config{
-		InsecureSkipVerify: true, // #nosec G402
+func newDefaultTransport(tlsConfig *tls.Config) http.RoundTripper {
+	return &http.Transport{
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 100,
+		MaxConnsPerHost:     200,
+		// Keep below typical server-side idle timeouts (ES/nginx/LB ~60s) so the
+		// client closes first. If the server closes a connection we still hold,
+		// the next request races into a stale conn and triggers a fresh handshake.
+		IdleConnTimeout:       50 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSClientConfig: tlsConfig,
+	}
+}
+
+func newTLSConfig(opts tlsOptions) (*tls.Config, error) {
+	insecureSkipVerify := true
+	if opts.InsecureSkipVerify != nil {
+		insecureSkipVerify = *opts.InsecureSkipVerify
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: insecureSkipVerify, // #nosec G402
 		ClientSessionCache: tls.NewLRUClientSessionCache(64),
-	},
+	}
+
+	if opts.CAFile != "" {
+		rootCAs, err := x509.SystemCertPool()
+		if err != nil {
+			rootCAs = x509.NewCertPool()
+		}
+
+		caPEM, err := os.ReadFile(opts.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read elasticsearch ca file %q: %w", opts.CAFile, err)
+		}
+		if ok := rootCAs.AppendCertsFromPEM(caPEM); !ok {
+			return nil, fmt.Errorf("load elasticsearch ca file %q: no certificate found", opts.CAFile)
+		}
+		tlsConfig.RootCAs = rootCAs
+	}
+
+	if opts.CertFile != "" || opts.KeyFile != "" {
+		if opts.CertFile == "" || opts.KeyFile == "" {
+			return nil, fmt.Errorf("elasticsearch client cert file and key file must be configured together")
+		}
+
+		cert, err := tls.LoadX509KeyPair(opts.CertFile, opts.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load elasticsearch client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
 }
 
 // productHeaderTransport injects X-Elastic-Product: Elasticsearch into
@@ -88,13 +138,25 @@ func (t *productHeaderTransport) RoundTrip(req *http.Request) (*http.Response, e
 //   - ES v7 ≥ 7.14: CompatibilityMode headers + native product header.
 //   - ES v7 < 7.14: CompatibilityMode headers + injected product header.
 //   - OpenSearch:    returns X-Elastic-Product natively; no separate client needed.
-func newCompatClient(addresses []string, username, password string) (*elasticsearch.Client, error) {
+func newCompatClient(cfg *Config) (*elasticsearch.Client, error) {
+	tlsConfig, err := newTLSConfig(tlsOptions{
+		CAFile:             cfg.CAFile,
+		CertFile:           cfg.CertFile,
+		KeyFile:            cfg.KeyFile,
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses:               addresses,
-		Username:                username,
-		Password:                password,
+		Addresses:               cfg.Addresses,
+		Username:                cfg.Username,
+		Password:                cfg.Password,
 		EnableCompatibilityMode: true,
-		Transport:               &productHeaderTransport{inner: defaultTransport},
+		Transport: &productHeaderTransport{
+			inner: newDefaultTransport(tlsConfig),
+		},
 		// Whole-batch retry: covers transport failures and 429/5xx returned for
 		// the entire bulk request. Per-item failures inside a 200 response are
 		// surfaced through BulkIndexerItem.OnFailure instead.

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -50,10 +50,14 @@ const (
 
 // Config contains Elasticsearch backend settings.
 type Config struct {
-	Addresses []string
-	Username  string
-	Password  string
-	Index     string
+	Addresses          []string
+	Username           string
+	Password           string
+	Index              string
+	CAFile             string
+	CertFile           string
+	KeyFile            string
+	InsecureSkipVerify *bool
 }
 
 // Storage stores records in Elasticsearch, OpenSearch, or any compatible backend.
@@ -74,10 +78,14 @@ var _ driver.Backend = (*Storage)(nil)
 func init() {
 	factory := func(cfg *driver.Config) (driver.Backend, error) {
 		return NewBackend(&Config{
-			Addresses: cfg.ESAddresses,
-			Username:  cfg.ESUsername,
-			Password:  cfg.ESPassword,
-			Index:     cfg.ESIndex,
+			Addresses:          cfg.ESAddresses,
+			Username:           cfg.ESUsername,
+			Password:           cfg.ESPassword,
+			Index:              cfg.ESIndex,
+			CAFile:             cfg.ESCAFile,
+			CertFile:           cfg.ESCertFile,
+			KeyFile:            cfg.ESKeyFile,
+			InsecureSkipVerify: cfg.ESInsecureSkipVerify,
 		})
 	}
 	driver.RegisterBackend("elasticsearch", factory)
@@ -90,7 +98,7 @@ func NewBackend(cfg *Config) (*Storage, error) {
 	if prefix == "" {
 		prefix = defaultIndex
 	}
-	client, err := newCompatClient(cfg.Addresses, cfg.Username, cfg.Password)
+	client, err := newCompatClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -16,11 +16,20 @@ package elasticsearch
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -697,6 +706,65 @@ func newBackendForTest(t *testing.T, server *mockElasticsearchServer) *Storage {
 	return backend
 }
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func writeTestCertificatePair(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey() returned error: %v", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("rand.Int() returned error: %v", err)
+	}
+
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "huatuo-test-client",
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("x509.CreateCertificate() returned error: %v", err)
+	}
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "client.crt")
+	keyFile := filepath.Join(dir, "client.key")
+
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0o600); err != nil {
+		t.Fatalf("write client certificate: %v", err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}), 0o600); err != nil {
+		t.Fatalf("write client key: %v", err)
+	}
+
+	return certFile, keyFile
+}
+
+func writeCertificateFile(t *testing.T, name string, cert *x509.Certificate) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}), 0o600); err != nil {
+		t.Fatalf("write certificate file: %v", err)
+	}
+	return path
+}
+
 // flushBackend forces the bulk indexer to drain pending items. Save buffers
 // asynchronously, so tests must flush before issuing a read that depends on a
 // just-saved record. After flushing the indexer is closed; tests that need to
@@ -705,6 +773,92 @@ func flushBackend(t *testing.T, backend *Storage) {
 	t.Helper()
 	if err := backend.Close(t.Context()); err != nil {
 		t.Fatalf("flush bulk: %v", err)
+	}
+}
+
+func TestNewTLSConfig_DefaultPreservesInsecureSkipVerify(t *testing.T) {
+	cfg, err := newTLSConfig(tlsOptions{})
+	if err != nil {
+		t.Fatalf("newTLSConfig() returned error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("newTLSConfig() returned nil config")
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify = false, want true for historical default")
+	}
+	if cfg.ClientSessionCache == nil {
+		t.Error("ClientSessionCache = nil, want session cache")
+	}
+}
+
+func TestNewTLSConfig_CanDisableInsecureSkipVerify(t *testing.T) {
+	cfg, err := newTLSConfig(tlsOptions{InsecureSkipVerify: boolPtr(false)})
+	if err != nil {
+		t.Fatalf("newTLSConfig() returned error: %v", err)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify = true, want false")
+	}
+}
+
+func TestNewTLSConfig_ClientCertRequiresKeyPair(t *testing.T) {
+	certFile, _ := writeTestCertificatePair(t)
+
+	_, err := newTLSConfig(tlsOptions{CertFile: certFile})
+	if err == nil {
+		t.Fatal("newTLSConfig() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "configured together") {
+		t.Errorf("error = %q, want configured together", err.Error())
+	}
+}
+
+func TestNewTLSConfig_LoadsClientCertificate(t *testing.T) {
+	certFile, keyFile := writeTestCertificatePair(t)
+
+	cfg, err := newTLSConfig(tlsOptions{
+		CertFile: certFile,
+		KeyFile:  keyFile,
+	})
+	if err != nil {
+		t.Fatalf("newTLSConfig() returned error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("Certificates length = %d, want 1", len(cfg.Certificates))
+	}
+}
+
+func TestNewCompatClient_WithCAAndClientCertFiles(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"mock-es","version":{"number":"8.17.0"}}`))
+	})
+
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{
+		ClientAuth: tls.RequireAnyClientCert,
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	caFile := writeCertificateFile(t, "server-ca.crt", server.Certificate())
+	certFile, keyFile := writeTestCertificatePair(t)
+
+	client, err := newCompatClient(&Config{
+		Addresses:          []string{server.URL},
+		CAFile:             caFile,
+		CertFile:           certFile,
+		KeyFile:            keyFile,
+		InsecureSkipVerify: boolPtr(false),
+	})
+	if err != nil {
+		t.Fatalf("newCompatClient() returned error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("newCompatClient() returned nil client")
 	}
 }
 


### PR DESCRIPTION
This PR addresses three issues（issue#6,#11,#15):

1. Fix io_source_map counter races by using atomic add for shared map entries.
2. Add regex matching support for DeviceList configuration.
3. Add TLS certificate configuration support for Elasticsearch/OpenSearch storage.

Tested:
- build/clang.sh -I bpf/include -s bpf/iotracing.c -o /tmp/huatuo-iotracing-test.o
- go generate ./cmd/iotracing
- go test ./cmd/iotracing
- go test -v ./internal/bpf
- go test -v ./internal/matcher ./core/metrics ./core/events
- go test -v ./internal/storage/elasticsearch ./internal/storage/driver ./cmd/huatuo-bamai/config ./cmd/huatuo-bamai
- make bpf-build
- go test ./...
- make unit
- git diff --check

Note:
- make test enters E2E tests and requires a Kubernetes node environment with kubelet client certificates under /etc/kubernetes/pki, so it was not used as the final validation command in my local environment.