### PR TITLE
fix(container): URL-escape container_id query value

### DIFF
--- a/internal/command/container/container.go
+++ b/internal/command/container/container.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -36,7 +37,7 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 	}
 
 	if containerID != "" {
-		req.URL.RawQuery = fmt.Sprintf("container_id=%s", containerID)
+		req.URL.RawQuery = url.Values{"container_id": {containerID}}.Encode()
 	}
 
 	resp, err := client.Do(req)

--- a/internal/command/container/container_test.go
+++ b/internal/command/container/container_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-// TestGetContainersCompatibility covers the compatibility of container query callers. It verifies that the request path is unchanged when the container_id query parameter is present, that the unified response wrapper can be correctly decoded, and that both GetContainerByID and GetAllContainers continue to work.
+// TestGetContainersIncludesErrorBody covers the error response handling.
 func TestGetContainersIncludesErrorBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
@@ -85,5 +85,31 @@ func TestGetContainersCompatibility(t *testing.T) {
 	}
 	if len(allContainers) != 2 {
 		t.Errorf("len(allContainers) = %d, want %d", len(allContainers), 2)
+	}
+}
+
+// TestGetContainersURLEscaped verifies that containerID containing URL-special
+// characters (e.g. +, &) is properly URL-escaped in the query string.
+func TestGetContainersURLEscaped(t *testing.T) {
+	var requestedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"code":0,"message":"success","data":[]}`)
+	}))
+	defer server.Close()
+
+	serverAddr := strings.TrimPrefix(server.URL, "http://")
+
+	// containerID contains URL-special characters that must be escaped
+	_, err := getContainers(serverAddr, "container+2025&0226")
+	if err != nil {
+		t.Fatalf("getContainers() error = %v", err)
+	}
+
+	// The raw query should have + and & properly escaped
+	expected := "container_id=container%2B2025%260226"
+	if requestedQuery != expected {
+		t.Errorf("requested query = %q, want %q", requestedQuery, expected)
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #286

## Problem

`internal/command/container.getContainers` uses `fmt.Sprintf` to construct the query string:

```go
req.URL.RawQuery = fmt.Sprintf("container_id=%s", containerID)
```

If `containerID` contains URL-special characters (e.g. `+`, `&`, `=`, `%`), they are not escaped and will be misinterpreted as query syntax. For example, `container+2025&0226` produces `container_id=container+2025&0226`, where `&0226` is parsed as a separate query parameter.

## Fix

Replace `fmt.Sprintf` with `net/url.Values.Encode()` to properly URL-escape the container_id value:

```go
req.URL.RawQuery = url.Values{"container_id": {containerID}}.Encode()
```

Now `container+2025&0226` is correctly encoded as `container_id=container%2B2025%260226`.

## Testing

Added `TestGetContainersURLEscaped` to verify that containerID containing `+` and `&` is properly URL-escaped in the query string. All existing tests remain unchanged and pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added unit tests
- [x] DCO signed (`Signed-off-by`)

Signed-off-by: wc4440222 <199748891+wc4440222@users.noreply.github.com>