### PR TITLE
fix: metrics scraping time maybe timeout on 10s, especially when there are many containers

### DIFF
--- a/core/metrics/net_arp.go
+++ b/core/metrics/net_arp.go
@@ -15,15 +15,38 @@
 package collector
 
 import (
+	"context"
 	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
 
+	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/pod"
 	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/internal/utils/timeutil"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 )
 
-type arpCollector struct{}
+const arpCacheInterval = 60 * time.Second
+
+type arpContainerRaw struct {
+	container *pod.Container
+	entries   int64
+}
+
+type arpHostRaw struct {
+	entries      int64
+	cacheEntries uint64
+}
+
+type arpCollector struct {
+	mu           sync.RWMutex
+	arpCtrCache  []arpContainerRaw
+	arpHostCache *arpHostRaw
+	running      atomic.Bool
+}
 
 func init() {
 	tracing.RegisterEventTracing("arp", newArp)
@@ -32,49 +55,81 @@ func init() {
 func newArp() (*tracing.EventTracingAttr, error) {
 	return &tracing.EventTracingAttr{
 		TracingData: &arpCollector{},
-		Flag:        tracing.FlagMetric,
+		Interval:    10,
+		Flag:        tracing.FlagTracing | tracing.FlagMetric,
 	}, nil
 }
 
-func nodeArpCacheEntries() ([]*metric.Data, error) {
-	count, err := CountLines(procfs.Path("1/net/arp"))
-	if err != nil {
-		return nil, err
-	}
+func (c *arpCollector) Start(ctx context.Context) error {
+	c.running.Store(true)
+	defer c.running.Store(false)
 
-	cache, err := procfs.NetArpCache()
-	if err != nil {
-		return nil, err
-	}
-
-	return []*metric.Data{
-		metric.NewGaugeData("entries", float64(count-1), "host init namespace", nil),
-		metric.NewGaugeData("total", float64(cache.Stats["entries"]), "all entries in arp_cache for containers and host netns", nil),
-	}, nil
+	timeutil.RunEvery(ctx, arpCacheInterval, c.readAndCache)
+	return nil
 }
 
 func (c *arpCollector) Update() ([]*metric.Data, error) {
-	var data []*metric.Data
-
-	containers, err := pod.NormalContainers()
-	if err != nil {
-		return nil, err
+	if !c.running.Load() {
+		return nil, nil
 	}
 
+	c.mu.RLock()
+	arpCtrCache := c.arpCtrCache
+	arpHostCache := c.arpHostCache
+	c.mu.RUnlock()
+
+	return buildArpMetrics(arpCtrCache, arpHostCache), nil
+}
+
+func (c *arpCollector) readAndCache() {
+	containers, err := pod.NormalContainers()
+	if err != nil {
+		log.Warnf("arp: list containers failed: %v", err)
+		return
+	}
+
+	arpCtrCache := make([]arpContainerRaw, 0, len(containers))
 	for _, container := range containers {
 		count, err := CountLines(procfs.Path(strconv.Itoa(container.InitPid), "net/arp"))
 		if err != nil {
-			// return data collected
-			return data, err
+			log.Debugf("arp metrics for container %v: %v", container, err)
+			continue
 		}
-
-		data = append(data, metric.NewContainerGaugeData(container, "entries", float64(count-1), "arp entries in container netns", nil))
+		arpCtrCache = append(arpCtrCache, arpContainerRaw{container: container, entries: count - 1})
 	}
 
-	entries, err := nodeArpCacheEntries()
-	if err != nil {
-		return data, err
+	var hostEntries int64
+	if count, err := CountLines(procfs.Path("1/net/arp")); err == nil && count > 1 {
+		hostEntries = count - 1
+	}
+	var cacheEntries uint64
+	if cache, err := procfs.NetArpCache(); err == nil {
+		cacheEntries = cache.Stats["entries"]
 	}
 
-	return append(data, entries...), nil
+	c.mu.Lock()
+	c.arpCtrCache = arpCtrCache
+	c.arpHostCache = &arpHostRaw{
+		entries:      hostEntries,
+		cacheEntries: cacheEntries,
+	}
+	c.mu.Unlock()
+}
+
+func buildArpMetrics(arpCtrCache []arpContainerRaw, arpHostCache *arpHostRaw) []*metric.Data {
+	var data []*metric.Data
+	for _, cd := range arpCtrCache {
+		data = append(data, metric.NewContainerGaugeData(cd.container, "entries",
+			float64(cd.entries), "arp entries in container netns", nil))
+	}
+	if arpHostCache != nil {
+		data = append(
+			data,
+			metric.NewGaugeData("entries", float64(arpHostCache.entries),
+				"arp entries in host init network namespace", nil),
+			metric.NewGaugeData("total", float64(arpHostCache.cacheEntries),
+				"all entries in arp_cache for containers and host netns", nil),
+		)
+	}
+	return data
 }

--- a/core/metrics/net_netstat.go
+++ b/core/metrics/net_netstat.go
@@ -19,20 +19,37 @@ package collector
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/pod"
 	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/internal/utils/timeutil"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 )
 
-type netstatCollector struct{}
+const netstatCacheInterval = 30 * time.Second
+
+// holds the raw /proc/net/(netstat|snmp) parse result for one container.
+type netstatContainerRaw struct {
+	container *pod.Container
+	stats     map[string]map[string]string
+}
+
+type netstatCollector struct {
+	mu      sync.RWMutex
+	cache   []netstatContainerRaw
+	running atomic.Bool
+}
 
 func init() {
 	tracing.RegisterEventTracing("netstat", newNetstatCollector)
@@ -41,14 +58,41 @@ func init() {
 func newNetstatCollector() (*tracing.EventTracingAttr, error) {
 	return &tracing.EventTracingAttr{
 		TracingData: &netstatCollector{},
-		Flag:        tracing.FlagMetric,
+		Interval:    10,
+		Flag:        tracing.FlagTracing | tracing.FlagMetric,
 	}, nil
 }
 
+func (c *netstatCollector) Start(ctx context.Context) error {
+	c.running.Store(true)
+	defer c.running.Store(false)
+
+	timeutil.RunEvery(ctx, netstatCacheInterval, c.readAndCache)
+	return nil
+}
+
 func (c *netstatCollector) Update() ([]*metric.Data, error) {
+	if !c.running.Load() {
+		return nil, nil
+	}
+
+	f, err := matcher.NewValueMatcher(cfg.Netstat.Included, cfg.Netstat.Excluded)
+	if err != nil {
+		return nil, fmt.Errorf("netstat filter: %w", err)
+	}
+
+	c.mu.RLock()
+	cache := c.cache
+	c.mu.RUnlock()
+
+	return buildNetstatMetrics(cache, f), nil
+}
+
+func (c *netstatCollector) readAndCache() {
 	containers, err := pod.NormalContainers()
 	if err != nil {
-		return nil, err
+		log.Warnf("netstat: list containers failed: %v", err)
+		return
 	}
 
 	// support the host metrics
@@ -59,68 +103,57 @@ func (c *netstatCollector) Update() ([]*metric.Data, error) {
 	// append init namespace into containers
 	containers[""] = nil
 
-	f, err := matcher.NewValueMatcher(cfg.Netstat.Included, cfg.Netstat.Excluded)
-	if err != nil {
-		return nil, fmt.Errorf("netstat filter: %w", err)
-	}
-
-	var metrics []*metric.Data
+	var cache []netstatContainerRaw
 	for _, container := range containers {
-		m, err := buildNetAndSnmpStat(container, f)
+		pid := container.InitPidOrInitnsPid()
+		netStats, err := parseNetStat(procfs.Path(strconv.Itoa(pid), "net", "netstat"))
 		if err != nil {
-			log.Errorf("netstat/snmp metrics for container %v: %v", container, err)
+			log.Debugf("netstat/snmp metrics for container %v: %v", container, err)
 			continue
 		}
-		metrics = append(metrics, m...)
+		snmpStats, err := parseNetStat(procfs.Path(strconv.Itoa(pid), "net", "snmp"))
+		if err != nil {
+			log.Debugf("netstat/snmp metrics for container %v: %v", container, err)
+			continue
+		}
+		for k, v := range snmpStats {
+			netStats[k] = v
+		}
+
+		cache = append(cache, netstatContainerRaw{container: container, stats: netStats})
 	}
-	log.Debugf("Updated netstat metrics by filter %v: %v", f, metrics)
-	return metrics, nil
+
+	c.mu.Lock()
+	c.cache = cache
+	c.mu.Unlock()
 }
 
-func buildNetAndSnmpStat(container *pod.Container, f *matcher.ValueMatcher) ([]*metric.Data, error) {
-	pid := container.InitPidOrInitnsPid()
-
-	netStats, err := parseNetStat(procfs.Path(strconv.Itoa(pid), "net", "netstat"))
-	if err != nil {
-		return nil, err
-	}
-
-	snmpStats, err := parseNetStat(procfs.Path(strconv.Itoa(pid), "net", "snmp"))
-	if err != nil {
-		return nil, err
-	}
-
-	// Merge the results of snmpStats into netStats (collisions are possible, but
-	// we know that the keys are always unique for the given use case).
-	for k, v := range snmpStats {
-		netStats[k] = v
-	}
-
+func buildNetstatMetrics(cache []netstatContainerRaw, f *matcher.ValueMatcher) []*metric.Data {
 	var metrics []*metric.Data
-	for protocol, protocolStats := range netStats {
-		for name, value := range protocolStats {
-			v, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				return nil, err
-			}
+	for _, entry := range cache {
+		for protocol, protocolStats := range entry.stats {
+			for name, value := range protocolStats {
+				v, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					continue
+				}
 
-			key := protocol + "_" + name
-			if !f.Match(key) {
-				log.Debugf("Ignoring netstat metric %s", key)
-				continue
-			}
+				key := protocol + "_" + name
+				if !f.Match(key) {
+					log.Debugf("Ignoring netstat metric %s", key)
+					continue
+				}
 
-			if container != nil {
-				metrics = append(metrics,
-					metric.NewContainerGaugeData(container, key, v, fmt.Sprintf("statistic %s.", protocol+name), nil))
-			} else {
-				metrics = append(metrics,
-					metric.NewGaugeData(key, v, fmt.Sprintf("statistic %s.", protocol+name), nil))
+				help := fmt.Sprintf("statistic %s_%s.", protocol, name)
+				if entry.container != nil {
+					metrics = append(metrics, metric.NewContainerGaugeData(entry.container, key, v, help, nil))
+				} else {
+					metrics = append(metrics, metric.NewGaugeData(key, v, help, nil))
+				}
 			}
 		}
 	}
-
-	return metrics, nil
+	return metrics
 }
 
 func parseNetStat(fileName string) (map[string]map[string]string, error) {
@@ -137,8 +170,14 @@ func parseNetStat(fileName string) (map[string]map[string]string, error) {
 
 	for scanner.Scan() {
 		nameParts := strings.Split(scanner.Text(), " ")
+		if len(nameParts) == 0 || nameParts[0] == "" {
+			continue
+		}
 
-		scanner.Scan()
+		if !scanner.Scan() {
+			break
+		}
+
 		valueParts := strings.Split(scanner.Text(), " ")
 
 		// remove trailing ":"

--- a/internal/utils/timeutil/ticker.go
+++ b/internal/utils/timeutil/ticker.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutil
+
+import (
+	"context"
+	"time"
+)
+
+// RunEvery calls fn on every tick of d until ctx is done.
+func RunEvery(ctx context.Context, d time.Duration, fn func()) {
+	fn()
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fn()
+		}
+	}
+}


### PR DESCRIPTION
优化指标请求耗时，后台刷新，`cat /proc/<pid>/net/arp` 不是单纯的文件读，会遍历当前 netns 的邻居表之后 copy_to_user，复杂度 O(N)，尤其大量 Pod 的时候，ARP 项可能非常大，直接 http 访问 metrics 端点，当 1c1g 情况下多指标同时刮削，goroutine 间争抢 cpu 会导致刮削时间可能超过 10s（改成 2c1g 效果有改善，但是对于一个 agent 采集端来说设置较大 cpu 和内存配额仅为了解决偶尔的超时问题认为不太可取，会压榨用户可用资源），scrape timeout 的时候，这次拉取视为失败，该周期的指标数据全部丢弃，图表上出现 gap 断点，影响连续监控，改为后台刷新，60s 对于 ARP 表项这种变化不频繁的情况应该没问题。同理，也修改 net_stat 相关指标，改为后台刷新，其他指标也有类似问题，不是最严重，后续修改
- 修复前：<img width="965" height="99" alt="image" src="https://github.com/user-attachments/assets/27579433-3691-48cc-bf81-450f4d3b01d1" />
- 修复后：<img width="956" height="98" alt="image" src="https://github.com/user-attachments/assets/f3a71e35-510d-4b84-b91f-92a4f00dd59e" />

如上，根据实际环境测试结果得出。