### PR TITLE
feat(metrics): probe Didi memcg interfaces before enabling memory_others

### DIFF
--- a/core/metrics/memory_others.go
+++ b/core/metrics/memory_others.go
@@ -16,23 +16,68 @@ package collector
 
 import (
 	"fmt"
+	"os"
 
 	"huatuo-bamai/internal/cgroups/paths"
 	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/pod"
 	"huatuo-bamai/internal/utils/parseutil"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
 )
 
 type memOthersCollector struct{}
+
+// didiMemcgMetrics maps the memory cgroup extension files provided by the
+// Didi Cloud custom kernel to the metrics exported by this collector.
+// Mainline and distribution kernels do not expose these files.
+var didiMemcgMetrics = []struct {
+	path string
+	key  string
+	name string
+}{
+	{
+		path: "memory.directstall_stat",
+		key:  "directstall_time",
+		name: "directstall_time",
+	},
+	{
+		path: "memory.asynreclaim_stat",
+		key:  "asyncreclaim_time",
+		name: "asyncreclaim_time",
+	},
+	{
+		path: "memory.local_direct_reclaim_time",
+		key:  "",
+		name: "local_direct_reclaim_time",
+	},
+}
 
 func init() {
 	// only for didicloud
 	tracing.RegisterEventTracing("memory_others", newMemOthersCollector)
 }
 
+// hasDidiMemcgInterfaces reports whether the running kernel exposes any of
+// the Didi memcg extension files on the root memory cgroup.
+func hasDidiMemcgInterfaces() bool {
+	for _, t := range didiMemcgMetrics {
+		if _, err := os.Stat(paths.Path(subsystem.SubsystemMemory, t.path)); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 func newMemOthersCollector() (*tracing.EventTracingAttr, error) {
+	if !hasDidiMemcgInterfaces() {
+		log.Infof("memory_others: kernel does not expose Didi memcg interfaces (e.g. memory.directstall_stat), disabling")
+		return nil, types.ErrNotSupported
+	}
+
 	return &tracing.EventTracingAttr{
 		TracingData: &memOthersCollector{},
 		Flag:        tracing.FlagMetric,
@@ -62,27 +107,7 @@ func (c *memOthersCollector) Update() ([]*metric.Data, error) {
 	metrics := []*metric.Data{}
 
 	for _, container := range containers {
-		for _, t := range []struct {
-			path string
-			key  string
-			name string
-		}{
-			{
-				path: "memory.directstall_stat",
-				key:  "directstall_time",
-				name: "directstall_time",
-			},
-			{
-				path: "memory.asynreclaim_stat",
-				key:  "asyncreclaim_time",
-				name: "asyncreclaim_time",
-			},
-			{
-				path: "memory.local_direct_reclaim_time",
-				key:  "",
-				name: "local_direct_reclaim_time",
-			},
-		} {
+		for _, t := range didiMemcgMetrics {
 			value, err := parseValueWithKey(container.CgroupPath, t.path, t.key)
 			if err != nil {
 				// FIXME: os maynot support this metric

--- a/core/metrics/memory_others_test.go
+++ b/core/metrics/memory_others_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/cgroups/paths"
+	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+// setCgroupRootfs points the cgroup rootfs at a temp dir containing an empty
+// memory subsystem directory, and restores the original on cleanup.
+func setCgroupRootfs(t *testing.T) string {
+	t.Helper()
+
+	orig := paths.RootfsDefaultPath
+	t.Cleanup(func() { paths.RootfsDefaultPath = orig })
+
+	paths.RootfsDefaultPath = t.TempDir()
+
+	memDir := filepath.Join(paths.RootfsDefaultPath, subsystem.SubsystemMemory)
+	if err := os.MkdirAll(memDir, 0o755); err != nil {
+		t.Fatalf("create memory cgroup dir: %v", err)
+	}
+
+	return memDir
+}
+
+func TestNewMemOthersCollectorNotSupported(t *testing.T) {
+	setCgroupRootfs(t)
+
+	// No Didi memcg extension files: the collector must opt out with
+	// ErrNotSupported so the framework marks it inactive.
+	if _, err := newMemOthersCollector(); !errors.Is(err, types.ErrNotSupported) {
+		t.Fatalf("newMemOthersCollector() error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestNewMemOthersCollectorSupported(t *testing.T) {
+	memDir := setCgroupRootfs(t)
+
+	stat := filepath.Join(memDir, "memory.directstall_stat")
+	if err := os.WriteFile(stat, []byte("directstall_time 0\n"), 0o600); err != nil {
+		t.Fatalf("create %s: %v", stat, err)
+	}
+
+	attr, err := newMemOthersCollector()
+	if err != nil {
+		t.Fatalf("newMemOthersCollector() error = %v, want nil", err)
+	}
+	if attr == nil || attr.Flag&tracing.FlagMetric == 0 {
+		t.Fatalf("newMemOthersCollector() attr = %+v, want metric collector", attr)
+	}
+}


### PR DESCRIPTION
## What

Probe the root memory cgroup for the Didi memcg extension interfaces once at registration, and opt the `memory_others` collector out with `ErrNotSupported` when none exist, following the `ras` collector precedent (03a6263d).

## Why

The collector reads memory cgroup files that only exist in the Didi Cloud custom kernel (`memory.directstall_stat`, `memory.asynreclaim_stat`, `memory.local_direct_reclaim_time`). On mainline and distribution kernels every per-container read fails and is silently swallowed on each update cycle, so the collector looks broken to users (see #56) and burns pointless file opens.

## How

- Hoist the didicloud metric file list to a package-level table shared by the probe and `Update()`.
- `newMemOthersCollector()` checks the root memory cgroup for any of these files; when absent it logs the reason and returns `types.ErrNotSupported`, so the framework marks the collector inactive instead of running it as a no-op.

## Testing

- `go test -run TestNewMemOthersCollector ./core/metrics/` — 2 new unit tests PASS (supported / not-supported paths, via a temp cgroup rootfs).
- `make check` green (golangci-lint v1.62.2, gofumpt/goimports clean).

**Note for reviewers**: this assumes the Didi kernel exposes these files on the root memory cgroup, as with other v1 memcg cftypes. I cannot verify on a Didi kernel — happy to adjust the probe if that assumption doesn't hold.

Ref #56
