### PR TITLE
fix(metrics,profiler): propagate cgroup init error and fix silent error returns

### DIFF
--- a/core/metrics/memory_events.go
+++ b/core/metrics/memory_events.go
@@ -34,7 +34,10 @@ func init() {
 }
 
 func newMemEvents() (*tracing.EventTracingAttr, error) {
-	cgroup, _ := cgroups.NewManager()
+	cgroup, err := cgroups.NewManager()
+	if err != nil {
+		return nil, fmt.Errorf("memory events: init cgroup manager: %w", err)
+	}
 
 	return &tracing.EventTracingAttr{
 		TracingData: &memEventsCollector{

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -301,8 +301,11 @@ func extractJavaMainClassFromPid(pid int) (string, error) {
 	}
 
 	cmdlineSlice, err := p.CmdlineSlice()
-	if err != nil || len(cmdlineSlice) == 0 {
+	if err != nil {
 		return "", err
+	}
+	if len(cmdlineSlice) == 0 {
+		return "", fmt.Errorf("empty cmdline for PID %d", pid)
 	}
 
 	// Match java keyword
@@ -369,7 +372,7 @@ func extractPythonThreadNameFromPid(pid int) (string, error) {
 
 	base := filepath.Base(resolvedExe)
 	if !strings.HasPrefix(base, "python") {
-		return "", err
+		return "", fmt.Errorf("process %d exe is %q, not a python process", pid, base)
 	}
 
 	p, err := process.NewProcess(int32(pid))
@@ -378,8 +381,11 @@ func extractPythonThreadNameFromPid(pid int) (string, error) {
 	}
 
 	cmdline, err := p.CmdlineSlice()
-	if err != nil || len(cmdline) == 0 {
+	if err != nil {
 		return "", err
+	}
+	if len(cmdline) == 0 {
+		return "", fmt.Errorf("empty cmdline for PID %d", pid)
 	}
 
 	// Extract main script，skip -u -m flags and etc.


### PR DESCRIPTION
## What does this PR do?

Fixes two categories of bugs: a nil pointer panic risk in the memory events collector and silent error returns in the profiler thread-name extraction functions.

## Problem

### 1. memory_events.go: nil cgroup panic

```go
cgroup, _ := cgroups.NewManager()  // error discarded
```

When `cgroups.NewManager()` fails (cgroup filesystem unavailable, permission denied, container without cgroup access), `cgroup` is `nil` and the error is silently discarded. The collector is then constructed with a nil cgroup, and the first call to `c.cgroup.MemoryEventRaw()` in `Update()` triggers a **nil pointer dereference panic**, crashing the metrics pipeline.

### 2. profiler.go: silent error returns in extractJavaMainClassFromPid

```go
cmdlineSlice, err := p.CmdlineSlice()
if err != nil || len(cmdlineSlice) == 0 {
    return "", err  // err is nil when only len==0, returns "", nil — caller thinks success
}
```

When `CmdlineSlice` succeeds but returns an empty slice (rare but possible for zombie processes), `err` is `nil` and the function returns `"", nil`. The caller (`parseMultiProcessData`) interprets this as "successfully got empty thread name" and produces a malformed profile header frame instead of falling back to the default extraction path.

### 3. profiler.go: silent error return in extractPythonThreadNameFromPid

```go
base := filepath.Base(resolvedExe)
if !strings.HasPrefix(base, "python") {
    return "", err  // err is nil here (from Readlink above, already handled) — returns "", nil
}
```

When the process executable is not Python (e.g., a shell wrapper), `err` is `nil` (it was from `os.Readlink` on L365, already checked and handled). The function returns `"", nil`, so the caller treats this as "successfully got empty thread name" instead of an error, producing a broken profile.

Similarly, the `CmdlineSlice` call on L380 has the same `err != nil || len == 0` pattern as the Java case.

## Fix

1. **memory_events.go**: Replace `cgroup, _ :=` with proper error check. Return error from `newMemEvents()` if cgroup manager init fails, preventing the nil cgroup from ever reaching `Update()`.

2. **profiler.go `extractJavaMainClassFromPid`**: Split `err != nil || len(cmdlineSlice) == 0` into two checks: return `err` if non-nil, otherwise return a descriptive `fmt.Errorf("empty cmdline for PID %d")` when the slice is empty.

3. **profiler.go `extractPythonThreadNameFromPid`**: 
   - Replace `return "", err` (where err was nil) with `return "", fmt.Errorf("process %d exe is %q, not a python process", pid, base)`.
   - Same `CmdlineSlice` empty-slice fix as Java case.

## Testing

- `go build ./core/metrics/` passes
- `go build ./internal/profiler/` passes
- `golangci-lint run ./core/metrics/ ./internal/profiler/ --config .golangci.yaml` clean
- `make import-fmt` applied (goimports + gofumpt + gofmt)

The fixed functions (`newMemEvents`, `extractJavaMainClassFromPid`, `extractPythonThreadNameFromPid`) depend on real cgroup filesystems and `/proc` access, so they are validated by compilation and lint rather than unit tests. The error paths now return descriptive errors instead of silent nil, which makes them diagnosable in production logs.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] No breaking API changes (error returns made explicit, nil cgroup prevented)
- [x] golangci-lint passes
- [x] DCO signed

Signed-off-by: wc4440222 <199748891+wc4440222@users.noreply.github.com>