### PR TITLE
fix(server): return nil from Run() retry path instead of misleading error

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -221,9 +221,13 @@ func (s *server) run(addr string) error {
 	return s.engine.RunListener(tcpListener)
 }
 
-// Run starts the TCP server with retry mechanism.
+// Run starts the TCP server. When RetryMaxTime > 0 and RetryInterval > 0,
+// it starts the server in a background goroutine with exponential backoff
+// retry and returns nil immediately. Without retry, it blocks until the
+// server stops.
 func (s *server) Run(option *Option) error {
 	if option.RetryMaxTime > 0 && option.RetryInterval > 0 {
+		log.Infof("tcp api server starting with retry on %s (max=%v, interval=%v)", option.Addr, option.RetryMaxTime, option.RetryInterval)
 		go func() {
 			b := backoff.New(option.RetryMaxTime, option.RetryInterval)
 			for {
@@ -241,7 +245,7 @@ func (s *server) Run(option *Option) error {
 				time.Sleep(retryInterval)
 			}
 		}()
-		return fmt.Errorf("init err")
+		return nil
 	}
 
 	return s.run(option.Addr)


### PR DESCRIPTION
## What does this PR do?

Fixes a misleading error return in `internal/server/server.go` `Run()` method.

## Problem

When retry is enabled (`RetryMaxTime > 0 && RetryInterval > 0`), `Run()` launches the server in a background goroutine with exponential backoff but **always returns `fmt.Errorf("init err")`** to the caller. This misleads callers into thinking the server failed to start when it is actually running.

```go
// Before
func (s *server) Run(option *Option) error {
    if option.RetryMaxTime > 0 && option.RetryInterval > 0 {
        go func() {
            // ... actual retry logic works fine ...
        }()
        return fmt.Errorf("init err")  // ← lying to the caller
    }
    return s.run(option.Addr)
}
```

The caller already uses `_ = s.Run(...)` which masks the error, so this bug has gone unnoticed.

## Fix

Return `nil` from the retry path since the server IS starting. Also log the retry configuration at startup for visibility.

```go
// After
func (s *server) Run(option *Option) error {
    if option.RetryMaxTime > 0 && option.RetryInterval > 0 {
        log.Infof("tcp api server starting with retry on %s (max=%v, interval=%v)", ...)
        go func() { /* ... retry logic unchanged ... */ }()
        return nil  // ← server is starting, no error
    }
    return s.run(option.Addr)
}
```

## Testing

- `go build ./internal/server/` — compiles ✅
- `go test ./internal/server/ -count=1` — all 21 existing tests pass ✅

## Checklist

- [x] No breaking API changes
- [x] All existing tests pass
- [x] DCO signed

Signed-off-by: wc4440222 <199748891+wc4440222@users.noreply.github.com>