### PR TITLE
fix(pod): replace kubeletConfigCacheUpdate panic with error return

### DIFF
--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -20,15 +20,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/utils/netutil"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"syscall"
 	"time"
-
-	"huatuo-bamai/internal/log"
-	"huatuo-bamai/internal/utils/netutil"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
@@ -532,10 +531,7 @@ func kubeletConfigCacheUpdate(ctx *ManagerCtx) error {
 
 	config, err = kubeletConfigFileDefault()
 	if err != nil {
-		panic(fmt.Sprintf(
-			"we cannot find any cgroup driver of kubelet after requesting configz and default files: %v",
-			err,
-		))
+		return fmt.Errorf("kubelet config unavailable: configz and default files failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

`kubeletConfigCacheUpdate()` panics when neither the kubelet configz API nor local config files can provide the cgroup driver configuration:

```go
config, err = kubeletConfigFileDefault()
if err != nil {
    panic(fmt.Sprintf(
        "we cannot find any cgroup driver of kubelet after requesting configz and default files: %v",
        err,
    ))
}
```

This panic crashes the entire agent process. On minimal nodes where kubelet is not yet running or config files are absent, this is a runtime condition — not a programming error — and should not crash the process.

## Fix

Replace `panic(fmt.Sprintf(...))` with `return fmt.Errorf(...)`. The function already returns `error`, so this is a minimal, safe change.

**Impact**: The two callers (`ManagerInit` and the goroutine in `ManagerInit`) already discard the error with `_ = kubeletConfigCacheUpdate(ctx)`. Instead of crashing, the agent will now continue running with the default cgroup driver (`cgroupfs`).

## Testing

- `go build ./internal/pod/` passes
- `make import-fmt` applied (goimports + gofumpt + gofmt)