### PR TITLE
feat(netdev): allow regex device lists

### DIFF
--- a/core/events/netdev_events.go
+++ b/core/events/netdev_events.go
@@ -17,12 +17,12 @@ package events
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
 	"huatuo-bamai/internal/linkstatus"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 
@@ -148,10 +148,14 @@ func (netdev *netdevTracing) checkAndInitLinkStatus() error {
 	}
 	defer eth.Close()
 
+	deviceMatcher, err := matcher.NewListMatcher(cfg.Netdev.DeviceList)
+	if err != nil {
+		return fmt.Errorf("netdev device list: %w", err)
+	}
+
 	for _, link := range links {
 		ifname := link.Attrs().Name
-		if !slices.Contains(cfg.Netdev.DeviceList,
-			ifname) {
+		if !deviceMatcher.Match(ifname) {
 			continue
 		}
 

--- a/core/metrics/netdev_dcb.go
+++ b/core/metrics/netdev_dcb.go
@@ -21,6 +21,8 @@ import (
 	"syscall"
 	"unsafe"
 
+	"huatuo-bamai/internal/matcher"
+	"huatuo-bamai/internal/procfs/sysfs"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 
@@ -28,15 +30,22 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type dcbCollector struct{}
+type dcbCollector struct {
+	deviceMatcher *matcher.ListMatcher
+}
 
 func init() {
 	tracing.RegisterEventTracing("netdev_dcb", newDcb)
 }
 
 func newDcb() (*tracing.EventTracingAttr, error) {
+	deviceMatcher, err := matcher.NewListMatcher(cfg.NetdevDCB.DeviceList)
+	if err != nil {
+		return nil, fmt.Errorf("netdev dcb device list: %w", err)
+	}
+
 	return &tracing.EventTracingAttr{
-		TracingData: &dcbCollector{},
+		TracingData: &dcbCollector{deviceMatcher: deviceMatcher},
 		Flag:        tracing.FlagMetric,
 	}, nil
 }
@@ -124,7 +133,12 @@ func parseAttributes(attrs []syscall.NetlinkRouteAttr) (*ieeePfc, error) {
 func (dcb *dcbCollector) Update() ([]*metric.Data, error) {
 	data := []*metric.Data{}
 
-	for _, ifname := range cfg.NetdevDCB.DeviceList {
+	ifaces, err := sysfs.DefaultNetClassDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ifname := range dcb.deviceMatcher.Filter(ifaces) {
 		msgs, err := doDcbRequest(ifname)
 		if err != nil {
 			if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.ENODEV) {

--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -27,6 +27,7 @@ import (
 
 	"huatuo-bamai/internal/bpf"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/procfs/sysfs"
 	"huatuo-bamai/internal/utils/parseutil"
 	"huatuo-bamai/pkg/metric"
@@ -63,6 +64,11 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 		return nil, err
 	}
 
+	deviceMatcher, err := matcher.NewListMatcher(cfg.NetdevHW.DeviceList)
+	if err != nil {
+		return nil, fmt.Errorf("netdev hw device list: %w", err)
+	}
+
 	ifaceList := make(map[string]*ethtool.DrvInfo)
 	ifaceSwCounter := make(map[string]uint64)
 
@@ -74,7 +80,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 		}
 
 		// skip processing if the interface is not in the whitelist or the driver is not allowed
-		if !slices.Contains(cfg.NetdevHW.DeviceList, iface) ||
+		if !deviceMatcher.Match(iface) ||
 			!slices.Contains(deviceDriverList, drv.Driver) {
 			log.Debugf("%s is skipped (not in whitelist or driver not allowed)", iface)
 			continue

--- a/docs/configuration_en.md
+++ b/docs/configuration_en.md
@@ -716,7 +716,7 @@ This section is responsible for capturing key kernel events and monitoring laten
 	DeviceList = ["eth0", "eth1", "bond4", "lo"]
 ```
 
-- **DeviceList**: List of network devices to monitor.
+- **DeviceList**: List of network device full-match regex patterns to monitor. Literal names such as `"eth0"` keep exact-match behavior; patterns such as `"bond[0-9]+"` can select multiple devices.
 
   Default example includes "eth0", "eth1", "bond4", "lo". An empty list means no devices are monitored.
 
@@ -840,7 +840,7 @@ This section defines collection rules for various system and network metrics. Al
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**: List of network devices for which DCB (Data Center Bridging) PFC information is collected.
+- **DeviceList**: List of network device full-match regex patterns for which DCB (Data Center Bridging) PFC information is collected.
 
   Default: empty.
 
@@ -859,7 +859,7 @@ This section defines collection rules for various system and network metrics. Al
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**: List of network devices for hardware-level statistics (e.g., rx_dropped).
+- **DeviceList**: List of network device full-match regex patterns for hardware-level statistics (e.g., rx_dropped).
 
   Default: empty.
 

--- a/docs/configuration_zh.md
+++ b/docs/configuration_zh.md
@@ -715,7 +715,7 @@ IssuesList = []
 	DeviceList = ["eth0", "eth1", "bond4", "lo"]
 ```
 
-- **DeviceList**：需要监控的网卡设备列表。
+- **DeviceList**：需要监控的网卡设备完整匹配正则列表。`"eth0"` 等字面量名称保持精确匹配，`"bond[0-9]+"` 等模式可匹配多块网卡。
 
   默认示例包含 "eth0", "eth1", "bond4", "lo"。 为空列表时表示不监控任何设备。 监控网络设备的物理链路状态事件等。
 
@@ -841,7 +841,7 @@ IssuesList = []
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**：需要采集 DCB（优先流控 PFC）信息的网卡列表。
+- **DeviceList**：需要采集 DCB（优先流控 PFC）信息的网卡完整匹配正则列表。
 
   默认空。 
 
@@ -862,7 +862,7 @@ IssuesList = []
 	DeviceList = ["eth0", "eth1"]
 ```
 
-- **DeviceList**：需要采集硬件层统计（如 rx_dropped）的网卡列表。
+- **DeviceList**：需要采集硬件层统计（如 rx_dropped）的网卡完整匹配正则列表。
 
   默认空。 
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -391,7 +391,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # monitor the net device events.
     #
     # - DeviceList
-    # The net devices we take care of.
+    # Full-match regex patterns for the net devices we take care of.
+    # Literal names such as "eth0" keep exact-match behavior.
     # Default: [] is empty, meaning no devices.
     #
     [EventTracing.Netdev]
@@ -475,7 +476,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # Collecting the DCB PFC (Priority-based Flow Control).
     #
     # - DeviceList
-    # The net devices we take care of.
+    # Full-match regex patterns for the net devices we take care of.
+    # Literal names such as "eth0" keep exact-match behavior.
     # Default: [] is empty, meaning no devices.
     #
     [MetricCollector.NetdevDCB]
@@ -486,7 +488,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # Collecting the hardware statistic of net devices, e.g, rx_dropped.
     #
     # - DeviceList
-    # The net devices we take care of.
+    # Full-match regex patterns for the net devices we take care of.
+    # Literal names such as "eth0" keep exact-match behavior.
     # Default: [] is empty, meaning no devices.
     #
     [MetricCollector.NetdevHW]

--- a/internal/matcher/list_matcher.go
+++ b/internal/matcher/list_matcher.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ListMatcher matches a value against a whitelist of full-match regex patterns.
+// An empty ListMatcher matches nothing.
+type ListMatcher struct {
+	rules []*regexp.Regexp
+}
+
+// NewListMatcher compiles whitelist patterns. Each pattern is anchored so a
+// literal device name such as "eth0" keeps the old exact-match behavior, while
+// patterns such as "eth.*" can select a group of values.
+func NewListMatcher(patterns []string) (*ListMatcher, error) {
+	m := &ListMatcher{rules: make([]*regexp.Regexp, 0, len(patterns))}
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		re, err := regexp.Compile("^(?:" + pattern + ")$")
+		if err != nil {
+			return nil, fmt.Errorf("invalid list pattern %q: %w", pattern, err)
+		}
+		m.rules = append(m.rules, re)
+	}
+	return m, nil
+}
+
+// Match reports whether value matches any whitelist pattern.
+func (m *ListMatcher) Match(value string) bool {
+	if m == nil {
+		return false
+	}
+	for _, re := range m.rules {
+		if re.MatchString(value) {
+			return true
+		}
+	}
+	return false
+}
+
+// Filter returns values that match the whitelist, preserving the input order.
+func (m *ListMatcher) Filter(values []string) []string {
+	var out []string
+	for _, value := range values {
+		if m.Match(value) {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/matcher/list_matcher_test.go
+++ b/internal/matcher/list_matcher_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListMatcherMatch(t *testing.T) {
+	m, err := NewListMatcher([]string{"eth0", "bond[0-9]+"})
+	require.NoError(t, err)
+
+	require.True(t, m.Match("eth0"))
+	require.True(t, m.Match("bond4"))
+	require.False(t, m.Match("eth0.100"))
+	require.False(t, m.Match("bond"))
+}
+
+func TestListMatcherFilter(t *testing.T) {
+	m, err := NewListMatcher([]string{"eth.*", "lo"})
+	require.NoError(t, err)
+
+	got := m.Filter([]string{"lo", "docker0", "eth0", "eth1"})
+	require.Equal(t, []string{"lo", "eth0", "eth1"}, got)
+}
+
+func TestListMatcherEmptyMatchesNothing(t *testing.T) {
+	m, err := NewListMatcher(nil)
+	require.NoError(t, err)
+
+	require.False(t, m.Match("eth0"))
+	require.Empty(t, m.Filter([]string{"eth0"}))
+}
+
+func TestListMatcherInvalidPattern(t *testing.T) {
+	_, err := NewListMatcher([]string{"eth["})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "eth[")
+}


### PR DESCRIPTION
DeviceList was still using exact string matching in a few netdev paths, so configs like `eth.*` could not select a group of interfaces.

This compiles DeviceList entries as full-match regex patterns and applies the same behavior to netdev events, DCB, and hardware stats. Simple names like `eth0` keep the existing exact-match behavior.

Testing:
- gofmt -w internal/matcher/list_matcher.go internal/matcher/list_matcher_test.go core/events/netdev_events.go core/metrics/netdev_dcb.go core/metrics/netdev_hw.go
- git diff --check
- GOOS=linux GOARCH=amd64 go test -c ./internal/matcher -o NUL
- GOOS=linux GOARCH=amd64 go test -c ./core/metrics -o NUL
- Not run: GOOS=linux GOARCH=amd64 go test -c ./core/events -o NUL is blocked by missing generated capnp transport types on main.