### PR TITLE
Security: Unsafe Type Conversion in Config Handler

### DIFF
--- a/cmd/huatuo-bamai/handlers/config.go
+++ b/cmd/huatuo-bamai/handlers/config.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"math"
 	"net/http"
 	"reflect"
 
@@ -48,7 +49,11 @@ func (h *ConfigHandler) update(ctx *server.Context) error {
 
 	for k, v := range req.Config {
 		if reflect.ValueOf(v).Kind() == reflect.Float64 {
-			v = int(v.(float64))
+			f := v.(float64)
+			if f > math.MaxInt64 || f < math.MinInt64 {
+				return response.ErrInvalidRequest.WithMessage("integer value out of range")
+			}
+			v = int64(f)
 		}
 		if err := config.Set(k, v); err != nil {
 			return response.ErrInvalidRequest.WithMessage(err.Error())


### PR DESCRIPTION
## Summary

Security: Unsafe Type Conversion in Config Handler

## Problem

**Severity**: `Medium` | **File**: `cmd/huatuo-bamai/handlers/config.go:L55`

In `cmd/huatuo-bamai/handlers/config.go`, the `update` method performs an unsafe type conversion from `float64` to `int` without bounds checking. The code uses `v.(float64)` and then casts to `int(v.(float64))`, which can cause integer overflow on 32-bit systems or when large values are provided. Additionally, the `reflect.ValueOf(v).Kind() == reflect.Float64` check is insufficient as it doesn't validate the actual value range before conversion.

## Solution

Add proper bounds checking before converting float64 to int, and use `int64` instead of `int` to avoid architecture-dependent overflow issues. Consider using a safer conversion pattern like checking if the value fits within int64 bounds before casting.

## Changes

- `cmd/huatuo-bamai/handlers/config.go` (modified)