### PR TITLE
feat(agent): add read-only metrics insight CLI

### DIFF
--- a/cmd/huatuo-insight/main.go
+++ b/cmd/huatuo-insight/main.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"huatuo-bamai/internal/agent"
+)
+
+const defaultMetricsURL = "http://127.0.0.1:19704/metrics"
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "huatuo-insight: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("huatuo-insight", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	metricsURL := fs.String("metrics-url", defaultMetricsURL, "HUATUO /metrics endpoint")
+	file := fs.String("file", "", "read Prometheus text metrics from file instead of HTTP")
+	prefix := fs.String("prefix", "", "comma-separated metric name prefixes to include; empty means all")
+	topN := fs.Int("top", 20, "number of largest absolute-value samples to include in top list")
+	timeout := fs.Duration("timeout", 5*time.Second, "HTTP request timeout")
+	pretty := fs.Bool("pretty", false, "pretty-print JSON output")
+	includeSamples := fs.Bool("include-samples", false, "include all matched samples in addition to the top list")
+	help := fs.Bool("help", false, "show help")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *help {
+		fs.SetOutput(out)
+		fs.Usage()
+		return nil
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %v", fs.Args())
+	}
+
+	source, text, err := readMetrics(*file, *metricsURL, *timeout)
+	if err != nil {
+		return err
+	}
+
+	summary, err := agent.BuildSummary(source, text, agent.SummaryOptions{
+		Prefixes:       splitCSV(*prefix),
+		TopN:           *topN,
+		IncludeSamples: *includeSamples,
+	})
+	if err != nil {
+		return err
+	}
+
+	var payload []byte
+	if *pretty {
+		payload, err = json.MarshalIndent(summary, "", "  ")
+	} else {
+		payload, err = json.Marshal(summary)
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, string(payload))
+	return err
+}
+
+func readMetrics(file, metricsURL string, timeout time.Duration) (string, string, error) {
+	if file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return "", "", err
+		}
+		return file, string(data), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metricsURL, http.NoBody)
+	if err != nil {
+		return "", "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("GET %s: unexpected status %s", metricsURL, resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+	return metricsURL, string(data), nil
+}
+
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/cmd/huatuo-insight/main_test.go
+++ b/cmd/huatuo-insight/main_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRunReadsMetricsFromHTTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metrics" {
+			t.Fatalf("path = %q, want /metrics", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("huatuo_cpu_usage 10\nnode_other 99\n"))
+	}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := run([]string{"--metrics-url", server.URL + "/metrics", "--prefix", "huatuo_", "--top", "1"}, &out)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+
+	var decoded struct {
+		MatchedSamples int `json:"matched_samples"`
+		Top            []struct {
+			Name string `json:"name"`
+		} `json:"top"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON output %q: %v", out.String(), err)
+	}
+	if decoded.MatchedSamples != 1 || len(decoded.Top) != 1 || decoded.Top[0].Name != "huatuo_cpu_usage" {
+		t.Fatalf("unexpected output: %s", out.String())
+	}
+}

--- a/docs/best-practice/agent-cli_en.md
+++ b/docs/best-practice/agent-cli_en.md
@@ -1,0 +1,79 @@
+# HUATUO Agent CLI Integration
+
+This document describes `huatuo-insight`, a small read-only CLI that converts HUATUO Prometheus text metrics into a compact JSON summary for automation scripts, diagnostic tools, and AI agents.
+
+## Background
+
+HUATUO already exposes runtime data through `/metrics`. `huatuo-insight` does not mutate node state, start tracing jobs, load BPF programs, or write configuration. It only reads existing metrics and emits a structured summary, making it a minimal and safe integration point for automated diagnostics.
+
+## Build
+
+```bash
+go build ./cmd/huatuo-insight
+```
+
+## Read from a local HUATUO instance
+
+```bash
+./huatuo-insight \
+  --metrics-url http://127.0.0.1:19704/metrics \
+  --prefix huatuo_ \
+  --top 20 \
+  --pretty
+```
+
+Example output:
+
+```json
+{
+  "source": "http://127.0.0.1:19704/metrics",
+  "generated_at": "2026-07-05T00:00:00Z",
+  "total_samples": 120,
+  "matched_samples": 80,
+  "categories": {
+    "cpu": 12,
+    "memory": 10,
+    "network": 8
+  },
+  "top": [
+    {
+      "name": "huatuo_cpu_usage",
+      "value": 12.5,
+      "category": "cpu"
+    }
+  ]
+}
+```
+
+## Read from a metrics file
+
+For environments where the production node should not expose the metrics endpoint directly, metrics can be captured first and analyzed offline:
+
+```bash
+curl -s http://127.0.0.1:19704/metrics > huatuo.metrics
+./huatuo-insight --file huatuo.metrics --prefix huatuo_ --pretty
+```
+
+By default, the output contains category counts and top samples. Add `--include-samples` when downstream tools need every matched sample.
+
+## Agent usage
+
+Agents should consume only the JSON output from `huatuo-insight` rather than receiving direct shell access to the node. This keeps the integration focused on reading metrics, summarizing anomalies, and suggesting troubleshooting steps.
+
+Suggested prompt:
+
+```text
+You are a Linux kernel observability assistant. Based on the following HUATUO metrics summary, identify whether CPU, memory, network, I/O, scheduling, or container signals look abnormal. Only reason from the provided data.
+```
+
+## Safety boundary
+
+`huatuo-insight` is read-only:
+
+- it does not require root privileges;
+- it does not start or stop HUATUO;
+- it does not modify BPF programs, kernel parameters, or business processes;
+- it does not write to storage backends;
+- it does not directly access kubelet, CRI, or sensitive host files.
+
+This makes it a minimal integration layer for exposing HUATUO signals to automated diagnostic systems.

--- a/docs/best-practice/agent-cli_zh.md
+++ b/docs/best-practice/agent-cli_zh.md
@@ -1,0 +1,79 @@
+# HUATUO Agent CLI 最小接入方案
+
+本文档说明如何使用 `huatuo-insight` 将 HUATUO 的 Prometheus 文本指标转换为紧凑的 JSON 摘要，方便自动化脚本、诊断工具或 AI Agent 进行只读分析。
+
+## 背景
+
+HUATUO 已经提供 `/metrics` 指标出口。`huatuo-insight` 不修改节点状态、不触发内核探针、不写入配置，只读取现有指标并生成结构化摘要，适合作为自动化诊断链路中的最小安全边界。
+
+## 构建
+
+```bash
+go build ./cmd/huatuo-insight
+```
+
+## 从本地 HUATUO 读取指标
+
+```bash
+./huatuo-insight \
+  --metrics-url http://127.0.0.1:19704/metrics \
+  --prefix huatuo_ \
+  --top 20 \
+  --pretty
+```
+
+输出示例：
+
+```json
+{
+  "source": "http://127.0.0.1:19704/metrics",
+  "generated_at": "2026-07-05T00:00:00Z",
+  "total_samples": 120,
+  "matched_samples": 80,
+  "categories": {
+    "cpu": 12,
+    "memory": 10,
+    "network": 8
+  },
+  "top": [
+    {
+      "name": "huatuo_cpu_usage",
+      "value": 12.5,
+      "category": "cpu"
+    }
+  ]
+}
+```
+
+## 从文件读取指标
+
+当生产节点不能直接暴露 HTTP 端口时，可以先保存指标，再离线分析：
+
+```bash
+curl -s http://127.0.0.1:19704/metrics > huatuo.metrics
+./huatuo-insight --file huatuo.metrics --prefix huatuo_ --pretty
+```
+
+默认输出包含分类统计和 Top 样本。如果需要把所有匹配样本也交给下游工具，可以增加 `--include-samples`。
+
+## 面向 Agent 的使用建议
+
+推荐让 Agent 只消费 `huatuo-insight` 输出的 JSON，而不是直接获得节点 Shell 权限。这样可以把能力限制在“读取指标、总结异常、给出排查建议”范围内。
+
+推荐提示词：
+
+```text
+你是 Linux 内核可观测性分析助手。请根据以下 HUATUO 指标摘要判断 CPU、内存、网络、I/O、调度或容器维度是否存在异常。只基于输入数据分析，不要假设未提供的信息。
+```
+
+## 安全边界
+
+`huatuo-insight` 是只读工具：
+
+- 不需要 root 权限；
+- 不启动或停止 HUATUO；
+- 不修改 BPF 程序、内核参数或业务进程；
+- 不写入存储后端；
+- 不直接访问 Kubernetes kubelet、CRI 或宿主机敏感文件。
+
+因此它适合作为 HUATUO 对外暴露给自动化诊断系统的最小接入层。

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -1,0 +1,284 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bufio"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SummaryOptions controls how raw Prometheus text metrics are converted into a
+// compact, read-only summary suitable for scripts and AI/automation agents.
+type SummaryOptions struct {
+	// Prefixes limits returned samples to metric names with one of the prefixes.
+	// Empty Prefixes means all metrics are considered.
+	Prefixes       []string
+	TopN           int
+	IncludeSamples bool
+	Now            func() time.Time
+}
+
+// MetricSample is a single parsed Prometheus text exposition sample.
+type MetricSample struct {
+	Name     string            `json:"name"`
+	Labels   map[string]string `json:"labels,omitempty"`
+	Value    float64           `json:"value"`
+	Category string            `json:"category"`
+}
+
+// Summary is a small machine-readable view over HUATUO metrics. It intentionally
+// excludes any mutating operation; callers can use it to reason about system
+// health without giving agents write access to the node or the kernel.
+type Summary struct {
+	Source         string         `json:"source"`
+	GeneratedAt    string         `json:"generated_at"`
+	TotalSamples   int            `json:"total_samples"`
+	MatchedSamples int            `json:"matched_samples"`
+	Categories     map[string]int `json:"categories"`
+	Top            []MetricSample `json:"top"`
+	Samples        []MetricSample `json:"samples,omitempty"`
+}
+
+// BuildSummary parses Prometheus text metrics and returns a compact summary.
+func BuildSummary(source, text string, opts SummaryOptions) (*Summary, error) {
+	if opts.TopN < 0 {
+		return nil, fmt.Errorf("topN must be >= 0")
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+
+	samples, err := ParsePrometheusText(text)
+	if err != nil {
+		return nil, err
+	}
+
+	matched := make([]MetricSample, 0, len(samples))
+	categories := make(map[string]int)
+	for _, sample := range samples {
+		if !matchesPrefix(sample.Name, opts.Prefixes) {
+			continue
+		}
+		sample.Category = categorizeMetric(sample.Name)
+		matched = append(matched, sample)
+		categories[sample.Category]++
+	}
+
+	top := append([]MetricSample(nil), matched...)
+	sort.SliceStable(top, func(i, j int) bool {
+		return math.Abs(top[i].Value) > math.Abs(top[j].Value)
+	})
+	if opts.TopN > 0 && len(top) > opts.TopN {
+		top = top[:opts.TopN]
+	}
+
+	summary := &Summary{
+		Source:         source,
+		GeneratedAt:    opts.Now().UTC().Format(time.RFC3339),
+		TotalSamples:   len(samples),
+		MatchedSamples: len(matched),
+		Categories:     categories,
+		Top:            top,
+	}
+	if opts.IncludeSamples {
+		summary.Samples = matched
+	}
+	return summary, nil
+}
+
+// ParsePrometheusText parses the Prometheus text exposition format enough for
+// HUATUO's /metrics output and common exporters. It skips HELP/TYPE comments and
+// ignores unsupported histogram metadata lines that do not contain a sample.
+func ParsePrometheusText(text string) ([]MetricSample, error) {
+	var samples []MetricSample
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	// Allow long metric lines with many labels.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(strings.TrimPrefix(scanner.Text(), "\ufeff"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		sample, ok, err := parseSampleLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("parse metrics line %d: %w", lineNo, err)
+		}
+		if ok {
+			samples = append(samples, sample)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return samples, nil
+}
+
+func parseSampleLine(line string) (MetricSample, bool, error) {
+	nameAndLabels, rest := splitFirstField(line)
+	if nameAndLabels == "" || rest == "" {
+		return MetricSample{}, false, nil
+	}
+
+	valueField, _ := splitFirstField(rest)
+	value, err := strconv.ParseFloat(valueField, 64)
+	if err != nil {
+		return MetricSample{}, false, fmt.Errorf("invalid value %q: %w", valueField, err)
+	}
+	// Prometheus text format permits NaN and +/-Inf, but encoding/json cannot
+	// marshal non-finite floating-point values. Ignore them so the CLI always
+	// emits valid JSON for downstream automation.
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return MetricSample{}, false, nil
+	}
+
+	name := nameAndLabels
+	labels := map[string]string(nil)
+	if i := strings.IndexByte(nameAndLabels, '{'); i >= 0 {
+		if !strings.HasSuffix(nameAndLabels, "}") {
+			return MetricSample{}, false, fmt.Errorf("invalid label set %q", nameAndLabels)
+		}
+		name = nameAndLabels[:i]
+		labelText := strings.TrimSuffix(nameAndLabels[i+1:], "}")
+		parsedLabels, err := parseLabels(labelText)
+		if err != nil {
+			return MetricSample{}, false, err
+		}
+		labels = parsedLabels
+	}
+
+	if name == "" {
+		return MetricSample{}, false, fmt.Errorf("empty metric name")
+	}
+	return MetricSample{Name: name, Labels: labels, Value: value}, true, nil
+}
+
+func splitFirstField(s string) (string, string) {
+	s = strings.TrimSpace(s)
+	for i, r := range s {
+		if r == ' ' || r == '\t' {
+			return s[:i], strings.TrimSpace(s[i:])
+		}
+	}
+	return s, ""
+}
+
+func parseLabels(labelText string) (map[string]string, error) {
+	labels := make(map[string]string)
+	if strings.TrimSpace(labelText) == "" {
+		return labels, nil
+	}
+
+	for len(labelText) > 0 {
+		labelText = strings.TrimSpace(labelText)
+		eq := strings.IndexByte(labelText, '=')
+		if eq <= 0 {
+			return nil, fmt.Errorf("invalid label near %q", labelText)
+		}
+		key := strings.TrimSpace(labelText[:eq])
+		labelText = strings.TrimSpace(labelText[eq+1:])
+		if !strings.HasPrefix(labelText, "\"") {
+			return nil, fmt.Errorf("label %q must use quoted value", key)
+		}
+
+		value, consumed, err := parseQuoted(labelText)
+		if err != nil {
+			return nil, fmt.Errorf("label %q: %w", key, err)
+		}
+		labels[key] = value
+		labelText = strings.TrimSpace(labelText[consumed:])
+		if strings.HasPrefix(labelText, ",") {
+			labelText = labelText[1:]
+			continue
+		}
+		if labelText != "" {
+			return nil, fmt.Errorf("unexpected label suffix %q", labelText)
+		}
+	}
+	return labels, nil
+}
+
+func parseQuoted(s string) (string, int, error) {
+	var b strings.Builder
+	escaped := false
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			switch c {
+			case 'n':
+				b.WriteByte('\n')
+			case '\\', '"':
+				b.WriteByte(c)
+			default:
+				b.WriteByte(c)
+			}
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if c == '"' {
+			return b.String(), i + 1, nil
+		}
+		b.WriteByte(c)
+	}
+	return "", 0, fmt.Errorf("unterminated quoted value")
+}
+
+func matchesPrefix(name string, prefixes []string) bool {
+	if len(prefixes) == 0 {
+		return true
+	}
+	for _, prefix := range prefixes {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" || strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func categorizeMetric(name string) string {
+	n := strings.ToLower(name)
+	switch {
+	case strings.Contains(n, "cpu") || strings.Contains(n, "load"):
+		return "cpu"
+	case strings.Contains(n, "mem") || strings.Contains(n, "oom") || strings.Contains(n, "page"):
+		return "memory"
+	case strings.Contains(n, "io") || strings.Contains(n, "disk") || strings.Contains(n, "block"):
+		return "io"
+	case strings.Contains(n, "net") || strings.Contains(n, "tcp") || strings.Contains(n, "udp") || strings.Contains(n, "drop"):
+		return "network"
+	case strings.Contains(n, "sched") || strings.Contains(n, "runqueue") || strings.Contains(n, "softlockup") || strings.Contains(n, "hungtask"):
+		return "scheduler"
+	case strings.Contains(n, "trace") || strings.Contains(n, "profile") || strings.Contains(n, "flame") || strings.Contains(n, "perf"):
+		return "profiling"
+	case strings.Contains(n, "container") || strings.Contains(n, "cgroup") || strings.Contains(n, "pod"):
+		return "container"
+	case strings.Contains(n, "error") || strings.Contains(n, "fail") || strings.Contains(n, "timeout"):
+		return "errors"
+	default:
+		return "other"
+	}
+}

--- a/internal/agent/metrics_test.go
+++ b/internal/agent/metrics_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParsePrometheusText(t *testing.T) {
+	input := `# HELP huatuo_cpu_usage CPU usage
+# TYPE huatuo_cpu_usage gauge
+huatuo_cpu_usage{cpu="0",mode="user"} 12.5
+huatuo_net_drop_total{device="eth0"} 3
+other_metric 7
+`
+	samples, err := ParsePrometheusText(input)
+	if err != nil {
+		t.Fatalf("ParsePrometheusText() error = %v", err)
+	}
+	if len(samples) != 3 {
+		t.Fatalf("len(samples) = %d, want 3", len(samples))
+	}
+	if samples[0].Name != "huatuo_cpu_usage" || samples[0].Labels["cpu"] != "0" || samples[0].Value != 12.5 {
+		t.Fatalf("unexpected first sample: %#v", samples[0])
+	}
+}
+
+func TestBuildSummaryFiltersPrefixesAndCategorizes(t *testing.T) {
+	input := `huatuo_cpu_usage 12
+huatuo_mem_oom_total 2
+node_unrelated 99
+`
+	summary, err := BuildSummary("fixture", input, SummaryOptions{
+		Prefixes: []string{"huatuo_"},
+		TopN:     1,
+		Now: func() time.Time {
+			return time.Date(2026, 7, 5, 0, 0, 0, 0, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSummary() error = %v", err)
+	}
+	if summary.TotalSamples != 3 || summary.MatchedSamples != 2 {
+		t.Fatalf("sample counts = (%d, %d), want (3, 2)", summary.TotalSamples, summary.MatchedSamples)
+	}
+	if summary.Categories["cpu"] != 1 || summary.Categories["memory"] != 1 {
+		t.Fatalf("unexpected categories: %#v", summary.Categories)
+	}
+	if len(summary.Top) != 1 || summary.Top[0].Name != "huatuo_cpu_usage" {
+		t.Fatalf("unexpected top samples: %#v", summary.Top)
+	}
+	if summary.GeneratedAt != "2026-07-05T00:00:00Z" {
+		t.Fatalf("GeneratedAt = %q", summary.GeneratedAt)
+	}
+}
+
+func TestParsePrometheusTextInvalidValue(t *testing.T) {
+	_, err := ParsePrometheusText("huatuo_cpu_usage not-a-number\n")
+	if err == nil {
+		t.Fatal("ParsePrometheusText() error = nil, want error")
+	}
+}
+
+func TestParseEscapedLabels(t *testing.T) {
+	samples, err := ParsePrometheusText(`huatuo_label_test{path="/tmp/a\\b",quote="a\"b"} 1`)
+	if err != nil {
+		t.Fatalf("ParsePrometheusText() error = %v", err)
+	}
+	if samples[0].Labels["path"] != `/tmp/a\b` || samples[0].Labels["quote"] != `a"b` {
+		t.Fatalf("unexpected labels: %#v", samples[0].Labels)
+	}
+}
+
+func TestParsePrometheusTextSkipsNonFiniteValues(t *testing.T) {
+	samples, err := ParsePrometheusText("huatuo_nan NaN\nhuatuo_inf +Inf\nhuatuo_cpu_usage 1\n")
+	if err != nil {
+		t.Fatalf("ParsePrometheusText() error = %v", err)
+	}
+	if len(samples) != 1 || samples[0].Name != "huatuo_cpu_usage" {
+		t.Fatalf("unexpected samples: %#v", samples)
+	}
+}
+
+func TestBuildSummaryCanIncludeSamples(t *testing.T) {
+	summary, err := BuildSummary("fixture", "huatuo_cpu_usage 1\n", SummaryOptions{
+		Prefixes:       []string{"huatuo_"},
+		IncludeSamples: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildSummary() error = %v", err)
+	}
+	if len(summary.Samples) != 1 || summary.Samples[0].Name != "huatuo_cpu_usage" {
+		t.Fatalf("unexpected samples: %#v", summary.Samples)
+	}
+}
+
+func TestParsePrometheusTextSkipsCommentsWithBOM(t *testing.T) {
+	samples, err := ParsePrometheusText("\ufeff# HELP huatuo_cpu_usage CPU usage\n# TYPE huatuo_cpu_usage gauge\nhuatuo_cpu_usage 1\n")
+	if err != nil {
+		t.Fatalf("ParsePrometheusText() error = %v", err)
+	}
+	if len(samples) != 1 || samples[0].Name != "huatuo_cpu_usage" {
+		t.Fatalf("unexpected samples: %#v", samples)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a read-only `huatuo-insight` CLI for HUATUO metrics analysis.

The CLI can read Prometheus-format metrics from either a local file or a HUATUO `/metrics` endpoint, then convert raw metrics into a compact JSON summary. It is intended to help scripts, diagnostic tools, and agent-style workflows consume HUATUO observability data more easily.

## Changes

- Add `cmd/huatuo-insight` as a new CLI entrypoint.
- Add `internal/agent` for Prometheus metrics parsing, filtering, categorization, and summarization.
- Support reading metrics from:
  - local metrics files
  - HTTP metrics endpoints
- Support filtering by metric prefix, such as `huatuo_`.
- Support top-N metric summary output.
- Support optional full sample output.
- Skip Prometheus comment lines such as `# HELP` and `# TYPE`.
- Handle Windows UTF-8 BOM input safely.
- Skip `NaN` and `Inf` values to keep JSON output valid.
- Add unit tests for parser and CLI behavior.
- Add English and Chinese usage documentation.

## Usage

Build the CLI:

```bash
go build -o huatuo-insight ./cmd/huatuo-insight
```

Analyze a local metrics file:

```bash
./huatuo-insight \
  --file sample.metrics \
  --prefix huatuo_ \
  --top 20 \
  --pretty
```

Analyze a running HUATUO metrics endpoint:

```bash
./huatuo-insight \
  --metrics-url http://127.0.0.1:19704/metrics \
  --prefix huatuo_ \
  --top 20 \
  --pretty
```

## Tests

The following checks were run locally:

```bash
gofmt -w cmd/huatuo-insight internal/agent
go test ./internal/agent ./cmd/huatuo-insight
go vet ./internal/agent ./cmd/huatuo-insight
go build -o huatuo-insight ./cmd/huatuo-insight
```

## Related Issue

Related to #176.