### PR TITLE
feat(net_tx_latency): add TCP send-path latency tracing

### DIFF
--- a/bpf/net_tx_latency.c
+++ b/bpf/net_tx_latency.c
@@ -1,0 +1,230 @@
+// go:build ignore
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "bpf_common.h"
+#include "bpf_map.h"
+#include "bpf_net_namespace.h"
+#include "bpf_ratelimit.h"
+#include "bpf_sock.h"
+#include "vmlinux_net.h"
+
+// Thresholds in nanoseconds, patched from userspace (config values are ms).
+// TX_STAGE_SENDMSG: tcp_sendmsg -> net_dev_queue (how long the packet waits
+//   from the user handing it to TCP until it reaches the device/qdisc layer).
+// TX_STAGE_NIC:     net_dev_queue -> net_dev_xmit (qdisc scheduling + driver
+//   + NIC transmit completion).
+volatile const long long txlat_thresh_sendmsg = 50 * 1000 * 1000; // 50ms
+volatile const long long txlat_thresh_nic = 1 * 1000 * 1000;	// 1ms
+
+BPF_RATELIMIT(rate, 1, 100);
+
+enum tx_lat_stage {
+	TX_STAGE_SENDMSG,
+	TX_STAGE_NIC,
+};
+
+// Mirrors net_rx_latency's perf_event_t layout so the userspace decoder and
+// Grafana panels stay consistent. lat_stage is reused to carry tx_stage.
+struct perf_event_t {
+	char comm[COMPAT_TASK_COMM_LEN];
+	u64 latency;
+	u64 tgid_pid;
+	u64 pkt_len;
+	u16 tcp_sport;
+	u16 tcp_dport;
+	u32 tcp_saddr;
+	u32 tcp_daddr;
+	u32 tcp_seq;
+	u32 tcp_ack_seq;
+	u8 tcp_state;
+	u8 lat_stage;
+	u8 _pad[2];
+	char netdev_name[IFNAMSIZ];
+	u32 netns_inum;
+	u64 net_cookie;
+};
+
+// Carries the sender identity + the stage's anchor timestamp across the TX
+// path: sock -> skb. Keeping pid/comm here lets both stage events report the
+// originating process even though NIC transmit may run in softirq context.
+struct tx_send_info {
+	u64 ts;
+	u64 tgid_pid;
+	char comm[COMPAT_TASK_COMM_LEN];
+};
+
+// tcp_sendmsg entry: anchor sendmsg time + capture the sender process.
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__type(key, struct sock *);
+	__type(value, struct tx_send_info);
+	__uint(max_entries, 65536);
+} tx_sock_start SEC(".maps");
+
+// net_dev_queue entry: anchor qdisc/device time, carrying the sender forward
+// to the net_dev_xmit completion probe.
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__type(key, struct sk_buff *);
+	__type(value, struct tx_send_info);
+	__uint(max_entries, 65536);
+} tx_skb_start SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(int));
+	__uint(value_size, sizeof(u32));
+} net_tx_lat_event_map SEC(".maps");
+
+static inline bool skb_is_ipv4_tcp(struct sk_buff *skb)
+{
+	if (unlikely(BPF_CORE_READ(skb, protocol) != bpf_ntohs(ETH_P_IP)))
+		return false;
+
+	struct iphdr ip_hdr;
+
+	bpf_probe_read(&ip_hdr, sizeof(ip_hdr), skb_network_header(skb));
+	return ip_hdr.protocol == IPPROTO_TCP;
+}
+
+static inline bool sk_is_ipv4_tcp(struct sock *sk)
+{
+	return BPF_CORE_READ(sk, __sk_common.skc_family) == AF_INET &&
+	       BPF_CORE_READ_BITFIELD_PROBED(sk, sk_protocol) == IPPROTO_TCP;
+}
+
+static __always_inline void
+submit_txlat_event(void *ctx, struct sk_buff *skb, u64 lat, u8 stage,
+		   u64 tgid_pid, const char *comm_src)
+{
+	struct perf_event_t event = {};
+	struct iphdr ip_hdr;
+	struct tcphdr tcp_hdr;
+	struct net_device *dev;
+
+	if (bpf_ratelimited(&rate))
+		return;
+
+	bpf_probe_read(&ip_hdr, sizeof(ip_hdr), skb_network_header(skb));
+	bpf_probe_read(&tcp_hdr, sizeof(tcp_hdr), skb_transport_header(skb));
+	event.latency = lat;
+	event.tcp_saddr = ip_hdr.saddr;
+	event.tcp_daddr = ip_hdr.daddr;
+	event.tcp_sport = tcp_hdr.source;
+	event.tcp_dport = tcp_hdr.dest;
+	event.tcp_seq = tcp_hdr.seq;
+	event.tcp_ack_seq = tcp_hdr.ack_seq;
+	event.pkt_len = BPF_CORE_READ(skb, len);
+	event.tcp_state = skb_sk_state(skb);
+	event.lat_stage = stage;
+	event.netns_inum = skb_netns_inum(skb);
+	event.net_cookie = skb_netns_cookie(skb);
+	event.tgid_pid = tgid_pid;
+	event.netdev_name[0] = '-';
+
+	if (comm_src)
+		bpf_probe_read_kernel_str(event.comm, sizeof(event.comm),
+					  comm_src);
+	else
+		event.comm[0] = '-';
+
+	dev = BPF_CORE_READ(skb, dev);
+	if (dev)
+		bpf_probe_read_kernel_str(event.netdev_name,
+					  sizeof(event.netdev_name), dev->name);
+
+	bpf_perf_event_output(ctx, &net_tx_lat_event_map,
+			      COMPAT_BPF_F_CURRENT_CPU, &event,
+			      sizeof(struct perf_event_t));
+}
+
+// tcp_sendmsg(struct sock *sk, struct msghdr *msg, size_t size)
+SEC("kprobe/tcp_sendmsg")
+int tcp_sendmsg_prog(struct pt_regs *ctx)
+{
+	struct sock *sk = (struct sock *)PT_REGS_PARM1_CORE(ctx);
+
+	if (!sk || !sk_is_ipv4_tcp(sk))
+		return 0;
+
+	struct tx_send_info info = {};
+
+	info.ts = bpf_ktime_get_ns();
+	info.tgid_pid = bpf_get_current_pid_tgid();
+	bpf_get_current_comm(&info.comm, sizeof(info.comm));
+	bpf_map_update_elem(&tx_sock_start, &sk, &info, BPF_ANY);
+	return 0;
+}
+
+// skb is handed to the device/qdisc. Emit the sendmsg->qdisc stage if we saw
+// the originating tcp_sendmsg, then anchor the NIC-stage timer on the skb.
+SEC("tracepoint/net/net_dev_queue")
+int net_dev_queue_prog(struct trace_event_raw_net_dev_template *args)
+{
+	struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
+
+	if (!skb_is_ipv4_tcp(skb))
+		return 0;
+
+	u64 now = bpf_ktime_get_ns();
+	struct sock *sk = BPF_CORE_READ(skb, sk);
+
+	struct tx_send_info kinfo = {};
+
+	kinfo.ts = now;
+	kinfo.tgid_pid = 0;
+	kinfo.comm[0] = '-';
+
+	if (sk) {
+		struct tx_send_info *sinfo =
+			bpf_map_lookup_elem(&tx_sock_start, &sk);
+
+		if (sinfo) {
+			u64 lat = now - sinfo->ts;
+
+			if (lat >= txlat_thresh_sendmsg)
+				submit_txlat_event(args, skb, lat,
+						   TX_STAGE_SENDMSG,
+						   sinfo->tgid_pid, sinfo->comm);
+			kinfo.tgid_pid = sinfo->tgid_pid;
+			bpf_probe_read_kernel_str(kinfo.comm,
+						  sizeof(kinfo.comm),
+						  sinfo->comm);
+			bpf_map_delete_elem(&tx_sock_start, &sk);
+		}
+	}
+
+	bpf_map_update_elem(&tx_skb_start, &skb, &kinfo, BPF_ANY);
+	return 0;
+}
+
+// Driver/NIC transmit completed. Emit the qdisc->nic stage.
+SEC("tracepoint/net/net_dev_xmit")
+int net_dev_xmit_prog(struct trace_event_raw_net_dev_xmit *args)
+{
+	struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
+
+	if (!skb)
+		return 0;
+
+	struct tx_send_info *kinfo = bpf_map_lookup_elem(&tx_skb_start, &skb);
+
+	if (!kinfo)
+		return 0;
+
+	u64 lat = bpf_ktime_get_ns() - kinfo->ts;
+
+	bpf_map_delete_elem(&tx_skb_start, &skb);
+	if (lat >= txlat_thresh_nic)
+		submit_txlat_event(args, skb, lat, TX_STAGE_NIC,
+				   kinfo->tgid_pid, kinfo->comm);
+	return 0;
+}
+
+char __license[] SEC("license") = "Dual MIT/GPL";

--- a/build/docker/grafana/dashboards/autotracing-event.json
+++ b/build/docker/grafana/dashboards/autotracing-event.json
@@ -1600,6 +1600,84 @@
       "gridPos": {
         "h": 5,
         "w": 3,
+        "x": 21,
+        "y": 5
+      },
+      "id": 200,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "uploaded_time",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "huatuo-bamai-es"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "tracer_name:net_tx_latency AND region:$region AND hostname:$hostname",
+          "refId": "A",
+          "timeField": "uploaded_time"
+        }
+      ],
+      "title": "net_tx_latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "huatuo-bamai-es"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
         "x": 18,
         "y": 5
       },

--- a/core/events/config.go
+++ b/core/events/config.go
@@ -34,6 +34,13 @@ type Config struct {
 		ExcludedContainerQos     []string
 	}
 
+	NetTxLatency struct {
+		Sendmsg2Qdisc            uint64 `default:"50"`
+		Qdisc2Nic                uint64 `default:"1"`
+		ExcludedHostNetnamespace bool   `default:"true"`
+		ExcludedContainerQos     []string
+	}
+
 	Dropwatch struct {
 		Filter             string `default:"tcp"`
 		MaxEventsPerSecond uint64 `default:"100"`

--- a/core/events/net_tx_latency.go
+++ b/core/events/net_tx_latency.go
@@ -1,0 +1,214 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/matcher"
+	"huatuo-bamai/internal/packet"
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/internal/utils/bytesutil"
+	"huatuo-bamai/internal/utils/netutil"
+	"huatuo-bamai/pkg/tracing"
+)
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/net_tx_latency.c -o $BPF_DIR/net_tx_latency.o
+
+type netTxLatTracing struct{}
+
+// The TX BPF perf_event_t is intentionally identical in layout to the RX one,
+// so it reuses NetTracingData for storage/Grafana consistency. The lat_stage
+// field carries a TX_STAGE_* value from txStageNames.
+type netTxPerfEvent = netRcvPerfEvent
+
+var txStageNames = []string{
+	"TX_STAGE_SENDMSG", // tcp_sendmsg -> net_dev_queue
+	"TX_STAGE_NIC",     // net_dev_queue -> net_dev_xmit
+}
+
+func init() {
+	tracing.RegisterEventTracing("net_tx_latency", newNetTxLat)
+}
+
+func newNetTxLat() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &netTxLatTracing{},
+		Interval:    10,
+		Flag:        tracing.FlagTracing,
+	}, nil
+}
+
+func (c *netTxLatTracing) Start(ctx context.Context) error {
+	txlatThreshSendmsg := cfg.NetTxLatency.Sendmsg2Qdisc // ms, tcp_sendmsg -> qdisc (net_dev_queue)
+	txlatThreshNic := cfg.NetTxLatency.Qdisc2Nic         // ms, qdisc -> nic (net_dev_xmit)
+
+	if txlatThreshSendmsg == 0 || txlatThreshNic == 0 {
+		return fmt.Errorf("net_tx_latency threshold [%v %v]ms invalid", txlatThreshSendmsg, txlatThreshNic)
+	}
+
+	log.Debugf("net_tx_latency start, latency threshold [%v %v]ms", txlatThreshSendmsg, txlatThreshNic)
+
+	latThresholds := []uint64{txlatThreshSendmsg, txlatThreshNic}
+
+	// TX timestamps are all bpf_ktime_get_ns (monotonic) across tcp_sendmsg,
+	// net_dev_queue and net_dev_xmit, so no mono/wall offset is needed (unlike
+	// RX, which diffs against the skb's receive timestamp).
+
+	args := map[string]any{
+		"txlat_thresh_sendmsg": txlatThreshSendmsg * 1000 * 1000,
+		"txlat_thresh_nic":     txlatThreshNic * 1000 * 1000,
+	}
+	b, err := bpf.LoadBpf(bpf.ThisBpfOBJ(), args)
+	if err != nil {
+		return err
+	}
+	defer b.Close()
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	reader, err := b.AttachAndEventPipe(childCtx, "net_tx_lat_event_map", 8192)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	b.WaitDetachByBreaker(childCtx, cancel)
+
+	// save host netns
+	hostNetNsInode, err := netutil.NetNSInodeByPid(1)
+	if err != nil {
+		return fmt.Errorf("get host netns inode: %w", err)
+	}
+
+	for {
+		select {
+		case <-childCtx.Done():
+			return nil
+		default:
+			var pd netTxPerfEvent
+			if err := reader.ReadInto(&pd); err != nil {
+				return fmt.Errorf("read from perf event fail: %w", err)
+			}
+
+			containerID, ok := filterTxByConfigAndResolveContainerID(&pd, hostNetNsInode)
+			if !ok {
+				continue
+			}
+
+			where := txStageNames[pd.LatStage]
+			lat := float64(pd.Latency) / 1000 / 1000 // ms
+			latThreshold := latThresholds[pd.LatStage]
+			state := packet.TCPStateName(pd.TCPState)
+			saddr, daddr := netutil.Inetv4Ntop(pd.TCPSaddr).String(), netutil.Inetv4Ntop(pd.TCPDaddr).String()
+			sport, dport := netutil.Ntohs(pd.TCPSport), netutil.Ntohs(pd.TCPDport)
+			seq, ackSeq := netutil.Ntohl(pd.TCPSeq), netutil.Ntohl(pd.TCPAckSeq)
+			pktLen := pd.PktLen
+
+			comm := bytesutil.ToStr(pd.Comm[:])
+			pid := pd.TgidPid >> 32
+
+			title := fmt.Sprintf("comm=%s:%d to=%s lat(ms)=%.2f state=%s saddr=%s sport=%d daddr=%s dport=%d seq=%d ackSeq=%d pktLen=%d",
+				comm, pid, where, lat, state, saddr, sport, daddr, dport, seq, ackSeq, pktLen)
+
+			// known issue filter
+			if _, found := matcher.Classify(cfg.IssuesList, title); found {
+				log.Debugf("net_tx_latency known issue")
+				continue
+			}
+
+			tracerData := &NetTracingData{
+				Comm:               comm,
+				Pid:                pid,
+				LatStage:           where,
+				LatMs:              lat,
+				LatThresholds:      latThreshold,
+				NetdevName:         bytesutil.ToStr(pd.NetdevName[:]),
+				NetNamespaceInode:  pd.NetNamespaceInode,
+				NetNamespaceCookie: pd.NetNamespaceCookie,
+				TCPState:           state,
+				TCPSaddr:           saddr,
+				TCPDaddr:           daddr,
+				TCPSport:           sport,
+				TCPDport:           dport,
+				TCPSeq:             seq,
+				TCPAckSeq:          ackSeq,
+				PktLen:             pktLen,
+			}
+			log.Debugf("net_tx_latency tracerData: %+v", tracerData)
+
+			// save storage
+			if err := tracing.Save(&tracing.WriteRequest{
+				TracerName:  "net_tx_latency",
+				ContainerID: containerID,
+				TracerTime:  time.Now(),
+				TracerData:  tracerData,
+			}); err != nil {
+				log.Warnf("failed to save tracing data: %v", err)
+			}
+		}
+	}
+}
+
+func isTxQosExcluded(container *pod.Container) bool {
+	for _, level := range cfg.NetTxLatency.ExcludedContainerQos {
+		if strings.EqualFold(container.Qos.String(), level) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterTxByConfigAndResolveContainerID(pd *netTxPerfEvent, hostNetnsInode uint64) (string, bool) {
+	inode := uint64(pd.NetNamespaceInode)
+
+	if cfg.NetTxLatency.ExcludedHostNetnamespace && inode == hostNetnsInode {
+		return "", false
+	}
+
+	var container *pod.Container
+
+	if pd.NetNamespaceCookie != 0 {
+		ct, err := pod.ContainerByNetCookie(pd.NetNamespaceCookie)
+		if err != nil {
+			log.Debugf("net_tx_latency: net_cookie lookup %d failed: %v", pd.NetNamespaceCookie, err)
+		} else if ct != nil {
+			container = ct
+		}
+	}
+
+	if container == nil {
+		ct, err := pod.ContainerByNetInode(inode)
+		if err != nil {
+			log.Warnf("net_tx_latency: get container by netns inode %d failed: %v", inode, err)
+			return "", true
+		}
+		if ct == nil {
+			return "", true
+		}
+		container = ct
+	}
+
+	if isTxQosExcluded(container) {
+		return container.ID, false
+	}
+	return container.ID, true
+}

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -386,6 +386,34 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
         ExcludedContainerQos = ["besteffort"]
         # ExcludedHostNetnamespace = true
 
+    # networking tx latency
+    #
+    # linux net stack tx latency for tcp skbs on the send path.
+    #
+    # - Sendmsg2Qdisc
+    # The latency from tcp_sendmsg to the device/qdisc queue, e.g. net_dev_queue.
+    # Default: 50ms
+    #
+    # - Qdisc2Nic
+    # The latency from the device/qdisc queue to nic transmit completion, e.g. net_dev_xmit.
+    # Default: 1ms
+    #
+    # - ExcludedContainerQos
+    # Blacklist: skip containers whose qos level matches any entry in this list.
+    # Values: "guaranteed", "burstable", "besteffort" (case-insensitive).
+    # Default: [].
+    #
+    # - ExcludedHostNetnamespace
+    # Don't care the skbs, packets in the host net namespace.
+    # Default: true
+    #
+    [EventTracing.NetTxLatency]
+        # Sendmsg2Qdisc = 50
+        # Qdisc2Nic = 1
+        # ExcludedContainerQos = []
+        ExcludedContainerQos = ["besteffort"]
+        # ExcludedHostNetnamespace = true
+
     # netdev events
     #
     # monitor the net device events.

--- a/integration/env.sh
+++ b/integration/env.sh
@@ -62,6 +62,12 @@ export PYTHON_PROFILER_TOOL_PATH
 HUATUO_BAMAI_E2E_ARGS_STR="${HUATUO_BAMAI_ARGS_E2E[*]}"
 export HUATUO_BAMAI_E2E_ARGS_STR
 
+# Initialized empty so the net latency integration tests' save/restore of this
+# var works on the first run under `set -u` (the test reads its current value
+# before overwriting it). Mirrors HUATUO_BAMAI_E2E_ARGS_STR above.
+HUATUO_BAMAI_INTEGRATION_ARGS_STR=""
+export HUATUO_BAMAI_INTEGRATION_ARGS_STR
+
 # k8s: metadata.name == pod-name, ct-hostname
 # huatuo-bamai: name == ct-hostname, hostname == pod-name == metadata.name
 BUSINESS_POD_NS="default"

--- a/integration/test_net_tx_latency.sh
+++ b/integration/test_net_tx_latency.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Authors:
+# Tonghao Zhang <tonghao@bamaicloud.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify net_tx_latency BPF program detects TCP send-path latency events.
+#
+# The peer veth end lives in its own network namespace. This is essential:
+# if both ends share the host netns the peer IP is "local" and the kernel
+# routes host->peer over loopback, so the packets never traverse the veth and
+# net_dev_queue / net_dev_xmit never fire. A netem egress delay on the host
+# side inflates the net_dev_queue -> net_dev_xmit (qdisc/driver) latency above
+# the 1ms threshold so TX_STAGE_NIC events fire reliably.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+source "${ROOT_DIR}/integration/config.sh"
+
+[[ $EUID -eq 0 ]] || skip "requires root"
+
+VETH_HOST="veth-txlat-h"
+VETH_PEER="veth-txlat-p"
+NS_PEER="txlat-ns"
+VETH_HOST_IP="10.200.2.1"
+VETH_PEER_IP="10.200.2.2"
+TEST_PORT=19877
+
+ip netns add "${NS_PEER}" 2> /dev/null || skip "netns creation failed"
+ip link add "${VETH_HOST}" type veth peer name "${VETH_PEER}" 2> /dev/null || {
+	ip netns del "${NS_PEER}" 2> /dev/null || true
+	skip "veth creation failed"
+}
+ip link set "${VETH_PEER}" netns "${NS_PEER}"
+ip addr add "${VETH_HOST_IP}/24" dev "${VETH_HOST}" 2> /dev/null || true
+ip link set "${VETH_HOST}" up 2> /dev/null || true
+ip netns exec "${NS_PEER}" ip addr add "${VETH_PEER_IP}/24" dev "${VETH_PEER}" 2> /dev/null || true
+ip netns exec "${NS_PEER}" ip link set "${VETH_PEER}" up 2> /dev/null || true
+ip netns exec "${NS_PEER}" ip link set lo up 2> /dev/null || true
+sleep 0.5
+
+# Inflate TX (qdisc/driver) latency so it exceeds the 1ms threshold.
+modprobe sch_netem 2> /dev/null || true
+tc qdisc add dev "${VETH_HOST}" root netem delay 2ms 2> /dev/null || {
+	ip link del "${VETH_HOST}" 2> /dev/null || true
+	ip netns del "${NS_PEER}" 2> /dev/null || true
+	skip "netem qdisc unavailable, cannot inflate TX latency"
+}
+
+_original_args_str="${HUATUO_BAMAI_INTEGRATION_ARGS_STR}"
+_sink_pid=""
+cleanup_all() {
+	if [[ -n "${_sink_pid}" ]]; then
+		kill "${_sink_pid}" 2> /dev/null || true
+		wait "${_sink_pid}" 2> /dev/null || true
+	fi
+	huatuo_bamai_stop $? 2> /dev/null || true
+	tc qdisc del dev "${VETH_HOST}" root 2> /dev/null || true
+	ip link del "${VETH_HOST}" 2> /dev/null || true
+	ip netns del "${NS_PEER}" 2> /dev/null || true
+	export HUATUO_BAMAI_INTEGRATION_ARGS_STR="${_original_args_str}"
+	HUATUO_BAMAI_ARGS_INTEGRATION=""
+}
+trap cleanup_all EXIT
+
+HUATUO_BAMAI_ARGS_INTEGRATION=(
+	"--config-dir" "${HUATUO_BAMAI_TEST_TMPDIR}"
+	"--config" "bamai.conf"
+	"--region" "dev"
+	"--procfs-prefix" "${HUATUO_BAMAI_TEST_FIXTURES}"
+	"--disable-kubelet"
+)
+HUATUO_BAMAI_INTEGRATION_ARGS_STR="${HUATUO_BAMAI_ARGS_INTEGRATION[*]}"
+export HUATUO_BAMAI_INTEGRATION_ARGS_STR
+
+write_net_tx_latency_config() {
+	cat > "${HUATUO_BAMAI_TEST_TMPDIR}/bamai.conf" << EOF
+BlackList = ["metax_gpu", "ascend_npu", "softlockup", "ethtool", "netstat_hw", "iolatency", "memory_free", "memory_reclaim", "reschedipi", "softirq", "iotracing", "dropwatch", "net_rx_latency"]
+
+[EventTracing.NetTxLatency]
+    Sendmsg2Qdisc = 1
+    Qdisc2Nic = 1
+    ExcludedHostNetnamespace = false
+
+[Storage.LocalFile]
+    Path = "${HUATUO_BAMAI_TEST_TMPDIR}/events"
+EOF
+}
+
+integration_huatuo_bamai_start write_net_tx_latency_config
+trap cleanup_all EXIT
+
+TCP_SINK="${HUATUO_BAMAI_TEST_TMPDIR}/tx-sink"
+cc -O2 -Wall -Wextra -o "${TCP_SINK}" \
+	"${ROOT_DIR}/integration/testdata/test_net_tx_latency_sink.c" \
+	|| skip "failed to compile tx sink"
+
+ip netns exec "${NS_PEER}" "${TCP_SINK}" \
+	> "${HUATUO_BAMAI_TEST_TMPDIR}/sink.log" 2>&1 &
+_sink_pid=$!
+sleep 0.5
+
+# Push a few MB of TX through the netem-delayed veth so the net_dev_queue ->
+# net_dev_xmit latency reliably exceeds the 1ms threshold.
+for i in $(seq 1 3); do
+	log_info "tx burst #${i} -> ${VETH_PEER_IP}:${TEST_PORT}"
+	dd if=/dev/zero bs=1024 count=2048 2>/dev/null | \
+		curl -s --connect-timeout 1 --max-time 5 \
+			--interface "${VETH_HOST_IP}" \
+			--data-binary @- \
+			"http://${VETH_PEER_IP}:${TEST_PORT}/" \
+			>> "${HUATUO_BAMAI_TEST_TMPDIR}/curl.log" 2>&1 || true
+done
+
+sleep 5
+
+EVENTS_FILE="${HUATUO_BAMAI_TEST_TMPDIR}/events/net_tx_latency"
+[[ -f "${EVENTS_FILE}" ]] || {
+	dump_file "HUATUO" "${HUATUO_BAMAI_TEST_TMPDIR}/huatuo.log"
+	fatal "no events file: ${EVENTS_FILE}"
+}
+
+# TX direction: saddr = host, daddr = peer.
+MATCHED=$(jq -s --arg saddr "${VETH_HOST_IP}" --arg daddr "${VETH_PEER_IP}" \
+	'[.[] | select(.tracer_data.tcp_saddr == $saddr and .tracer_data.tcp_daddr == $daddr)]' \
+	"${EVENTS_FILE}" 2> /dev/null)
+
+event_count=$(echo "${MATCHED}" | jq 'length' 2> /dev/null || echo 0)
+event_count=$(echo "${event_count}" | tr -d '[:space:]')
+log_info "net_tx_latency events (${VETH_HOST_IP} -> ${VETH_PEER_IP}): ${event_count}"
+
+if [[ "${event_count}" -eq 0 ]]; then
+	dump_file "EVENTS" "${EVENTS_FILE}"
+	dump_file "SINK" "${HUATUO_BAMAI_TEST_TMPDIR}/sink.log"
+	dump_file "HUATUO" "${HUATUO_BAMAI_TEST_TMPDIR}/huatuo.log"
+	fatal "no matching net_tx_latency events found"
+fi
+
+log_info "net_tx_latency integration test passed: ${event_count} events"
+log_info "event details:"
+echo "${MATCHED}" | jq '.' 2> /dev/null || echo "${MATCHED}"

--- a/integration/test_net_tx_latency.sh
+++ b/integration/test_net_tx_latency.sh
@@ -101,7 +101,11 @@ BlackList = ["metax_gpu", "ascend_npu", "softlockup", "ethtool", "netstat_hw", "
 EOF
 }
 
-integration_huatuo_bamai_start write_net_tx_latency_config
+# Pass HUATUO_BAMAI_ARGS_INTEGRATION explicitly so integration_huatuo_bamai_start
+# takes its non-default branch — otherwise the helper defaults to
+# --disable-storage and the [Storage.LocalFile] events this test asserts on are
+# never written.
+integration_huatuo_bamai_start write_net_tx_latency_config "${HUATUO_BAMAI_ARGS_INTEGRATION[@]}"
 trap cleanup_all EXIT
 
 TCP_SINK="${HUATUO_BAMAI_TEST_TMPDIR}/tx-sink"

--- a/integration/testdata/test_net_tx_latency_sink.c
+++ b/integration/testdata/test_net_tx_latency_sink.c
@@ -1,0 +1,48 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define BIND_PORT 19877
+
+int main(void)
+{
+	int lfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (lfd < 0) {
+		perror("socket");
+		return 1;
+	}
+
+	int opt = 1;
+	setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+	// Bind to any address so the same binary works regardless of which
+	// netns / IP the test places it under.
+	struct sockaddr_in addr = {
+		.sin_family = AF_INET,
+		.sin_port = htons(BIND_PORT),
+		.sin_addr.s_addr = htonl(INADDR_ANY),
+	};
+	if (bind(lfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		perror("bind");
+		return 1;
+	}
+	if (listen(lfd, 5) < 0) {
+		perror("listen");
+		return 1;
+	}
+
+	// Drain whatever the client sends so the test can push a lot of TX data
+	// through the veth, then close and accept the next connection.
+	for (;;) {
+		int cfd = accept(lfd, NULL, NULL);
+		if (cfd < 0)
+			continue;
+
+		char buf[65536];
+		while (recv(cfd, buf, sizeof(buf), 0) > 0) {
+		}
+		close(cfd);
+	}
+}


### PR DESCRIPTION
## What

Adds `net_tx_latency`, the send-path counterpart to the existing `net_rx_latency` tracer — TCP **TX (send-path) latency** tracing.

## Why

huatuo already traces latency on the receive path (`net_rx_latency`), but the send path was a blind spot. This fills that gap so we can tell whether a slow TCP send is stalled in the stack (`tcp_sendmsg → qdisc`) or in the qdisc/driver/NIC (`net_dev_queue → net_dev_xmit`).

Refs ccfos/huatuo#323.

## How

Splits the TX path into two stages, each with its own threshold; an event fires only when a stage exceeds its threshold:

| stage | segment | default threshold |
|---|---|---|
| `TX_STAGE_SENDMSG` | `tcp_sendmsg → net_dev_queue` | 50 ms |
| `TX_STAGE_NIC` | `net_dev_queue → net_dev_xmit` | 1 ms |

Unlike RX (which diffs `skb->tstamp` set on receive), TX has no pre-existing timestamp, so the BPF program anchors timestamps itself and correlates the stages with two LRU hash maps:

- `tx_sock_start` (key = `sock *`) — captured at `kprobe/tcp_sendmsg`
- `tx_skb_start` (key = `sk_buff *`) — captured at `tracepoint/net/net_dev_queue`

The sender's `pid`/`comm` are carried sock→skb so NIC-stage events (which run in softirq context) still report the originating process. The `perf_event_t` layout intentionally mirrors `net_rx_latency`, so userspace reuses `NetTracingData` for storage and Grafana consistency.

## Changes

- **new** `bpf/net_tx_latency.c` — eBPF: 3 probes (`tcp_sendmsg`, `net_dev_queue`, `net_dev_xmit`), 2 hash maps, threshold-gated event submission.
- **new** `core/events/net_tx_latency.go` — userspace decode + filtering (host-netns exclusion, QoS blacklist); reuses `NetTracingData`.
- **mod** `core/events/config.go` — `NetTxLatency` config struct (`Sendmsg2Qdisc`, `Qdisc2Nic`, `ExcludedHostNetnamespace`, `ExcludedContainerQos`).
- **mod** `huatuo-bamai.conf` — `[EventTracing.NetTxLatency]` section + docs.
- **mod** `build/docker/grafana/dashboards/autotracing-event.json` — `net_tx_latency` stat panel (id 200).
- **new** `integration/test_net_tx_latency.sh` + `integration/testdata/test_net_tx_latency_sink.c` — integration test.

## Testing

- `make all` green; `gofmt` + `go vet` clean.
- BPF loads & attaches all 3 probes (verified in huatuo.log).
- Integration test passes: a veth pair with the peer end in its own network namespace + 2 ms netem egress delay makes `TX_STAGE_NIC` events fire reliably (latency ≈ 2 ms, matching netem).
- Test gotcha: both veth ends must **not** share the host netns — otherwise the peer IP is local, the kernel routes host→peer over loopback, and `net_dev_queue`/`net_dev_xmit` never fire (zero events).

## Scope / out of scope

This covers 3 of the 4 acceptance criteria in #323 (TX stages collected + displayed, RX-compatible event layout, Grafana panel). **Prometheus metrics are deferred to a follow-up** — `net_rx_latency` exposes none today, so this keeps parity and avoids introducing a metrics pipeline for TX alone.
