### PR TITLE
docs(metrics): document Didi-kernel-only memory_others metrics

### DIFF
--- a/docs/faq/_index_en.md
+++ b/docs/faq/_index_en.md
@@ -3,3 +3,11 @@ title: FAQ
 type: docs
 weight: 9
 ---
+
+## Metrics
+
+### Why do the `memory_others_*` metrics (e.g. `directstall_time`) have no data?
+
+The `memory_others` collector reads memory cgroup extension interfaces provided by the Didi Cloud custom kernel (`memory.directstall_stat`, `memory.asynreclaim_stat`, `memory.local_direct_reclaim_time`). Mainline and common distribution kernels do not expose these interfaces, and no loadable kernel module provides them, so these metrics are simply not emitted on standard kernels — this is expected behavior.
+
+To observe container direct reclaim behavior on standard kernels, use the eBPF-based `memory_reclaim_container_directstall` metric instead; see the Memory System section in "Key Features / Kernel-Wide Insight".

--- a/docs/faq/_index_zh.md
+++ b/docs/faq/_index_zh.md
@@ -3,3 +3,11 @@ title: 常见问题
 type: docs
 weight: 9
 ---
+
+## 指标
+
+### 为什么 `memory_others_*`（如 `directstall_time`）指标没有数据？
+
+`memory_others` 采集器读取的是滴滴云定制内核提供的 memory cgroup 扩展接口（`memory.directstall_stat`、`memory.asynreclaim_stat`、`memory.local_direct_reclaim_time`）。主线内核及常见发行版内核不提供这些接口，也没有可加载的内核模块能提供，因此在标准内核上这些指标不会输出，属预期行为。
+
+在标准内核上观测容器直接回收（direct reclaim）行为，请使用基于 eBPF 实现的 `memory_reclaim_container_directstall` 指标，详见「核心特性 / 内核全景观测」文档中的内存系统章节。

--- a/docs/key-feature/kernel-wide-insight_en.md
+++ b/docs/key-feature/kernel-wide-insight_en.md
@@ -226,6 +226,8 @@ huatuo_bamai_memory_reclaim_container_directstall{container_host="coredns-855c4d
 |memory_free_compaction_stall|Time stalled in memory compaction| nanoseconds|Host| eBPF | host, region|
 |memory_reclaim_container_directstall|Number of direct reclaim events in container| count| Container| eBPF | container_host, container_hostnamespace, container_level, container_name, container_type, host, region|
 
+> **Note**: The `memory_others_container_directstall_time`, `memory_others_container_asyncreclaim_time`, and `memory_others_container_local_direct_reclaim_time` metrics read memory cgroup extension interfaces provided by the Didi Cloud custom kernel (`memory.directstall_stat`, `memory.asynreclaim_stat`, `memory.local_direct_reclaim_time`). Mainline and common distribution kernels do not expose these interfaces, so these metrics are simply not emitted there — this is expected, and no extra kernel module can provide them. To observe container direct reclaim behavior on standard kernels, use the eBPF-based `memory_reclaim_container_directstall` listed above.
+
 ### State
 
 From cgroup memory.stat:

--- a/docs/key-feature/kernel-wide-insight_zh.md
+++ b/docs/key-feature/kernel-wide-insight_zh.md
@@ -219,6 +219,8 @@ huatuo_bamai_memory_reclaim_container_directstall{container_host="coredns-855c4d
 |memory_free_compaction_stall|系统在规整内存页过程中的耗时计数| 纳秒|物理机| eBPF | host, region|
 |memory_reclaim_container_directstall|容器直接内存事件次数| 计数| 容器| eBPF | container_host, container_hostnamespace, container_level, container_name, container_type, host, region|
 
+> **注意**：`memory_others_container_directstall_time`、`memory_others_container_asyncreclaim_time`、`memory_others_container_local_direct_reclaim_time` 指标读取的是滴滴云定制内核提供的 memory cgroup 扩展接口（`memory.directstall_stat`、`memory.asynreclaim_stat`、`memory.local_direct_reclaim_time`）。主线内核及常见发行版内核不提供这些接口，因此这些指标不会输出，属预期行为，无需额外加载内核模块。在标准内核上观测容器直接回收（direct reclaim）行为，请使用上表基于 eBPF 实现的 `memory_reclaim_container_directstall`。
+
 ### 资源状态
 
 通过如下指标可以了解整体系统、容器的内存状态。


### PR DESCRIPTION
## What

Document that the `memory_others_*` metrics depend on the Didi Cloud custom kernel, in the kernel-wide-insight metric docs (zh/en) and a new FAQ entry.

## Why

The `memory_others` collector reads memory cgroup extension interfaces that only exist in the Didi Cloud custom kernel (`memory.directstall_stat`, `memory.asynreclaim_stat`, `memory.local_direct_reclaim_time`). On mainline and distribution kernels these files are absent and the metrics are silently skipped, which has confused users into thinking the collector is broken or that a kernel module is missing (#56). Nothing in the docs mentioned this today, while the bundled Grafana dashboard even references `memory_others_container_directstall_time`, so the confusion is easy to hit.

## How

- `docs/key-feature/kernel-wide-insight_{zh,en}.md`: add a note under the Memory / Reclaim metric table stating these metrics are Didi-kernel-only, that their absence on standard kernels is expected, and pointing to the eBPF-based `memory_reclaim_container_directstall` as the standard-kernel alternative.
- `docs/faq/_index_{zh,en}.md`: add the same answer as the first FAQ entry.

Docs-only change, no code touched.

Closes #56
