### PR TITLE
feat(memray): enrich code object metadata and line labels

### DIFF
--- a/internal/profiler/memray/decoder.go
+++ b/internal/profiler/memray/decoder.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"huatuo-bamai/internal/symbol"
@@ -64,14 +65,15 @@ type reader struct {
 	header Header
 
 	// per-stream state
-	lastDataPtr     uint64
-	lastNativeFrame uint64
-	lastInstrPtr    uint64
-	lastThreadID    uint64
-	recentPtrs      [15]uint64
-	threadStacks    map[uint64][]uint64
-	frameTree       frameTree
-	codeObjects     map[uint64]codeObject
+	lastDataPtr       uint64
+	lastNativeFrame   uint64
+	lastInstrPtr      uint64
+	lastCodeFirstLine int64
+	lastThreadID      uint64
+	recentPtrs        [15]uint64
+	threadStacks      map[uint64][]uint64
+	frameTree         frameTree
+	codeObjects       map[uint64]codeObject
 
 	nativeFrames    []nativeFrame
 	nativeSymbolize *nativeSymbolizer
@@ -82,9 +84,10 @@ type reader struct {
 }
 
 type codeObject struct {
-	Func string
-	// TODO(python-mem): Extend this struct to retain filename/firstlineno/linetable
-	// and render line-aware stack labels. We currently keep function-only labels.
+	Func      string
+	Filename  string
+	FirstLine int64
+	LineTable []byte
 }
 
 type locationKey struct {
@@ -244,16 +247,17 @@ func (rd *reader) handleFramePush(flags uint8) error {
 	}
 	frame.InstrOffset = sv
 
-	frameID, err := packPythonFrameID(frame.CodeObjectID, frame.IsEntry)
-	if err != nil {
-		return err
+	frameKey := pythonFrameKey{
+		CodeObjectID: frame.CodeObjectID,
+		InstrOffset:  frame.InstrOffset,
+		IsEntry:      frame.IsEntry,
 	}
 	stack := rd.threadStacks[rd.lastThreadID]
 	parent := uint64(0)
 	if len(stack) > 0 {
 		parent = stack[len(stack)-1]
 	}
-	newIdx := rd.frameTree.getTraceIndex(parent, frameID)
+	newIdx := rd.frameTree.getTraceIndex(parent, frameKey)
 	rd.threadStacks[rd.lastThreadID] = append(stack, newIdx)
 	return nil
 }
@@ -278,26 +282,29 @@ func (rd *reader) handleCodeObject() error {
 	if err != nil {
 		return err
 	}
-	if _, err := rd.readCString(); err != nil { // filename
+	filename, err := rd.readCString()
+	if err != nil {
 		return err
 	}
-	if _, err := rd.readSignedVarint(); err != nil { // firstlineno delta
+	firstLineDelta, err := rd.readSignedVarint()
+	if err != nil {
 		return err
 	}
-	// TODO(python-mem): Decode and retain linetable payload so we can reconstruct
-	// precise source line info in stack rendering.
+	rd.lastCodeFirstLine += firstLineDelta
 	ltSize, err := rd.readVarint()
 	if err != nil {
 		return err
 	}
-	if ltSize > 0 {
-		if _, err := io.CopyN(io.Discard, rd.r, int64(ltSize)); err != nil {
-			return err
-		}
+	lineTable := make([]byte, ltSize)
+	if _, err := io.ReadFull(rd.r, lineTable); err != nil {
+		return err
 	}
-	// TODO(python-mem): Keep richer code object metadata and include it in rendered
-	// stack frame labels. Today we intentionally map codeID -> function name only.
-	rd.codeObjects[codeID] = codeObject{Func: funcName}
+	rd.codeObjects[codeID] = codeObject{
+		Func:      funcName,
+		Filename:  filename,
+		FirstLine: rd.lastCodeFirstLine,
+		LineTable: lineTable,
+	}
 	return nil
 }
 
@@ -460,14 +467,20 @@ type frameTree struct {
 	badParents uint64
 }
 
+type pythonFrameKey struct {
+	CodeObjectID uint64
+	InstrOffset  int64
+	IsEntry      bool
+}
+
 type frameNode struct {
-	FrameID  uint64
+	Frame    pythonFrameKey
 	Parent   uint64
 	Children []childEdge
 }
 
 type childEdge struct {
-	FrameID  uint64
+	Frame    pythonFrameKey
 	ChildIdx uint64
 }
 
@@ -477,27 +490,26 @@ type frameInfo struct {
 	InstrOffset  int64
 }
 
-const maxPackedCodeObjectID = ^uint64(0) >> 1
-
-func packPythonFrameID(codeID uint64, isEntry bool) (uint64, error) {
-	// frameID packs codeID and isEntry into one uint64:
-	// - bits [63:1]: codeID
-	// - bit [0]: isEntry
-	if codeID > maxPackedCodeObjectID {
-		return 0, fmt.Errorf("code object id %d exceeds max packed range %d", codeID, maxPackedCodeObjectID)
+func comparePythonFrameKey(a, b pythonFrameKey) int {
+	switch {
+	case a.CodeObjectID < b.CodeObjectID:
+		return -1
+	case a.CodeObjectID > b.CodeObjectID:
+		return 1
+	case a.InstrOffset < b.InstrOffset:
+		return -1
+	case a.InstrOffset > b.InstrOffset:
+		return 1
+	case !a.IsEntry && b.IsEntry:
+		return -1
+	case a.IsEntry && !b.IsEntry:
+		return 1
+	default:
+		return 0
 	}
-	frameID := codeID << 1
-	if isEntry {
-		frameID |= 1
-	}
-	return frameID, nil
 }
 
-func unpackPythonFrameID(frameID uint64) (codeID uint64, isEntry bool) {
-	return frameID >> 1, frameID&1 == 1
-}
-
-func (ft *frameTree) getTraceIndex(parent, frameID uint64) uint64 {
+func (ft *frameTree) getTraceIndex(parent uint64, frame pythonFrameKey) uint64 {
 	if ft.nodes == nil {
 		ft.nodes = []frameNode{{}}
 	}
@@ -507,20 +519,18 @@ func (ft *frameTree) getTraceIndex(parent, frameID uint64) uint64 {
 		parent = 0
 	}
 	edges := ft.nodes[parent].Children
-	i := 0
-	// TODO: use binary search? (Children are kept sorted by FrameID; linear scan is OK for now.)
-	for i < len(edges) && edges[i].FrameID < frameID {
-		i++
-	}
-	if i < len(edges) && edges[i].FrameID == frameID {
+	i := sort.Search(len(edges), func(i int) bool {
+		return comparePythonFrameKey(edges[i].Frame, frame) >= 0
+	})
+	if i < len(edges) && comparePythonFrameKey(edges[i].Frame, frame) == 0 {
 		return edges[i].ChildIdx
 	}
 	newIdx := uint64(len(ft.nodes))
 	edges = append(edges, childEdge{})
 	copy(edges[i+1:], edges[i:])
-	edges[i] = childEdge{FrameID: frameID, ChildIdx: newIdx}
+	edges[i] = childEdge{Frame: frame, ChildIdx: newIdx}
 	ft.nodes[parent].Children = edges
-	ft.nodes = append(ft.nodes, frameNode{FrameID: frameID, Parent: parent})
+	ft.nodes = append(ft.nodes, frameNode{Frame: frame, Parent: parent})
 	return newIdx
 }
 
@@ -554,19 +564,177 @@ func (rd *reader) pythonStackFrames(idx uint64) ([]string, []bool) {
 	entries := make([]bool, 0, 16)
 	for idx != 0 {
 		node := rd.frameTree.nodes[idx]
-		frameID := node.FrameID
-		codeID, isEntry := unpackPythonFrameID(frameID)
-		// TODO(python-mem): Switch to line/file aware labels once code object metadata
-		// retention is implemented in handleCodeObject.
-		fn := rd.codeObjects[codeID].Func
-		if fn == "" {
-			fn = "[unknown]"
-		}
-		frames = append(frames, fn)
-		entries = append(entries, isEntry)
+		frames = append(frames, rd.renderPythonFrameLabel(node.Frame))
+		entries = append(entries, node.Frame.IsEntry)
 		idx = node.Parent
 	}
 	return frames, entries
+}
+
+func (rd *reader) renderPythonFrameLabel(frame pythonFrameKey) string {
+	co, ok := rd.codeObjects[frame.CodeObjectID]
+	if !ok {
+		return "[unknown]"
+	}
+
+	fn := co.Func
+	if fn == "" {
+		fn = "[unknown]"
+	}
+
+	line, ok := co.lineForOffset(rd.header.PythonVersion, frame.InstrOffset)
+	switch {
+	case ok && co.Filename != "":
+		return fmt.Sprintf("%s %s:%d", fn, co.Filename, line)
+	case ok:
+		return fmt.Sprintf("%s :%d", fn, line)
+	default:
+		return fn
+	}
+}
+
+func (co codeObject) lineForOffset(pythonVersion int32, instrOffset int64) (int64, bool) {
+	if instrOffset < 0 {
+		return 0, false
+	}
+	if len(co.LineTable) == 0 {
+		return 0, false
+	}
+
+	switch {
+	case pythonVersion >= 0x030B0000:
+		return parseLineTable311(co.LineTable, instrOffset, co.FirstLine)
+	case pythonVersion >= 0x030A0000:
+		return parseLineTable310(co.LineTable, instrOffset, co.FirstLine)
+	default:
+		return parseLineTable39(co.LineTable, instrOffset, co.FirstLine)
+	}
+}
+
+func parseLineTable311(lineTable []byte, instrOffset, firstLine int64) (int64, bool) {
+	addrq := uint64(instrOffset) / 2
+	ptr := 0
+	addr := uint64(0)
+	line := firstLine
+
+	scanVarint := func() (uint64, bool) {
+		if ptr >= len(lineTable) {
+			return 0, false
+		}
+		read := uint64(lineTable[ptr])
+		ptr++
+		val := read & 63
+		shift := uint(0)
+		for read&64 != 0 {
+			if ptr >= len(lineTable) {
+				return 0, false
+			}
+			read = uint64(lineTable[ptr])
+			ptr++
+			shift += 6
+			val |= (read & 63) << shift
+		}
+		return val, true
+	}
+
+	scanSignedVarint := func() (int64, bool) {
+		uval, ok := scanVarint()
+		if !ok {
+			return 0, false
+		}
+		sval := int64(uval >> 1)
+		if uval&1 == 1 {
+			sval = -sval
+		}
+		return sval, true
+	}
+
+	for ptr < len(lineTable) && lineTable[ptr] != 0 {
+		firstByte := lineTable[ptr]
+		ptr++
+		code := (firstByte >> 3) & 15
+		length := uint64(firstByte&7) + 1
+		endAddr := addr + length
+
+		switch code {
+		case 15:
+		case 14:
+			lineDelta, ok := scanSignedVarint()
+			if !ok {
+				return 0, false
+			}
+			line += lineDelta
+			if _, ok := scanVarint(); !ok {
+				return 0, false
+			}
+			if _, ok := scanVarint(); !ok {
+				return 0, false
+			}
+			if _, ok := scanVarint(); !ok {
+				return 0, false
+			}
+		case 13:
+			lineDelta, ok := scanSignedVarint()
+			if !ok {
+				return 0, false
+			}
+			line += lineDelta
+		case 10, 11, 12:
+			line += int64(code) - 10
+			if ptr+1 >= len(lineTable) {
+				return 0, false
+			}
+			ptr += 2
+		default:
+			if ptr >= len(lineTable) {
+				return 0, false
+			}
+			ptr++
+		}
+
+		if addr <= addrq && endAddr > addrq {
+			return line, true
+		}
+		addr = endAddr
+	}
+	return 0, false
+}
+
+func parseLineTable310(lineTable []byte, instrOffset, firstLine int64) (int64, bool) {
+	line := firstLine
+	lastExecutedInstruction := instrOffset << 1
+
+	for i, currentInstruction := 0, int64(0); i+1 < len(lineTable); {
+		startDelta := int64(lineTable[i])
+		i++
+		lineDelta := int8(lineTable[i])
+		i++
+		currentInstruction += startDelta
+		if lineDelta != -0x80 {
+			line += int64(lineDelta)
+		}
+		if currentInstruction > lastExecutedInstruction {
+			break
+		}
+	}
+
+	return line, true
+}
+
+func parseLineTable39(lineTable []byte, instrOffset, firstLine int64) (int64, bool) {
+	line := firstLine
+
+	for i, bc := 0, int64(0); i+1 < len(lineTable); {
+		bc += int64(lineTable[i])
+		i++
+		if bc > instrOffset {
+			break
+		}
+		line += int64(int8(lineTable[i]))
+		i++
+	}
+
+	return line, true
 }
 
 func (rd *reader) pythonStackKey(idx, tid uint64) string {

--- a/internal/profiler/memray/decoder.go
+++ b/internal/profiler/memray/decoder.go
@@ -131,6 +131,8 @@ const (
 	recordTypeAllocation = 128
 )
 
+const maxCodeObjectLineTableSize = 16 << 20
+
 const (
 	fileFormatAllAllocations = 0
 )
@@ -295,7 +297,10 @@ func (rd *reader) handleCodeObject() error {
 	if err != nil {
 		return err
 	}
-	lineTable := make([]byte, ltSize)
+	if ltSize > maxCodeObjectLineTableSize {
+		return fmt.Errorf("code object line table too large: %d", ltSize)
+	}
+	lineTable := make([]byte, int(ltSize))
 	if _, err := io.ReadFull(rd.r, lineTable); err != nil {
 		return err
 	}
@@ -583,14 +588,24 @@ func (rd *reader) renderPythonFrameLabel(frame pythonFrameKey) string {
 	}
 
 	line, ok := co.lineForOffset(rd.header.PythonVersion, frame.InstrOffset)
+	filename := sanitizeFoldedStackFilename(co.Filename, rd.opt.Separator)
 	switch {
-	case ok && co.Filename != "":
-		return fmt.Sprintf("%s %s:%d", fn, co.Filename, line)
+	case ok && filename != "":
+		return fmt.Sprintf("%s %s:%d", fn, filename, line)
 	case ok:
 		return fmt.Sprintf("%s :%d", fn, line)
 	default:
 		return fn
 	}
+}
+
+func sanitizeFoldedStackFilename(filename, sep string) string {
+	filename = strings.ReplaceAll(filename, "\r", " ")
+	filename = strings.ReplaceAll(filename, "\n", " ")
+	if sep != "" {
+		filename = strings.ReplaceAll(filename, sep, "_")
+	}
+	return filename
 }
 
 func (co codeObject) lineForOffset(pythonVersion int32, instrOffset int64) (int64, bool) {

--- a/internal/profiler/memray/decoder_test.go
+++ b/internal/profiler/memray/decoder_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memray
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestFrameTreeGetTraceIndexDistinguishesInstrOffset(t *testing.T) {
+	var ft frameTree
+
+	first := pythonFrameKey{CodeObjectID: 7, InstrOffset: 10, IsEntry: true}
+	second := pythonFrameKey{CodeObjectID: 7, InstrOffset: 20, IsEntry: true}
+
+	firstIdx := ft.getTraceIndex(0, first)
+	secondIdx := ft.getTraceIndex(0, second)
+
+	if firstIdx == secondIdx {
+		t.Fatalf("getTraceIndex() returned same index %d for different instruction offsets", firstIdx)
+	}
+
+	if got := ft.nodes[firstIdx].Frame; got != first {
+		t.Fatalf("first frame = %#v, want %#v", got, first)
+	}
+
+	if got := ft.nodes[secondIdx].Frame; got != second {
+		t.Fatalf("second frame = %#v, want %#v", got, second)
+	}
+}
+
+func TestFrameTreeGetTraceIndexReusesSameFrameKey(t *testing.T) {
+	var ft frameTree
+
+	frame := pythonFrameKey{CodeObjectID: 11, InstrOffset: 32, IsEntry: false}
+
+	firstIdx := ft.getTraceIndex(0, frame)
+	secondIdx := ft.getTraceIndex(0, frame)
+
+	if firstIdx != secondIdx {
+		t.Fatalf("getTraceIndex() = (%d, %d), want same index", firstIdx, secondIdx)
+	}
+
+	if got := len(ft.nodes); got != 2 {
+		t.Fatalf("node count = %d, want 2", got)
+	}
+}
+
+func TestHandleCodeObjectStoresMetadata(t *testing.T) {
+	lineTable := []byte{0x01, 0x02, 0x03}
+	rd := &reader{
+		r:           bytes.NewReader(encodeCodeObjectRecord(42, "alloc", "app.py", 128, lineTable)),
+		codeObjects: make(map[uint64]codeObject),
+	}
+
+	if err := rd.handleCodeObject(); err != nil {
+		t.Fatalf("handleCodeObject() error = %v", err)
+	}
+
+	got, ok := rd.codeObjects[42]
+	if !ok {
+		t.Fatal("code object 42 was not stored")
+	}
+
+	if got.Func != "alloc" {
+		t.Fatalf("Func = %q, want %q", got.Func, "alloc")
+	}
+	if got.Filename != "app.py" {
+		t.Fatalf("Filename = %q, want %q", got.Filename, "app.py")
+	}
+	if got.FirstLine != 128 {
+		t.Fatalf("FirstLine = %d, want %d", got.FirstLine, 128)
+	}
+	if !bytes.Equal(got.LineTable, lineTable) {
+		t.Fatalf("LineTable = %v, want %v", got.LineTable, lineTable)
+	}
+}
+
+func TestHandleCodeObjectWithEmptyLineTable(t *testing.T) {
+	rd := &reader{
+		r:           bytes.NewReader(encodeCodeObjectRecord(7, "main", "main.py", 1, nil)),
+		codeObjects: make(map[uint64]codeObject),
+	}
+
+	if err := rd.handleCodeObject(); err != nil {
+		t.Fatalf("handleCodeObject() error = %v", err)
+	}
+
+	got, ok := rd.codeObjects[7]
+	if !ok {
+		t.Fatal("code object 7 was not stored")
+	}
+
+	if got.Func != "main" || got.Filename != "main.py" || got.FirstLine != 1 {
+		t.Fatalf("stored code object = %#v, want Func=%q Filename=%q FirstLine=%d", got, "main", "main.py", 1)
+	}
+
+	if len(got.LineTable) != 0 {
+		t.Fatalf("LineTable length = %d, want 0", len(got.LineTable))
+	}
+}
+
+func TestHandleCodeObjectRestoresFirstLineFromDelta(t *testing.T) {
+	var payload bytes.Buffer
+	payload.Write(encodeCodeObjectRecord(1, "outer", "sample.py", 120, nil))
+	payload.Write(encodeCodeObjectRecord(2, "inner", "sample.py", -4, nil))
+
+	rd := &reader{
+		r:           bytes.NewReader(payload.Bytes()),
+		codeObjects: make(map[uint64]codeObject),
+	}
+
+	if err := rd.handleCodeObject(); err != nil {
+		t.Fatalf("first handleCodeObject() error = %v", err)
+	}
+	if err := rd.handleCodeObject(); err != nil {
+		t.Fatalf("second handleCodeObject() error = %v", err)
+	}
+
+	if got := rd.codeObjects[1].FirstLine; got != 120 {
+		t.Fatalf("first code object FirstLine = %d, want 120", got)
+	}
+	if got := rd.codeObjects[2].FirstLine; got != 116 {
+		t.Fatalf("second code object FirstLine = %d, want 116", got)
+	}
+}
+
+func TestRenderPythonFrameLabelFallsBackToFuncName(t *testing.T) {
+	rd := &reader{
+		codeObjects: map[uint64]codeObject{
+			3: {Func: "worker"},
+		},
+	}
+
+	got := rd.renderPythonFrameLabel(pythonFrameKey{CodeObjectID: 3, InstrOffset: 6, IsEntry: true})
+	if got != "worker" {
+		t.Fatalf("renderPythonFrameLabel() = %q, want %q", got, "worker")
+	}
+}
+
+func TestRenderPythonFrameLabelUsesLineNumberWhenAvailable(t *testing.T) {
+	rd := &reader{
+		header: Header{PythonVersion: 0x030A0000},
+		codeObjects: map[uint64]codeObject{
+			5: {
+				Func:      "alloc",
+				Filename:  "app.py",
+				FirstLine: 120,
+				LineTable: []byte{2, 3},
+			},
+		},
+	}
+
+	got := rd.renderPythonFrameLabel(pythonFrameKey{CodeObjectID: 5, InstrOffset: 1, IsEntry: true})
+	if got != "alloc app.py:123" {
+		t.Fatalf("renderPythonFrameLabel() = %q, want %q", got, "alloc app.py:123")
+	}
+}
+
+func TestPythonStackFramesUsesEnhancedLabels(t *testing.T) {
+	rd := &reader{
+		header: Header{PythonVersion: 0x030A0000},
+		codeObjects: map[uint64]codeObject{
+			5: {
+				Func:      "alloc",
+				Filename:  "app.py",
+				FirstLine: 120,
+				LineTable: []byte{2, 3},
+			},
+		},
+		frameTree: frameTree{
+			nodes: []frameNode{
+				{},
+				{
+					Frame: pythonFrameKey{
+						CodeObjectID: 5,
+						InstrOffset:  1,
+						IsEntry:      true,
+					},
+				},
+			},
+		},
+	}
+
+	frames, entries := rd.pythonStackFrames(1)
+	if len(frames) != 1 || frames[0] != "alloc app.py:123" {
+		t.Fatalf("pythonStackFrames() frames = %#v, want [\"alloc app.py:123\"]", frames)
+	}
+	if len(entries) != 1 || !entries[0] {
+		t.Fatalf("pythonStackFrames() entries = %#v, want [true]", entries)
+	}
+}
+
+func TestFrameTreeGetTraceIndexKeepsChildrenSorted(t *testing.T) {
+	var ft frameTree
+
+	frames := []pythonFrameKey{
+		{CodeObjectID: 9, InstrOffset: 10, IsEntry: true},
+		{CodeObjectID: 2, InstrOffset: 30, IsEntry: true},
+		{CodeObjectID: 9, InstrOffset: 5, IsEntry: false},
+	}
+
+	for _, frame := range frames {
+		ft.getTraceIndex(0, frame)
+	}
+
+	children := ft.nodes[0].Children
+	for i := 1; i < len(children); i++ {
+		if comparePythonFrameKey(children[i-1].Frame, children[i].Frame) > 0 {
+			t.Fatalf("children not sorted at %d: %#v > %#v", i, children[i-1].Frame, children[i].Frame)
+		}
+	}
+}
+
+func encodeCodeObjectRecord(codeID uint64, funcName, filename string, firstLine int64, lineTable []byte) []byte {
+	var buf bytes.Buffer
+	buf.Write(encodeVarint(codeID))
+	buf.WriteString(funcName)
+	buf.WriteByte(0)
+	buf.WriteString(filename)
+	buf.WriteByte(0)
+	buf.Write(encodeSignedVarint(firstLine))
+	buf.Write(encodeVarint(uint64(len(lineTable))))
+	buf.Write(lineTable)
+	return buf.Bytes()
+}
+
+func encodeVarint(v uint64) []byte {
+	buf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(buf, v)
+	return buf[:n]
+}
+
+func encodeSignedVarint(v int64) []byte {
+	uv := uint64(v<<1) ^ uint64(v>>63)
+	return encodeVarint(uv)
+}

--- a/internal/profiler/memray/decoder_test.go
+++ b/internal/profiler/memray/decoder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -113,6 +113,30 @@ func TestHandleCodeObjectWithEmptyLineTable(t *testing.T) {
 	}
 }
 
+func TestHandleCodeObjectRejectsOversizedLineTable(t *testing.T) {
+	var payload bytes.Buffer
+	payload.Write(encodeVarint(7))
+	payload.WriteString("main")
+	payload.WriteByte(0)
+	payload.WriteString("main.py")
+	payload.WriteByte(0)
+	payload.Write(encodeSignedVarint(1))
+	payload.Write(encodeVarint(maxCodeObjectLineTableSize + 1))
+
+	rd := &reader{
+		r:           bytes.NewReader(payload.Bytes()),
+		codeObjects: make(map[uint64]codeObject),
+	}
+
+	err := rd.handleCodeObject()
+	if err == nil {
+		t.Fatal("handleCodeObject() error = nil, want oversized line table error")
+	}
+	if got, want := err.Error(), "code object line table too large"; !bytes.Contains([]byte(got), []byte(want)) {
+		t.Fatalf("handleCodeObject() error = %q, want substring %q", got, want)
+	}
+}
+
 func TestHandleCodeObjectRestoresFirstLineFromDelta(t *testing.T) {
 	var payload bytes.Buffer
 	payload.Write(encodeCodeObjectRecord(1, "outer", "sample.py", 120, nil))
@@ -167,6 +191,26 @@ func TestRenderPythonFrameLabelUsesLineNumberWhenAvailable(t *testing.T) {
 	got := rd.renderPythonFrameLabel(pythonFrameKey{CodeObjectID: 5, InstrOffset: 1, IsEntry: true})
 	if got != "alloc app.py:123" {
 		t.Fatalf("renderPythonFrameLabel() = %q, want %q", got, "alloc app.py:123")
+	}
+}
+
+func TestRenderPythonFrameLabelSanitizesFilenameForFoldedStacks(t *testing.T) {
+	rd := &reader{
+		header: Header{PythonVersion: 0x030A0000},
+		opt:    Options{Separator: ";"},
+		codeObjects: map[uint64]codeObject{
+			5: {
+				Func:      "alloc",
+				Filename:  "dir;a\npp.py",
+				FirstLine: 120,
+				LineTable: []byte{2, 3},
+			},
+		},
+	}
+
+	got := rd.renderPythonFrameLabel(pythonFrameKey{CodeObjectID: 5, InstrOffset: 1, IsEntry: true})
+	if got != "alloc dir_a pp.py:123" {
+		t.Fatalf("renderPythonFrameLabel() = %q, want %q", got, "alloc dir_a pp.py:123")
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR improves the memray decoder for Python memory profiling by enriching code object metadata and rendering more precise stack labels.

### What changed

- retain `filename`, `firstlineno`, and `linetable` for memray code objects
- restore `firstlineno` from stream delta encoding
- distinguish Python frames by `InstrOffset` in frame tree keys
- render Python stack labels with `func file:line` when line info is available
- add focused unit tests for code object metadata, frame identity, and line label rendering

## Verification

- `go test ./internal/profiler/memray -count=1 -v`
- verified with a real Python 3.12 memray sample:
  - negative line numbers are gone
  - sample frames resolve to reasonable source lines

## Notes

This PR focuses on a memray decoder subtask under #331 and does not claim to complete the whole issue.