### PR TITLE
fix(server): replace MustRegisterRoutes panic with error return, protect TCPListener type assertion

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -208,7 +208,10 @@ func (s *server) run(addr string) error {
 		return fmt.Errorf("listen %w", err)
 	}
 
-	tcpListener := listener.(*net.TCPListener)
+	tcpListener, ok := listener.(*net.TCPListener)
+	if !ok {
+		return fmt.Errorf("expected *net.TCPListener, got %T", listener)
+	}
 	file, err := tcpListener.File()
 	if err != nil {
 		return fmt.Errorf("get listener fd %w", err)


### PR DESCRIPTION
## Problem

`internal/server/server.go` has two safety issues:

### 1. MustRegisterRoutes panics on unknown type
`panic("unknown type")` crashes the entire agent if a route is registered with an unrecognized HTTP method type. This should return an error instead.

### 2. Bare type assertion in run()
`tcpListener := listener.(*net.TCPListener)` — while `net.Listen("tcp", ...)` almost always returns `*net.TCPListener`, this is an implementation detail, not a guarantee. A defensive `ok` check prevents a potential runtime panic.

## Fix

1. **MustRegisterRoutes**: Changed from `void` to `error` return. `panic` replaced with `fmt.Errorf`.
2. **run()**: Added `ok` check for `listener.(*net.TCPListener)` with descriptive error message.
3. **Updated all callers**:
   - `internal/server` NewServer: log warning on error
   - `cmd/huatuo-bamai` handlers: log error on failure
   - `cmd/huatuo-apiserver` handlers: propagate error (return)

## Testing
- `make import-fmt` applied
- All callers updated to handle new error return