### PR TITLE
test(metrics): add Prometheus naming convention linter for metric names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,6 @@ e2e: all
 # metric names defined in core/metrics/. Uses static analysis (go/ast)
 # — no BPF or runtime dependencies required.
 metrics-naming-check:
-	@go test -run "TestMetricNames|TestCounterNames" ./core/metrics/ -v
+	@go test -run "TestMetricNames|TestCounterNames" -count=1 ./core/metrics/ -v
 
 .PHONY: all build-nostatic bpf-build gen-build sync build check import-fmt golangci-lint vendor clean test unit integration e2e docker-build docker-clean metrics-naming-check

--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,10 @@ integration: all
 e2e: all
 	@bash e2e/run.sh
 
-.PHONY: all build-nostatic bpf-build gen-build sync build check import-fmt golangci-lint vendor clean test unit integration e2e docker-build docker-clean
+# metrics-naming-check validates Prometheus naming conventions for all
+# metric names defined in core/metrics/. Uses static analysis (go/ast)
+# — no BPF or runtime dependencies required.
+metrics-naming-check:
+	@go test -run "TestMetricNames|TestCounterNames" ./core/metrics/ -v
+
+.PHONY: all build-nostatic bpf-build gen-build sync build check import-fmt golangci-lint vendor clean test unit integration e2e docker-build docker-clean metrics-naming-check

--- a/core/metrics/metrics_naming_test.go
+++ b/core/metrics/metrics_naming_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics
+package collector
 
 import (
 	"fmt"
@@ -33,7 +33,7 @@ type metricCallInfo struct {
 	line     int
 	funcName string // NewGaugeData, NewCounterData, NewContainerGaugeData, NewContainerCounterData
 	name     string // the metric name argument (if it's a string literal)
-	isString bool  // true if the name argument was a string literal
+	isString bool   // true if the name argument was a string literal
 }
 
 // validMetricName matches Prometheus metric naming rules:
@@ -46,10 +46,10 @@ func findMetricCalls(t *testing.T, dir string) []metricCallInfo {
 	var calls []metricCallInfo
 
 	targetFuncs := map[string]bool{
-		"NewGaugeData":             true,
-		"NewCounterData":           true,
-		"NewContainerGaugeData":    true,
-		"NewContainerCounterData":  true,
+		"NewGaugeData":            true,
+		"NewCounterData":          true,
+		"NewContainerGaugeData":   true,
+		"NewContainerCounterData": true,
 	}
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -163,14 +163,14 @@ func TestCounterNamesHaveTotalSuffix(t *testing.T) {
 	// are exposed as-is for compatibility.
 	allowlist := map[string]bool{
 		// Ascend NPU HBM error counters use _cnt suffix (vendor convention)
-		"npu_hbm_single_bit_error_cnt":               true,
-		"npu_hbm_double_bit_error_cnt":               true,
-		"npu_hbm_total_single_bit_error_cnt":         true,
-		"npu_hbm_total_double_bit_error_cnt":         true,
-		"npu_hbm_single_bit_isolated_pages_cnt":      true,
-		"npu_hbm_double_bit_isolated_pages_cnt":      true,
-		"npu_mac_tx_mac_pause_num":                   true,
-		"npu_mac_rx_mac_pause_num":                   true,
+		"npu_hbm_single_bit_error_cnt":          true,
+		"npu_hbm_double_bit_error_cnt":          true,
+		"npu_hbm_total_single_bit_error_cnt":    true,
+		"npu_hbm_total_double_bit_error_cnt":    true,
+		"npu_hbm_single_bit_isolated_pages_cnt": true,
+		"npu_hbm_double_bit_isolated_pages_cnt": true,
+		"npu_mac_tx_mac_pause_num":              true,
+		"npu_mac_rx_mac_pause_num":              true,
 	}
 
 	var violations []string

--- a/core/metrics/metrics_naming_test.go
+++ b/core/metrics/metrics_naming_test.go
@@ -106,7 +106,6 @@ func findMetricCalls(t *testing.T, dir string) []metricCallInfo {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatalf("filepath.Walk failed: %v", err)
 	}

--- a/core/metrics/metrics_naming_test.go
+++ b/core/metrics/metrics_naming_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// metricCallInfo records a single NewGaugeData/NewCounterData call site.
+type metricCallInfo struct {
+	file     string
+	line     int
+	funcName string // NewGaugeData, NewCounterData, NewContainerGaugeData, NewContainerCounterData
+	name     string // the metric name argument (if it's a string literal)
+	isString bool  // true if the name argument was a string literal
+}
+
+// validMetricName matches Prometheus metric naming rules:
+// [a-zA-Z_:][a-zA-Z0-9_:]*
+var validMetricName = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+
+// findMetricCalls walks all .go files in dir and collects calls to the
+// four metric constructor functions.
+func findMetricCalls(t *testing.T, dir string) []metricCallInfo {
+	var calls []metricCallInfo
+
+	targetFuncs := map[string]bool{
+		"NewGaugeData":             true,
+		"NewCounterData":           true,
+		"NewContainerGaugeData":    true,
+		"NewContainerCounterData":  true,
+	}
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		node, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			t.Logf("Warning: failed to parse %s: %v", path, parseErr)
+			return nil
+		}
+
+		ast.Inspect(node, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			var funcName string
+			switch fn := call.Fun.(type) {
+			case *ast.Ident:
+				funcName = fn.Name
+			case *ast.SelectorExpr:
+				funcName = fn.Sel.Name
+			default:
+				return true
+			}
+
+			if !targetFuncs[funcName] {
+				return true
+			}
+
+			info := metricCallInfo{
+				file:     path,
+				line:     fset.Position(call.Pos()).Line,
+				funcName: funcName,
+			}
+
+			if len(call.Args) >= 1 {
+				if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					info.name = strings.Trim(lit.Value, `"`)
+					info.isString = true
+				}
+			}
+
+			calls = append(calls, info)
+			return true
+		})
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("filepath.Walk failed: %v", err)
+	}
+
+	return calls
+}
+
+// TestMetricNamesValid checks that all metric names defined via
+// NewGaugeData, NewCounterData, NewContainerGaugeData, and
+// NewContainerCounterData in core/metrics/ are valid Prometheus metric names.
+func TestMetricNamesValid(t *testing.T) {
+	calls := findMetricCalls(t, ".")
+
+	if len(calls) == 0 {
+		t.Skip("No metric calls found — package directory may have changed")
+	}
+
+	var violations []string
+	for _, c := range calls {
+		if !c.isString {
+			continue // skip dynamic names (can't validate statically)
+		}
+
+		if !validMetricName.MatchString(c.name) {
+			relPath, _ := filepath.Rel(".", c.file)
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: invalid metric name %q (does not match [a-zA-Z_:][a-zA-Z0-9_:]*)",
+				relPath, c.line, c.name,
+			))
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("Invalid metric names found:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+// TestCounterNamesHaveTotalSuffix checks that counter-type metrics
+// (created via NewCounterData or NewContainerCounterData) with static
+// string names end with "_total".
+//
+// This follows the Prometheus naming convention:
+// https://prometheus.io/docs/practices/naming/#metric-names
+//
+// A allowlist is provided for existing metrics that don't follow the
+// convention yet but are exposed to users and can't be renamed without
+// breaking dashboards.
+func TestCounterNamesHaveTotalSuffix(t *testing.T) {
+	calls := findMetricCalls(t, ".")
+
+	// Allowlist for counters that don't end with _total.
+	// These are typically dynamic or kernel-derived names that
+	// are exposed as-is for compatibility.
+	allowlist := map[string]bool{
+		// Ascend NPU HBM error counters use _cnt suffix (vendor convention)
+		"npu_hbm_single_bit_error_cnt":               true,
+		"npu_hbm_double_bit_error_cnt":               true,
+		"npu_hbm_total_single_bit_error_cnt":         true,
+		"npu_hbm_total_double_bit_error_cnt":         true,
+		"npu_hbm_single_bit_isolated_pages_cnt":      true,
+		"npu_hbm_double_bit_isolated_pages_cnt":      true,
+		"npu_mac_tx_mac_pause_num":                   true,
+		"npu_mac_rx_mac_pause_num":                   true,
+	}
+
+	var violations []string
+	for _, c := range calls {
+		if !c.isString {
+			continue
+		}
+
+		isCounter := c.funcName == "NewCounterData" || c.funcName == "NewContainerCounterData"
+		if !isCounter {
+			continue
+		}
+
+		if allowlist[c.name] {
+			continue
+		}
+
+		if !strings.HasSuffix(c.name, "_total") {
+			relPath, _ := filepath.Rel(".", c.file)
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: counter metric %q should end with _total (func: %s)",
+				relPath, c.line, c.name, c.funcName,
+			))
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("Counter metrics without _total suffix:\n%s\n"+
+			"If these are intentional, add them to the allowlist in this test.",
+			strings.Join(violations, "\n"))
+	}
+}
+
+// TestMetricNamesUseSnakeCase checks that metric names use snake_case
+// (lowercase with underscores) and don't contain camelCase or hyphens.
+func TestMetricNamesUseSnakeCase(t *testing.T) {
+	calls := findMetricCalls(t, ".")
+
+	// Allow uppercase for kernel-derived dynamic names that are
+	// exposed as-is (e.g., Tcp_Inuse, TcpExt_ListenDrops).
+	// We only flag obvious camelCase patterns in static names.
+	camelCase := regexp.MustCompile(`[a-z][A-Z]`)
+
+	var violations []string
+	for _, c := range calls {
+		if !c.isString {
+			continue
+		}
+
+		if camelCase.MatchString(c.name) {
+			relPath, _ := filepath.Rel(".", c.file)
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: metric name %q contains camelCase — use snake_case instead",
+				relPath, c.line, c.name,
+			))
+		}
+
+		if strings.Contains(c.name, "-") {
+			relPath, _ := filepath.Rel(".", c.file)
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: metric name %q contains hyphen — use underscore instead",
+				relPath, c.line, c.name,
+			))
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Errorf("Metric names with non-snake_case characters:\n%s",
+			strings.Join(violations, "\n"))
+	}
+}
+
+// TestMetricNamesNotEmpty checks that metric names are not empty strings.
+func TestMetricNamesNotEmpty(t *testing.T) {
+	calls := findMetricCalls(t, ".")
+
+	for _, c := range calls {
+		if c.isString && c.name == "" {
+			relPath, _ := filepath.Rel(".", c.file)
+			t.Errorf("%s:%d: empty metric name in %s call",
+				relPath, c.line, c.funcName)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Related to #293.

Adds a Prometheus naming convention linter as a Go unit test that statically analyzes all metric definitions in `core/metrics/` and validates them against [Prometheus naming best practices](https://prometheus.io/docs/practices/naming/#metric-names).

## Changes

### New Files
- **`core/metrics/metrics_naming_test.go`** — static analysis test using `go/parser` and `go/ast`

### Modified Files
- **`Makefile`** — added `metrics-naming-check` target

## How It Works

The test uses Go's built-in `go/parser` and `go/ast` packages to scan all `.go` files in `core/metrics/` for calls to:
- `NewGaugeData(name, ...)`
- `NewCounterData(name, ...)`
- `NewContainerGaugeData(container, name, ...)`
- `NewContainerCounterData(container, name, ...)`

It then validates the metric `name` argument (when it's a string literal) against four rules:

### 1. `TestMetricNamesValid`
Metric names must match `[a-zA-Z_:][a-zA-Z0-9_:]*` (Prometheus metric naming rule).

### 2. `TestCounterNamesHaveTotalSuffix`
Counter-type metrics (created via `NewCounterData` or `NewContainerCounterData`) should end with `_total`. An allowlist is provided for existing vendor-convention names (e.g., Ascend NPU HBM error counters using `_cnt` suffix).

### 3. `TestMetricNamesUseSnakeCase`
Metric names should use snake_case — no camelCase or hyphens.

### 4. `TestMetricNamesNotEmpty`
Metric names must not be empty strings.

## Key Design Decisions

1. **Static analysis, not runtime** — Uses `go/ast` to parse source files, so no BPF, no runtime, no external dependencies. Can run in any CI environment.
2. **Allowlist for existing violations** — The `_cnt` suffix counters from Ascend NPU are added to an allowlist rather than forcing a rename (which would break existing dashboards). New metrics must follow the convention.
3. **Skips dynamic names** — Metrics with non-string-literal names (e.g., from `/proc/net/dev` parsing) are skipped since they can't be validated statically.
4. **Makefile target** — `make metrics-naming-check` runs just the naming tests for fast feedback.

## Testing

```
$ make metrics-naming-check
=== RUN   TestMetricNamesValid
--- PASS: TestMetricNamesValid (0.01s)
=== RUN   TestCounterNamesHaveTotalSuffix
--- PASS: TestCounterNamesHaveTotalSuffix (0.01s)
=== RUN   TestMetricNamesUseSnakeCase
--- PASS: TestMetricNamesUseSnakeCase (0.01s)
=== RUN   TestMetricNamesNotEmpty
--- PASS: TestMetricNamesNotEmpty (0.01s)
PASS
ok  	huatuo-bamai/core/metrics	0.064s
```

All 4 tests pass on the current codebase. The existing metrics that don't follow conventions (identified in the issue analysis) are either in the allowlist or use dynamic names that are skipped.

## Checklist

- [x] No breaking changes (test-only addition)
- [x] All tests pass
- [x] No external dependencies (uses Go standard library only)
- [x] DCO signed

Signed-off-by: wc4440222 <199748891+wc4440222@users.noreply.github.com>