### PR TITLE
test(localfile): discard os.Chmod return in cleanup to satisfy errcheck

### DIFF
--- a/internal/storage/localfile/localfile_test.go
+++ b/internal/storage/localfile/localfile_test.go
@@ -74,7 +74,7 @@ func TestBackendSaveMkdirAllError(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	// Ensure cleanup can remove it even though it's read-only.
-	t.Cleanup(func() { os.Chmod(readOnlyDir, 0o755) })
+	t.Cleanup(func() { _ = os.Chmod(readOnlyDir, 0o755) })
 
 	// Use a subdirectory under the read-only dir that doesn't exist.
 	// MkdirAll will fail because the parent is read-only.


### PR DESCRIPTION
### Problem

`golangci-lint run ./...` (invoked by `make check`) currently fails on `main`:

```
internal/storage/localfile/localfile_test.go:77:29: Error return value of `os.Chmod` is not checked (errcheck)
	t.Cleanup(func() { os.Chmod(readOnlyDir, 0o755) })
```

Because the lint step scans the whole repository, this pre-existing violation
fails the **Build, Lint and Vendor** CI job for every branch cut from current
`main`, not just the PR that would touch this file.

### Fix

Explicitly discard the `os.Chmod` return value with `_ =`. A failed chmod during
test cleanup is harmless, and this matches the existing convention in the codebase
(e.g. `_ = os.Remove(...)`).

### Verification

```
# before (on main): fails
golangci-lint run ./internal/storage/localfile/ --config .golangci.yaml
#   localfile_test.go:77:29: Error return value of `os.Chmod` is not checked (errcheck)

# after (this PR): clean, exit 0
golangci-lint run ./internal/storage/localfile/ --config .golangci.yaml

go test ./internal/storage/localfile/   # ok
```

golangci-lint v1.62.2 (same version as CI).