### PR TITLE
feat(profiling): continuous profiling infrastructure & Grafana dashboards

### DIFF
--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -28,10 +28,29 @@ services:
       - ./grafana/datasources/elasticsearch.yaml:/etc/grafana/provisioning/datasources/elasticsearch.yaml:ro
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro
       - ./grafana/datasources/infinity.yaml:/etc/grafana/provisioning/datasources/infinity.yaml:ro
+      - ./grafana/datasources/pyroscope.yaml:/etc/grafana/provisioning/datasources/pyroscope.yaml:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
     depends_on:
       - prometheus
       - elasticsearch
+
+  huatuo-apiserver:
+    image: huatuo/huatuo-bamai:latest
+    container_name: huatuo-apiserver
+    network_mode: host
+    environment:
+      ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST:-}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
+      RUN_PATH: ${RUN_PATH:-}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ../../huatuo-apiserver.conf:${RUN_PATH}/conf/huatuo-apiserver.conf:rw
+      - ./run-huatuo-apiserver.sh:${RUN_PATH}/run-huatuo-apiserver.sh:rw
+    working_dir: ${RUN_PATH}
+    command: ["./run-huatuo-apiserver.sh"]
+    depends_on:
+      - elasticsearch
+      - prometheus
 
   huatuo-bamai:
     image: huatuo/huatuo-bamai:latest
@@ -39,6 +58,7 @@ services:
     network_mode: host
     cgroup: host
     privileged: true
+    working_dir: ${RUN_PATH:-/home/huatuo-bamai}
     environment:
       ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST:-}
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
@@ -50,8 +70,8 @@ services:
       - /etc:/etc:ro
       - /var:/var:ro
       - ../../huatuo-bamai.conf:${RUN_PATH}/conf/huatuo-bamai.conf:rw
-      - ./run.sh:${RUN_PATH}/run.sh:ro
-    command: ["./run.sh"]
+      - ./run-huatuo-bamai.sh:${RUN_PATH}/conf/../run-huatuo-bamai.sh:rw
+    command: ["./run-huatuo-bamai.sh"]
     depends_on:
       - elasticsearch
       - prometheus

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -1,0 +1,260 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "huatuo-bamai-es"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "uploaded_time",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "huatuo-bamai-es"
+          },
+          "hide": false,
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "hostname.keyword:$hostname\nAND container_hostname.keyword:$container_hostname\nAND tracer_data.flamedata.profile_type.keyword:$type",
+          "refId": "A",
+          "timeField": "uploaded_time"
+        }
+      ],
+      "title": "",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 1,
+      "maxPerRow": 2,
+      "options": {},
+      "pluginVersion": "12.0.3",
+      "repeat": "hostname",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{container_hostname=\"$container_hostname\"}",
+          "profileTypeId": "$type",
+          "queryType": "profile",
+          "refId": "A",
+          "spanSelector": []
+        }
+      ],
+      "title": "$container_hostname",
+      "type": "flamegraph"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Selects container-level profiles.",
+        "label": "container hostname",
+        "name": "container_hostname",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allowCustomValue": false,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
+        "description": "Read-only. Displays the host where the selected container resides. Not used as a query filter; filtering is by container_hostname only.",
+        "label": "hostname(Read-only)",
+        "name": "hostname",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "description": "profiling type",
+        "label": "type",
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+            "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+          },
+          {
+            "selected": false,
+            "text": "memory:alloc_space:bytes:space:bytes",
+            "value": "memory:alloc_space:bytes:space:bytes"
+          },
+          {
+            "selected": false,
+            "text": "process_lock:lock:count:lock:count",
+            "value": "process_lock:lock:count:lock:count"
+          },
+          {
+            "selected": false,
+            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
+            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
+          }
+        ],
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Continuous Profiling(container)",
+  "uid": "continuous-profiling-container"
+}

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -1,0 +1,245 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "huatuo-bamai-es"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 8,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "uploaded_time",
+              "id": "2",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "huatuo-bamai-es"
+          },
+          "hide": false,
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "hostname.keyword:$hostname\nAND NOT _exists_:container_hostname\nAND tracer_data.flamedata.profile_type.keyword:$type",
+          "refId": "A",
+          "timeField": "uploaded_time"
+        }
+      ],
+      "title": "",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 20,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 1,
+      "maxPerRow": 2,
+      "options": {},
+      "pluginVersion": "12.0.3",
+      "repeat": "hostname",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{hostname=\"$hostname\"}",
+          "profileTypeId": "$type",
+          "queryType": "profile",
+          "refId": "A",
+          "spanSelector": []
+        }
+      ],
+      "title": "$hostname",
+      "type": "flamegraph"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "description": "Selects host-level profiles.",
+        "label": "hostname",
+        "name": "hostname",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "description": "profiling type",
+        "label": "type",
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+            "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+          },
+          {
+            "selected": false,
+            "text": "memory:alloc_space:bytes:space:bytes",
+            "value": "memory:alloc_space:bytes:space:bytes"
+          },
+          {
+            "selected": false,
+            "text": "process_lock:lock:count:lock:count",
+            "value": "process_lock:lock:count:lock:count"
+          },
+          {
+            "selected": false,
+            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
+            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
+          }
+        ],
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1y",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Continuous Profiling(host)",
+  "uid": "continuous-profiling-host"
+}

--- a/build/docker/grafana/datasources/pyroscope.yaml
+++ b/build/docker/grafana/datasources/pyroscope.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: huatuo-apiserver-pyroscope
+    type: grafana-pyroscope-datasource
+    uid: huatuo-apiserver-pyroscope
+    access: proxy
+    orgId: 1
+    url: http://127.0.0.1:12740/v1/profiles/flamegraph/
+    jsonData:
+      minStep: '15s'
+      httpHeaderName1: 'Authorization'
+    secureJsonData:
+      httpHeaderValue1: REPLACE_WITH_RANDOM_HEX
+    editable: false

--- a/build/docker/run-huatuo-apiserver.sh
+++ b/build/docker/run-huatuo-apiserver.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+#
+# Copyright 2026 The HuaTuo Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:-localhost}
+ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-huatuo-bamai}
+
+RUN_PATH=${RUN_PATH:-/home/huatuo-bamai}
+
+# Wait for Elasticsearch to be ready
+wait_for_elasticsearch() {
+	target_url="http://${ELASTICSEARCH_HOST}:9200/"
+
+	# Try to extract Elasticsearch address from config file
+	if [ -f "huatuo-apiserver.conf" ]; then
+		conf_addr=$(sed -n '/\[ElasticSearch\]/,/\[.*\]/p' huatuo-apiserver.conf | grep '^[[:space:]]*Address' | head -n 1 | awk -F'"' '{print $2}')
+
+		if [ -n "$conf_addr" ]; then
+			echo "Found Elasticsearch address in config: $conf_addr"
+			target_url="${conf_addr}/"
+		fi
+	fi
+
+	args="-s -D- -m15 -w '%{http_code}' ${target_url}"
+	if [ -n "${ELASTIC_PASSWORD}" ]; then
+		args="$args -u elastic:${ELASTIC_PASSWORD}"
+	fi
+
+	result=1
+	output=""
+
+	# retry for up to 180 seconds
+	for sec in $(seq 1 180); do
+		exit_code=0
+		output=$(eval "curl $args") || exit_code=$?
+		if [ $exit_code -ne 0 ]; then
+			result=$exit_code
+		fi
+
+		http_code=$(echo "$output" | tail -c 4)
+		if [ "$http_code" -eq 200 ]; then
+			result=0
+			break
+		fi
+
+		echo "Waiting for Elasticsearch ready... ${sec}s"
+		sleep 1
+	done
+
+	if [ $result -ne 0 ] && [ "$http_code" -ne 000 ]; then
+		echo "$output" | head -c -3
+	fi
+
+	if [ $result -ne 0 ]; then
+		case $result in
+		6)
+			echo 'Could not resolve host. Is Elasticsearch running?'
+			;;
+		7)
+			echo 'Failed to connect to host. Is Elasticsearch healthy?'
+			;;
+		28)
+			echo 'Timeout connecting to host. Is Elasticsearch healthy?'
+			;;
+		*)
+			echo "Connection to Elasticsearch failed. Exit code: ${result}"
+			;;
+		esac
+
+		exit $result
+	fi
+}
+
+wait_for_elasticsearch
+sleep 5 # Waiting for initialization of Elasticsearch built-in users
+echo "Elasticsearch is ready."
+
+exec ./bin/huatuo-apiserver --config huatuo-apiserver.conf

--- a/build/docker/run-huatuo-bamai.sh
+++ b/build/docker/run-huatuo-bamai.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# Copyright 2025 The HuaTuo Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:-localhost}
+ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-huatuo-bamai}
+
+RUN_PATH=${RUN_PATH:-/home/huatuo-bamai}
+
+# Wait for Elasticsearch to be ready
+wait_for_elasticsearch() {
+	target_url="http://${ELASTICSEARCH_HOST}:9200/"
+
+	# Try to extract Elasticsearch address from config file
+	if [ -f "huatuo-bamai.conf" ]; then
+		# Extract Address from [Storage.ES] section
+		# sed: range from [Storage.ES] to next section start [
+		# grep: find Address line
+		# awk: extract text between double quotes
+		conf_addr=$(sed -n '/\[Storage\.ES\]/,/\[.*\]/p' huatuo-bamai.conf | grep '^[[:space:]]*Address' | head -n 1 | awk -F'"' '{print $2}')
+
+		if [ -n "$conf_addr" ]; then
+			echo "Found Elasticsearch address in config: $conf_addr"
+			target_url="${conf_addr}/"
+		fi
+	fi
+
+	args="-s -D- -m15 -w '%{http_code}' ${target_url}"
+	if [ -n "${ELASTIC_PASSWORD}" ]; then
+		args="$args -u elastic:${ELASTIC_PASSWORD}"
+	fi
+
+	result=1
+	output=""
+
+	# retry for up to 180 seconds
+	for sec in $(seq 1 180); do
+		exit_code=0
+		output=$(eval "curl $args") || exit_code=$?
+		# echo "exec curl $args, exit code: $exit_code, output: $output"
+		if [ $exit_code -ne 0 ]; then
+			result=$exit_code
+		fi
+
+		# Extract the last three characters of the output to check the HTTP status code
+		http_code=$(echo "$output" | tail -c 4)
+		if [ "$http_code" -eq 200 ]; then
+			result=0
+			break
+		fi
+
+		echo "Waiting for Elasticsearch ready... ${sec}s"
+		sleep 1
+	done
+
+	if [ $result -ne 0 ] && [ "$http_code" -ne 000 ]; then
+		echo "$output" | head -c -3
+	fi
+
+	if [ $result -ne 0 ]; then
+		case $result in
+		6)
+			echo 'Could not resolve host. Is Elasticsearch running?'
+			;;
+		7)
+			echo 'Failed to connect to host. Is Elasticsearch healthy?'
+			;;
+		28)
+			echo 'Timeout connecting to host. Is Elasticsearch healthy?'
+			;;
+		*)
+			echo "Connection to Elasticsearch failed. Exit code: ${result}"
+			;;
+		esac
+
+		exit $result
+	fi
+}
+
+wait_for_elasticsearch
+sleep 5 # Waiting for initialization of Elasticsearch built-in users
+echo "Elasticsearch is ready."
+
+exec ./bin/huatuo-bamai --region example --config huatuo-bamai.conf --disable-kubelet

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -29,6 +29,7 @@ import (
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/server/response"
+	"huatuo-bamai/pkg/tracing"
 
 	"github.com/gin-gonic/gin/binding"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -149,6 +150,12 @@ func (h *Handler) start(ctx *server.Context) error {
 	if config.Get().Profiling.ThirdPartyToolLimit > 0 {
 		agentTaskReq.TracerArgs = append(agentTaskReq.TracerArgs, "--tool-limit", strconv.Itoa(config.Get().Profiling.ThirdPartyToolLimit))
 	}
+
+	agentTaskReq.TracerArgs = append(agentTaskReq.TracerArgs,
+		"--output-format", "remote",
+		"--output-storage", "/var/run/huatuo-toolstream.sock",
+		"--metadata", "tracer_name=profiler",
+		"--metadata", "tracer_type="+tracing.TracerRunTypeTask)
 
 	var jobType string
 	if req.Type == "memory" {
@@ -542,6 +549,7 @@ func (h *Handler) DisplaySelectMergeStacktraces(ctx *server.Context) error {
 
 	resp, err := profileService.SelectMergeStacktraces(req)
 	if err != nil {
+		log.Warnf("SelectMergeStacktraces failed: %v", err)
 		ctx.JSON(http.StatusInternalServerError, map[string]any{"message": err.Error()})
 		return nil
 	}

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -90,7 +90,7 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 			ESAddresses: splitStorageAddresses(cfg.Storage.ES.Address),
 			ESUsername:  cfg.Storage.ES.Username,
 			ESPassword:  cfg.Storage.ES.Password,
-			ESIndex:     profiler.MetadataCollection,
+			ESIndex:     cfg.Storage.ES.Index,
 		}, profiler.MetadataCollection, tracing.DocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("new profiling document store (elasticsearch): %w", err)

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -1,0 +1,140 @@
+---
+title: Continuous Profiling
+type: docs
+description:
+author: HUATUO Team
+date: 2026-07-09
+weight: 4
+---
+
+## Overview
+
+**Continuous Profiling** performs long-running, continuous performance sampling of the operating system and applications, covering **CPU, memory, and lock** profiles. It produces standard pprof flame-graph data, persists samples to Elasticsearch, and supports aggregated viewing over arbitrary time windows in Grafana — providing a data foundation for capacity planning, performance regression analysis, and post-mortem diagnosis.
+
+### Architecture
+
+Continuous Profiling is built on three cooperating components:
+
+| Component | Role | Description |
+| --- | --- | --- |
+| huatuo-apiserver | Control plane | Receives profiling jobs, dispatches them to target nodes, and exposes a Pyroscope-compatible flame-graph query API |
+| huatuo-bamai | Data plane | Runs collection on the target node, sampling call stacks via eBPF (C/C++/Go) or third-party tools (Java/Python) |
+| Grafana | Visualization | Connects directly to apiserver through the pyroscope datasource plugin to render flame graphs |
+
+Supported languages and underlying implementations:
+
+| Language | Profile types | Implementation |
+| --- | --- | --- |
+| C / C++ / Go | CPU / memory / lock | eBPF (perf_event + stack maps) |
+| Java | CPU / memory / lock | async-profiler |
+| Python | CPU / memory | py-spy / memray |
+
+Profile type identifiers (used in Grafana queries):
+
+| Type | profile_type |
+| --- | --- |
+| CPU | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
+| Memory | `memory:alloc_space:bytes:space:bytes` |
+| Lock | `process_lock:lock:count:lock:count`<br>`process_lock:lock:nanoseconds:lock:nanoseconds` |
+
+## Running
+
+The simplest way is to bring up Elasticsearch, Prometheus, Grafana, huatuo-apiserver, and huatuo-bamai together with Docker Compose:
+
+```bash
+$ docker compose --project-directory ./build/docker up
+```
+
+Component addresses after startup:
+
+| Component | Address |
+| --- | --- |
+| huatuo-apiserver | `http://127.0.0.1:12740` |
+| huatuo-bamai metrics | `http://127.0.0.1:19704/metrics` |
+| Grafana | `http://localhost:3000` (admin / admin) |
+| Elasticsearch | `http://127.0.0.1:9200` |
+
+Profiling-related configuration lives in the `[Profiling]` section of `huatuo-apiserver.conf`:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `CPUProfilingInterval` | 10 | Single CPU sampling duration (seconds) |
+| `MemoryProfilingInterval` | 10 | Single memory sampling duration (seconds) |
+| `CPUSingleTraceTimeout` | 20 | Single CPU sampling timeout (seconds) |
+| `MemorySingleTraceTimeout` | 20 | Single memory sampling timeout (seconds) |
+| `ThirdPartyToolLimit` | 10 | Max concurrent third-party tools (async-profiler, etc.) |
+| `FlameGraphBaseURL` | `http://localhost:8006/d` | Flame-graph dashboard base URL, used to build task result links |
+
+> To make the `results.url` returned by a task point directly at Grafana, set `FlameGraphBaseURL` to the actual Grafana address (e.g. `http://localhost:3000/d`).
+
+Apiserver API calls require an `Authorization` request header carrying the user ID (configured under `[[Auth.users]]` in `huatuo-apiserver.conf`).
+
+> The default conf ships with no users configured, so the auth middleware is disabled and `Authorization` can be any non-empty value. In production, always configure real users under `[[Auth.users]]` and replace `<user-id>` with the actual ID.
+
+## Collection: Host CPU Example
+
+The following starts a CPU profile on a host. Host-level collection omits the `container` field; `target_process_language` is set to `go` (or `c`/`c++`) to trigger the eBPF native profiler:
+
+```bash
+$ curl -X POST http://127.0.0.1:12740/v1/profiles \
+    -H "Content-Type: application/json" \
+    -H "Authorization: <user-id>" \
+    -d '{
+        "type": "cpu",
+        "target_process_language": "go",
+        "hostname": "<target-host>",
+        "duration": 600
+    }'
+```
+
+Request fields:
+
+| Field | Description |
+| --- | --- |
+| `type` | Profile type: `cpu` / `memory` |
+| `target_process_language` | Target language: `go`, `c`, `c++`, `java`, `python` |
+| `hostname` | **Required**. Target host name; apiserver dispatches the job to the huatuo-bamai agent at `http://{hostname}:19704` (must match the hostname reported by the agent) |
+| `duration` | Total profiling duration (seconds); the agent samples periodically at `CPUProfilingInterval` |
+| `container` | Container hostname for container-level collection; leave empty for host-level |
+| `target_exec_path` | Optional, filter target processes by executable path |
+
+Response returns the task ID:
+
+```json
+{ "id": "<task-id>" }
+```
+
+Collection flow:
+
+1. apiserver creates the job and dispatches it to the huatuo-bamai agent on the target host.
+2. huatuo-bamai loads an eBPF program (`perf_event_sw_cpu_clock`) and samples kernel and user stacks at the default 99 Hz.
+3. Samples are symbolized, converted to pprof format, and written to Elasticsearch (the index name is the `[ElasticSearch].Index` setting in `huatuo-apiserver.conf`, default `huatuo_bamai`).
+
+Query job status and stop a job:
+
+```bash
+# Query job status
+$ curl -H "Authorization: <user-id>" \
+    http://127.0.0.1:12740/v1/profiles/<task-id>
+
+# Stop a job
+$ curl -X PATCH http://127.0.0.1:12740/v1/profiles/<task-id> \
+    -H "Content-Type: application/json" \
+    -H "Authorization: <user-id>" \
+    -d '{"status":"stopped"}'
+```
+
+On completion, the `results.url` field in the status response carries a flame-graph link built from `FlameGraphBaseURL`.
+
+## Viewing
+
+Flame graphs are viewed through pre-provisioned Grafana dashboards that load automatically with Docker Compose:
+
+| Dashboard | UID | Scope |
+| --- | --- | --- |
+| Continuous Profiling(host) | `continuous-profiling-host` | Host |
+| Continuous Profiling(container) | `continuous-profiling-container` | Container |
+
+Open `http://localhost:3000/d/continuous-profiling-host`, select `hostname` and `type` (profile_type) to view the aggregated flame graph. The time-series panel at the top shows the sample distribution, and the flame-graph panel below supports aggregated viewing over a selectable time range.
+
+> **How it works**: Grafana forwards flame-graph requests to the apiserver's `/v1/profiles/flamegraph/` path via the `grafana-pyroscope-datasource` plugin. The apiserver implements the Pyroscope Querier protocol (`SelectMergeStacktraces`, etc.), retrieving pprof data from Elasticsearch, merging it, and returning the result.

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -1,0 +1,140 @@
+---
+title: 持续 Profiling
+type: docs
+description:
+author: HUATUO Team
+date: 2026-07-09
+weight: 4
+---
+
+## 概述
+
+**持续 Profiling（Continuous Profiling）** 对操作系统与应用进行长期、持续的性能采样，覆盖 **CPU、内存、锁** 三类 Profile，产出标准 pprof 格式的火焰图数据。采样数据持久化至存储后端，并支持在 Grafana 中按时间窗口聚合查看，为性能回归分析与故障复盘等场景提供数据底座。
+
+### 架构
+
+持续 Profiling 由三个组件协作完成：
+
+| 组件 | 角色 | 说明 |
+| --- | --- | --- |
+| huatuo-apiserver | 控制面 | 接收 Profiling 任务并调度至目标节点，提供 Pyroscope 兼容的火焰图查询接口 |
+| huatuo-bamai | 数据面 | 在目标节点执行采集，基于 eBPF（C/C++/Go）或第三方工具（Java/Python）采样调用栈 |
+| Grafana | 可视化 | 通过 pyroscope 数据源插件直连 apiserver，渲染火焰图 |
+
+支持的采集语言与底层实现：
+
+| 语言 | 采集类型 | 底层实现 |
+| --- | --- | --- |
+| C / C++ / Go | CPU / 内存 / 锁 | eBPF（perf_event + 栈映射） |
+| Java | CPU / 内存 / 锁 | async-profiler |
+| Python | CPU / 内存 | py-spy / memray |
+
+Profile 类型标识（Grafana 查询用）：
+
+| 类型 | profile_type |
+| --- | --- |
+| CPU | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
+| 内存 | `memory:alloc_space:bytes:space:bytes` |
+| 锁 | `process_lock:lock:count:lock:count`<br>`process_lock:lock:nanoseconds:lock:nanoseconds` |
+
+## 运行
+
+最简方式是使用 Docker Compose 一键拉起 Elasticsearch、Prometheus、Grafana、huatuo-apiserver 与 huatuo-bamai：
+
+```bash
+$ docker compose --project-directory ./build/docker up
+```
+
+启动后各组件地址：
+
+| 组件 | 地址 |
+| --- | --- |
+| huatuo-apiserver | `http://127.0.0.1:12740` |
+| huatuo-bamai 指标 | `http://127.0.0.1:19704/metrics` |
+| Grafana | `http://localhost:3000`（admin / admin） |
+| Elasticsearch | `http://127.0.0.1:9200` |
+
+Profiling 相关配置位于 `huatuo-apiserver.conf` 的 `[Profiling]` 段：
+
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `CPUProfilingInterval` | 10 | 单次 CPU 采样时长（秒） |
+| `MemoryProfilingInterval` | 10 | 单次内存采样时长（秒） |
+| `CPUSingleTraceTimeout` | 20 | 单次 CPU 采样超时（秒） |
+| `MemorySingleTraceTimeout` | 20 | 单次内存采样超时（秒） |
+| `ThirdPartyToolLimit` | 10 | 第三方工具（async-profiler 等）最大并发数 |
+| `FlameGraphBaseURL` | `http://localhost:8006/d` | 火焰图大盘基址，用于拼接任务结果链接 |
+
+> 若希望任务返回的 `results.url` 直达 Grafana 大盘，将 `FlameGraphBaseURL` 改为实际 Grafana 地址（如 `http://localhost:3000/d`）。
+
+调用 apiserver API 需通过 `Authorization` 请求头携带用户 ID（在 `huatuo-apiserver.conf` 的 `[[Auth.users]]` 中配置）。
+
+> 默认 conf 未配置任何用户，此时鉴权中间件不启用，`Authorization` 可填任意非空值。生产环境请务必在 `[[Auth.users]]` 中配置真实用户，并将 `<user-id>` 替换为对应 ID。
+
+## 采集：以宿主 CPU 为例
+
+以对宿主机进行 CPU Profiling 为例。宿主级采集不指定 `container` 字段，`target_process_language` 设为 `go`（或 `c`/`c++`）以触发 eBPF 原生采集器：
+
+```bash
+$ curl -X POST http://127.0.0.1:12740/v1/profiles \
+    -H "Content-Type: application/json" \
+    -H "Authorization: <user-id>" \
+    -d '{
+        "type": "cpu",
+        "target_process_language": "go",
+        "hostname": "<target-host>",
+        "duration": 30
+    }'
+```
+
+请求字段说明：
+
+| 字段 | 说明 |
+| --- | --- |
+| `type` | 采集类型：`cpu` / `memory` |
+| `target_process_language` | 目标语言：`go`、`c`、`c++`、`java`、`python` |
+| `hostname` | **必填**。目标宿主机名，apiserver 据此将任务下发至 `http://{hostname}:19704` 上的 huatuo-bamai agent（需与 agent 上报的 hostname 一致） |
+| `duration` | 采集总时长（秒），期间 agent 按 `CPUProfilingInterval` 周期采样 |
+| `container` | 容器级采集时填容器 hostname，宿主级采集留空 |
+| `target_exec_path` | 可选，按可执行文件路径过滤目标进程 |
+
+返回任务 ID：
+
+```json
+{ "id": "<task-id>" }
+```
+
+采集流程：
+
+1. apiserver 创建任务并下发至目标宿主上的 huatuo-bamai。
+2. huatuo-bamai 加载 eBPF 程序（`perf_event_sw_cpu_clock`），按默认 99Hz 采样内核栈与用户栈。
+3. 采样数据经符号化后转换为 pprof 格式，写入 Elasticsearch（index 名为 `huatuo-apiserver.conf` 中 `[ElasticSearch].Index` 配置项，默认 `huatuo_bamai`）。
+
+查询任务状态与停止任务：
+
+```bash
+# 查询任务状态
+$ curl -H "Authorization: <user-id>" \
+    http://127.0.0.1:12740/v1/profiles/<task-id>
+
+# 停止任务
+$ curl -X PATCH http://127.0.0.1:12740/v1/profiles/<task-id> \
+    -H "Content-Type: application/json" \
+    -H "Authorization: <user-id>" \
+    -d '{"status":"stopped"}'
+```
+
+任务完成后，状态响应体 `results.url` 字段返回火焰图链接（基于 `FlameGraphBaseURL` 拼接）。
+
+## 查看
+
+火焰图通过 Grafana 大盘查看，大盘已预置并随 Docker Compose 自动加载：
+
+| 大盘 | UID | 适用对象 |
+| --- | --- | --- |
+| Continuous Profiling(host) | `continuous-profiling-host` | 宿主机 |
+| Continuous Profiling(container) | `continuous-profiling-container` | 容器 |
+
+打开 `http://localhost:3000/d/continuous-profiling-host`，选择 `hostname` 与 `type`（profile_type），即可查看聚合火焰图。大盘上方时序图展示采样点分布，下方为火焰图面板，支持按时间范围聚合查看。
+
+> **原理**：Grafana 通过 `grafana-pyroscope-datasource` 插件将火焰图请求转发至 apiserver 的 `/v1/profiles/flamegraph/` 路径；apiserver 实现 Pyroscope Querier 协议（`SelectMergeStacktraces` 等），从 Elasticsearch 检索 pprof 数据并合并返回。

--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -75,11 +75,11 @@
 # Default: false
 #
 [ElasticSearch]
-    # Address  = "http://127.0.0.1:9200"
-    # Username = "elastic"
-    # Password = "huatuo-bamai"
-    # Index    = "huatuo_bamai"
-    # Debug    = false
+    Address  = "http://127.0.0.1:9200"
+    Username = "elastic"
+    Password = "huatuo-bamai"
+    Index    = "huatuo_bamai"
+    Debug    = false
 
 # Authentication configuration.
 #

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -63,8 +63,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # There is no default username and password.
     #
     [Storage.ES]
-        # Address = "http://127.0.0.1:9200"
-        # Index = "huatuo_bamai"
+        Address = "http://127.0.0.1:9200"
+        Index = "huatuo_bamai"
         Username = "elastic"
         Password = "huatuo-bamai"
 

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -216,7 +216,7 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	query := buildProfileAggregationQuery(filter)
 	query.Limit = normalizeProfileSearchLimit(filter)
 	query.Sorts = []driver.Sort{
-		{Field: profileFieldTime, Desc: true},
+		{Field: profileFieldUploadedTime, Desc: true},
 	}
 	return query
 }
@@ -232,16 +232,16 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 
 	if !filter.StartTime.IsZero() {
 		query.Filters = append(query.Filters, driver.Filter{
-			Field: profileFieldTime,
+			Field: profileFieldUploadedTime,
 			Op:    driver.OpGte,
-			Value: filter.StartTime.UTC(),
+			Value: filter.StartTime.UTC().Format(time.RFC3339Nano),
 		})
 	}
 	if !filter.EndTime.IsZero() {
 		query.Filters = append(query.Filters, driver.Filter{
-			Field: profileFieldTime,
+			Field: profileFieldUploadedTime,
 			Op:    driver.OpLte,
-			Value: filter.EndTime.UTC(),
+			Value: filter.EndTime.UTC().Format(time.RFC3339Nano),
 		})
 	}
 
@@ -260,7 +260,7 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 		query.Filters = append(
 			query.Filters,
 			driver.Filter{
-				Field: profileFieldHostname,
+				Field: profileFieldHostname + ".keyword",
 				Op:    driver.OpEq,
 				Value: filter.Hostname,
 			},
@@ -272,7 +272,7 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 		)
 	case filter.ContainerHostname != "":
 		query.Filters = append(query.Filters, driver.Filter{
-			Field: profileFieldContainerHostname,
+			Field: profileFieldContainerHostname + ".keyword",
 			Op:    driver.OpEq,
 			Value: filter.ContainerHostname,
 		})
@@ -280,7 +280,7 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 
 	if filter.ProfileType != "" {
 		query.Filters = append(query.Filters, driver.Filter{
-			Field: profileFieldProfileType,
+			Field: profileFieldProfileType + ".keyword",
 			Op:    driver.OpEq,
 			Value: filter.ProfileType,
 		})

--- a/internal/storage/elasticsearch/dsl.go
+++ b/internal/storage/elasticsearch/dsl.go
@@ -165,6 +165,13 @@ func buildClause(filter driver.Filter) (types.Query, bool, error) {
 
 	switch filter.Op {
 	case driver.OpEq:
+		// empty string match -> must_not exists (field does not exist)
+		if s, ok := filter.Value.(string); ok && s == "" {
+			q := types.Query{
+				Exists: &types.ExistsQuery{Field: filter.Field},
+			}
+			return q, true, nil
+		}
 		q := types.Query{Term: map[string]types.TermQuery{filter.Field: {Value: driver.NormalizeValue(filter.Value)}}}
 		return q, false, nil
 	case driver.OpNe:


### PR DESCRIPTION
- Add Pyroscope datasource provisioning for Grafana
- Add continuous-profiling Grafana dashboards (host & container)
- Add huatuo-apiserver service to docker-compose, enable anonymous Grafana access
- Set --output-format=remote on profiling tracer args for toolstream upload
- Add metadata (tracer_name, tracer_type) to profiling task args
- Fix host-level profiling excluding container data: use must_not exists instead of term with empty string (which never matched)
- Use .keyword sub-fields for term queries on text-mapped ES fields
- Uncomment ElasticSearch config in huatuo-bamai/apiserver confs
- Add --disable-kubelet flag in bamai run script