### PR TITLE
fix: ticker goroutine delayed release and chan reuse

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -318,11 +318,14 @@ func (c *cpuIdleTracing) Start(ctx context.Context) error {
 		return fmt.Errorf("container filter: %w", err)
 	}
 
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return types.ErrExitByCancelCtx
-		case <-time.After(time.Duration(interval) * time.Second):
+		case <-ticker.C:
 			if err := updateContainersCPUIdle(containerFilter); err != nil {
 				return err
 			}

--- a/core/autotracing/cpusys.go
+++ b/core/autotracing/cpusys.go
@@ -170,11 +170,14 @@ func (c *cpuSysTracing) Start(ctx context.Context) error {
 		usage: cfg.CPUSys.SysThreshold,
 	}
 
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return types.ErrExitByCancelCtx
-		case <-time.After(time.Duration(interval) * time.Second):
+		case <-ticker.C:
 			if err := c.updateCpuSysUsage(); err != nil {
 				return err
 			}

--- a/core/events/netdev_events.go
+++ b/core/events/netdev_events.go
@@ -25,6 +25,7 @@ import (
 	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
 
 	"github.com/safchain/ethtool"
 	"github.com/vishvananda/netlink"
@@ -72,8 +73,6 @@ func newNetdevTracing() (*tracing.EventTracingAttr, error) {
 
 	return &tracing.EventTracingAttr{
 		TracingData: &netdevTracing{
-			linkUpdateCh:          make(chan netlink.LinkUpdate),
-			linkDoneCh:            make(chan struct{}),
 			netdevInfoStore:       make(map[string]*netdevInfo),
 			linkStatusEventCounts: initMap,
 			name:                  "netdev_events",
@@ -83,10 +82,15 @@ func newNetdevTracing() (*tracing.EventTracingAttr, error) {
 	}, nil
 }
 
-func (netdev *netdevTracing) Start(ctx context.Context) (err error) {
+func (netdev *netdevTracing) Start(ctx context.Context) error {
 	if err := netdev.checkAndInitLinkStatus(); err != nil {
 		return err
 	}
+
+	// Create new channels because linkDoneCh and linkUpdateCh
+	// cannot be reused after stop/restart.
+	netdev.linkUpdateCh = make(chan netlink.LinkUpdate)
+	netdev.linkDoneCh = make(chan struct{})
 
 	if err := netlink.LinkSubscribe(netdev.linkUpdateCh, netdev.linkDoneCh); err != nil {
 		return err
@@ -94,20 +98,19 @@ func (netdev *netdevTracing) Start(ctx context.Context) (err error) {
 	defer netdev.close()
 
 	for {
-		update, ok := <-netdev.linkUpdateCh
-		if !ok {
-			return nil
-		}
-		switch update.Header.Type {
-		case unix.NLMSG_ERROR:
-			return fmt.Errorf("NLMSG_ERROR")
-		case unix.RTM_NEWLINK:
-			ifname := update.Link.Attrs().Name
-			if _, ok := netdev.netdevInfoStore[ifname]; !ok {
-				// new interface
-				continue
+		select {
+		case <-ctx.Done():
+			return types.ErrExitByCancelCtx
+		case update, ok := <-netdev.linkUpdateCh:
+			if !ok {
+				return nil
 			}
-			netdev.handleEvent(&update)
+			switch update.Header.Type {
+			case unix.NLMSG_ERROR:
+				return fmt.Errorf("NLMSG_ERROR")
+			case unix.RTM_NEWLINK:
+				netdev.handleEvent(&update)
+			}
 		}
 	}
 }
@@ -165,12 +168,12 @@ func (netdev *netdevTracing) checkAndInitLinkStatus() error {
 		}
 
 		flags := link.Attrs().RawFlags
-		netdev.netdevInfoStore[ifname] = &netdevInfo{
+		netdev.setInfo(ifname, &netdevInfo{
 			flags:           flags,
 			driver:          drvInfo.Driver,
 			driverVersion:   drvInfo.Version,
 			firmwareVersion: drvInfo.FwVersion,
-		}
+		})
 
 		data := &netdevEventData{
 			linkFlags:       flags,
@@ -213,14 +216,37 @@ func (netdev *netdevTracing) updateAndSaveEvent(data *netdevEventData) {
 	}
 }
 
+func (netdev *netdevTracing) setInfo(ifname string, info *netdevInfo) {
+	netdev.mu.Lock()
+	netdev.netdevInfoStore[ifname] = info
+	netdev.mu.Unlock()
+}
+
+func (netdev *netdevTracing) recordLinkFlags(ifname string, newFlags uint32) (prevFlags uint32, info netdevInfo, ok bool) {
+	netdev.mu.Lock()
+	defer netdev.mu.Unlock()
+
+	stored, ok := netdev.netdevInfoStore[ifname]
+	if !ok {
+		// new interface
+		return 0, netdevInfo{}, false
+	}
+
+	prevFlags = stored.flags
+	stored.flags = newFlags
+	return prevFlags, *stored, true
+}
+
 func (netdev *netdevTracing) handleEvent(ev *netlink.LinkUpdate) {
 	ifname := ev.Link.Attrs().Name
 
 	currFlags := ev.Attrs().RawFlags
-	lastFlags := netdev.netdevInfoStore[ifname].flags
-	change := currFlags ^ lastFlags
 
-	netdev.netdevInfoStore[ifname].flags = currFlags
+	lastFlags, info, ok := netdev.recordLinkFlags(ifname, currFlags)
+	if !ok {
+		return
+	}
+	change := currFlags ^ lastFlags
 
 	data := &netdevEventData{
 		linkFlags:       currFlags,
@@ -229,14 +255,14 @@ func (netdev *netdevTracing) handleEvent(ev *netlink.LinkUpdate) {
 		Index:           ev.Link.Attrs().Index,
 		Mac:             ev.Link.Attrs().HardwareAddr.String(),
 		AtStart:         false,
-		Driver:          netdev.netdevInfoStore[ifname].driver,
-		DriverVersion:   netdev.netdevInfoStore[ifname].driverVersion,
-		FirmwareVersion: netdev.netdevInfoStore[ifname].firmwareVersion,
+		Driver:          info.driver,
+		DriverVersion:   info.driverVersion,
+		FirmwareVersion: info.firmwareVersion,
 	}
 	netdev.updateAndSaveEvent(data)
 }
 
 func (netdev *netdevTracing) close() {
+	// netlink.LinkSubscribe closes linkUpdateCh inner
 	close(netdev.linkDoneCh)
-	close(netdev.linkUpdateCh)
 }

--- a/core/events/softirq_tracing.go
+++ b/core/events/softirq_tracing.go
@@ -147,18 +147,10 @@ func softirqDumpTrace(addrs []uint64) string {
 }
 
 func attachIrqAndEventPipe(ctx context.Context, b bpf.BPF) (bpf.PerfEventReader, error) {
-	var err error
-
 	reader, err := b.EventPipeByName(ctx, "irqoff_event_map", 8192)
 	if err != nil {
 		return nil, err
 	}
-
-	defer func() {
-		if err != nil {
-			reader.Close()
-		}
-	}()
 
 	/*
 	 * NOTE: There might be more than 100ms gap between the attachment of hooks,
@@ -186,6 +178,7 @@ func attachIrqAndEventPipe(ctx context.Context, b bpf.BPF) (bpf.PerfEventReader,
 			Symbol:      "timer/tick_stop",
 		},
 	}); err != nil {
+		reader.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
修复代码走读发现的几个问题：
1. `func (c *cpuIdleTracing) Start(ctx context.Context) error`：time.After 会每次 for 创建一个 ticker，当 ctx 生命周期结束时，如果 ticker 刚刚创建好，那么不会立刻销毁，而是需要定时器到期后销毁，这段时间窗口存在短暂的资源残留，改成 time.NewTicker 触发机制，ctxp->Done 之后立刻释放。
2. `func (c *cpuSysTracing) Start(ctx context.Context) error`：同上
3. `func attachIrqAndEventPipe(ctx context.Context, b bpf.BPF) (bpf.PerfEventReader, error)`：err 被内部变量掩藏，导致即使 AttachWithOptions 失败也不会销毁 reader，当前是改成了显式释放（或者可以改成把 err 放到 if 外面）
4. `netdev_events.go` 这个问题比较多，如下：
- 看了下 LinkSubscribe 的实现原理，传递两个 channel，内部是起了两个 goroutine，一个作为读者（等待外部终止），一个作为写者（更新 netdev 状态变化），按理 channel 由写端来维护，因此 `func (netdev *netdevTracing) close()` 应该只关闭 linkDoneCh，而 linkUpdateCh 是 netlink.LinkSubscribe 内部自己处理关闭的，我们在关闭一次会导致重复释放。
- 还有一个就是每次 start 需要重新创建 channel，而不是仅仅 newNetdevTracing 只创建一次，因为 start 退出会 close 这两个通道，导致下一次会复用已经建好的通道，可能异常退出或者 panic 吧。
- 其他改了一下锁范围，保证数据原子更新。