### PR TITLE
fix(profiler/java): correct misleading retry delay log and comment

### DIFF
--- a/internal/profiler/runtime/java/retry.go
+++ b/internal/profiler/runtime/java/retry.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	// Starts with an initial delay of 10ms, increasing by 10ms with each retry.
-	// Retries up to 1000 times, with a maximum total wait time of approximately 10 seconds.
+	// Retries up to maxRetries times with a fixed retryInterval delay between
+	// attempts, for a maximum total wait time of approximately 10 seconds.
 	maxRetries    = 1000
 	retryInterval = 10 * time.Millisecond
 
@@ -58,7 +58,7 @@ func RetrySampleProfiler(ctx context.Context, pid, dur, freq int, toolPath, outp
 			}
 		}
 
-		log.Infof("PID[%d] sampling attempt %d/%d (delay: %s)", pid, attempt, maxRetries, delay*time.Duration(attempt))
+		log.Infof("PID[%d] sampling attempt %d/%d (delay: %s)", pid, attempt, maxRetries, delay)
 
 		res := sampleFn(ctx, onePid, dur, freq, toolPath, outputFormat)
 		cmdRes := res[0]


### PR DESCRIPTION
Closes #322

### Problem

In `RetrySampleProfiler` (`internal/profiler/runtime/java/retry.go`), `delay`
is initialized to `retryInterval` (10ms) and never modified in the loop, so the
actual wait between attempts is a constant 10ms. But:

- the log statement printed `delay*time.Duration(attempt)` (10ms, 20ms, 30ms …), and
- the doc comment claimed the delay "increas[es] by 10ms with each retry",

both of which contradict the real constant-delay behavior and can mislead anyone
debugging from the logs.

### Why this direction (no behavior change)

The comment's own budget — "approximately 10 seconds" — is only consistent with a
constant delay: `1000 * 10ms = 10s`. A true increasing backoff would total
`10ms * (1+2+…+1000) ≈ 83 minutes`, contradicting that budget. So the running
behavior (constant 10ms) is treated as the intended one, and only the misleading
log and comment are corrected. Runtime behavior is unchanged.

### Changes

- Log the real `delay` instead of `delay*attempt`.
- Reword the comment to describe the fixed-interval behavior.

### Verification

```
gofmt -l internal/profiler/runtime/java/retry.go   # no output
go vet   ./internal/profiler/runtime/java/          # clean
go build ./internal/profiler/runtime/java/          # ok
go test  ./internal/profiler/runtime/java/          # no test files in package
```

Not unit-tested: the change only affects a log line and a comment (no logic change),
so it was verified by build/vet/gofmt and manual inspection.