### PR TITLE
docs: complete Chinese translations for autotracing and metrics dev docs

### DIFF
--- a/docs/development/autotracing_zh.md
+++ b/docs/development/autotracing_zh.md
@@ -7,10 +7,66 @@ date: 2026-01-11
 weight: 4
 ---
 
-`AutoTracing` 与 `Event` 类型在框架实现上没有区别，只是针对不同的场景进行应用区分。
+### 概述
+- **类型**：异常事件驱动（tracing/autotracing）
+- **功能**：自动追踪系统异常状态，在异常发生时触发上下文信息捕获
+- **特点**：
+    - 当系统出现异常时，`autotracing` 自动触发并捕获相关上下文信息
+    - 事件数据实时存储到本地，同时发送到远程 ES，还可以生成 Prometheus 指标进行观测
+    - 适用于**性能开销较大**的场景，例如在检测到指标超过阈值或上升过快时触发捕获
+- **已集成**：CPU 空闲异常追踪（cpu idle）、D 状态追踪（dload）、容器内外部竞争（waitrate）、内存突发分配（memburst）、磁盘异常追踪（iotracer）
+
+### 如何添加 Autotracing
+`AutoTracing` 只需实现 `ITracingEvent` 接口并完成注册即可将事件添加到系统。
+> `AutoTracing` 与 `Event` 在框架实现上没有区别，只是根据实际应用场景进行区分。
 
 ```go
+// ITracingEvent represents a autotracing or event
 type ITracingEvent interface {
     Start(ctx context.Context) error
 }
 ```
+
+#### 1. 创建结构体
+```go
+type exampleTracing struct{}
+```
+
+#### 2. 注册回调函数
+```go
+func init() {
+    tracing.RegisterEventTracing("example", newExample)
+}
+
+func newExample() (*tracing.EventTracingAttr, error) {
+    return &tracing.EventTracingAttr{
+        TracingData: &exampleTracing{},
+        Internal:    10, // 重新触发追踪的间隔（秒）
+        Flag:        tracing.FlagTracing, // 标记为 tracing 类型；| tracing.FlagMetric（可选）
+    }, nil
+}
+```
+
+#### 3. 实现 ITracingEvent
+```go
+func (t *exampleTracing) Start(ctx context.Context) error {
+    // 检测你关注的内容
+    ...
+
+    // 将数据存储到 ES 和本地
+    storage.Save("example", ccontainerID, time.Now(), tracerData)
+}
+```
+
+此外，可以选择实现 Collector 接口以 Prometheus 格式输出：
+
+```go
+func (c *exampleTracing) Update() ([]*metric.Data, error) {
+    // 将 tracerData 转换为 prometheus.Metric
+    ...
+
+    return data, nil
+}
+```
+
+项目 `core/autotracing` 目录中已集成多种实用的 `autotracing` 示例，框架还提供了丰富的底层接口，包括 BPF 程序和 map 数据交互、容器信息等。更多详情请参考对应的代码实现。

--- a/docs/development/metrics_zh.md
+++ b/docs/development/metrics_zh.md
@@ -7,23 +7,43 @@ date: 2026-01-11
 weight: 2
 ---
 
-只需实现 `Collector` 接口并完成注册即可。
+### 概述
+
+Metrics 类型用于采集系统性能等指标数据，可以 Prometheus 格式输出，作为 `/metrics`（`curl localhost:<port>/metrics`）的数据提供方。
+
+- **类型**：指标采集
+- **功能**：采集各子系统的性能指标
+- **特点**：
+  - 指标主要用于采集 CPU 使用率、内存使用量、网络统计等系统性能数据，适用于监控系统性能，支持实时分析和长期趋势观察。
+  - 指标来源可以是常规 procfs/sysfs 采集，也可以由 tracing 类型（autotracing、event）生成。
+  - 以 Prometheus 格式输出，无缝集成 Prometheus 可观测性生态。
+
+- **已集成**：
+    - CPU（sys、usr、util、load、nr_running...）
+    - 内存（vmstat、memory_stat、directreclaim、asyncreclaim...）
+    - IO（d2c、q2c、freeze、flush...）
+    - 网络（arp、socket mem、qdisc、netstat、netdev、socketstat...）
+
+### 如何添加统计指标
+
+只需实现 `Collector` 接口并完成注册即可将指标添加到系统。
 
 ```go
 type Collector interface {
+    // Get new metrics and expose them via prometheus registry.
     Update() ([]*Data, error)
 }
 ```
 
-#### 创建
+#### 1. 创建结构体
 
-在 `core/metrics/your-new-metric` 目录创建 `Collector` 接口的结构体：
+在 `core/metrics` 目录下创建实现 `Collector` 接口的结构体：
 
 ```go
 type exampleMetric struct{}
 ```
 
-#### 注册
+#### 2. 注册回调函数
 ```go
 func init() {
     tracing.RegisterEventTracing("example", newExample)
@@ -35,18 +55,18 @@ func newExample() (*tracing.EventTracingAttr, error) {
         Flag: tracing.FlagMetric, // 标记为 Metric 类型
     }, nil
 }
-
 ```
 
-#### 实现 `Update`
+#### 3. 实现 `Update` 方法
 
 ```go
 func (c *exampleMetric) Update() ([]*metric.Data, error) {
     // do something
+    ...
     return []*metric.Data{
         metric.NewGaugeData("example", value, "description of example", nil),
     }, nil
 }
 ```
 
-框架提供的丰富底层接口，包括 eBPF, Procfs, Cgroups, Storage, Utils, Pods 等。
+项目 `core/metrics` 目录中已集成多种实用的 `Metrics` 示例，框架还提供了丰富的底层接口，包括 BPF 程序和 map 数据交互、容器信息等。更多详情请参考对应的代码实现。


### PR DESCRIPTION
## What does this PR do?

Completes the Chinese translations of two development docs that were significantly shorter than their English counterparts.

## Changes

| File | Before | After | English version |
|------|--------|-------|-----------------|
| `docs/development/autotracing_zh.md` | 298 bytes (only frontmatter + 2 lines) | ~2700 bytes (full translation) | 2723 bytes |
| `docs/development/metrics_zh.md` | 992 bytes (partial content) | ~2500 bytes (full translation) | 2471 bytes |

Both files now match the structure and content of their English versions (`autotracing_en.md` and `metrics_en.md`).

## Checklist

- [x] Content matches English version structure
- [x] Code blocks preserved as-is
- [x] Frontmatter preserved
- [x] DCO signed

Signed-off-by: wc4440222 <199748891+wc4440222@users.noreply.github.com>