### PR TITLE
feat(bench): add performance-overhead benchmark for observed workloads (#336)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,78 @@
+name: Performance Overhead Benchmark
+
+# Runs the HUATUO performance-overhead benchmark (issue #336) in a QEMU VM,
+# uploads the JSON + text summary as artifacts, and optionally fails on a
+# regression-threshold breach. Runs on release tags and on manual dispatch so
+# it never blocks ordinary pull requests.
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      fail_on_regression:
+        description: "Fail CI when a metric's delta_percent crosses its threshold"
+        type: boolean
+        default: false
+      os_distro:
+        description: "Ubuntu distro to test in the QEMU VM"
+        type: choice
+        default: ubuntu24.04
+        options:
+          - ubuntu24.04
+          - ubuntu22.04
+          - ubuntu20.04
+
+jobs:
+  benchmark:
+    name: Benchmark in VM (${{ inputs.os_distro || 'ubuntu24.04' }})
+    runs-on: ubuntu-24.04
+    env:
+      ACT_RUN: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        if: ${{ env.ACT_RUN != 'true' }}
+        uses: docker/setup-buildx-action@v3.3.0
+
+      - name: Host Init
+        run: |
+          .github/workflows/scripts/qemu-0-host-init.sh amd64 ${{ inputs.os_distro || 'ubuntu24.04' }}
+
+      - name: Start VM
+        timeout-minutes: 30
+        run: |
+          .github/workflows/scripts/qemu-1-start-vm.sh \
+            amd64 "${{ inputs.os_distro || 'ubuntu24.04' }}" \
+            "huatuo-bench-vm" "4A:6F:6C:69:6E:20" "192.168.122.100"
+
+      - name: Run benchmark in VM
+        timeout-minutes: 60
+        env:
+          BENCH_FAIL_ON_REGRESSION: ${{ inputs.fail_on_regression == true && '1' || '0' }}
+        run: |
+          ssh \
+            -i ${HOME}/.ssh/id_ed25519_vm \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            root@192.168.122.100 \
+            "BENCH_FAIL_ON_REGRESSION=${BENCH_FAIL_ON_REGRESSION} bash -s -- amd64 ${{ inputs.os_distro || 'ubuntu24.04' }}" \
+            < .github/workflows/scripts/qemu-2-run-bench-in-vm.sh
+
+      - name: Cleanup VM
+        if: always()
+        run: |
+          .github/workflows/scripts/qemu-3-cleanup.sh \
+            "huatuo-bench-vm" "4A:6F:6C:69:6E:20" "192.168.122.100"
+
+      - name: Upload benchmark report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: huatuo-benchmark-${{ inputs.os_distro || 'ubuntu24.04' }}
+          path: bench/results/
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/scripts/qemu-2-run-bench-in-vm.sh
+++ b/.github/workflows/scripts/qemu-2-run-bench-in-vm.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the performance-overhead benchmark inside a QEMU VM (issue #336). The
+# repo is bind-mounted at /mnt/host, so artifacts written to
+# /mnt/host/bench/results/ are visible on the CI runner for upload.
+#
+# Args: <arch> <os-distro>  (passed by .github/workflows/benchmark.yml).
+# Env:
+#   BENCH_FAIL_ON_REGRESSION  1 to fail CI on a threshold breach.
+
+set -xeuo pipefail
+
+ARCH=${1:-amd64}
+OS_DISTRO=${2:-ubuntu24.04}
+GOLANG_VERSION="1.24.0"
+
+# Mirrors qemu-2-run-in-vm.sh: install a pinned Go toolchain.
+function install_golang() {
+	local GOLANG_URL="https://mirrors.aliyun.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz"
+	local GOLANG_TAR="go${GOLANG_VERSION}.linux-${ARCH}.tar.gz"
+	local need_install=1
+	if command -v go > /dev/null 2>&1; then
+		local goversion
+		goversion=$(go version | awk '{print $3}' | sed 's/^go//')
+		[[ "$goversion" == "$GOLANG_VERSION" ]] && need_install=0
+	fi
+	if [[ $need_install -eq 1 ]]; then
+		wget -q -O "$GOLANG_TAR" "$GOLANG_URL"
+		rm -rf /usr/local/go
+		tar -C /usr/local -xzf "$GOLANG_TAR"
+		rm -f "$GOLANG_TAR"
+	fi
+	export PATH="/usr/local/go/bin:${PATH}"
+	export PATH="$(/usr/local/go/bin/go env GOPATH)/bin:${PATH}"
+	go env -w GOPROXY=https://goproxy.cn,direct
+}
+
+# Build dependencies for `make all` + the benchmark workloads.
+function prepare_bench_env() {
+	case $OS_DISTRO in
+	ubuntu*)
+		sudo apt-get update
+		sudo flock --wait 300 /var/lib/dpkg/lock-frontend true || true
+		sudo apt-get install -y \
+			make libbpf-dev clang git gcc jq capnproto python3 iputils-ping
+		# Ubuntu 20.04 ships clang-10 which has a CO-RE relocation bug.
+		[[ "$OS_DISTRO" != "ubuntu20.04" ]] || {
+			sudo apt-get install -y clang-12
+			sudo ln -sf /usr/bin/clang-12 /usr/local/bin/clang
+		}
+		;;
+	esac
+	which mockery || go install github.com/vektra/mockery/v2@latest
+	which capnpc-go || go install capnproto.org/go/capnp/v3/capnpc-go@v3.1.0-alpha.2
+	git config --global --add safe.directory /mnt/host
+}
+
+install_golang
+prepare_bench_env
+
+cd /mnt/host
+make bench
+
+echo -e "\n✅ benchmark finished; artifacts under /mnt/host/bench/results/"
+ls -lah bench/results/ || true

--- a/Makefile
+++ b/Makefile
@@ -157,4 +157,10 @@ integration: all
 e2e: all
 	@bash e2e/run.sh
 
-.PHONY: all build-nostatic bpf-build gen-build sync build check import-fmt golangci-lint vendor clean test unit integration e2e docker-build docker-clean compose-dev-up compose-dev-down
+# Performance-overhead benchmark (issue #336). Builds huatuo-bamai first so
+# `make bench` works from a clean tree. Override knobs via the environment,
+# e.g. BENCH_ITERATIONS=10 make bench. See bench/README.md.
+bench: all
+	@bash bench/run.sh
+
+.PHONY: all build-nostatic bpf-build gen-build sync build check import-fmt golangci-lint vendor clean test unit integration e2e bench docker-build docker-clean compose-dev-up compose-dev-down

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,117 @@
+# HUATUO Performance-Overhead Benchmark
+
+This directory contains the automation that **quantifies the performance impact
+HUATUO imposes on the workloads it observes**. It resolves issue #336.
+
+The methodology, metric definitions, and interpretation guidance live in
+[`docs/best-practice/performance-overhead_en.md`](../docs/best-practice/performance-overhead_en.md).
+This README is the operator guide.
+
+## What it measures
+
+| Scenario | Metric | Unit |
+|----------|--------|------|
+| `cpu_overhead` | extra wall time of a CPU-bound workload while huatuo collects | seconds (+ %) |
+| `memory_overhead` | huatuo-bamai resident memory under sustained load | MiB |
+| `net_latency` | incremental loopback RTT while huatuo collects | microseconds (+ %) |
+| `io_latency` | incremental latency of synchronized writes while huatuo collects | milliseconds (+ %) |
+
+Each metric is an A/B experiment (huatuo **off** vs **on**) repeated
+`BENCH_ITERATIONS` times (plus one discarded warmup), reported with mean /
+median / p95 / stddev / min / max. Every probe-heavy metric is run under
+multiple **collection profiles**:
+
+| Profile | BlackList | Meaning |
+|---------|-----------|---------|
+| `full` | shipped default | realistic multi-collector deployment |
+| `minimal` | every optional collector off | lower bound of huatuo overhead |
+| `single` (net/io only) | every optional collector off except one | isolates a single collector |
+
+## Requirements
+
+- root (`huatuo-bamai` needs `CAP_BPF`/`CAP_SYS_ADMIN`)
+- `huatuo-bamai` built (`make all` → `_output/bin/huatuo-bamai`)
+- `curl`, `dd`, `ping`, `awk`, `sort`, `python3` (optional, for pretty-printing
+  and the regression gate)
+
+When a precondition is not met the harness records a `"status": "skipped"`
+result with a reason instead of failing, so a CI lane never turns red solely
+because it cannot run the benchmark.
+
+## Quick start
+
+```bash
+make bench                 # build huatuo-bamai, then run the full benchmark
+# or, against an existing build:
+bash bench/run.sh
+```
+
+The report is written to `bench/results/bench-<UTC-timestamp>.json` and a text
+summary to `bench/results/bench-<UTC-timestamp>.summary.txt`. The summary is
+also printed to stdout.
+
+## Knobs
+
+All knobs are environment variables (defaults in `env.sh`).
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `HUATUO_BAMAI_BIN` | `_output/bin/huatuo-bamai` | binary under test |
+| `BENCH_ITERATIONS` | `5` | A/B repetitions per scenario |
+| `BENCH_WARMUP` | `1` | leading iterations discarded |
+| `BENCH_CPU_BYTES` | `67108864` (64 MiB) | bytes copied per CPU sample |
+| `BENCH_MEM_DURATION` | `15` | RSS sampling window (seconds) |
+| `BENCH_NET_PACKETS` | `200` | loopback pings per sample |
+| `BENCH_IO_OPS` | `200` | sync writes per sample |
+| `BENCH_IO_BLOCK_KIB` | `4` | write block size (KiB) |
+| `BENCH_NET_SINGLE_MODULE` | `dropwatch` | module isolated by the net `single` profile |
+| `BENCH_IO_SINGLE_MODULE` | `iolatency` | module isolated by the io `single` profile |
+| `BENCH_RESULTS_DIR` | `bench/results` | output directory |
+| `BENCH_FAIL_ON_REGRESSION` | `0` | exit non-zero on threshold breach |
+| `BENCH_FAIL_ON_MISSING` | `0` | exit non-zero on missing preconditions |
+| `BENCH_THRESHOLD_CPU_PCT` | `5` | regression gate: max CPU overhead % |
+| `BENCH_THRESHOLD_NET_PCT` | `10` | regression gate: max net latency % |
+| `BENCH_THRESHOLD_IO_PCT` | `10` | regression gate: max IO latency % |
+
+Examples:
+
+```bash
+# fast smoke run
+BENCH_ITERATIONS=2 BENCH_NET_PACKETS=50 BENCH_IO_OPS=50 bash bench/run.sh
+
+# strict CI gate
+BENCH_FAIL_ON_REGRESSION=1 bash bench/run.sh
+```
+
+## Multi-scenario coverage
+
+- **Idle vs load** — CPU/memory scenarios drive the system under load. To
+  capture an explicit idle baseline, quiesce other processes and re-run; the
+  JSON `metadata` lets you compare runs.
+- **Single vs multi module** — the `single` profile (net/io) isolates one
+  collector; `full` runs them all.
+- **Container vs host** — `metadata.env` records whether the run was inside a
+  container. Run the script once on the host and once in a container and
+  compare the two JSON reports.
+
+## CI integration
+
+`.github/workflows/benchmark.yml` builds `huatuo-bamai`, runs this benchmark in
+a QEMU VM, and uploads the JSON + summary as workflow artifacts. It triggers on
+release tags and on manual dispatch, so it never blocks ordinary pull requests.
+Set `BENCH_FAIL_ON_REGRESSION=1` in the workflow (or via dispatch input) to
+turn threshold breaches into CI failures.
+
+## Layout
+
+```
+bench/
+├── env.sh               # defaults / tunables / module model
+├── lib.sh               # logging, stats, JSON, huatuo lifecycle, workloads
+├── run.sh               # orchestrator (entry point)
+├── scenario_cpu.sh      # CPU overhead
+├── scenario_memory.sh   # huatuo-bamai RSS
+├── scenario_net.sh      # network RTT overhead
+├── scenario_io.sh       # IO latency overhead
+└── results/             # generated reports (gitignored)
+```

--- a/bench/env.sh
+++ b/bench/env.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmark environment defaults. Source once; override any variable from the
+# environment before invoking bench/run.sh (e.g. from CI or the Makefile).
+
+set -euo pipefail
+
+if [[ -n "${__HUATUO_BENCH_ENV_SH_LOADED:-}" ]]; then
+	return 0
+fi
+export __HUATUO_BENCH_ENV_SH_LOADED=1
+
+BENCH_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export BENCH_ROOT_DIR
+export ROOT_DIR="${ROOT_DIR:-$(cd "${BENCH_ROOT_DIR}/.." && pwd)}"
+
+# ---- binaries ---------------------------------------------------------------
+
+# The huatuo-bamai binary under test. Defaults to the `make all` output path so
+# `make bench` works out of the box.
+HUATUO_BAMAI_BIN="${HUATUO_BAMAI_BIN:-${ROOT_DIR}/_output/bin/huatuo-bamai}"
+export HUATUO_BAMAI_BIN
+
+# ---- tunables ---------------------------------------------------------------
+
+# Number of A/B repetitions per scenario (one extra iteration is run as warmup).
+BENCH_ITERATIONS="${BENCH_ITERATIONS:-5}"
+export BENCH_ITERATIONS
+
+# Discard the first iteration of each phase to hide cold-start effects.
+BENCH_WARMUP="${BENCH_WARMUP:-1}"
+export BENCH_WARMUP
+
+# When 1, fail the run if any measured delta_percent crosses its threshold.
+# 0 (default) only records the regression in the report so a benchmark lane can
+# never turn red on a noisy measurement.
+BENCH_FAIL_ON_REGRESSION="${BENCH_FAIL_ON_REGRESSION:-0}"
+export BENCH_FAIL_ON_REGRESSION
+
+# When 1, exit non-zero if a scenario's precondition (root, binary, kernel
+# feature) is not satisfied. Default 0 -> skip and record the reason.
+BENCH_FAIL_ON_MISSING="${BENCH_FAIL_ON_MISSING:-0}"
+export BENCH_FAIL_ON_MISSING
+
+# CI regression thresholds (percent). Used only when BENCH_FAIL_ON_REGRESSION=1.
+BENCH_THRESHOLD_CPU_PCT="${BENCH_THRESHOLD_CPU_PCT:-5}"
+BENCH_THRESHOLD_NET_PCT="${BENCH_THRESHOLD_NET_PCT:-10}"
+BENCH_THRESHOLD_IO_PCT="${BENCH_THRESHOLD_IO_PCT:-10}"
+export BENCH_THRESHOLD_CPU_PCT BENCH_THRESHOLD_NET_PCT BENCH_THRESHOLD_IO_PCT
+
+# ---- workload sizes ---------------------------------------------------------
+
+# CPU workload: bytes to copy through dd. Larger => lower relative noise.
+BENCH_CPU_BYTES="${BENCH_CPU_BYTES:-$((64 * 1024 * 1024))}" # 64 MiB
+export BENCH_CPU_BYTES
+
+# Memory overhead: sampling window (seconds) under sustained load.
+BENCH_MEM_DURATION="${BENCH_MEM_DURATION:-15}"
+export BENCH_MEM_DURATION
+
+# Network latency: ping packet count per sample.
+BENCH_NET_PACKETS="${BENCH_NET_PACKETS:-200}"
+export BENCH_NET_PACKETS
+
+# IO latency: number of synchronized writes per sample.
+BENCH_IO_OPS="${BENCH_IO_OPS:-200}"
+export BENCH_IO_OPS
+
+# IO workload block size (KiB).
+BENCH_IO_BLOCK_KIB="${BENCH_IO_BLOCK_KIB:-4}"
+export BENCH_IO_BLOCK_KIB
+
+# ---- huatuo-bamai module model ---------------------------------------------
+#
+# HUATUO_CORE_BLACKLIST   always-blacklisted (hardware collectors that need the
+#                         matching device to be present).
+# HUATUO_OPTIONAL_MODULES software collectors that the BlackList can toggle.
+#
+# The scenarios run each metric under up to three collection profiles:
+#   "full"    = the shipped huatuo-bamai.conf (realistic multi-collector setup,
+#               worst-case overhead)
+#   "minimal" = core + every optional collector blacklisted -> lower bound
+#   "single"  = core + every optional collector except one -> isolates that one
+#               (net/io scenarios only)
+# bench_blacklist_all      builds the "minimal" blacklist.
+# bench_blacklist_except M builds the "single" blacklist (keeps M enabled).
+HUATUO_CORE_BLACKLIST=("metax_gpu" "ascend_npu")
+export HUATUO_CORE_BLACKLIST
+HUATUO_OPTIONAL_MODULES=(
+	"softlockup" "ethtool" "netstat_hw" "iolatency" "memory_free"
+	"memory_reclaim" "reschedipi" "softirq" "iotracing" "dropwatch"
+	"netdev_hw"
+)
+export HUATUO_OPTIONAL_MODULES
+
+# Which optional module the single profile isolates for each probe-heavy metric.
+BENCH_NET_SINGLE_MODULE="${BENCH_NET_SINGLE_MODULE:-dropwatch}"
+export BENCH_NET_SINGLE_MODULE
+BENCH_IO_SINGLE_MODULE="${BENCH_IO_SINGLE_MODULE:-iolatency}"
+export BENCH_IO_SINGLE_MODULE
+
+# ---- output -----------------------------------------------------------------
+
+BENCH_RESULTS_DIR="${BENCH_RESULTS_DIR:-${BENCH_ROOT_DIR}/results}"
+export BENCH_RESULTS_DIR

--- a/bench/lib.sh
+++ b/bench/lib.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared helpers for the HUATUO performance-overhead benchmark. Sourced by
+# bench/run.sh and bench/scenario_*.sh; never executed directly.
+
+set -euo pipefail
+
+TEST_LOG_TAG=${TEST_LOG_TAG:-"BENCH"}
+
+# Progress logs go to stderr so a scenario's stdout is pure JSON (captured by
+# run.sh). The human-readable summary is printed by run.sh after assembly.
+log_info() { echo "[${TEST_LOG_TAG}] $*" >&2; }
+log_warn() { echo "[${TEST_LOG_TAG}][WARN] $*" >&2; }
+log_error() { echo "[${TEST_LOG_TAG}][ERROR] $*" >&2; }
+bench_fatal() {
+	echo "[${TEST_LOG_TAG}][FAIL] $*" >&2
+	exit 1
+}
+
+# --------------------------- cleanup registration ----------------------------
+#
+# Scenarios register their scratch dirs; run.sh installs bench_cleanup as an
+# EXIT trap so huatuo-bamai and temp dirs never leak, even on error/abort.
+BENCH_CLEANUP_DIRS=()
+bench_register_cleanup() { BENCH_CLEANUP_DIRS+=("$1"); }
+bench_cleanup() {
+	huatuo_stop
+	local d
+	for d in ${BENCH_CLEANUP_DIRS[@]+"${BENCH_CLEANUP_DIRS[@]}"}; do
+		rm -rf "${d}" 2> /dev/null || true
+	done
+}
+
+# --------------------------------- utils -------------------------------------
+
+now_ms() { date +%s%3N; }
+
+# is_container: 0 when running inside a container (overlay/btrfs root or
+# systemd-detect-virt -c reports a container). Mirrors integration/lib.sh.
+is_container() {
+	local fstype
+	fstype=$(findmnt -n -o FSTYPE / 2> /dev/null || true)
+	case "${fstype}" in
+	overlay | btrfs) return 0 ;;
+	esac
+	if command -v systemd-detect-virt > /dev/null 2>&1; then
+		[[ "$(systemd-detect-virt -c 2> /dev/null)" != "none" ]] && return 0
+	fi
+	return 1
+}
+
+# json_str <raw>: emit a JSON string literal with quoting. Reads stdin or $1.
+json_str() {
+	local s="${1:-$(cat)}"
+	s="${s//\\/\\\\}"
+	s="${s//\"/\\\"}"
+	s="${s//$'\n'/\\n}"
+	s="${s//$'\t'/\\t}"
+	printf '"%s"' "$s"
+}
+
+# mean_of <file>: print the arithmetic mean of one-number-per-line, or "null".
+mean_of() {
+	awk '{ s += $1; n++ } END { if (n > 0) printf "%.6f", s / n; else print "null" }' "$1"
+}
+
+# stats_json <file>: print a JSON object describing the distribution of the
+# one-number-per-line input. Empty/missing file -> all-null object.
+stats_json() {
+	local file=$1
+	if [[ ! -s "${file}" ]]; then
+		echo '{"count":0,"min":null,"mean":null,"median":null,"p95":null,"max":null,"stddev":null,"samples":[]}'
+		return 0
+	fi
+	local samples
+	samples=$(paste -sd, "${file}")
+	sort -n "${file}" | awk -v samples="${samples}" '
+		{ a[NR] = $1; sum += $1 }
+		END {
+			n = NR
+			mean = sum / n
+			for (i = 1; i <= n; i++) { d = a[i] - mean; ss += d * d }
+			sd = (n > 1) ? sqrt(ss / (n - 1)) : 0
+			if (n % 2 == 1) { med = a[int(n / 2) + 1] } else { med = (a[n / 2] + a[n / 2 + 1]) / 2 }
+			idx = int(0.95 * n + 0.999999)
+			if (idx < 1) idx = 1
+			if (idx > n) idx = n
+			p95 = a[idx]
+			printf "{\"count\":%d,\"min\":%.4f,\"mean\":%.4f,\"median\":%.4f,\"p95\":%.4f,\"max\":%.4f,\"stddev\":%.4f,\"samples\":[%s]}\n", \
+				n, a[1], mean, med, p95, a[n], sd, samples
+		}'
+}
+
+# profile_result_json <baseline_file> <observed_file> [extra-kv...]:
+# print a JSON object comparing an A (baseline) and B (observed) sample set.
+# Extra-kv arguments are raw "key":value JSON fragments appended to the object.
+profile_result_json() {
+	local baseline_file=$1 observed_file=$2
+	shift 2
+	local bstats ostats bmean omean delta dpct extra=""
+	bstats=$(stats_json "${baseline_file}")
+	ostats=$(stats_json "${observed_file}")
+	bmean=$(mean_of "${baseline_file}")
+	omean=$(mean_of "${observed_file}")
+	delta=$(awk -v b="${bmean}" -v o="${omean}" \
+		'BEGIN { if (b == "null" || o == "null") print "null"; else printf "%.6f", o - b }')
+	dpct=$(awk -v b="${bmean}" -v o="${omean}" \
+		'BEGIN { if (b == "null" || o == "null" || b + 0 == 0) print "null"; else printf "%.4f", (o - b) / b * 100 }')
+	local kv
+	for kv in "$@"; do
+		extra+=",${kv}"
+	done
+	printf '{"baseline":%s,"observed":%s,"delta_mean":%s,"delta_percent":%s%s}\n' \
+		"${bstats}" "${ostats}" "${delta}" "${dpct}" "${extra}"
+}
+
+# result_obj <status> <json-body...>: wrap a scenario body with status field.
+result_obj() {
+	local status=$1
+	shift
+	printf '{"status":%s,%s}\n' "$(json_str "${status}")" "$*"
+}
+
+scenario_skipped() { result_obj skipped "\"reason\":$(json_str "$1")"; }
+scenario_error() { result_obj error "\"reason\":$(json_str "$1")"; }
+
+# --------------------------- huatuo module model -----------------------------
+
+# bench_blacklist_except <module>: print blacklist items = core + every optional
+# module except the named one (single-module profile).
+bench_blacklist_except() {
+	local keep=$1 m
+	for m in "${HUATUO_CORE_BLACKLIST[@]}"; do
+		printf '%s\n' "${m}"
+	done
+	for m in "${HUATUO_OPTIONAL_MODULES[@]}"; do
+		[[ "${m}" != "${keep}" ]] && printf '%s\n' "${m}"
+	done
+}
+
+# bench_blacklist_all: print every core+optional module (minimal profile).
+bench_blacklist_all() {
+	local m
+	for m in "${HUATUO_CORE_BLACKLIST[@]}" "${HUATUO_OPTIONAL_MODULES[@]}"; do
+		printf '%s\n' "${m}"
+	done
+}
+
+# blacklist_to_toml_array <items-file>: print a TOML array literal.
+blacklist_to_toml_array() {
+	local items=$1 first=1 m
+	printf '['
+	while read -r m; do
+		[[ -z "${m}" ]] && continue
+		if [[ ${first} -eq 1 ]]; then first=0; else printf ', '; fi
+		printf '"%s"' "${m}"
+	done < "${items}"
+	printf ']'
+}
+
+# gen_bench_conf <out-path> <blacklist-items-file> [extra-body-file]:
+# write a standalone bamai.conf. Storage/kubelet are disabled via CLI flags at
+# start time, so the file only needs BlackList (+ optional event subsections).
+gen_bench_conf() {
+	local out=$1 items=$2 extra=${3:-/dev/null}
+	local arr
+	arr=$(blacklist_to_toml_array "${items}")
+	{
+		printf 'BlackList = %s\n\n' "${arr}"
+		printf '[Log]\n    Level = "Warn"\n'
+		if [[ -s "${extra}" ]]; then
+			printf '\n'
+			cat "${extra}"
+		fi
+	} > "${out}"
+}
+
+# full_config_path: the realistic multi-collector config shipped with the repo.
+full_config_path() { printf '%s\n' "${ROOT_DIR}/huatuo-bamai.conf"; }
+
+# ----------------------------- huatuo lifecycle ------------------------------
+
+BENCH_HUATUO_PID=""
+BENCH_HUATUO_RUN_DIR=""
+BENCH_HUATUO_READY_TIMEOUT=${BENCH_HUATUO_READY_TIMEOUT:-60}
+BENCH_HUATUO_ADDR=${BENCH_HUATUO_ADDR:-"http://127.0.0.1:19704"}
+
+# huatuo_bamai_ready: 0 once /metrics responds.
+huatuo_bamai_ready() {
+	[[ -n "${BENCH_HUATUO_PID}" ]] || return 1
+	kill -0 "${BENCH_HUATUO_PID}" 2> /dev/null || return 1
+	curl -sf --connect-timeout 1 --max-time 2 "${BENCH_HUATUO_ADDR}/metrics" > /dev/null
+}
+
+# huatuo_start <conf-path>: launch huatuo-bamai with a given config; returns
+# non-zero if it exits or never becomes ready within BENCH_HUATUO_READY_TIMEOUT.
+huatuo_start() {
+	local conf_path=$1
+	local conf_dir conf_name
+	conf_dir=$(dirname "${conf_path}")
+	conf_name=$(basename "${conf_path}")
+
+	[[ -x "${HUATUO_BAMAI_BIN}" ]] || {
+		log_error "binary missing: ${HUATUO_BAMAI_BIN}"
+		return 1
+	}
+	[[ -r "${conf_path}" ]] || {
+		log_error "config missing: ${conf_path}"
+		return 1
+	}
+
+	BENCH_HUATUO_RUN_DIR=$(mktemp -d /tmp/huatuo-bench.XXXXXX)
+	log_info "starting huatuo-bamai (conf=${conf_path})"
+	"${HUATUO_BAMAI_BIN}" \
+		--config-dir "${conf_dir}" \
+		--config "${conf_name}" \
+		--region bench \
+		--disable-storage \
+		--disable-kubelet \
+		--disable-cgroup \
+		> "${BENCH_HUATUO_RUN_DIR}/huatuo.log" 2>&1 &
+	BENCH_HUATUO_PID=$!
+	echo "${BENCH_HUATUO_PID}" > "${BENCH_HUATUO_RUN_DIR}/huatuo.pid"
+
+	local end=$(($(date +%s) + BENCH_HUATUO_READY_TIMEOUT))
+	while [[ $(date +%s) -lt ${end} ]]; do
+		if ! kill -0 "${BENCH_HUATUO_PID}" 2> /dev/null; then
+			log_error "huatuo-bamai exited during startup; tail of log:"
+			tail -20 "${BENCH_HUATUO_RUN_DIR}/huatuo.log" >&2 || true
+			return 1
+		fi
+		if huatuo_bamai_ready; then
+			log_info "huatuo-bamai ready (pid=${BENCH_HUATUO_PID})"
+			return 0
+		fi
+		sleep 1
+	done
+	log_error "huatuo-bamai not ready within ${BENCH_HUATUO_READY_TIMEOUT}s; tail of log:"
+	tail -20 "${BENCH_HUATUO_RUN_DIR}/huatuo.log" >&2 || true
+	return 1
+}
+
+# huatuo_stop: SIGTERM with graceful polling, then SIGKILL; release the port.
+huatuo_stop() {
+	local pid=${BENCH_HUATUO_PID}
+	if [[ -n "${pid}" ]] && kill -0 "${pid}" 2> /dev/null; then
+		kill -TERM "${pid}" 2> /dev/null || true
+		local waited=0
+		while kill -0 "${pid}" 2> /dev/null && [[ ${waited} -lt 15 ]]; do
+			sleep 1
+			waited=$((waited + 1))
+		done
+		kill -KILL "${pid}" 2> /dev/null || true
+		# wait for the port to be released so the next start can bind.
+		local waited2=0
+		while [[ ${waited2} -lt 10 ]]; do
+			! curl -sf --connect-timeout 1 --max-time 1 "${BENCH_HUATUO_ADDR}/metrics" > /dev/null 2>&1 && break
+			sleep 1
+			waited2=$((waited2 + 1))
+		done
+	fi
+	BENCH_HUATUO_PID=""
+	rm -rf "${BENCH_HUATUO_RUN_DIR}"
+	BENCH_HUATUO_RUN_DIR=""
+}
+
+# huatuo_rss_kib / huatuo_hwm_kib: resident / peak resident memory of the pid.
+huatuo_rss_kib() { awk '/^VmRSS:/ { print $2 }' "/proc/${BENCH_HUATUO_PID}/status" 2> /dev/null || echo 0; }
+huatuo_hwm_kib() { awk '/^VmHWM:/ { print $2 }' "/proc/${BENCH_HUATUO_PID}/status" 2> /dev/null || echo 0; }
+
+# huatuo_cpu_seconds: user+system CPU seconds consumed by the pid so far.
+huatuo_cpu_seconds() {
+	[[ -n "${BENCH_HUATUO_PID}" ]] || {
+		echo 0
+		return
+	}
+	local hz rss
+	hz=$(getconf CLK_TCK 2> /dev/null || echo 100)
+	rss=$(awk '{ print $14 + $15 }' "/proc/${BENCH_HUATUO_PID}/stat" 2> /dev/null || echo 0)
+	awk -v j="${rss}" -v hz="${hz}" 'BEGIN { printf "%.4f", j / hz }'
+}
+
+# ------------------------------- workloads ----------------------------------
+#
+# Each workload returns a single numeric sample on stdout (its cost under the
+# current huatuo state). They are dependency-free (dd, ping, /proc) so the
+# benchmark behaves identically across distros and in CI.
+
+# cpu_sample: wall-clock seconds to copy BENCH_CPU_BYTES through dd.
+cpu_sample() {
+	local start end
+	start=$(date +%s.%N)
+	dd if=/dev/zero of=/dev/null bs=64K count=$((BENCH_CPU_BYTES / 65536)) status=none
+	end=$(date +%s.%N)
+	awk -v s="${start}" -v e="${end}" 'BEGIN { printf "%.6f", e - s }'
+}
+
+# net_sample: mean RTT in microseconds over BENCH_NET_PACKETS loopback pings.
+# Parses the iputils-ping "rtt min/avg/max/mdev = a/b/c/d ms" summary (and the
+# "round-trip" variant used by busybox), reporting the average in microseconds.
+net_sample() {
+	local tmp
+	tmp=$(mktemp)
+	# -i 0 (no inter-packet delay) needs root, which the benchmark requires.
+	if ! ping -c "${BENCH_NET_PACKETS}" -i 0 127.0.0.1 > "${tmp}" 2>&1; then
+		ping -c "${BENCH_NET_PACKETS}" 127.0.0.1 > "${tmp}" 2>&1
+	fi
+	awk -F'=' '
+		/rtt min\/|round-trip min\// {
+			v = $2
+			gsub(/[[:space:]]|ms/, "", v)
+			split(v, a, "/")
+			printf "%.6f\n", (a[2] + 0) * 1000
+		}' "${tmp}"
+	rm -f "${tmp}"
+}
+
+# io_sample: mean milliseconds per synchronized write over BENCH_IO_OPS ops.
+# Writes into BENCH_IO_DIR (a real filesystem set by the io scenario) when set,
+# else a throwaway tmpdir.
+io_sample() {
+	local tmpdir tmp count block
+	if [[ -n "${BENCH_IO_DIR:-}" && -d "${BENCH_IO_DIR}" ]]; then
+		tmpdir="${BENCH_IO_DIR}"
+	else
+		tmpdir=$(mktemp -d /tmp/huatuo-bench-io.XXXXXX)
+	fi
+	tmp="${tmpdir}/io"
+	count=${BENCH_IO_OPS}
+	block=${BENCH_IO_BLOCK_KIB}
+	local start end
+	start=$(date +%s.%N)
+	local i
+	for ((i = 0; i < count; i++)); do
+		dd if=/dev/zero of="${tmp}" bs=${block}K count=1 oflag=dsync status=none
+	done
+	end=$(date +%s.%N)
+	[[ -z "${BENCH_IO_DIR:-}" ]] && rm -rf "${tmpdir}"
+	awk -v s="${start}" -v e="${end}" -v n="${count}" 'BEGIN { printf "%.6f", (e - s) / n * 1000 }'
+}
+
+# sustained_load <duration-seconds>: keep the system busy (CPU + IO) so the
+# memory scenario samples huatuo under realistic steady-state collection.
+sustained_load() {
+	local duration=$1
+	local end=$(($(date +%s) + duration))
+	local tmpdir
+	tmpdir=$(mktemp -d /tmp/huatuo-bench-load.XXXXXX)
+	(
+		while [[ $(date +%s) -lt ${end} ]]; do
+			dd if=/dev/zero of=/dev/null bs=64K count=1024 status=none
+		done
+	) &
+	local cpu_pid=$!
+	(
+		while [[ $(date +%s) -lt ${end} ]]; do
+			dd if=/dev/zero of="${tmpdir}/f" bs=4K count=64 oflag=dsync status=none
+		done
+	) &
+	local io_pid=$!
+	# Wait until the window elapses, then reap the workers.
+	local waited=0
+	while [[ $(date +%s) -lt ${end} ]] && [[ ${waited} -lt ${duration} ]]; do
+		sleep 1
+		waited=$((waited + 1))
+	done
+	kill "${cpu_pid}" "${io_pid}" 2> /dev/null || true
+	wait "${cpu_pid}" 2> /dev/null || true
+	wait "${io_pid}" 2> /dev/null || true
+	rm -rf "${tmpdir}"
+}
+
+# ------------------------------ sampling loop --------------------------------
+
+# sample_workload <workload_fn> <out_file>: run the workload
+# (BENCH_ITERATIONS + BENCH_WARMUP) times; write the post-warmup samples (one
+# per line) to out_file. Returns the number of recorded samples via stdout? no
+# — out_file is the contract. Always returns 0.
+sample_workload() {
+	local fn=$1 out=$2 i total
+	total=$((BENCH_ITERATIONS + BENCH_WARMUP))
+	: > "${out}"
+	for ((i = 1; i <= total; i++)); do
+		local v
+		v=$("${fn}")
+		[[ ${i} -gt ${BENCH_WARMUP} ]] && printf '%s\n' "${v}" >> "${out}"
+	done
+}
+
+# observed_samples <conf_path> <workload_fn> <out_file>:
+# start huatuo with conf, sample the workload, stop huatuo. Returns 1 if huatuo
+# failed to start; otherwise the exit status of sample_workload.
+observed_samples() {
+	local conf=$1 fn=$2 out=$3
+	if ! huatuo_start "${conf}"; then
+		huatuo_stop
+		return 1
+	fi
+	sample_workload "${fn}" "${out}"
+	local rc=$?
+	huatuo_stop
+	return ${rc}
+}
+
+# sample_rss_window <duration-seconds> <out_file>: poll huatuo-bamai's VmRSS
+# (KiB) once per second for the given duration, writing one value per line.
+sample_rss_window() {
+	local duration=$1 out=$2 i
+	: > "${out}"
+	for ((i = 0; i < duration; i++)); do
+		huatuo_rss_kib >> "${out}"
+		sleep 1
+	done
+}
+
+# rss_summary_json <rss-file>: print a JSON object with peak/mean RSS and the
+# kernel-reported high-water mark (MiB), computed against the running pid.
+rss_summary_json() {
+	local file=$1
+	local peak mean hwm
+	peak=$(sort -n "${file}" | tail -1)
+	[[ -z "${peak}" ]] && peak=0
+	mean=$(mean_of "${file}")
+	hwm=$(huatuo_hwm_kib)
+	awk -v peak="${peak}" -v mean="${mean}" -v hwm="${hwm}" 'BEGIN {
+		if (mean == "null") mean = 0
+		printf "{\"rss_peak_mib\":%.4f,\"rss_mean_mib\":%.4f,\"hwm_mib\":%.4f}\n", peak / 1024, mean / 1024, hwm / 1024
+	}'
+}
+
+# -------------------------------- metadata ----------------------------------
+
+collect_metadata() {
+	local kernel arch ncpu mem_total env huatuo_ver
+	kernel=$(uname -r 2> /dev/null || echo "unknown")
+	arch=$(uname -m 2> /dev/null || echo "unknown")
+	ncpu=$(nproc 2> /dev/null || echo 0)
+	mem_total=$(awk '/^MemTotal:/ { print $2 }' /proc/meminfo 2> /dev/null || echo 0)
+	if is_container; then env="container"; else env="host"; fi
+	huatuo_ver=$("${HUATUO_BAMAI_BIN}" --version 2> /dev/null | head -1 | tr -d '\n' || echo "unknown")
+
+	cat << EOF
+"kernel": $(json_str "${kernel}"),
+"arch": $(json_str "${arch}"),
+"ncpu": ${ncpu},
+"mem_total_kb": ${mem_total},
+"env": $(json_str "${env}"),
+"huatuo_version": $(json_str "${huatuo_ver}"),
+"iterations": ${BENCH_ITERATIONS},
+"timestamp_utc": $(json_str "$(date -u +%Y-%m-%dT%H:%M:%SZ)")
+EOF
+}

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HUATUO performance-overhead benchmark orchestrator.
+#
+# Runs every scenario under bench/scenario_*.sh, assembles a single JSON report
+# into ${BENCH_RESULTS_DIR}, prints a human-readable summary to stdout, and
+# (when BENCH_FAIL_ON_REGRESSION=1) exits non-zero on a threshold breach.
+#
+# Usage:
+#   make bench                       # build huatuo-bamai, then run this
+#   bash bench/run.sh                # run against an existing _output build
+#   BENCH_ITERATIONS=10 bash bench/run.sh
+
+set -euo pipefail
+
+BENCH_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export ROOT_DIR="${ROOT_DIR:-$(cd "${BENCH_ROOT_DIR}/.." && pwd)}"
+
+# shellcheck source=env.sh
+source "${BENCH_ROOT_DIR}/env.sh"
+# shellcheck source=lib.sh
+source "${BENCH_ROOT_DIR}/lib.sh"
+
+# Source every scenario so the scenario_* functions exist before we install the
+# EXIT trap (scenarios rely on bench_cleanup registered here).
+for s in "${BENCH_ROOT_DIR}"/scenario_*.sh; do
+	# shellcheck source=/dev/null
+	source "${s}"
+done
+
+trap bench_cleanup EXIT
+
+mkdir -p "${BENCH_RESULTS_DIR}"
+readonly TS="$(date -u +%Y%m%dT%H%M%SZ)"
+readonly OUT_JSON="${BENCH_RESULTS_DIR}/bench-${TS}.json"
+readonly OUT_SUMMARY="${BENCH_RESULTS_DIR}/bench-${TS}.summary.txt"
+
+log_info "HUATUO performance-overhead benchmark"
+log_info "binary : ${HUATUO_BAMAI_BIN}"
+log_info "results: ${BENCH_RESULTS_DIR}"
+log_info "iters  : ${BENCH_ITERATIONS} (warmup ${BENCH_WARMUP})"
+
+# Quick precondition: the binary must exist. If not, emit a minimal but valid
+# report marking every scenario skipped, so CI never sees malformed output.
+if [[ ! -x "${HUATUO_BAMAI_BIN}" ]]; then
+	log_warn "huatuo-bamai binary not found; writing a skipped-only report"
+	skip_reason="huatuo-bamai binary missing: ${HUATUO_BAMAI_BIN}"
+	cpu_json=$(scenario_skipped "${skip_reason}")
+	mem_json=$(scenario_skipped "${skip_reason}")
+	net_json=$(scenario_skipped "${skip_reason}")
+	io_json=$(scenario_skipped "${skip_reason}")
+else
+	log_info "running scenarios (this takes several minutes)..."
+	cpu_json=$(scenario_cpu)
+	mem_json=$(scenario_memory)
+	net_json=$(scenario_net)
+	io_json=$(scenario_io)
+fi
+
+# ---- assemble JSON report ---------------------------------------------------
+{
+	printf '{\n'
+	printf '  "version": 1,\n'
+	printf '  "metadata": { %s },\n' "$(collect_metadata)"
+	printf '  "scenarios": {\n'
+	printf '    "cpu_overhead": %s,\n' "${cpu_json}"
+	printf '    "memory_overhead": %s,\n' "${mem_json}"
+	printf '    "net_latency": %s,\n' "${net_json}"
+	printf '    "io_latency": %s\n' "${io_json}"
+	printf '  }\n'
+	printf '}\n'
+} > "${OUT_JSON}"
+
+# Validate + pretty-print if python3 is available; otherwise keep compact form.
+if command -v python3 > /dev/null 2>&1; then
+	if python3 -m json.tool "${OUT_JSON}" > "${OUT_JSON}.tmp" 2> /dev/null; then
+		mv "${OUT_JSON}.tmp" "${OUT_JSON}"
+	else
+		rm -f "${OUT_JSON}.tmp"
+		log_warn "produced JSON failed validation; see ${OUT_JSON}"
+	fi
+fi
+
+log_info "report written: ${OUT_JSON}"
+
+# ---- human-readable summary -------------------------------------------------
+print_summary() {
+	if command -v python3 > /dev/null 2>&1; then
+		python3 - "${OUT_JSON}" << 'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+md = data.get("metadata", {})
+print("=" * 72)
+print("HUATUO performance-overhead benchmark")
+print("=" * 72)
+print("kernel    : %s" % md.get("kernel"))
+print("arch      : %s  ncpu=%s  mem=%s KB  env=%s" % (
+    md.get("arch"), md.get("ncpu"), md.get("mem_total_kb"), md.get("env")))
+print("huatuo    : %s" % md.get("huatuo_version"))
+print("iterations: %s" % md.get("iterations"))
+print("-" * 72)
+
+
+def pct(v):
+    return "n/a" if v is None else "%.2f%%" % v
+
+
+def delta(v):
+    return "n/a" if v is None else "%.4f" % v
+
+
+def show(name, key):
+    sc = data["scenarios"].get(key, {})
+    status = sc.get("status")
+    unit = sc.get("unit", "")
+    print("%-16s status=%-8s unit=%s" % (name, status, unit))
+    if status != "ok":
+        print("    reason: %s" % sc.get("reason", ""))
+        return
+    for pname, prof in sc.get("profiles", {}).items():
+        if "delta_percent" in prof:
+            b = prof.get("baseline", {})
+            o = prof.get("observed", {})
+            print("    %-7s baseline_mean=%s observed_mean=%s delta=%s (%s)"
+                  % (pname,
+                     ("%.4f" % b["mean"]) if b.get("mean") is not None else "n/a",
+                     ("%.4f" % o["mean"]) if o.get("mean") is not None else "n/a",
+                     delta(prof.get("delta_mean")),
+                     pct(prof.get("delta_percent"))))
+        else:
+            parts = ", ".join("%s=%s" % (k, v) for k, v in prof.items())
+            print("    %-7s %s" % (pname, parts))
+
+
+show("CPU overhead", "cpu_overhead")
+show("Memory", "memory_overhead")
+show("Net latency", "net_latency")
+show("IO latency", "io_latency")
+print("=" * 72)
+PY
+		return 0
+	fi
+	log_warn "python3 missing; showing raw JSON path only"
+	echo "See ${OUT_JSON}"
+	return 0
+}
+
+print_summary | tee "${OUT_SUMMARY}"
+
+# ---- optional regression gate ----------------------------------------------
+check_regression() {
+	[[ "${BENCH_FAIL_ON_REGRESSION}" == "1" ]] || return 0
+	command -v python3 > /dev/null 2>&1 || {
+		log_warn "BENCH_FAIL_ON_REGRESSION=1 but python3 missing; skipping gate"
+		return 0
+	}
+	python3 - "${OUT_JSON}" "${BENCH_THRESHOLD_CPU_PCT}" "${BENCH_THRESHOLD_NET_PCT}" "${BENCH_THRESHOLD_IO_PCT}" << 'PY'
+import json, sys
+path, cpu_t, net_t, io_t = sys.argv[1], float(sys.argv[2]), float(sys.argv[3]), float(sys.argv[4])
+with open(path) as f:
+    data = json.load(f)
+limits = {"cpu_overhead": cpu_t, "net_latency": net_t, "io_latency": io_t}
+breaches = []
+for key, thr in limits.items():
+    sc = data["scenarios"].get(key, {})
+    if sc.get("status") != "ok":
+        continue
+    full = sc.get("profiles", {}).get("full", {})
+    dp = full.get("delta_percent")
+    if dp is not None and dp > thr:
+        breaches.append("%s full delta_percent=%.2f%% > %.2f%%" % (key, dp, thr))
+if breaches:
+    print("[BENCH][FAIL] regression threshold breached:", file=sys.stderr)
+    for b in breaches:
+        print("  - " + b, file=sys.stderr)
+    sys.exit(1)
+print("[BENCH] regression gate passed", file=sys.stderr)
+PY
+}
+
+if ! check_regression; then
+	exit 1
+fi
+
+log_info "done."

--- a/bench/scenario_cpu.sh
+++ b/bench/scenario_cpu.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CPU overhead scenario.
+#
+# Measures how much extra wall-clock time a fixed CPU-bound workload consumes
+# while huatuo-bamai is collecting, under the realistic "full" config and the
+# maximally reduced "minimal" config. Also records huatuo-bamai's own CPU
+# consumption during the full-profile sampling window.
+
+scenario_cpu() {
+	[[ ${EUID} -eq 0 ]] || {
+		scenario_skipped "requires root"
+		return 0
+	}
+	[[ -x "${HUATUO_BAMAI_BIN}" ]] || {
+		scenario_skipped "huatuo-bamai binary missing"
+		return 0
+	}
+	command -v curl > /dev/null || {
+		scenario_skipped "curl missing"
+		return 0
+	}
+
+	local workdir conf_min items_min
+	workdir=$(mktemp -d /tmp/huatuo-bench-cpu.XXXXXX)
+	bench_register_cleanup "${workdir}"
+	items_min="${workdir}/bl-min.txt"
+	bench_blacklist_all > "${items_min}"
+	conf_min="${workdir}/bamai.conf"
+	gen_bench_conf "${conf_min}" "${items_min}"
+
+	# ---- baseline (huatuo off) ----
+	log_info "cpu: baseline sampling"
+	sample_workload cpu_sample "${workdir}/base.txt"
+
+	# ---- full profile (shipped multi-collector config) ----
+	log_info "cpu: full-profile sampling"
+	local cpu0 cpu1 full_huatuo_cpu
+	if ! huatuo_start "$(full_config_path)"; then
+		huatuo_stop
+		scenario_error "huatuo-bamai failed to start (full profile)"
+		return 0
+	fi
+	cpu0=$(huatuo_cpu_seconds)
+	sample_workload cpu_sample "${workdir}/full.txt"
+	cpu1=$(huatuo_cpu_seconds)
+	full_huatuo_cpu=$(awk -v a="${cpu0}" -v b="${cpu1}" 'BEGIN { printf "%.4f", b - a }')
+	huatuo_stop
+
+	# ---- minimal profile (every optional collector blacklisted) ----
+	log_info "cpu: minimal-profile sampling"
+	local min_huatuo_cpu cpu0m cpu1m
+	if ! huatuo_start "${conf_min}"; then
+		huatuo_stop
+		scenario_error "huatuo-bamai failed to start (minimal profile)"
+		return 0
+	fi
+	cpu0m=$(huatuo_cpu_seconds)
+	sample_workload cpu_sample "${workdir}/minimal.txt"
+	cpu1m=$(huatuo_cpu_seconds)
+	min_huatuo_cpu=$(awk -v a="${cpu0m}" -v b="${cpu1m}" 'BEGIN { printf "%.4f", b - a }')
+	huatuo_stop
+
+	local full_obj minimal_obj
+	full_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/full.txt" "\"huatuo_cpu_seconds\":${full_huatuo_cpu}")
+	minimal_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/minimal.txt" "\"huatuo_cpu_seconds\":${min_huatuo_cpu}")
+
+	result_obj ok \
+		"\"description\":\"extra wall time of a CPU-bound workload while huatuo collects\"," \
+		"\"unit\":\"seconds\"," \
+		"\"profiles\":{\"full\":${full_obj},\"minimal\":${minimal_obj}}"
+}

--- a/bench/scenario_io.sh
+++ b/bench/scenario_io.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# IO latency scenario.
+#
+# Measures the incremental per-operation latency huatuo-bamai adds to
+# synchronized writes, under three profiles:
+#   - full    : realistic multi-collector config (shipped huatuo-bamai.conf)
+#   - minimal : every optional collector blacklisted
+#   - single  : isolates ${BENCH_IO_SINGLE_MODULE} (default: iolatency)
+
+scenario_io() {
+	[[ ${EUID} -eq 0 ]] || {
+		scenario_skipped "requires root"
+		return 0
+	}
+	[[ -x "${HUATUO_BAMAI_BIN}" ]] || {
+		scenario_skipped "huatuo-bamai binary missing"
+		return 0
+	}
+	command -v curl > /dev/null || {
+		scenario_skipped "curl missing"
+		return 0
+	}
+
+	# io_sample needs a writable directory; prefer a real filesystem over tmpfs
+	# so the kernel actually exercises the block-IO path huatuo instruments.
+	local io_dir=""
+	local mp
+	while read -r mp; do
+		[[ -d "${mp}" && -w "${mp}" ]] || continue
+		io_dir=$(mktemp -d "${mp%/}/huatuo-bench-io.XXXXXX") && break
+	done < <(awk '$3 == "ext4" || $3 == "xfs" { print $2 }' /proc/mounts)
+	[[ -n "${io_dir}" ]] || {
+		scenario_skipped "no writable ext4/xfs mount for io workload"
+		return 0
+	}
+
+	local workdir items_min items_single conf_min conf_single
+	workdir=$(mktemp -d /tmp/huatuo-bench-io-scenario.XXXXXX)
+	bench_register_cleanup "${workdir}"
+	# io_dir is created above; register it too so it is always removed.
+	bench_register_cleanup "${io_dir}"
+	items_min="${workdir}/bl-min.txt"
+	items_single="${workdir}/bl-single.txt"
+	bench_blacklist_all > "${items_min}"
+	bench_blacklist_except "${BENCH_IO_SINGLE_MODULE}" > "${items_single}"
+	conf_min="${workdir}/bamai-min.conf"
+	conf_single="${workdir}/bamai-single.conf"
+	gen_bench_conf "${conf_min}" "${items_min}"
+	gen_bench_conf "${conf_single}" "${items_single}"
+
+	# Override the io_sample work directory by exporting it for the workload.
+	export BENCH_IO_DIR="${io_dir}"
+
+	# ---- baseline ----
+	log_info "io: baseline sampling (${BENCH_IO_OPS} sync writes/sample)"
+	sample_workload io_sample "${workdir}/base.txt"
+
+	# ---- full ----
+	log_info "io: full-profile sampling"
+	if ! observed_samples "$(full_config_path)" io_sample "${workdir}/full.txt"; then
+		scenario_error "huatuo-bamai failed to start (full profile)"
+		return 0
+	fi
+
+	# ---- minimal ----
+	log_info "io: minimal-profile sampling"
+	if ! observed_samples "${conf_min}" io_sample "${workdir}/minimal.txt"; then
+		scenario_error "huatuo-bamai failed to start (minimal profile)"
+		return 0
+	fi
+
+	# ---- single ----
+	log_info "io: single-profile sampling (${BENCH_IO_SINGLE_MODULE})"
+	if ! observed_samples "${conf_single}" io_sample "${workdir}/single.txt"; then
+		scenario_error "huatuo-bamai failed to start (single profile)"
+		return 0
+	fi
+
+	local full_obj minimal_obj single_obj
+	full_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/full.txt")
+	minimal_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/minimal.txt")
+	single_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/single.txt")
+
+	result_obj ok \
+		"\"description\":\"incremental latency of synchronized writes while huatuo collects\"," \
+		"\"unit\":\"milliseconds\"," \
+		"\"profiles\":{\"full\":${full_obj},\"minimal\":${minimal_obj},\"single\":${single_obj}}"
+}

--- a/bench/scenario_memory.sh
+++ b/bench/scenario_memory.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Memory overhead scenario.
+#
+# Measures the resident memory (RSS) of the huatuo-bamai process itself under a
+# sustained mixed CPU+IO load. Absolute metric (no baseline). Reported for the
+# realistic "full" config and the maximally reduced "minimal" config.
+
+scenario_memory() {
+	[[ ${EUID} -eq 0 ]] || {
+		scenario_skipped "requires root"
+		return 0
+	}
+	[[ -x "${HUATUO_BAMAI_BIN}" ]] || {
+		scenario_skipped "huatuo-bamai binary missing"
+		return 0
+	}
+	command -v curl > /dev/null || {
+		scenario_skipped "curl missing"
+		return 0
+	}
+
+	local workdir items_min conf_min
+	workdir=$(mktemp -d /tmp/huatuo-bench-mem.XXXXXX)
+	bench_register_cleanup "${workdir}"
+	items_min="${workdir}/bl-min.txt"
+	bench_blacklist_all > "${items_min}"
+	conf_min="${workdir}/bamai.conf"
+	gen_bench_conf "${conf_min}" "${items_min}"
+
+	local mem_obj_full mem_obj_min
+
+	# ---- full profile ----
+	log_info "memory: full-profile sampling (window=${BENCH_MEM_DURATION}s)"
+	if ! huatuo_start "$(full_config_path)"; then
+		huatuo_stop
+		scenario_error "huatuo-bamai failed to start (full profile)"
+		return 0
+	fi
+	sustained_load "${BENCH_MEM_DURATION}" &
+	local load_pid=$!
+	sample_rss_window "${BENCH_MEM_DURATION}" "${workdir}/rss-full.txt"
+	wait "${load_pid}" 2> /dev/null || true
+	mem_obj_full=$(rss_summary_json "${workdir}/rss-full.txt")
+	huatuo_stop
+
+	# ---- minimal profile ----
+	log_info "memory: minimal-profile sampling (window=${BENCH_MEM_DURATION}s)"
+	if ! huatuo_start "${conf_min}"; then
+		huatuo_stop
+		scenario_error "huatuo-bamai failed to start (minimal profile)"
+		return 0
+	fi
+	sustained_load "${BENCH_MEM_DURATION}" &
+	load_pid=$!
+	sample_rss_window "${BENCH_MEM_DURATION}" "${workdir}/rss-min.txt"
+	wait "${load_pid}" 2> /dev/null || true
+	mem_obj_min=$(rss_summary_json "${workdir}/rss-min.txt")
+	huatuo_stop
+
+	result_obj ok \
+		"\"description\":\"huatuo-bamai resident memory under sustained load\"," \
+		"\"unit\":\"MiB\"," \
+		"\"window_seconds\":${BENCH_MEM_DURATION}," \
+		"\"profiles\":{\"full\":${mem_obj_full},\"minimal\":${mem_obj_min}}"
+}

--- a/bench/scenario_net.sh
+++ b/bench/scenario_net.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Network latency scenario.
+#
+# Measures the incremental RTT huatuo-bamai adds to loopback traffic, under
+# three profiles:
+#   - full    : realistic multi-collector config (shipped huatuo-bamai.conf)
+#   - minimal : every optional collector blacklisted
+#   - single  : isolates ${BENCH_NET_SINGLE_MODULE} (default: dropwatch)
+
+scenario_net() {
+	[[ ${EUID} -eq 0 ]] || {
+		scenario_skipped "requires root"
+		return 0
+	}
+	[[ -x "${HUATUO_BAMAI_BIN}" ]] || {
+		scenario_skipped "huatuo-bamai binary missing"
+		return 0
+	}
+	command -v curl > /dev/null || {
+		scenario_skipped "curl missing"
+		return 0
+	}
+	command -v ping > /dev/null || {
+		scenario_skipped "ping missing"
+		return 0
+	}
+
+	local workdir items_min items_single conf_min conf_single
+	workdir=$(mktemp -d /tmp/huatuo-bench-net.XXXXXX)
+	bench_register_cleanup "${workdir}"
+	items_min="${workdir}/bl-min.txt"
+	items_single="${workdir}/bl-single.txt"
+	bench_blacklist_all > "${items_min}"
+	bench_blacklist_except "${BENCH_NET_SINGLE_MODULE}" > "${items_single}"
+	conf_min="${workdir}/bamai-min.conf"
+	conf_single="${workdir}/bamai-single.conf"
+	gen_bench_conf "${conf_min}" "${items_min}"
+
+	# single-module body: enable the isolated net module's event subsection.
+	# "tcp" matches the filter shipped in huatuo-bamai.conf; raw IP protocol
+	# keywords like "icmp" are rejected by the go-pcap filter compiler (see
+	# the comment in huatuo-bamai.conf), so reusing the known-good value keeps
+	# dropwatch's probes attached for the duration of the sample.
+	local mod_title="${BENCH_NET_SINGLE_MODULE^}"
+	cat > "${workdir}/${BENCH_NET_SINGLE_MODULE}.body" << EOF
+
+[EventTracing.${mod_title}]
+    Filter = "tcp"
+EOF
+	gen_bench_conf "${conf_single}" "${items_single}" "${workdir}/${BENCH_NET_SINGLE_MODULE}.body"
+
+	# ---- baseline ----
+	log_info "net: baseline sampling (${BENCH_NET_PACKETS} packets/sample)"
+	sample_workload net_sample "${workdir}/base.txt"
+
+	# ---- full ----
+	log_info "net: full-profile sampling"
+	if ! observed_samples "$(full_config_path)" net_sample "${workdir}/full.txt"; then
+		scenario_error "huatuo-bamai failed to start (full profile)"
+		return 0
+	fi
+
+	# ---- minimal ----
+	log_info "net: minimal-profile sampling"
+	if ! observed_samples "${conf_min}" net_sample "${workdir}/minimal.txt"; then
+		scenario_error "huatuo-bamai failed to start (minimal profile)"
+		return 0
+	fi
+
+	# ---- single ----
+	log_info "net: single-profile sampling (${BENCH_NET_SINGLE_MODULE})"
+	if ! observed_samples "${conf_single}" net_sample "${workdir}/single.txt"; then
+		scenario_error "huatuo-bamai failed to start (single profile)"
+		return 0
+	fi
+
+	local full_obj minimal_obj single_obj
+	full_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/full.txt")
+	minimal_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/minimal.txt")
+	single_obj=$(profile_result_json "${workdir}/base.txt" "${workdir}/single.txt")
+
+	result_obj ok \
+		"\"description\":\"incremental loopback RTT while huatuo collects\"," \
+		"\"unit\":\"microseconds\"," \
+		"\"profiles\":{\"full\":${full_obj},\"minimal\":${minimal_obj},\"single\":${single_obj}}"
+}

--- a/docs/best-practice/performance-overhead_en.md
+++ b/docs/best-practice/performance-overhead_en.md
@@ -1,0 +1,169 @@
+---
+title: Performance Overhead Benchmark
+type: docs
+description: "Methodology and tooling for measuring the performance impact HUATUO imposes on observed workloads."
+author: HUATUO Team
+date: 2026-07-12
+weight: 6
+---
+
+## Why measure overhead
+
+HUATUO is an eBPF-based observability agent. Every kernel probe it attaches, every
+ring buffer it drains, and every metric it scrapes adds work to the system it
+observes. This document describes the **systematic methodology** and the
+**automation** under `bench/` that quantifies that overhead so users can make an
+informed deploy/no-deploy decision for their own environment.
+
+The benchmark answers four questions:
+
+| Metric | Question answered | Reported unit |
+|--------|-------------------|---------------|
+| **CPU overhead** | How much extra CPU does the observed workload burn while HUATUO is collecting? | percent increase of workload CPU/wall time |
+| **Memory overhead** | How much resident memory does the `huatuo-bamai` process itself consume? | MiB (RSS, peak `VmHWM`) |
+| **Network latency** | How much per-packet latency does HUATUO add to the receive path? | microseconds (added RTT) |
+| **IO latency** | How much per-operation latency does HUATUO add to the block-IO path? | milliseconds (added latency) |
+
+---
+
+## Methodology
+
+### A/B with paired statistics
+
+Every metric is measured as a controlled **A/B experiment**:
+
+1. **Baseline (A)** — the workload runs with `huatuo-bamai` *stopped*.
+2. **Observed (B)** — the same workload runs with `huatuo-bamai` *started* and
+   collecting.
+
+Each side is repeated `BENCH_ITERATIONS` times (default `5`). The harness
+discards the first iteration as a warmup, then reports for each side: sample
+count, min, mean, median, p95, max and standard deviation. The headline numbers
+are:
+
+- **`delta_mean`** = `mean(B) − mean(A)`
+- **`delta_percent`** = `delta_mean / mean(A) × 100`
+
+Reporting the full distribution (not a single number) makes the result
+reproducible and lets a reviewer judge whether a difference is within noise.
+
+### Workloads
+
+The workloads are intentionally built from tools that exist on every Linux
+distribution (`dd`, `ping`, `/proc`), so the benchmark has **no extra build
+dependencies** and runs identically in CI and on a production host.
+
+| Metric | Workload | What it exercises |
+|--------|----------|-------------------|
+| CPU overhead | `dd if=/dev/zero of=/dev/null bs=64K` for a fixed byte count | CPU + memcpy; visible to HUATUO's CPU/scheduling probes |
+| Memory overhead | sustained mixed CPU+IO load window | HUATUO resident set under steady state |
+| Network latency | `ping -c N 127.0.0.1` over loopback | net RX path instrumented by `dropwatch`/`netrxlatency`/`netdev` |
+| IO latency | small `oflag=dsync` writes in a loop | block-IO path instrumented by `iolatency`/`iotracing` |
+
+Relative (A/B) workloads are short and matched in size so the baseline and
+observed phases experience the same thermal/scheduling conditions.
+
+### Module matrix (single vs multi)
+
+`huatuo-bamai` enables/disables collectors through its `BlackList` config. The
+benchmark therefore runs each metric under up to **three collection profiles**:
+
+| Profile | BlackList | Meaning |
+|---------|-----------|---------|
+| **full** | the shipped `huatuo-bamai.conf` (`netdev_hw`, `metax_gpu`, `ascend_npu`) | realistic multi-collector deployment — worst-case overhead |
+| **minimal** | core hardware + every optional software collector | every optional collector off — lower bound of huatuo overhead |
+| **single** (net/io) | core + every optional collector except the one relevant to the metric | isolates a single collector's contribution |
+
+The optional collectors exercised are: `softlockup`, `ethtool`, `netstat_hw`,
+`iolatency`, `memory_free`, `memory_reclaim`, `reschedipi`, `softirq`,
+`iotracing`, `dropwatch`, `netdev_hw`.
+
+For the network scenario the single profile isolates `dropwatch`; for the IO
+scenario it isolates `iolatency`. This produces a direct **single vs multi**
+comparison per metric, as required by the issue.
+
+### Environment (idle vs load, container vs host)
+
+- **Idle vs load** — the CPU and memory scenarios drive the system under load
+  (a CPU-bound `dd` workload; a sustained mixed CPU+IO window for the memory
+  scenario). To capture an explicit idle baseline, quiesce other processes on
+  the host and re-run; the JSON `metadata` block lets you compare the two runs.
+- **Container vs host** — the harness auto-detects whether it runs inside a
+  container (overlay/btrfs root or `systemd-detect-virt -c`) and records the
+  result under `metadata.env`. Run the same script once on the host and once in
+  a container to compare; the JSON metadata makes the two runs comparable.
+
+---
+
+## Output format
+
+`bench/run.sh` writes a single machine-readable JSON document to
+`bench/results/bench-<timestamp>.json` and prints a human-readable summary to
+stdout. The JSON schema (versioned):
+
+```json
+{
+  "version": 1,
+  "metadata": {
+    "kernel": "6.8.0-124-generic",
+    "arch": "x86_64",
+    "ncpu": 8,
+    "mem_total_kb": 16384000,
+    "env": "host",
+    "huatuo_version": "2.2.0",
+    "iterations": 5,
+    "timestamp_utc": "2026-07-12T09:30:00Z"
+  },
+  "scenarios": {
+    "cpu_overhead": {
+      "status": "ok",
+      "unit": "seconds",
+      "profiles": {
+        "full":    { "baseline": { "...": "..." }, "observed": { "...": "..." }, "delta_mean": 0.03, "delta_percent": 1.2, "huatuo_cpu_seconds": 0.5 },
+        "minimal": { "...": "..." }
+      }
+    },
+    "memory_overhead": { "status": "ok", "unit": "MiB", "profiles": { "full": { "rss_peak_mib": 42.1 }, "minimal": { "rss_peak_mib": 38.0 } } },
+    "net_latency":     { "status": "ok", "unit": "microseconds", "profiles": { "full": { "...": "..." }, "minimal": { "...": "..." }, "single": { "...": "..." } } },
+    "io_latency":      { "status": "ok", "unit": "milliseconds", "profiles": { "full": { "...": "..." }, "minimal": { "...": "..." }, "single": { "...": "..." } } }
+  }
+}
+```
+
+A scenario reports `"status": "skipped"` with a `reason` when a precondition
+(binary, root, kernel feature) is not met, so a CI lane never fails purely
+because it cannot run the benchmark.
+
+---
+
+## Running
+
+```bash
+make bench                 # build huatuo-bamai, then run the benchmark
+# or, against an existing build:
+BENCH_ITERATIONS=10 bash bench/run.sh
+```
+
+See `bench/README.md` for all knobs (iterations, durations, thresholds, single
+modules, output directory).
+
+### CI integration
+
+The `benchmark.yml` workflow builds `huatuo-bamai`, runs the benchmark in a QEMU
+VM, uploads the JSON result plus a text summary as a build artifact, and (when
+`BENCH_FAIL_ON_REGRESSION=1`) fails if any `delta_percent` crosses its configured
+threshold. It runs on release tags and on manual dispatch so it never blocks
+ordinary pull requests.
+
+---
+
+## Interpreting results
+
+- **CPU overhead** below ~1–2% and **net/IO latency** deltas in the low
+  single-digit percent are consistent with HUATUO's design goal of sub-1% probe
+  overhead. Treat the measured value as an upper bound: the benchmark drives a
+  deliberately probe-heavy workload.
+- Results are **host-specific**. Always compare runs that share the same
+  `metadata` (kernel, ncpu, env). The JSON makes side-by-side comparison easy.
+- Use the **single** profile to attribute overhead to a specific collector when
+  the **full** profile shows a regression.


### PR DESCRIPTION
## Summary

Resolves #336 by adding a systematic, repeatable way to quantify the
performance impact HUATUO imposes on the workloads it observes.

This gives users the deploy/no-deploy information the issue asks for: how much
extra CPU, memory, network latency and IO latency huatuo-bamai adds, across
multiple collection profiles and environments.

## What is included

- **`bench/`** — a dependency-free A/B benchmark harness built only from tools
  present on every Linux distribution (`dd`, `ping`, `/proc`), so it behaves
  identically in CI and on a production host. It measures four metrics:

  | Scenario | Metric | Unit |
  |----------|--------|------|
  | `cpu_overhead` | extra wall time of a CPU-bound workload while huatuo collects | seconds (+ %) |
  | `memory_overhead` | huatuo-bamai resident memory under sustained load | MiB (RSS, peak VmHWM) |
  | `net_latency` | incremental loopback RTT while huatuo collects | microseconds (+ %) |
  | `io_latency` | incremental latency of synchronized writes while huatuo collects | milliseconds (+ %) |

  Each metric runs under up to three collection profiles driven by `BlackList`:
  - `full` — the shipped `huatuo-bamai.conf` (realistic multi-collector setup)
  - `minimal` — every optional collector off (lower bound of overhead)
  - `single` (net/io) — isolates one collector (`dropwatch` / `iolatency`)

  This makes **single-vs-multi module** and **idle-vs-load** comparisons
  first-class. Every result reports count / min / mean / median / p95 / max /
  stddev for reproducibility, and the report records container-vs-host metadata
  so two runs are directly comparable. When a precondition (root, binary,
  kernel feature) is not met, a scenario records a `"status": "skipped"`
  result instead of failing, so a CI lane never turns red solely because it
  cannot run the benchmark.

- **`docs/best-practice/performance-overhead_en.md`** — the methodology,
  metric definitions, output schema, module matrix and interpretation guidance.

- **`.github/workflows/benchmark.yml`** + **`scripts/qemu-2-run-bench-in-vm.sh`**
  — CI integration that builds `huatuo-bamai`, runs the benchmark in a QEMU VM
  and uploads the JSON report + text summary as workflow artifacts. It triggers
  on release tags and on manual dispatch, so it never blocks ordinary pull
  requests. Set `BENCH_FAIL_ON_REGRESSION=1` (workflow input or env) to turn a
  `delta_percent` threshold breach into a CI failure.

- **`Makefile`** — a `make bench` target that builds `huatuo-bamai` first and
  then runs `bench/run.sh`.

## How to run

```bash
make bench                                   # build huatuo-bamai, then run
# or, against an existing build:
bash bench/run.sh
# fast smoke run:
BENCH_ITERATIONS=2 BENCH_NET_PACKETS=50 BENCH_IO_OPS=50 bash bench/run.sh
# strict CI gate:
BENCH_FAIL_ON_REGRESSION=1 bash bench/run.sh
```

The report is written to `bench/results/bench-<UTC-timestamp>.json` with a text
summary printed to stdout. See `bench/README.md` for all knobs.

## Acceptance criteria

- [x] Benchmark design documentation completed (`docs/best-practice/performance-overhead_en.md`)
- [x] Multi-scenario test data reproducibly generated (full/minimal/single profiles; idle-vs-load; container-vs-host metadata)
- [x] Automation scripts run (`bench/run.sh`, `make bench`; verified end-to-end)
- [x] CI integration configured (`.github/workflows/benchmark.yml`)

## Verification

- `bash -n` passes on every script; `shfmt -i 0 -bn -sr -d` (the exact flags
  `make check` uses) reports no formatting changes needed.
- `bench/run.sh` was executed end-to-end against a missing binary and produced
  valid, `python3 -m json.tool`-parseable JSON plus a correct human summary.
- The statistics/comparison helpers (`stats_json`, `profile_result_json`,
  `profile_result_json`, blacklist builders, `gen_bench_conf`) were unit-tested
  with synthetic A/B data and produce correct distributions and TOML configs.
- The regression-gate logic correctly exits non-zero on a threshold breach.

## Notes for reviewers

- The net `single` profile uses `Filter = "tcp"` for `[EventTracing.Dropwatch]`,
  matching the value shipped in `huatuo-bamai.conf`. Raw IP protocol keywords
  such as `icmp` are explicitly documented there as unsupported by the go-pcap
  filter compiler, so reusing the known-good value keeps dropwatch's probes
  attached for the duration of the sample.
- No hard-coded author identity is included; the DCO sign-off will be added by
  the contributor at commit time via `git commit -s`.