### PR TITLE
feat(apiserver): unified web console with RBAC, task management and module integration

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -133,3 +133,69 @@ type ProfilingCapabilitiesResponse struct {
 	DefaultMemorySingleTraceTimeout int               `json:"default_memory_single_trace_timeout"` // default memory single trace timeout in seconds
 	ThirdPartyToolLimit             int               `json:"third_party_tool_limit"`              // third-party tool limit
 }
+
+// UserResponse represents a registered user/API key in the access-control view.
+// The ID field is the credential presented in the Authorization header.
+type UserResponse struct {
+	ID          string   `json:"id"`          // unique credential / API key
+	Name        string   `json:"name"`        // human-readable display name
+	IsAdmin     bool     `json:"is_admin"`    // whether the user has administrator privileges
+	Permissions []string `json:"permissions"` // URL path patterns this user may access
+}
+
+// CreateUserRequest creates a new user/API key. When GenerateKey is true the
+// server generates a random credential and returns it once in the response;
+// the caller is then expected to treat it as a secret.
+type CreateUserRequest struct {
+	Name        string   `json:"name"`         // human-readable display name
+	IsAdmin     bool     `json:"is_admin"`     // whether the user has administrator privileges
+	Permissions []string `json:"permissions"`  // URL path patterns this user may access
+	GenerateKey bool     `json:"generate_key"` // when true, generate a random API key/ID
+	ID          string   `json:"id,omitempty"` // explicit ID; used when GenerateKey is false
+}
+
+// CreateUserResponse is returned when a user/API key is created.
+type CreateUserResponse struct {
+	ID string `json:"id"` // the credential to present in the Authorization header
+}
+
+// RoleResponse describes a named permission template that can be assigned to a user.
+type RoleResponse struct {
+	Name        string   `json:"name"`        // role identifier, e.g. "admin"
+	Description string   `json:"description"` // human-readable description
+	Permissions []string `json:"permissions"` // URL path patterns granted by the role
+	IsAdmin     bool     `json:"is_admin"`    // whether the role implies administrator privileges
+}
+
+// WhoAmIResponse describes the identity of the authenticated caller.
+type WhoAmIResponse struct {
+	ID          string   `json:"id"`          // credential / API key
+	Name        string   `json:"name"`        // display name
+	IsAdmin     bool     `json:"is_admin"`    // administrator privileges
+	Permissions []string `json:"permissions"` // effective URL path patterns (empty for admins)
+}
+
+// SystemInfoResponse aggregates status information for the dashboard.
+type SystemInfoResponse struct {
+	Version string       `json:"version"` // server version
+	Commit  string       `json:"commit"`  // git commit
+	Modules []ModuleInfo `json:"modules"` // integrated modules surfaced in the console
+	Limits  SystemLimits `json:"limits"`  // configured task scheduling limits
+}
+
+// ModuleInfo describes an integrated observability module.
+type ModuleInfo struct {
+	Name        string `json:"name"`         // module identifier, e.g. "profiling"
+	DisplayName string `json:"display_name"` // human-readable name
+	Description string `json:"description"`  // short description of the module
+	Endpoint    string `json:"endpoint"`     // primary API endpoint backing the module
+	Enabled     bool   `json:"enabled"`      // whether the module is available
+}
+
+// SystemLimits exposes the configured task scheduling limits.
+type SystemLimits struct {
+	MaxProfilingTasksPerHost int `json:"max_profiling_tasks_per_host"`
+	MaxTracingTasksPerHost   int `json:"max_tracing_tasks_per_host"`
+	MaxTotalProfilingTasks   int `json:"max_total_profiling_tasks"`
+	MaxTotalTracingTasks     int `json:"max_total_tracing_tasks"`
+}

--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -138,3 +138,69 @@ type ProfilingCapabilities struct {
 	AggregationIntervalSeconds int                 `json:"aggregation_interval_seconds"` // server aggregation interval
 	MaxConcurrentProfilers     int                 `json:"max_concurrent_profilers"`     // concurrent profiler limit
 }
+
+// UserResponse represents a registered user/API key in the access-control view.
+// The ID field is the credential presented in the Authorization header.
+type UserResponse struct {
+	ID          string   `json:"id"`          // unique credential / API key
+	Name        string   `json:"name"`        // human-readable display name
+	IsAdmin     bool     `json:"is_admin"`    // whether the user has administrator privileges
+	Permissions []string `json:"permissions"` // URL path patterns this user may access
+}
+
+// CreateUserRequest creates a new user/API key. When GenerateKey is true the
+// server generates a random credential and returns it once in the response;
+// the caller is then expected to treat it as a secret.
+type CreateUserRequest struct {
+	Name        string   `json:"name"`         // human-readable display name
+	IsAdmin     bool     `json:"is_admin"`     // whether the user has administrator privileges
+	Permissions []string `json:"permissions"`  // URL path patterns this user may access
+	GenerateKey bool     `json:"generate_key"` // when true, generate a random API key/ID
+	ID          string   `json:"id,omitempty"` // explicit ID; used when GenerateKey is false
+}
+
+// CreateUserResponse is returned when a user/API key is created.
+type CreateUserResponse struct {
+	ID string `json:"id"` // the credential to present in the Authorization header
+}
+
+// RoleResponse describes a named permission template that can be assigned to a user.
+type RoleResponse struct {
+	Name        string   `json:"name"`        // role identifier, e.g. "admin"
+	Description string   `json:"description"` // human-readable description
+	Permissions []string `json:"permissions"` // URL path patterns granted by the role
+	IsAdmin     bool     `json:"is_admin"`    // whether the role implies administrator privileges
+}
+
+// WhoAmIResponse describes the identity of the authenticated caller.
+type WhoAmIResponse struct {
+	ID          string   `json:"id"`          // credential / API key
+	Name        string   `json:"name"`        // display name
+	IsAdmin     bool     `json:"is_admin"`    // administrator privileges
+	Permissions []string `json:"permissions"` // effective URL path patterns (empty for admins)
+}
+
+// SystemInfoResponse aggregates status information for the dashboard.
+type SystemInfoResponse struct {
+	Version string       `json:"version"` // server version
+	Commit  string       `json:"commit"`  // git commit
+	Modules []ModuleInfo `json:"modules"` // integrated modules surfaced in the console
+	Limits  SystemLimits `json:"limits"`  // configured task scheduling limits
+}
+
+// ModuleInfo describes an integrated observability module.
+type ModuleInfo struct {
+	Name        string `json:"name"`         // module identifier, e.g. "profiling"
+	DisplayName string `json:"display_name"` // human-readable name
+	Description string `json:"description"`  // short description of the module
+	Endpoint    string `json:"endpoint"`     // primary API endpoint backing the module
+	Enabled     bool   `json:"enabled"`      // whether the module is available
+}
+
+// SystemLimits exposes the configured task scheduling limits.
+type SystemLimits struct {
+	MaxProfilingTasksPerHost int `json:"max_profiling_tasks_per_host"`
+	MaxTracingTasksPerHost   int `json:"max_tracing_tasks_per_host"`
+	MaxTotalProfilingTasks   int `json:"max_total_profiling_tasks"`
+	MaxTotalTracingTasks     int `json:"max_total_tracing_tasks"`
+}

--- a/cmd/huatuo-apiserver/handlers/console/console.go
+++ b/cmd/huatuo-apiserver/handlers/console/console.go
@@ -1,0 +1,334 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package console implements the access-control (RBAC), system-info and API-key
+// management endpoints that back the huatuo-apiserver web console. It also serves
+// the embedded single-page frontend.
+package console
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	v1 "huatuo-bamai/apis/v1"
+	"huatuo-bamai/cmd/huatuo-apiserver/config"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/server/response"
+	"huatuo-bamai/internal/version"
+)
+
+// apiKeyBytes is the length of generated API keys, in bytes (32 hex chars).
+const apiKeyBytes = 16
+
+// Handler handles RBAC, system-info and API-key management HTTP requests.
+type Handler struct {
+	userManager server.UserManager
+	versionInfo *version.Info
+	Handlers    []server.Handle
+}
+
+// NewHandler creates a new console handler.
+// userManager may be nil when authentication is disabled; in that case the
+// user/role management endpoints report that authentication is disabled.
+func NewHandler(userManager server.UserManager, versionInfo *version.Info) *Handler {
+	h := &Handler{
+		userManager: userManager,
+		versionInfo: versionInfo,
+	}
+
+	h.Handlers = []server.Handle{
+		{Typ: server.HttpGet, Uri: "/auth/whoami", Handle: h.whoami},
+		{Typ: server.HttpGet, Uri: "/roles", Handle: h.listRoles},
+		{Typ: server.HttpGet, Uri: "/users", Handle: h.listUsers},
+		{Typ: server.HttpPost, Uri: "/users", Handle: h.createUser},
+		{Typ: server.HttpDelete, Uri: "/users/:id", Handle: h.deleteUser},
+		{Typ: server.HttpGet, Uri: "/system/info", Handle: h.systemInfo},
+	}
+
+	return h
+}
+
+// whoami returns the identity of the authenticated caller. Any valid user may
+// call this; it powers the console login verification step.
+func (h *Handler) whoami(ctx *server.Context) error {
+	if h.userManager == nil {
+		response.Success(ctx, v1.WhoAmIResponse{})
+		return nil
+	}
+
+	user, ok := h.userManager.GetUserById(ctx.UserID)
+	if !ok {
+		return response.ErrUnauthorized.WithMessage("user not found")
+	}
+
+	perms := make([]string, 0, len(user.Permissions))
+	for _, p := range user.Permissions {
+		perms = append(perms, string(p))
+	}
+
+	response.Success(ctx, v1.WhoAmIResponse{
+		ID:          user.ID,
+		Name:        user.Name,
+		IsAdmin:     user.IsAdmin,
+		Permissions: perms,
+	})
+	return nil
+}
+
+// listUsers returns all registered users/API keys. Administrator only.
+func (h *Handler) listUsers(ctx *server.Context) error {
+	if !ctx.IsAdmin {
+		return response.ErrForbidden
+	}
+	if h.userManager == nil {
+		response.Success(ctx, []v1.UserResponse{})
+		return nil
+	}
+
+	users := h.userManager.ListUsers()
+	items := make([]v1.UserResponse, 0, len(users))
+	for _, u := range users {
+		items = append(items, toUserResponse(u))
+	}
+
+	response.Success(ctx, items)
+	return nil
+}
+
+// createUser registers a new user/API key. Administrator only.
+func (h *Handler) createUser(ctx *server.Context) error {
+	if !ctx.IsAdmin {
+		return response.ErrForbidden
+	}
+	if h.userManager == nil {
+		return response.ErrInvalidRequest.WithMessage("authentication is disabled")
+	}
+
+	var req v1.CreateUserRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		return response.ErrInvalidRequest.WithMessage(err.Error())
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		return response.ErrInvalidRequest.WithMessage("name is required")
+	}
+
+	id := strings.TrimSpace(req.ID)
+	if req.GenerateKey || id == "" {
+		generated, err := generateAPIKey()
+		if err != nil {
+			log.Errorf("Failed to generate API key: %v", err)
+			return response.ErrInternal.WithMessage("failed to generate API key")
+		}
+		id = generated
+	}
+
+	if _, exists := h.userManager.GetUserById(id); exists {
+		return response.ErrConflict.WithMessage("user ID already exists")
+	}
+
+	permissions := normalizePermissions(req.Permissions)
+	applyRolePermissions(&permissions, req.IsAdmin)
+
+	user := server.User{
+		ID:          id,
+		Name:        req.Name,
+		Permissions: permissions,
+		IsAdmin:     req.IsAdmin,
+	}
+	h.userManager.Add(user)
+
+	log.Infof("Created API key %q (name=%q, admin=%v) from console", maskKey(id), req.Name, req.IsAdmin)
+
+	response.Created(ctx, "/v1/users/"+id, v1.CreateUserResponse{ID: id})
+	return nil
+}
+
+// deleteUser removes a user/API key. Administrator only. The current admin may
+// not delete their own key, to avoid locking everyone out.
+func (h *Handler) deleteUser(ctx *server.Context) error {
+	if !ctx.IsAdmin {
+		return response.ErrForbidden
+	}
+	if h.userManager == nil {
+		return response.ErrInvalidRequest.WithMessage("authentication is disabled")
+	}
+
+	id := ctx.Param("id")
+	if id == "" {
+		return response.ErrInvalidRequest.WithMessage("id is required")
+	}
+	if id == ctx.UserID {
+		return response.ErrInvalidRequest.WithMessage("cannot delete your own API key")
+	}
+
+	if _, exists := h.userManager.GetUserById(id); !exists {
+		return response.ErrNotFound.WithMessage("user not found")
+	}
+
+	h.userManager.Delete(id)
+	log.Infof("Deleted API key %q from console", maskKey(id))
+
+	response.NoContent(ctx)
+	return nil
+}
+
+// listRoles returns the role/permission catalog that the console offers when
+// provisioning API keys.
+func (h *Handler) listRoles(ctx *server.Context) error {
+	response.Success(ctx, roleCatalog())
+	return nil
+}
+
+// systemInfo returns aggregated status used by the dashboard.
+func (h *Handler) systemInfo(ctx *server.Context) error {
+	cfg := config.Get()
+
+	resp := v1.SystemInfoResponse{
+		Modules: defaultModules(),
+		Limits: v1.SystemLimits{
+			MaxProfilingTasksPerHost: cfg.TaskConfig.MaxProfilingTasksPerHost,
+			MaxTracingTasksPerHost:   cfg.TaskConfig.MaxTracingTasksPerHost,
+			MaxTotalProfilingTasks:   cfg.TaskConfig.MaxTotalProfilingTasks,
+			MaxTotalTracingTasks:     cfg.TaskConfig.MaxTotalTracingTasks,
+		},
+	}
+
+	if h.versionInfo != nil {
+		resp.Version = h.versionInfo.Version
+		resp.Commit = h.versionInfo.GitCommit
+	}
+
+	response.Success(ctx, resp)
+	return nil
+}
+
+// toUserResponse converts an internal server.User to the v1 wire type.
+func toUserResponse(u server.User) v1.UserResponse {
+	perms := make([]string, 0, len(u.Permissions))
+	for _, p := range u.Permissions {
+		perms = append(perms, string(p))
+	}
+	return v1.UserResponse{
+		ID:          u.ID,
+		Name:        u.Name,
+		IsAdmin:     u.IsAdmin,
+		Permissions: perms,
+	}
+}
+
+// normalizePermissions trims and de-duplicates permission patterns.
+func normalizePermissions(perms []string) []server.Permission {
+	seen := make(map[string]bool, len(perms))
+	out := make([]server.Permission, 0, len(perms))
+	for _, p := range perms {
+		p = strings.TrimSpace(p)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, server.Permission(p))
+	}
+	return out
+}
+
+// applyRolePermissions ensures admins implicitly have access to everything and
+// that every user can at least read the console metadata endpoints.
+func applyRolePermissions(perms *[]server.Permission, isAdmin bool) {
+	if isAdmin {
+		*perms = nil
+		return
+	}
+	required := []string{"/v1/auth/whoami", "/v1/system/info", "/v1/profiles/capabilities", "/v1/roles"}
+	existing := make(map[string]bool, len(*perms))
+	for _, p := range *perms {
+		existing[string(p)] = true
+	}
+	for _, p := range required {
+		if !existing[p] {
+			*perms = append(*perms, server.Permission(p))
+		}
+	}
+}
+
+// generateAPIKey returns a cryptographically random hex string suitable for use
+// as the Authorization credential / API key.
+func generateAPIKey() (string, error) {
+	b := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("read random bytes: %w", err)
+	}
+	return "htk_" + hex.EncodeToString(b), nil
+}
+
+// maskKey returns a redacted form of an API key for log lines.
+func maskKey(id string) string {
+	if len(id) <= 8 {
+		return strings.Repeat("*", len(id))
+	}
+	return id[:4] + "..." + id[len(id)-4:]
+}
+
+// defaultModules describes the integrated modules shown in the console.
+func defaultModules() []v1.ModuleInfo {
+	return []v1.ModuleInfo{
+		{
+			Name:        "metrics",
+			DisplayName: "Metrics",
+			Description: "Kernel-wide Prometheus metrics exposed by the apiserver.",
+			Endpoint:    "/metrics",
+			Enabled:     true,
+		},
+		{
+			Name:        "tracing",
+			DisplayName: "Event Tracing",
+			Description: "On-demand distributed tracing jobs orchestrated across hosts.",
+			Endpoint:    "/v1/traces",
+			Enabled:     true,
+		},
+		{
+			Name:        "profiling",
+			DisplayName: "Continuous Profiling",
+			Description: "CPU and memory profiling with flame-graph integration.",
+			Endpoint:    "/v1/profiles",
+			Enabled:     true,
+		},
+	}
+}
+
+// roleCatalog returns the role templates offered by the console. The catalog is
+// path-based: a role grants the listed URL path patterns. Administrator roles
+// bypass path checks entirely.
+func roleCatalog() []v1.RoleResponse {
+	return []v1.RoleResponse{
+		{
+			Name:        "admin",
+			Description: "Full access. Permissions are ignored because IsAdmin is set.",
+			IsAdmin:     true,
+		},
+		{
+			Name:        "operator",
+			Description: "Read and write access to tracing, profiling and console metadata.",
+			Permissions: []string{"/v1/traces", "/v1/traces/**", "/v1/profiles", "/v1/profiles/**"},
+		},
+		{
+			Name:        "viewer",
+			Description: "Read-only access to job lists, details and capabilities.",
+			Permissions: []string{"/v1/traces", "/v1/traces/:id", "/v1/profiles", "/v1/profiles/:id"},
+		},
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/console/console.go
+++ b/cmd/huatuo-apiserver/handlers/console/console.go
@@ -1,0 +1,331 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package console implements the access-control (RBAC), system-info and API-key
+// management endpoints that back the huatuo-apiserver web console. It also serves
+// the embedded single-page frontend.
+package console
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	v1 "huatuo-bamai/apis/v1"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/server/response"
+	"huatuo-bamai/internal/version"
+)
+
+// apiKeyBytes is the length of generated API keys, in bytes (32 hex chars).
+const apiKeyBytes = 16
+
+// Handler handles RBAC, system-info and API-key management HTTP requests.
+type Handler struct {
+	userManager server.UserManager
+	versionInfo *version.Info
+	limits      v1.SystemLimits
+	Handlers    []server.Route
+}
+
+// NewHandler creates a new console handler.
+// userManager may be nil when authentication is disabled; in that case the
+// user/role management endpoints report that authentication is disabled.
+func NewHandler(userManager server.UserManager, versionInfo *version.Info, limits ...v1.SystemLimits) *Handler {
+	h := &Handler{
+		userManager: userManager,
+		versionInfo: versionInfo,
+	}
+	if len(limits) > 0 {
+		h.limits = limits[0]
+	}
+
+	h.Handlers = []server.Route{
+		{Method: http.MethodGet, Path: "/auth/whoami", Handler: h.whoami},
+		{Method: http.MethodGet, Path: "/roles", Handler: h.listRoles},
+		{Method: http.MethodGet, Path: "/users", Handler: h.listUsers},
+		{Method: http.MethodPost, Path: "/users", Handler: h.createUser},
+		{Method: http.MethodDelete, Path: "/users/:id", Handler: h.deleteUser},
+		{Method: http.MethodGet, Path: "/system/info", Handler: h.systemInfo},
+	}
+
+	return h
+}
+
+// whoami returns the identity of the authenticated caller. Any valid user may
+// call this; it powers the console login verification step.
+func (h *Handler) whoami(ctx *server.Context) error {
+	if h.userManager == nil {
+		response.Success(ctx, v1.WhoAmIResponse{})
+		return nil
+	}
+
+	user, ok := h.userManager.GetUserById(ctx.UserID)
+	if !ok {
+		return response.ErrUnauthorized.WithMessage("user not found")
+	}
+
+	perms := make([]string, 0, len(user.Permissions))
+	for _, p := range user.Permissions {
+		perms = append(perms, string(p))
+	}
+
+	response.Success(ctx, v1.WhoAmIResponse{
+		ID:          user.ID,
+		Name:        user.Name,
+		IsAdmin:     user.IsAdmin,
+		Permissions: perms,
+	})
+	return nil
+}
+
+// listUsers returns all registered users/API keys. Administrator only.
+func (h *Handler) listUsers(ctx *server.Context) error {
+	if !ctx.IsAdmin {
+		return response.ErrForbidden
+	}
+	if h.userManager == nil {
+		response.Success(ctx, []v1.UserResponse{})
+		return nil
+	}
+
+	users := h.userManager.ListUsers()
+	items := make([]v1.UserResponse, 0, len(users))
+	for _, u := range users {
+		items = append(items, toUserResponse(u))
+	}
+
+	response.Success(ctx, items)
+	return nil
+}
+
+// createUser registers a new user/API key. Administrator only.
+func (h *Handler) createUser(ctx *server.Context) error {
+	if !ctx.IsAdmin {
+		return response.ErrForbidden
+	}
+	if h.userManager == nil {
+		return response.ErrInvalidRequest.WithMessage("authentication is disabled")
+	}
+
+	var req v1.CreateUserRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		return response.ErrInvalidRequest.WithMessage(err.Error())
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		return response.ErrInvalidRequest.WithMessage("name is required")
+	}
+
+	id := strings.TrimSpace(req.ID)
+	if req.GenerateKey || id == "" {
+		generated, err := generateAPIKey()
+		if err != nil {
+			log.Errorf("Failed to generate API key: %v", err)
+			return response.ErrInternal.WithMessage("failed to generate API key")
+		}
+		id = generated
+	}
+
+	if _, exists := h.userManager.GetUserById(id); exists {
+		return response.ErrConflict.WithMessage("user ID already exists")
+	}
+
+	permissions := normalizePermissions(req.Permissions)
+	applyRolePermissions(&permissions, req.IsAdmin)
+
+	user := server.User{
+		ID:          id,
+		Name:        req.Name,
+		Permissions: permissions,
+		IsAdmin:     req.IsAdmin,
+	}
+	h.userManager.Add(user)
+
+	log.Infof("Created API key %q (name=%q, admin=%v) from console", maskKey(id), req.Name, req.IsAdmin)
+
+	response.Created(ctx, "/v1/users/"+id, v1.CreateUserResponse{ID: id})
+	return nil
+}
+
+// deleteUser removes a user/API key. Administrator only. The current admin may
+// not delete their own key, to avoid locking everyone out.
+func (h *Handler) deleteUser(ctx *server.Context) error {
+	if !ctx.IsAdmin {
+		return response.ErrForbidden
+	}
+	if h.userManager == nil {
+		return response.ErrInvalidRequest.WithMessage("authentication is disabled")
+	}
+
+	id := ctx.Param("id")
+	if id == "" {
+		return response.ErrInvalidRequest.WithMessage("id is required")
+	}
+	if id == ctx.UserID {
+		return response.ErrInvalidRequest.WithMessage("cannot delete your own API key")
+	}
+
+	if _, exists := h.userManager.GetUserById(id); !exists {
+		return response.ErrNotFound.WithMessage("user not found")
+	}
+
+	h.userManager.Delete(id)
+	log.Infof("Deleted API key %q from console", maskKey(id))
+
+	response.NoContent(ctx)
+	return nil
+}
+
+// listRoles returns the role/permission catalog that the console offers when
+// provisioning API keys.
+func (h *Handler) listRoles(ctx *server.Context) error {
+	response.Success(ctx, roleCatalog())
+	return nil
+}
+
+// systemInfo returns aggregated status used by the dashboard.
+func (h *Handler) systemInfo(ctx *server.Context) error {
+	resp := v1.SystemInfoResponse{
+		Modules: defaultModules(),
+		Limits:  h.limits,
+	}
+
+	if h.versionInfo != nil {
+		resp.Version = h.versionInfo.Version
+		resp.Commit = h.versionInfo.GitCommit
+	}
+
+	response.Success(ctx, resp)
+	return nil
+}
+
+// toUserResponse converts an internal server.User to the v1 wire type.
+func toUserResponse(u server.User) v1.UserResponse {
+	perms := make([]string, 0, len(u.Permissions))
+	for _, p := range u.Permissions {
+		perms = append(perms, string(p))
+	}
+	return v1.UserResponse{
+		ID:          u.ID,
+		Name:        u.Name,
+		IsAdmin:     u.IsAdmin,
+		Permissions: perms,
+	}
+}
+
+// normalizePermissions trims and de-duplicates permission patterns.
+func normalizePermissions(perms []string) []server.Permission {
+	seen := make(map[string]bool, len(perms))
+	out := make([]server.Permission, 0, len(perms))
+	for _, p := range perms {
+		p = strings.TrimSpace(p)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, server.Permission(p))
+	}
+	return out
+}
+
+// applyRolePermissions ensures admins implicitly have access to everything and
+// that every user can at least read the console metadata endpoints.
+func applyRolePermissions(perms *[]server.Permission, isAdmin bool) {
+	if isAdmin {
+		*perms = nil
+		return
+	}
+	required := []string{"/v1/auth/whoami", "/v1/system/info", "/v1/profiles/capabilities", "/v1/roles"}
+	existing := make(map[string]bool, len(*perms))
+	for _, p := range *perms {
+		existing[string(p)] = true
+	}
+	for _, p := range required {
+		if !existing[p] {
+			*perms = append(*perms, server.Permission(p))
+		}
+	}
+}
+
+// generateAPIKey returns a cryptographically random hex string suitable for use
+// as the Authorization credential / API key.
+func generateAPIKey() (string, error) {
+	b := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("read random bytes: %w", err)
+	}
+	return "htk_" + hex.EncodeToString(b), nil
+}
+
+// maskKey returns a redacted form of an API key for log lines.
+func maskKey(id string) string {
+	if len(id) <= 8 {
+		return strings.Repeat("*", len(id))
+	}
+	return id[:4] + "..." + id[len(id)-4:]
+}
+
+// defaultModules describes the integrated modules shown in the console.
+func defaultModules() []v1.ModuleInfo {
+	return []v1.ModuleInfo{
+		{
+			Name:        "metrics",
+			DisplayName: "Metrics",
+			Description: "Kernel-wide Prometheus metrics exposed by the apiserver.",
+			Endpoint:    "/metrics",
+			Enabled:     true,
+		},
+		{
+			Name:        "tracing",
+			DisplayName: "Event Tracing",
+			Description: "On-demand distributed tracing jobs orchestrated across hosts.",
+			Endpoint:    "/v1/traces",
+			Enabled:     true,
+		},
+		{
+			Name:        "profiling",
+			DisplayName: "Continuous Profiling",
+			Description: "CPU and memory profiling with flame-graph integration.",
+			Endpoint:    "/v1/profiles",
+			Enabled:     true,
+		},
+	}
+}
+
+// roleCatalog returns the role templates offered by the console. The catalog is
+// path-based: a role grants the listed URL path patterns. Administrator roles
+// bypass path checks entirely.
+func roleCatalog() []v1.RoleResponse {
+	return []v1.RoleResponse{
+		{
+			Name:        "admin",
+			Description: "Full access. Permissions are ignored because IsAdmin is set.",
+			IsAdmin:     true,
+		},
+		{
+			Name:        "operator",
+			Description: "Read and write access to tracing, profiling and console metadata.",
+			Permissions: []string{"/v1/traces", "/v1/traces/**", "/v1/profiles", "/v1/profiles/**"},
+		},
+		{
+			Name:        "viewer",
+			Description: "Read-only access to job lists, details and capabilities.",
+			Permissions: []string{"/v1/traces", "/v1/traces/:id", "/v1/profiles", "/v1/profiles/:id"},
+		},
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/console/console_test.go
+++ b/cmd/huatuo-apiserver/handlers/console/console_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "huatuo-bamai/apis/v1"
+	"huatuo-bamai/cmd/huatuo-apiserver/config"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/version"
+)
+
+// buildTestServer wires a real server with the given users and the console
+// routes so the full middleware stack (auth + routing) is exercised end to end.
+func buildTestServer(t *testing.T, users []server.UserConfig) (*httptest.Server, server.UserManager) {
+	t.Helper()
+	info := &version.Info{Version: "9.9.9", GitCommit: "testcommit"}
+	httpServer := server.NewServer(&server.Config{
+		AuthUsers:   users,
+		PublicPaths: []string{"/console"},
+		VersionInfo: info,
+	})
+	um := httpServer.UserManager()
+	httpServer.MustRegisterRoutes("/v1", NewHandler(um, info).Handlers)
+	httpServer.StaticFS("/console", WebFS())
+	ts := httptest.NewServer(httpServer.HTTPHandler())
+	t.Cleanup(ts.Close)
+	return ts, um
+}
+
+func do(t *testing.T, ts *httptest.Server, method, path, auth, body string) (*http.Response, []byte) {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, ts.URL+path, bodyReader)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	payload, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return resp, payload
+}
+
+func decodeEnvelope(t *testing.T, payload []byte, target any) {
+	t.Helper()
+	var env struct {
+		Code int             `json:"code"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil {
+		t.Fatalf("decode envelope: %v; body=%s", err, string(payload))
+	}
+	if env.Code != 0 {
+		t.Fatalf("envelope code = %d, body=%s", env.Code, string(payload))
+	}
+	if target != nil && len(env.Data) > 0 {
+		if err := json.Unmarshal(env.Data, target); err != nil {
+			t.Fatalf("decode data: %v; body=%s", err, string(env.Data))
+		}
+	}
+}
+
+func TestRoleCatalogContainsAdminOperatorViewer(t *testing.T) {
+	roles := roleCatalog()
+	names := map[string]bool{}
+	for _, r := range roles {
+		names[r.Name] = true
+	}
+	for _, want := range []string{"admin", "operator", "viewer"} {
+		if !names[want] {
+			t.Errorf("role catalog missing %q; got %v", want, names)
+		}
+	}
+}
+
+func TestNormalizePermissionsDedupsAndTrims(t *testing.T) {
+	got := normalizePermissions([]string{" /v1/traces ", "", "/v1/traces", "/v1/profiles"})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (%+v)", len(got), got)
+	}
+}
+
+func TestGenerateAPIKeyUniqueAndPrefixed(t *testing.T) {
+	a, err := generateAPIKey()
+	if err != nil {
+		t.Fatalf("generateAPIKey() error = %v", err)
+	}
+	b, err := generateAPIKey()
+	if err != nil {
+		t.Fatalf("generateAPIKey() error = %v", err)
+	}
+	if !strings.HasPrefix(a, "htk_") || !strings.HasPrefix(b, "htk_") {
+		t.Errorf("keys missing prefix: %q %q", a, b)
+	}
+	if a == b {
+		t.Errorf("generated keys are identical: %q", a)
+	}
+}
+
+func TestMaskKey(t *testing.T) {
+	if got := maskKey("htk_0123456789abcdef"); got != "htk_...cdef" {
+		t.Errorf("maskKey() = %q, want htk_...cdef", got)
+	}
+	if got := maskKey("short"); got == "short" {
+		t.Errorf("maskKey() did not mask short key: %q", got)
+	}
+}
+
+func TestDefaultModulesCoverThreeModules(t *testing.T) {
+	mods := defaultModules()
+	names := map[string]bool{}
+	for _, m := range mods {
+		names[m.Name] = true
+		if !m.Enabled {
+			t.Errorf("module %q not enabled", m.Name)
+		}
+	}
+	for _, want := range []string{"metrics", "tracing", "profiling"} {
+		if !names[want] {
+			t.Errorf("defaultModules missing %q; got %v", want, names)
+		}
+	}
+}
+
+func TestWebFSEmbedsAssets(t *testing.T) {
+	fsys := WebFS()
+	idx, err := fsys.Open("index.html")
+	if err != nil {
+		t.Fatalf("open index.html: %v", err)
+	}
+	defer idx.Close()
+	data, err := io.ReadAll(idx)
+	if err != nil {
+		t.Fatalf("read index.html: %v", err)
+	}
+	if !strings.Contains(string(data), "HuaTuo Console") {
+		t.Errorf("index.html missing title")
+	}
+	if _, err := fsys.Open("assets/app.js"); err != nil {
+		t.Errorf("open assets/app.js: %v", err)
+	}
+	if _, err := fsys.Open("assets/app.css"); err != nil {
+		t.Errorf("open assets/app.css: %v", err)
+	}
+}
+
+func TestSystemInfoReturnsConfigLimits(t *testing.T) {
+	cfg := config.Get()
+	old := cfg.TaskConfig
+	cfg.TaskConfig.MaxProfilingTasksPerHost = 7
+	cfg.TaskConfig.MaxTracingTasksPerHost = 9
+	cfg.TaskConfig.MaxTotalProfilingTasks = 11
+	cfg.TaskConfig.MaxTotalTracingTasks = 13
+	defer func() { cfg.TaskConfig = old }()
+
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	resp, payload := do(t, ts, http.MethodGet, "/v1/system/info", "admin-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(payload))
+	}
+	var info v1.SystemInfoResponse
+	decodeEnvelope(t, payload, &info)
+	if info.Limits.MaxProfilingTasksPerHost != 7 {
+		t.Errorf("MaxProfilingTasksPerHost = %d, want 7", info.Limits.MaxProfilingTasksPerHost)
+	}
+	if info.Limits.MaxTracingTasksPerHost != 9 {
+		t.Errorf("MaxTracingTasksPerHost = %d, want 9", info.Limits.MaxTracingTasksPerHost)
+	}
+	if info.Version != "9.9.9" {
+		t.Errorf("Version = %q, want 9.9.9", info.Version)
+	}
+}
+
+func TestWhoamiReturnsCurrentUserIdentity(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/traces", "/v1/auth/whoami"}},
+	})
+	resp, payload := do(t, ts, http.MethodGet, "/v1/auth/whoami", "viewer-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+	var who v1.WhoAmIResponse
+	decodeEnvelope(t, payload, &who)
+	if who.ID != "viewer-2026" || who.Name != "Viewer" {
+		t.Errorf("whoami = %+v", who)
+	}
+	if who.IsAdmin {
+		t.Errorf("whoami IsAdmin = true, want false")
+	}
+}
+
+func TestWhoamiRejectsUnknownKey(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	resp, _ := do(t, ts, http.MethodGet, "/v1/auth/whoami", "ghost", "")
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("unknown key status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestListUsersAdminOnly(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/users"}},
+	})
+
+	if resp, _ := do(t, ts, http.MethodGet, "/v1/users", "viewer-2026", ""); resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin listUsers status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	resp, payload := do(t, ts, http.MethodGet, "/v1/users", "admin-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin listUsers status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+	var users []v1.UserResponse
+	decodeEnvelope(t, payload, &users)
+	if len(users) != 2 {
+		t.Errorf("users len = %d, want 2", len(users))
+	}
+}
+
+func TestCreateUserGeneratesKeyAndEnforcesAdmin(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+
+	// Non-admin cannot create (no auth -> unauthorized at middleware).
+	if resp, _ := do(t, ts, http.MethodPost, "/v1/users", "nobody", `{"name":"x","generate_key":true}`); resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin create status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	resp, payload := do(t, ts, http.MethodPost, "/v1/users", "admin-2026", `{"name":"Operator","generate_key":true,"permissions":["/v1/traces"]}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+
+	var created v1.CreateUserResponse
+	decodeEnvelope(t, payload, &created)
+	if !strings.HasPrefix(created.ID, "htk_") {
+		t.Errorf("generated id = %q, want htk_ prefix", created.ID)
+	}
+
+	// Duplicate explicit ID conflicts.
+	body := `{"name":"Dup","generate_key":false,"id":"` + created.ID + `"}`
+	if resp, _ := do(t, ts, http.MethodPost, "/v1/users", "admin-2026", body); resp.StatusCode != http.StatusConflict {
+		t.Errorf("duplicate create status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestCreateUserRequiresName(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	if resp, _ := do(t, ts, http.MethodPost, "/v1/users", "admin-2026", `{"name":"","generate_key":true}`); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing name status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestDeleteUserAdminOnlyAndCannotDeleteSelf(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/users"}},
+	})
+
+	// Non-admin cannot delete.
+	if resp, _ := do(t, ts, http.MethodDelete, "/v1/users/viewer-2026", "viewer-2026", ""); resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin delete status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	// Admin cannot delete self.
+	if resp, _ := do(t, ts, http.MethodDelete, "/v1/users/admin-2026", "admin-2026", ""); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("delete self status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	// Admin can delete another user.
+	resp, _ := do(t, ts, http.MethodDelete, "/v1/users/viewer-2026", "admin-2026", "")
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("delete status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}
+
+func TestListRolesOpenToAnyAuthenticatedUser(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/roles"}},
+	})
+	resp, payload := do(t, ts, http.MethodGet, "/v1/roles", "viewer-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+	var roles []v1.RoleResponse
+	decodeEnvelope(t, payload, &roles)
+	if len(roles) == 0 {
+		t.Errorf("roles empty")
+	}
+}
+
+func TestConsoleAssetsServedWithoutAuth(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	resp, body := do(t, ts, http.MethodGet, "/console/", "", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("index status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "HuaTuo Console") {
+		t.Errorf("index body does not contain title")
+	}
+
+	resp, _ = do(t, ts, http.MethodGet, "/console/assets/app.css", "", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("app.css status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/console/console_test.go
+++ b/cmd/huatuo-apiserver/handlers/console/console_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "huatuo-bamai/apis/v1"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/version"
+)
+
+// buildTestServer wires a real server with the given users and the console
+// routes so the full middleware stack (auth + routing) is exercised end to end.
+func buildTestServer(t *testing.T, users []server.UserConfig, limits ...v1.SystemLimits) (*httptest.Server, server.UserManager) {
+	t.Helper()
+	info := &version.Info{Version: "9.9.9", GitCommit: "testcommit"}
+	httpServer := server.NewServer(&server.Config{
+		AuthUsers:   users,
+		PublicPaths: []string{"/console"},
+		VersionInfo: info,
+	})
+	um := httpServer.UserManager()
+	httpServer.MustRegisterRoutes("/v1", NewHandler(um, info, limits...).Handlers)
+	httpServer.StaticFS("/console", WebFS())
+	ts := httptest.NewServer(httpServer.HTTPHandler())
+	t.Cleanup(ts.Close)
+	return ts, um
+}
+
+type testResponse struct {
+	StatusCode int
+}
+
+func do(t *testing.T, ts *httptest.Server, method, path, auth, body string) (testResponse, []byte) {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, ts.URL+path, bodyReader)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if auth != "" {
+		req.Header.Set("Authorization", "Bearer "+auth)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	payload, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return testResponse{StatusCode: resp.StatusCode}, payload
+}
+
+func decodeEnvelope(t *testing.T, payload []byte, target any) {
+	t.Helper()
+	var env struct {
+		Code int             `json:"code"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &env); err != nil {
+		t.Fatalf("decode envelope: %v; body=%s", err, string(payload))
+	}
+	if env.Code != 0 {
+		t.Fatalf("envelope code = %d, body=%s", env.Code, string(payload))
+	}
+	if target != nil && len(env.Data) > 0 {
+		if err := json.Unmarshal(env.Data, target); err != nil {
+			t.Fatalf("decode data: %v; body=%s", err, string(env.Data))
+		}
+	}
+}
+
+func TestRoleCatalogContainsAdminOperatorViewer(t *testing.T) {
+	roles := roleCatalog()
+	names := map[string]bool{}
+	for _, r := range roles {
+		names[r.Name] = true
+	}
+	for _, want := range []string{"admin", "operator", "viewer"} {
+		if !names[want] {
+			t.Errorf("role catalog missing %q; got %v", want, names)
+		}
+	}
+}
+
+func TestNormalizePermissionsDedupsAndTrims(t *testing.T) {
+	got := normalizePermissions([]string{" /v1/traces ", "", "/v1/traces", "/v1/profiles"})
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (%+v)", len(got), got)
+	}
+}
+
+func TestGenerateAPIKeyUniqueAndPrefixed(t *testing.T) {
+	a, err := generateAPIKey()
+	if err != nil {
+		t.Fatalf("generateAPIKey() error = %v", err)
+	}
+	b, err := generateAPIKey()
+	if err != nil {
+		t.Fatalf("generateAPIKey() error = %v", err)
+	}
+	if !strings.HasPrefix(a, "htk_") || !strings.HasPrefix(b, "htk_") {
+		t.Errorf("keys missing prefix: %q %q", a, b)
+	}
+	if a == b {
+		t.Errorf("generated keys are identical: %q", a)
+	}
+}
+
+func TestMaskKey(t *testing.T) {
+	if got := maskKey("htk_0123456789abcdef"); got != "htk_...cdef" {
+		t.Errorf("maskKey() = %q, want htk_...cdef", got)
+	}
+	if got := maskKey("short"); got == "short" {
+		t.Errorf("maskKey() did not mask short key: %q", got)
+	}
+}
+
+func TestDefaultModulesCoverThreeModules(t *testing.T) {
+	mods := defaultModules()
+	names := map[string]bool{}
+	for _, m := range mods {
+		names[m.Name] = true
+		if !m.Enabled {
+			t.Errorf("module %q not enabled", m.Name)
+		}
+	}
+	for _, want := range []string{"metrics", "tracing", "profiling"} {
+		if !names[want] {
+			t.Errorf("defaultModules missing %q; got %v", want, names)
+		}
+	}
+}
+
+func TestWebFSEmbedsAssets(t *testing.T) {
+	fsys := WebFS()
+	idx, err := fsys.Open("index.html")
+	if err != nil {
+		t.Fatalf("open index.html: %v", err)
+	}
+	defer idx.Close()
+	data, err := io.ReadAll(idx)
+	if err != nil {
+		t.Fatalf("read index.html: %v", err)
+	}
+	if !strings.Contains(string(data), "HuaTuo Console") {
+		t.Errorf("index.html missing title")
+	}
+	if _, err := fsys.Open("assets/app.js"); err != nil {
+		t.Errorf("open assets/app.js: %v", err)
+	}
+	if _, err := fsys.Open("assets/app.css"); err != nil {
+		t.Errorf("open assets/app.css: %v", err)
+	}
+}
+
+func TestSystemInfoReturnsConfigLimits(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	}, v1.SystemLimits{
+		MaxProfilingTasksPerHost: 7,
+		MaxTracingTasksPerHost:   9,
+		MaxTotalProfilingTasks:   11,
+		MaxTotalTracingTasks:     13,
+	})
+	resp, payload := do(t, ts, http.MethodGet, "/v1/system/info", "admin-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", resp.StatusCode, string(payload))
+	}
+	var info v1.SystemInfoResponse
+	decodeEnvelope(t, payload, &info)
+	if info.Limits.MaxProfilingTasksPerHost != 7 {
+		t.Errorf("MaxProfilingTasksPerHost = %d, want 7", info.Limits.MaxProfilingTasksPerHost)
+	}
+	if info.Limits.MaxTracingTasksPerHost != 9 {
+		t.Errorf("MaxTracingTasksPerHost = %d, want 9", info.Limits.MaxTracingTasksPerHost)
+	}
+	if info.Version != "9.9.9" {
+		t.Errorf("Version = %q, want 9.9.9", info.Version)
+	}
+}
+
+func TestWhoamiReturnsCurrentUserIdentity(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/traces", "/v1/auth/whoami"}},
+	})
+	resp, payload := do(t, ts, http.MethodGet, "/v1/auth/whoami", "viewer-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+	var who v1.WhoAmIResponse
+	decodeEnvelope(t, payload, &who)
+	if who.ID != "viewer-2026" || who.Name != "Viewer" {
+		t.Errorf("whoami = %+v", who)
+	}
+	if who.IsAdmin {
+		t.Errorf("whoami IsAdmin = true, want false")
+	}
+}
+
+func TestWhoamiRejectsUnknownKey(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	resp, _ := do(t, ts, http.MethodGet, "/v1/auth/whoami", "ghost", "")
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unknown key status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestListUsersAdminOnly(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/users"}},
+	})
+
+	if resp, _ := do(t, ts, http.MethodGet, "/v1/users", "viewer-2026", ""); resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin listUsers status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	resp, payload := do(t, ts, http.MethodGet, "/v1/users", "admin-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin listUsers status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+	var users []v1.UserResponse
+	decodeEnvelope(t, payload, &users)
+	if len(users) != 2 {
+		t.Errorf("users len = %d, want 2", len(users))
+	}
+}
+
+func TestCreateUserGeneratesKeyAndEnforcesAdmin(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+
+	// Non-admin cannot create (no auth -> unauthorized at middleware).
+	if resp, _ := do(t, ts, http.MethodPost, "/v1/users", "nobody", `{"name":"x","generate_key":true}`); resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("non-admin create status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	resp, payload := do(t, ts, http.MethodPost, "/v1/users", "admin-2026", `{"name":"Operator","generate_key":true,"permissions":["/v1/traces"]}`)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+
+	var created v1.CreateUserResponse
+	decodeEnvelope(t, payload, &created)
+	if !strings.HasPrefix(created.ID, "htk_") {
+		t.Errorf("generated id = %q, want htk_ prefix", created.ID)
+	}
+
+	// Duplicate explicit ID conflicts.
+	body := `{"name":"Dup","generate_key":false,"id":"` + created.ID + `"}`
+	if resp, _ := do(t, ts, http.MethodPost, "/v1/users", "admin-2026", body); resp.StatusCode != http.StatusConflict {
+		t.Errorf("duplicate create status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestCreateUserRequiresName(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	if resp, _ := do(t, ts, http.MethodPost, "/v1/users", "admin-2026", `{"name":"","generate_key":true}`); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing name status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestDeleteUserAdminOnlyAndCannotDeleteSelf(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/users"}},
+	})
+
+	// Non-admin cannot delete.
+	if resp, _ := do(t, ts, http.MethodDelete, "/v1/users/viewer-2026", "viewer-2026", ""); resp.StatusCode != http.StatusForbidden {
+		t.Errorf("non-admin delete status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	// Admin cannot delete self.
+	if resp, _ := do(t, ts, http.MethodDelete, "/v1/users/admin-2026", "admin-2026", ""); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("delete self status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	// Admin can delete another user.
+	resp, _ := do(t, ts, http.MethodDelete, "/v1/users/viewer-2026", "admin-2026", "")
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("delete status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}
+
+func TestListRolesOpenToAnyAuthenticatedUser(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/roles"}},
+	})
+	resp, payload := do(t, ts, http.MethodGet, "/v1/roles", "viewer-2026", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", resp.StatusCode, string(payload))
+	}
+	var roles []v1.RoleResponse
+	decodeEnvelope(t, payload, &roles)
+	if len(roles) == 0 {
+		t.Errorf("roles empty")
+	}
+}
+
+func TestConsoleAssetsServedWithoutAuth(t *testing.T) {
+	ts, _ := buildTestServer(t, []server.UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+	resp, body := do(t, ts, http.MethodGet, "/console/", "", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("index status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "HuaTuo Console") {
+		t.Errorf("index body does not contain title")
+	}
+
+	resp, _ = do(t, ts, http.MethodGet, "/console/assets/app.css", "", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("app.css status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/console/web.go
+++ b/cmd/huatuo-apiserver/handlers/console/web.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// embeddedWeb holds the compiled web console assets. The directory is served by
+// the apiserver at /console and is exempt from authentication so the login
+// screen can be displayed before a credential is available.
+//
+//go:embed web
+var embeddedWeb embed.FS
+
+// WebFS returns the root filesystem of the embedded web console assets.
+func WebFS() fs.FS {
+	sub, err := fs.Sub(embeddedWeb, "web")
+	if err != nil {
+		// fs.Sub only fails if "web" is not a valid sub-tree; the //go:embed
+		// directive above guarantees it exists at compile time.
+		panic(err)
+	}
+	return sub
+}

--- a/cmd/huatuo-apiserver/handlers/console/web/assets/app.css
+++ b/cmd/huatuo-apiserver/handlers/console/web/assets/app.css
@@ -1,0 +1,562 @@
+:root {
+  --bg: #0b1220;
+  --bg-elev: #121b2e;
+  --bg-elev-2: #1b2740;
+  --panel: #15203a;
+  --border: #243352;
+  --text: #e6edf6;
+  --text-dim: #9fb0c8;
+  --text-mute: #6c7c95;
+  --accent: #3b82f6;
+  --accent-hover: #2f6fe0;
+  --accent-soft: rgba(59, 130, 246, 0.15);
+  --green: #22c55e;
+  --green-soft: rgba(34, 197, 94, 0.15);
+  --amber: #f59e0b;
+  --amber-soft: rgba(245, 158, 11, 0.15);
+  --red: #ef4444;
+  --red-soft: rgba(239, 68, 68, 0.15);
+  --radius: 10px;
+  --shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Top bar */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 24px;
+  height: 60px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topbar-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-weight: 700;
+}
+
+.logo {
+  font-size: 20px;
+  letter-spacing: 0.5px;
+}
+
+.logo-sub {
+  font-size: 13px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.nav {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+}
+
+.nav-link {
+  padding: 8px 14px;
+  border-radius: 8px;
+  color: var(--text-dim);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.nav-link:hover {
+  background: var(--bg-elev-2);
+  color: var(--text);
+}
+
+.nav-link.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.topbar-user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.user-badge {
+  font-size: 13px;
+  color: var(--text-dim);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-badge .admin-tag {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+/* View container */
+.view {
+  flex: 1;
+  padding: 28px;
+  max-width: 1280px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.page-title {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+
+.page-subtitle {
+  color: var(--text-dim);
+  font-size: 14px;
+  margin: 0 0 24px;
+}
+
+/* Cards / grid */
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.grid-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 980px) {
+  .grid-4,
+  .grid-3,
+  .grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+.card-title {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--text-mute);
+  margin: 0 0 12px;
+}
+
+.metric-value {
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.metric-label {
+  color: var(--text-dim);
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.module-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.module-card .module-name {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.module-card .module-desc {
+  color: var(--text-dim);
+  font-size: 13px;
+  flex: 1;
+}
+
+/* Tables */
+.table-wrap {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+table.data {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+table.data th,
+table.data td {
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+table.data th {
+  background: var(--bg-elev-2);
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+table.data tr:last-child td {
+  border-bottom: none;
+}
+
+table.data tr:hover td {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+
+/* Status badges */
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge-running {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.badge-pending {
+  background: var(--amber-soft);
+  color: var(--amber);
+}
+
+.badge-completed {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.badge-failed,
+.badge-stopped,
+.badge-timeout {
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.badge-muted {
+  background: var(--bg-elev-2);
+  color: var(--text-dim);
+}
+
+/* Forms */
+.form-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field label {
+  font-size: 13px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+
+.field input,
+.field select,
+.field textarea {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 10px 12px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
+  font-family: inherit;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  border-color: var(--accent);
+}
+
+.field .hint {
+  font-size: 12px;
+  color: var(--text-mute);
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 9px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--bg-elev-2);
+  color: var(--text);
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  font-family: inherit;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.btn-danger {
+  background: var(--red);
+  color: #fff;
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text-dim);
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: var(--bg-elev-2);
+  color: var(--text);
+}
+
+.btn-sm {
+  padding: 5px 10px;
+  font-size: 13px;
+}
+
+/* Login */
+.login-wrap {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 32px;
+  box-shadow: var(--shadow);
+}
+
+.login-card h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+}
+
+.login-card p {
+  margin: 0 0 24px;
+  color: var(--text-dim);
+  font-size: 14px;
+}
+
+/* Toasts / alerts */
+.alert {
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+.alert-error {
+  background: var(--red-soft);
+  color: var(--red);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.alert-success {
+  background: var(--green-soft);
+  color: var(--green);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+
+.alert-info {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
+.toast-host {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 100;
+}
+
+.toast {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-size: 13px;
+  box-shadow: var(--shadow);
+  max-width: 360px;
+}
+
+.toast.toast-error {
+  border-left-color: var(--red);
+}
+
+.toast.toast-success {
+  border-left-color: var(--green);
+}
+
+/* Misc */
+.row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.empty {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-mute);
+  font-size: 14px;
+}
+
+.code-block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.perm-tag {
+  background: var(--bg-elev-2);
+  color: var(--text-dim);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-family: ui-monospace, monospace;
+}
+
+.footer {
+  padding: 16px 24px;
+  color: var(--text-mute);
+  font-size: 12px;
+  text-align: center;
+  border-top: 1px solid var(--border);
+}
+
+.section + .section {
+  margin-top: 28px;
+}
+
+.toolbar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.toolbar .field {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}

--- a/cmd/huatuo-apiserver/handlers/console/web/assets/app.js
+++ b/cmd/huatuo-apiserver/handlers/console/web/assets/app.js
@@ -1,0 +1,969 @@
+/*
+ * HuaTuo Console - single-page application.
+ *
+ * Vanilla JS, no build step. Authenticated API calls carry the stored API key
+ * in the Authorization header, matching the huatuo-apiserver auth model.
+ */
+(function () {
+  "use strict";
+
+  const STORAGE_KEY = "huatuo_api_key";
+
+  const NAV = [
+    { id: "dashboard", label: "Dashboard", admin: false },
+    { id: "tasks", label: "Tasks", admin: false },
+    { id: "tracing", label: "Event Tracing", admin: false },
+    { id: "profiling", label: "Profiling", admin: false },
+    { id: "metrics", label: "Metrics", admin: false },
+    { id: "access", label: "Access Control", admin: true },
+  ];
+
+  const state = {
+    apiKey: localStorage.getItem(STORAGE_KEY) || "",
+    user: null,
+    system: null,
+    pollTimers: [],
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* Tiny helpers                                                        */
+  /* ------------------------------------------------------------------ */
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const el = (tag, attrs = {}, ...children) => {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (k === "class") node.className = v;
+      else if (k === "html") node.innerHTML = v;
+      else if (k.startsWith("on") && typeof v === "function")
+        node.addEventListener(k.slice(2).toLowerCase(), v);
+      else if (v !== null && v !== undefined) node.setAttribute(k, v);
+    }
+    for (const c of children) {
+      if (c === null || c === undefined) continue;
+      node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    }
+    return node;
+  };
+
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return "";
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function statusBadge(status) {
+    const s = String(status || "").toLowerCase();
+    return `<span class="badge badge-${escapeHtml(s) || "muted"}">${escapeHtml(
+      status || "unknown"
+    )}</span>`;
+  }
+
+  function relativeTime(iso) {
+    if (!iso) return "-";
+    const d = new Date(iso);
+    if (isNaN(d)) return iso;
+    return d.toLocaleString();
+  }
+
+  function toast(message, type = "info") {
+    const host = $("#toast-host") || (() => {
+      const h = el("div", { class: "toast-host", id: "toast-host" });
+      document.body.appendChild(h);
+      return h;
+    })();
+    const t = el("div", { class: `toast toast-${type}` }, message);
+    host.appendChild(t);
+    setTimeout(() => t.remove(), 4000);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* API client                                                          */
+  /* ------------------------------------------------------------------ */
+
+  async function api(path, opts = {}) {
+    const headers = Object.assign({}, opts.headers || {});
+    if (state.apiKey) headers["Authorization"] = state.apiKey;
+    if (opts.body && !headers["Content-Type"])
+      headers["Content-Type"] = "application/json";
+
+    const resp = await fetch(path, {
+      method: opts.method || "GET",
+      headers,
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+    });
+
+    if (resp.status === 204) return null;
+
+    const text = await resp.text();
+    const ct = resp.headers.get("content-type") || "";
+    if (!ct.includes("application/json")) {
+      if (!resp.ok) throw new Error(text || resp.statusText);
+      return text;
+    }
+
+    let payload;
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      throw new Error("invalid JSON response");
+    }
+
+    if (!resp.ok) {
+      const msg = payload && payload.message ? payload.message : resp.statusText;
+      const err = new Error(msg);
+      err.status = resp.status;
+      err.payload = payload;
+      throw err;
+    }
+
+    if (payload && typeof payload === "object" && "code" in payload) {
+      if (payload.code !== 0) {
+        throw new Error(payload.message || "request failed");
+      }
+      return payload.data;
+    }
+    return payload;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Bootstrapping / navigation                                          */
+  /* ------------------------------------------------------------------ */
+
+  function stopPolling() {
+    state.pollTimers.forEach((t) => clearInterval(t));
+    state.pollTimers = [];
+  }
+
+  function pollEvery(fn, ms) {
+    fn();
+    const id = setInterval(fn, ms);
+    state.pollTimers.push(id);
+  }
+
+  async function bootstrap() {
+    if (!state.apiKey) {
+      renderLogin();
+      return;
+    }
+    try {
+      state.user = await api("/v1/auth/whoami");
+      try {
+        state.system = await api("/v1/system/info");
+      } catch {
+        state.system = null;
+      }
+      showChrome();
+      route();
+    } catch (err) {
+      if (err.status === 401 || err.status === 403) {
+        toast("API key is invalid or unauthorized", "error");
+      }
+      state.apiKey = "";
+      localStorage.removeItem(STORAGE_KEY);
+      renderLogin();
+    }
+  }
+
+  function showChrome() {
+    const topbar = $(".topbar");
+    topbar.hidden = false;
+
+    const nav = $("#nav");
+    nav.innerHTML = "";
+    for (const item of NAV) {
+      if (item.admin && !(state.user && state.user.is_admin)) continue;
+      const link = el(
+        "button",
+        {
+          class: "nav-link",
+          "data-nav": item.id,
+          onclick: () => {
+            location.hash = "#/" + item.id;
+          },
+        },
+        item.label
+      );
+      nav.appendChild(link);
+    }
+
+    const badge = $("#user-badge");
+    badge.innerHTML = "";
+    badge.appendChild(document.createTextNode(state.user.name || state.user.id || "user"));
+    if (state.user.is_admin) {
+      badge.appendChild(el("span", { class: "admin-tag" }, "admin"));
+    }
+
+    const versionEl = $("#server-version");
+    if (state.system && state.system.version) {
+      versionEl.textContent =
+        "HuaTuo apiserver v" + state.system.version +
+        (state.system.commit ? " (" + state.system.commit + ")" : "");
+    }
+
+    $("#logout-btn").onclick = () => {
+      stopPolling();
+      state.apiKey = "";
+      state.user = null;
+      localStorage.removeItem(STORAGE_KEY);
+      renderLogin();
+    };
+  }
+
+  function route() {
+    stopPolling();
+    const hash = location.hash.replace(/^#\/?/, "") || "dashboard";
+    document.querySelectorAll(".nav-link").forEach((n) => {
+      n.classList.toggle("active", n.getAttribute("data-nav") === hash);
+    });
+    const view = $("#view");
+    view.innerHTML = "";
+    try {
+      switch (hash) {
+        case "dashboard":
+          return renderDashboard(view);
+        case "tasks":
+          return renderTasks(view);
+        case "tracing":
+          return renderTracing(view);
+        case "profiling":
+          return renderProfiling(view);
+        case "metrics":
+          return renderMetrics(view);
+        case "access":
+          if (!(state.user && state.user.is_admin)) {
+            view.appendChild(emptyState("Access Control is available to administrators only."));
+            return;
+          }
+          return renderAccess(view);
+        default:
+          return renderDashboard(view);
+      }
+    } catch (err) {
+      view.appendChild(alertBox(err.message, "error"));
+    }
+  }
+
+  window.addEventListener("hashchange", route);
+
+  /* ------------------------------------------------------------------ */
+  /* Shared UI fragments                                                 */
+  /* ------------------------------------------------------------------ */
+
+  function alertBox(message, type = "info") {
+    return el("div", { class: `alert alert-${type}` }, message);
+  }
+
+  function emptyState(message) {
+    return el("div", { class: "empty" }, message);
+  }
+
+  function pageHeader(title, subtitle) {
+    return el("div", {}, el("h2", { class: "page-title" }, title), el("p", { class: "page-subtitle" }, subtitle));
+  }
+
+  function panel(title, bodyNodes) {
+    return el("section", { class: "card" }, el("p", { class: "card-title" }, title), ...bodyNodes);
+  }
+
+  function metricCard(value, label, opts = {}) {
+    return el("div", { class: "card" }, el("div", { class: "metric-value", style: opts.color ? `color:${opts.color}` : "" }, String(value)), el("div", { class: "metric-label" }, label));
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Login view                                                          */
+  /* ------------------------------------------------------------------ */
+
+  function renderLogin() {
+    $(".topbar").hidden = true;
+    const view = $("#view");
+    view.innerHTML = "";
+    const card = el("div", { class: "login-card" });
+    card.appendChild(el("h1", {}, "HuaTuo Console"));
+    card.appendChild(el("p", {}, "Sign in with your API key. Administrators provision keys from Access Control."));
+
+    let input;
+    let submitBtn;
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      const key = input.value.trim();
+      if (!key) return;
+      submitBtn.disabled = true;
+      try {
+        state.apiKey = key;
+        localStorage.setItem(STORAGE_KEY, key);
+        state.user = await api("/v1/auth/whoami");
+        try {
+          state.system = await api("/v1/system/info");
+        } catch {
+          state.system = null;
+        }
+        showChrome();
+        location.hash = "#/dashboard";
+        route();
+      } catch (err) {
+        state.apiKey = "";
+        localStorage.removeItem(STORAGE_KEY);
+        card.insertBefore(alertBox(err.message || "Login failed", "error"), form);
+      } finally {
+        submitBtn.disabled = false;
+      }
+    } });
+
+    const field = el("div", { class: "field" }, el("label", { for: "api-key" }, "API key"), (input = el("input", { id: "api-key", type: "password", placeholder: "htk_...", autocomplete: "current-password", required: true })), el("div", { class: "hint" }, "The API key is the credential sent in the Authorization header."));
+    form.appendChild(field);
+
+    submitBtn = el("button", { class: "btn btn-primary", type: "submit" }, "Sign in");
+    form.appendChild(el("div", { class: "form-actions" }, submitBtn));
+    card.appendChild(form);
+    view.appendChild(el("div", { class: "login-wrap" }, card));
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Dashboard view                                                      */
+  /* ------------------------------------------------------------------ */
+
+  async function renderDashboard(root) {
+    root.appendChild(pageHeader("Dashboard", "Unified overview of integrated observability modules."));
+
+    let info = state.system;
+    try {
+      info = await api("/v1/system/info");
+      state.system = info;
+    } catch (err) {
+      root.appendChild(alertBox("Failed to load system info: " + err.message, "error"));
+    }
+
+    const totals = { tracing: 0, profiling: 0, running: 0 };
+    try {
+      const traces = await api("/v1/traces?limit=500");
+      totals.tracing = traces.total;
+      totals.running += countRunning(traces.items);
+    } catch {
+      /* non-fatal */
+    }
+    try {
+      const profiles = await api("/v1/profiles?limit=500");
+      totals.profiling = profiles.total;
+      totals.running += countRunning(profiles.items);
+    } catch {
+      /* non-fatal */
+    }
+
+    const cards = el("div", { class: "grid grid-4" });
+    cards.appendChild(metricCard(totals.running, "Running jobs", { color: "var(--green)" }));
+    cards.appendChild(metricCard(totals.tracing, "Tracing jobs"));
+    cards.appendChild(metricCard(totals.profiling, "Profiling jobs"));
+    cards.appendChild(metricCard(info ? info.version : "-", "Server version"));
+    root.appendChild(cards);
+
+    if (info && info.modules && info.modules.length) {
+      const grid = el("div", { class: "grid grid-3" });
+      for (const m of info.modules) {
+        const card = el("div", { class: "card module-card" });
+        card.appendChild(el("div", { class: "row" }, el("span", { class: "module-name" }, m.display_name || m.name), el("span", { class: "spacer" }), el("span", { class: m.enabled ? "badge badge-completed" : "badge badge-muted" }, m.enabled ? "enabled" : "disabled")));
+        card.appendChild(el("div", { class: "module-desc" }, m.description || ""));
+        card.appendChild(el("div", { class: "row" }, el("span", { class: "mono perm-tag" }, m.endpoint || "-"), el("a", { class: "btn btn-ghost btn-sm", href: moduleHref(m.name) }, "Open")));
+        grid.appendChild(card);
+      }
+      root.appendChild(el("div", { class: "section" }, panel("Integrated modules", [grid])));
+    }
+
+    if (info && info.limits) {
+      const limits = info.limits;
+      root.appendChild(el("div", { class: "section" }, panel("Scheduling limits", [el("div", { class: "grid grid-4" }, metricCard(limits.max_profiling_tasks_per_host, "Profiling / host"), metricCard(limits.max_tracing_tasks_per_host, "Tracing / host"), metricCard(limits.max_total_profiling_tasks, "Total profiling"), metricCard(limits.max_total_tracing_tasks, "Total tracing"))])));
+    }
+  }
+
+  function countRunning(items) {
+    if (!items) return 0;
+    return items.filter((i) => String(i.status).toLowerCase() === "running").length;
+  }
+
+  function moduleHref(name) {
+    return "#/" + (name === "tracing" ? "tracing" : name === "profiling" ? "profiling" : name === "metrics" ? "metrics" : "dashboard");
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Tasks view (unified)                                                */
+  /* ------------------------------------------------------------------ */
+
+  async function renderTasks(root) {
+    root.appendChild(pageHeader("Tasks", "All collection jobs across tracing and profiling, with live status."));
+
+    const toolbar = el("div", { class: "toolbar" });
+    const statusSel = el("select", { class: "field" });
+    for (const s of ["", "running", "pending", "completed", "failed", "stopped", "timeout"]) {
+      statusSel.appendChild(el("option", { value: s }, s || "all statuses"));
+    }
+    const hostInput = el("input", { type: "text", placeholder: "filter by host" });
+    const reload = el("button", { class: "btn btn-ghost btn-sm", onclick: () => load() }, "Refresh");
+    toolbar.appendChild(el("label", {}, "Status", statusSel));
+    toolbar.appendChild(el("label", {}, "Host", hostInput));
+    toolbar.appendChild(el("span", { class: "spacer" }));
+    toolbar.appendChild(reload);
+    root.appendChild(toolbar);
+
+    const tableHost = el("div", { class: "table-wrap" });
+    root.appendChild(tableHost);
+
+    async function load() {
+      try {
+        const params = new URLSearchParams();
+        params.set("limit", "200");
+        if (statusSel.value) params.set("status", statusSel.value);
+        if (hostInput.value.trim()) params.set("host", hostInput.value.trim());
+        const q = "?" + params.toString();
+
+        let traces = [];
+        let profiles = [];
+        try {
+          const t = await api("/v1/traces" + q);
+          traces = (t.items || []).map((i) => Object.assign({}, i, { _kind: "trace" }));
+        } catch (err) {
+          tableHost.replaceChildren(alertBox("Failed to load traces: " + err.message, "error"));
+        }
+        try {
+          const p = await api("/v1/profiles" + q);
+          profiles = (p.items || []).map((i) => Object.assign({}, i, { _kind: "profile" }));
+        } catch (err) {
+          tableHost.replaceChildren(alertBox("Failed to load profiles: " + err.message, "error"));
+        }
+
+        const all = traces.concat(profiles).sort((a, b) => (b.start_time || "").localeCompare(a.start_time || ""));
+        renderTaskTable(tableHost, all);
+      } catch (err) {
+        tableHost.replaceChildren(alertBox(err.message, "error"));
+      }
+    }
+
+    pollEvery(load, 5000);
+  }
+
+  function renderTaskTable(host, rows) {
+    if (!rows.length) {
+      host.replaceChildren(emptyState("No jobs match the current filters."));
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "Module"), el("th", {}, "ID"), el("th", {}, "Host"), el("th", {}, "Container"), el("th", {}, "Status"), el("th", {}, "Started"), el("th", {}, "Result"))));
+    const tbody = el("tbody");
+    for (const r of rows) {
+      const resultUrl = r.results && r.results.url;
+      const resultCell = resultUrl
+        ? el("a", { class: "btn btn-ghost btn-sm", href: resultUrl, target: "_blank", rel: "noopener" }, "Open")
+        : el("span", { class: "badge badge-muted" }, "-");
+      tbody.appendChild(el("tr", {}, el("td", {}, r._kind === "profile" ? "Profiling" : "Tracing"), el("td", { class: "mono" }, r.id), el("td", {}, r.hostname || "-"), el("td", {}, r.container || "-"), el("td", { html: statusBadge(r.status) }), el("td", {}, relativeTime(r.start_time)), el("td", {}, resultCell)));
+    }
+    table.appendChild(tbody);
+    host.replaceChildren(table);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Event Tracing view                                                  */
+  /* ------------------------------------------------------------------ */
+
+  async function renderTracing(root) {
+    root.appendChild(pageHeader("Event Tracing", "Create, monitor and stop on-demand tracing jobs."));
+
+    root.appendChild(buildTraceForm());
+
+    const listHost = el("div", { class: "section" });
+    root.appendChild(listHost);
+
+    async function load() {
+      try {
+        const data = await api("/v1/traces?limit=100");
+        renderJobList(listHost, "Tracing jobs", data.items || [], {
+          kind: "trace",
+          onStop: stopJob("/v1/traces"),
+          onDelete: deleteJob("/v1/traces"),
+        });
+      } catch (err) {
+        listHost.replaceChildren(alertBox(err.message, "error"));
+      }
+    }
+    pollEvery(load, 5000);
+  }
+
+  function buildTraceForm() {
+    const card = panel("Start a trace", []);
+    const host = el("input", { type: "text", placeholder: "host name", required: true });
+    const container = el("input", { type: "text", placeholder: "container (optional)" });
+    const duration = el("input", { type: "number", min: "1", max: "300", value: "30", required: true });
+    const typeSel = el("select", {});
+    for (const t of ["tracing", "syscall", "network"]) {
+      typeSel.appendChild(el("option", { value: t }, t));
+    }
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      const btn = form.querySelector("button[type=submit]");
+      btn.disabled = true;
+      try {
+        await api("/v1/traces", {
+          method: "POST",
+          body: {
+            hostname: host.value.trim(),
+            container: container.value.trim(),
+            duration: Number(duration.value),
+            type: typeSel.value,
+          },
+        });
+        toast("Trace job created", "success");
+        form.reset();
+        location.hash = "#/tracing";
+      } catch (err) {
+        toast(err.message, "error");
+      } finally {
+        btn.disabled = false;
+      }
+    } });
+
+    const grid = el("div", { class: "grid grid-4" });
+    grid.appendChild(fieldWrap("Host", host));
+    grid.appendChild(fieldWrap("Container", container));
+    grid.appendChild(fieldWrap("Duration (s)", duration, "Maximum 300 seconds."));
+    grid.appendChild(fieldWrap("Type", typeSel));
+    form.appendChild(grid);
+    form.appendChild(el("div", { class: "form-actions" }, el("button", { class: "btn btn-primary", type: "submit" }, "Start trace")));
+    card.replaceChildren(el("p", { class: "card-title" }, "Start a trace"), form);
+    return card;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Profiling view                                                      */
+  /* ------------------------------------------------------------------ */
+
+  async function renderProfiling(root) {
+    root.appendChild(pageHeader("Continuous Profiling", "CPU and memory profiling with flame-graph integration."));
+
+    let caps = null;
+    try {
+      caps = await api("/v1/profiles/capabilities");
+    } catch (err) {
+      root.appendChild(alertBox("Failed to load capabilities: " + err.message, "error"));
+    }
+
+    root.appendChild(buildProfilingForm(caps));
+
+    const listHost = el("div", { class: "section" });
+    root.appendChild(listHost);
+
+    async function load() {
+      try {
+        const data = await api("/v1/profiles?limit=100");
+        renderJobList(listHost, "Profiling jobs", data.items || [], {
+          kind: "profile",
+          onStop: stopJob("/v1/profiles"),
+          onDelete: deleteJob("/v1/profiles"),
+        });
+      } catch (err) {
+        listHost.replaceChildren(alertBox(err.message, "error"));
+      }
+    }
+    pollEvery(load, 5000);
+  }
+
+  function buildProfilingForm(caps) {
+    const card = panel("Start profiling", []);
+    const typeSel = el("select", {});
+    const profileTypes = (caps && caps.profile_types) || ["cpu", "memory"];
+    for (const t of profileTypes) {
+      typeSel.appendChild(el("option", { value: t }, t));
+    }
+
+    const host = el("input", { type: "text", placeholder: "host name", required: true });
+    const container = el("input", { type: "text", placeholder: "container (optional)" });
+    const execPath = el("input", { type: "text", placeholder: "/usr/bin/myapp" });
+    const langSel = el("select", {});
+    const modeSel = el("select", {});
+    const duration = el("input", { type: "number", min: "1", value: "60", required: true });
+
+    const cpuLangs = (caps && caps.cpu_supported_languages) || [];
+    const memLangs = (caps && caps.memory_supported_languages) || [];
+    const modes = (caps && caps.memory_modes) || {};
+
+    function refreshControls() {
+      const t = typeSel.value;
+      langSel.innerHTML = "";
+      modeSel.innerHTML = "";
+      const langs = t === "memory" ? memLangs : cpuLangs;
+      for (const l of langs) langSel.appendChild(el("option", { value: l }, l));
+      if (t === "memory") {
+        for (const [display, internal] of Object.entries(modes)) {
+          modeSel.appendChild(el("option", { value: display }, display));
+        }
+      }
+    }
+    typeSel.addEventListener("change", refreshControls);
+    refreshControls();
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      const btn = form.querySelector("button[type=submit]");
+      btn.disabled = true;
+      try {
+        const body = {
+          hostname: host.value.trim(),
+          container: container.value.trim(),
+          duration: Number(duration.value),
+          type: typeSel.value,
+        };
+        if (typeSel.value === "cpu") {
+          body.target_exec_path = execPath.value.trim();
+          body.target_process_language = langSel.value;
+        } else {
+          body.target_process_language = langSel.value;
+          body.memory_mode = modeSel.value;
+        }
+        await api("/v1/profiles", { method: "POST", body });
+        toast("Profiling job created", "success");
+        form.reset();
+        refreshControls();
+      } catch (err) {
+        toast(err.message, "error");
+      } finally {
+        btn.disabled = false;
+      }
+    } });
+
+    const grid = el("div", { class: "grid grid-4" });
+    grid.appendChild(fieldWrap("Host", host));
+    grid.appendChild(fieldWrap("Container", container));
+    grid.appendChild(fieldWrap("Profile type", typeSel));
+    grid.appendChild(fieldWrap("Duration (s)", duration));
+    grid.appendChild(fieldWrap("Executable path", execPath, "CPU profiling target executable."));
+    grid.appendChild(fieldWrap("Language", langSel));
+    grid.appendChild(fieldWrap("Memory mode", modeSel, "Only used for memory profiling."));
+    form.appendChild(grid);
+    form.appendChild(el("div", { class: "form-actions" }, el("button", { class: "btn btn-primary", type: "submit" }, "Start profiling")));
+    card.replaceChildren(el("p", { class: "card-title" }, "Start profiling"), form);
+    return card;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Shared job list with stop/delete                                    */
+  /* ------------------------------------------------------------------ */
+
+  function renderJobList(host, title, items, opts) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, title));
+    if (!items.length) {
+      card.appendChild(emptyState("No jobs yet."));
+      host.replaceChildren(card);
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "ID"), el("th", {}, "Host"), el("th", {}, "Status"), el("th", {}, "Started"), el("th", {}, "Result"), el("th", {}, "Actions"))));
+    const tbody = el("tbody");
+    for (const job of items) {
+      const status = String(job.status).toLowerCase();
+      const isActive = status === "running" || status === "pending";
+      const resultUrl = job.results && job.results.url;
+      const actions = el("div", { class: "row" });
+      if (isActive) {
+        actions.appendChild(el("button", { class: "btn btn-ghost btn-sm", onclick: () => opts.onStop(job) }, "Stop"));
+      }
+      actions.appendChild(el("button", { class: "btn btn-danger btn-sm", onclick: () => opts.onDelete(job) }, "Delete"));
+      const resultCell = resultUrl
+        ? el("a", { class: "btn btn-ghost btn-sm", href: resultUrl, target: "_blank", rel: "noopener" }, "Open")
+        : el("span", { class: "badge badge-muted" }, "-");
+      tbody.appendChild(el("tr", {}, el("td", { class: "mono" }, job.id), el("td", {}, job.hostname || "-"), el("td", { html: statusBadge(job.status) }), el("td", {}, relativeTime(job.start_time)), el("td", {}, resultCell), el("td", {}, actions)));
+    }
+    table.appendChild(tbody);
+    card.appendChild(table);
+    host.replaceChildren(card);
+  }
+
+  function stopJob(base) {
+    return async (job) => {
+      try {
+        await api(base + "/" + encodeURIComponent(job.id), { method: "PATCH", body: { status: "stopped" } });
+        toast("Job " + job.id + " stop requested", "success");
+        route();
+      } catch (err) {
+        toast(err.message, "error");
+      }
+    };
+  }
+
+  function deleteJob(base) {
+    return async (job) => {
+      if (!confirm("Delete job " + job.id + "?")) return;
+      try {
+        await api(base + "/" + encodeURIComponent(job.id), { method: "DELETE" });
+        toast("Job " + job.id + " deleted", "success");
+        route();
+      } catch (err) {
+        toast(err.message, "error");
+      }
+    };
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Metrics view                                                        */
+  /* ------------------------------------------------------------------ */
+
+  async function renderMetrics(root) {
+    root.appendChild(pageHeader("Metrics", "Prometheus exposition surface scraped from /metrics."));
+    const toolbar = el("div", { class: "toolbar" });
+    const refresh = el("button", { class: "btn btn-ghost btn-sm", onclick: load }, "Refresh");
+    const filter = el("input", { type: "text", placeholder: "filter metric families" });
+    toolbar.appendChild(el("label", {}, "Filter", filter));
+    toolbar.appendChild(el("span", { class: "spacer" }));
+    toolbar.appendChild(refresh);
+    root.appendChild(toolbar);
+
+    const host = el("div", { class: "section" });
+    root.appendChild(host);
+
+    async function load() {
+      try {
+        const text = await api("/metrics");
+        const families = parsePrometheus(text);
+        const needle = filter.value.trim().toLowerCase();
+        const rows = needle ? families.filter((f) => f.name.toLowerCase().includes(needle)) : families;
+        renderMetricsTable(host, rows, text);
+      } catch (err) {
+        host.replaceChildren(alertBox("Failed to load metrics: " + err.message, "error"));
+      }
+    }
+    filter.addEventListener("input", load);
+    pollEvery(load, 10000);
+  }
+
+  function parsePrometheus(text) {
+    const families = [];
+    let current = null;
+    for (const line of text.split("\n")) {
+      if (!line) continue;
+      if (line.startsWith("# HELP ")) {
+        const rest = line.slice(8);
+        const sp = rest.indexOf(" ");
+        const name = rest.slice(0, sp);
+        const help = rest.slice(sp + 1);
+        current = { name, help, samples: [] };
+        families.push(current);
+      } else if (line.startsWith("# TYPE ") || line.startsWith("#")) {
+        continue;
+      } else {
+        const m = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([-+eE0-9.]+)/);
+        if (m) {
+          if (!current || current.name.split("_")[0] !== m[1].split("_")[0]) {
+            // best-effort grouping
+          }
+          const fam = families.find((f) => f.name === m[1]) || (() => {
+            const f = { name: m[1], help: "", samples: [] };
+            families.push(f);
+            return f;
+          })();
+          fam.samples.push({ labels: m[2] || "", value: m[3] });
+        }
+      }
+    }
+    return families.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  function renderMetricsTable(host, families, raw) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, families.length + " metric families"));
+    if (!families.length) {
+      card.appendChild(emptyState("No metric families match the filter."));
+      host.replaceChildren(card);
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "Metric"), el("th", {}, "Help"), el("th", {}, "Samples"))));
+    const tbody = el("tbody");
+    for (const f of families) {
+      tbody.appendChild(el("tr", {}, el("td", { class: "mono" }, f.name), el("td", {}, escapeHtml(f.help)), el("td", {}, String(f.samples.length))));
+    }
+    table.appendChild(tbody);
+    card.appendChild(table);
+    card.appendChild(el("div", { class: "row", style: "margin-top:12px;justify-content:flex-end" }, el("a", { class: "btn btn-ghost btn-sm", href: "/metrics", target: "_blank" }, "Open raw /metrics")));
+    host.replaceChildren(card);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Access Control view (RBAC)                                          */
+  /* ------------------------------------------------------------------ */
+
+  async function renderAccess(root) {
+    root.appendChild(pageHeader("Access Control", "Manage users, roles and API keys."));
+
+    root.appendChild(buildCreateUserForm());
+
+    const rolesHost = el("div", { class: "section" });
+    root.appendChild(rolesHost);
+    const usersHost = el("div", { class: "section" });
+    root.appendChild(usersHost);
+
+    async function load() {
+      try {
+        const roles = await api("/v1/roles");
+        renderRoles(rolesHost, roles || []);
+      } catch (err) {
+        rolesHost.replaceChildren(alertBox("Failed to load roles: " + err.message, "error"));
+      }
+      try {
+        const users = await api("/v1/users");
+        renderUsers(usersHost, users || []);
+      } catch (err) {
+        usersHost.replaceChildren(alertBox("Failed to load users: " + err.message, "error"));
+      }
+    }
+    load();
+  }
+
+  function renderRoles(host, roles) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, "Role catalog"));
+    if (!roles.length) {
+      card.appendChild(emptyState("No roles defined."));
+      host.replaceChildren(card);
+      return;
+    }
+    for (const r of roles) {
+      const block = el("div", { class: "section" }, el("div", { class: "row" }, el("strong", {}, r.name), r.is_admin ? el("span", { class: "badge badge-completed" }, "admin") : null), el("div", { class: "metric-label", style: "margin-top:6px" }, r.description || ""));
+      const tags = el("div", { class: "tag-list", style: "margin-top:8px" });
+      for (const p of r.permissions || []) tags.appendChild(el("span", { class: "perm-tag" }, p));
+      block.appendChild(tags);
+      card.appendChild(block);
+    }
+    host.replaceChildren(card);
+  }
+
+  function renderUsers(host, users) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, "Users & API keys (" + users.length + ")"));
+    if (!users.length) {
+      card.appendChild(emptyState("No users configured."));
+      host.replaceChildren(card);
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "Name"), el("th", {}, "ID"), el("th", {}, "Role"), el("th", {}, "Permissions"), el("th", {}, "Actions"))));
+    const tbody = el("tbody");
+    for (const u of users) {
+      const actions = el("div", { class: "row" });
+      if (u.id !== state.user.id) {
+        actions.appendChild(el("button", { class: "btn btn-danger btn-sm", onclick: () => deleteUser(u) }, "Revoke"));
+      } else {
+        actions.appendChild(el("span", { class: "badge badge-muted" }, "you"));
+      }
+      const perms = el("div", { class: "tag-list" });
+      if (u.is_admin) {
+        perms.appendChild(el("span", { class: "perm-tag" }, "admin (all)"));
+      } else {
+        for (const p of u.permissions || []) perms.appendChild(el("span", { class: "perm-tag" }, p));
+      }
+      tbody.appendChild(el("tr", {}, el("td", {}, u.name || "-"), el("td", { class: "mono" }, maskKey(u.id)), el("td", {}, u.is_admin ? "admin" : "custom"), el("td", {}, perms), el("td", {}, actions)));
+    }
+    table.appendChild(tbody);
+    card.appendChild(table);
+    host.replaceChildren(card);
+  }
+
+  function maskKey(id) {
+    if (!id) return "-";
+    if (id.length <= 8) return id;
+    return id.slice(0, 4) + "..." + id.slice(-4);
+  }
+
+  function buildCreateUserForm() {
+    const card = panel("Provision API key", []);
+    const name = el("input", { type: "text", required: true, placeholder: "display name" });
+    const roleSel = el("select", {});
+    roleSel.appendChild(el("option", { value: "viewer" }, "viewer"));
+    roleSel.appendChild(el("option", { value: "operator" }, "operator"));
+    roleSel.appendChild(el("option", { value: "admin" }, "admin"));
+    const generate = el("input", { type: "checkbox", checked: true });
+    const resultBox = el("div");
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      resultBox.innerHTML = "";
+      const btn = form.querySelector("button[type=submit]");
+      btn.disabled = true;
+      try {
+        const role = roleSel.value;
+        const body = { name: name.value.trim(), generate_key: generate.checked };
+        if (role === "admin") {
+          body.is_admin = true;
+        } else {
+          const catalog = await loadRoleCatalog();
+          const tmpl = (catalog || []).find((r) => r.name === role);
+          body.is_admin = false;
+          body.permissions = tmpl ? tmpl.permissions : [];
+        }
+        const created = await api("/v1/users", { method: "POST", body });
+        toast("API key created", "success");
+        resultBox.appendChild(alertBox("Store this key securely. It will not be shown again.", "success"));
+        resultBox.appendChild(el("div", { class: "code-block" }, created.id));
+        form.reset();
+        generate.checked = true;
+        route();
+      } catch (err) {
+        toast(err.message, "error");
+        resultBox.appendChild(alertBox(err.message, "error"));
+      } finally {
+        btn.disabled = false;
+      }
+    } });
+
+    const grid = el("div", { class: "grid grid-3" });
+    grid.appendChild(fieldWrap("Name", name));
+    grid.appendChild(fieldWrap("Role", roleSel));
+    grid.appendChild(fieldWrap("Generate key", generate, "Generate a random secret API key."));
+    form.appendChild(grid);
+    form.appendChild(el("div", { class: "form-actions" }, el("button", { class: "btn btn-primary", type: "submit" }, "Create API key")));
+    form.appendChild(resultBox);
+    card.replaceChildren(el("p", { class: "card-title" }, "Provision API key"), form);
+    return card;
+  }
+
+  let roleCatalogCache = null;
+  async function loadRoleCatalog() {
+    if (roleCatalogCache) return roleCatalogCache;
+    try {
+      roleCatalogCache = await api("/v1/roles");
+    } catch {
+      roleCatalogCache = [];
+    }
+    return roleCatalogCache;
+  }
+
+  async function deleteUser(u) {
+    if (!confirm("Revoke API key for " + (u.name || u.id) + "?")) return;
+    try {
+      await api("/v1/users/" + encodeURIComponent(u.id), { method: "DELETE" });
+      toast("API key revoked", "success");
+      route();
+    } catch (err) {
+      toast(err.message, "error");
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Field helper                                                        */
+  /* ------------------------------------------------------------------ */
+
+  function fieldWrap(labelText, control, hint) {
+    const f = el("div", { class: "field" });
+    f.appendChild(el("label", {}, labelText));
+    f.appendChild(control);
+    if (hint) f.appendChild(el("div", { class: "hint" }, hint));
+    return f;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Go                                                                  */
+  /* ------------------------------------------------------------------ */
+
+  bootstrap();
+})();

--- a/cmd/huatuo-apiserver/handlers/console/web/assets/app.js
+++ b/cmd/huatuo-apiserver/handlers/console/web/assets/app.js
@@ -1,0 +1,969 @@
+/*
+ * HuaTuo Console - single-page application.
+ *
+ * Vanilla JS, no build step. Authenticated API calls carry the stored API key
+ * in the Authorization header, matching the huatuo-apiserver auth model.
+ */
+(function () {
+  "use strict";
+
+  const STORAGE_KEY = "huatuo_api_key";
+
+  const NAV = [
+    { id: "dashboard", label: "Dashboard", admin: false },
+    { id: "tasks", label: "Tasks", admin: false },
+    { id: "tracing", label: "Event Tracing", admin: false },
+    { id: "profiling", label: "Profiling", admin: false },
+    { id: "metrics", label: "Metrics", admin: false },
+    { id: "access", label: "Access Control", admin: true },
+  ];
+
+  const state = {
+    apiKey: localStorage.getItem(STORAGE_KEY) || "",
+    user: null,
+    system: null,
+    pollTimers: [],
+  };
+
+  /* ------------------------------------------------------------------ */
+  /* Tiny helpers                                                        */
+  /* ------------------------------------------------------------------ */
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const el = (tag, attrs = {}, ...children) => {
+    const node = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (k === "class") node.className = v;
+      else if (k === "html") node.innerHTML = v;
+      else if (k.startsWith("on") && typeof v === "function")
+        node.addEventListener(k.slice(2).toLowerCase(), v);
+      else if (v !== null && v !== undefined) node.setAttribute(k, v);
+    }
+    for (const c of children) {
+      if (c === null || c === undefined) continue;
+      node.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+    }
+    return node;
+  };
+
+  function escapeHtml(s) {
+    if (s === null || s === undefined) return "";
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function statusBadge(status) {
+    const s = String(status || "").toLowerCase();
+    return `<span class="badge badge-${escapeHtml(s) || "muted"}">${escapeHtml(
+      status || "unknown"
+    )}</span>`;
+  }
+
+  function relativeTime(iso) {
+    if (!iso) return "-";
+    const d = new Date(iso);
+    if (isNaN(d)) return iso;
+    return d.toLocaleString();
+  }
+
+  function toast(message, type = "info") {
+    const host = $("#toast-host") || (() => {
+      const h = el("div", { class: "toast-host", id: "toast-host" });
+      document.body.appendChild(h);
+      return h;
+    })();
+    const t = el("div", { class: `toast toast-${type}` }, message);
+    host.appendChild(t);
+    setTimeout(() => t.remove(), 4000);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* API client                                                          */
+  /* ------------------------------------------------------------------ */
+
+  async function api(path, opts = {}) {
+    const headers = Object.assign({}, opts.headers || {});
+    if (state.apiKey) headers["Authorization"] = "Bearer " + state.apiKey;
+    if (opts.body && !headers["Content-Type"])
+      headers["Content-Type"] = "application/json";
+
+    const resp = await fetch(path, {
+      method: opts.method || "GET",
+      headers,
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+    });
+
+    if (resp.status === 204) return null;
+
+    const text = await resp.text();
+    const ct = resp.headers.get("content-type") || "";
+    if (!ct.includes("application/json")) {
+      if (!resp.ok) throw new Error(text || resp.statusText);
+      return text;
+    }
+
+    let payload;
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      throw new Error("invalid JSON response");
+    }
+
+    if (!resp.ok) {
+      const msg = payload && payload.message ? payload.message : resp.statusText;
+      const err = new Error(msg);
+      err.status = resp.status;
+      err.payload = payload;
+      throw err;
+    }
+
+    if (payload && typeof payload === "object" && "code" in payload) {
+      if (payload.code !== 0) {
+        throw new Error(payload.message || "request failed");
+      }
+      return payload.data;
+    }
+    return payload;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Bootstrapping / navigation                                          */
+  /* ------------------------------------------------------------------ */
+
+  function stopPolling() {
+    state.pollTimers.forEach((t) => clearInterval(t));
+    state.pollTimers = [];
+  }
+
+  function pollEvery(fn, ms) {
+    fn();
+    const id = setInterval(fn, ms);
+    state.pollTimers.push(id);
+  }
+
+  async function bootstrap() {
+    if (!state.apiKey) {
+      renderLogin();
+      return;
+    }
+    try {
+      state.user = await api("/v1/auth/whoami");
+      try {
+        state.system = await api("/v1/system/info");
+      } catch {
+        state.system = null;
+      }
+      showChrome();
+      route();
+    } catch (err) {
+      if (err.status === 401 || err.status === 403) {
+        toast("API key is invalid or unauthorized", "error");
+      }
+      state.apiKey = "";
+      localStorage.removeItem(STORAGE_KEY);
+      renderLogin();
+    }
+  }
+
+  function showChrome() {
+    const topbar = $(".topbar");
+    topbar.hidden = false;
+
+    const nav = $("#nav");
+    nav.innerHTML = "";
+    for (const item of NAV) {
+      if (item.admin && !(state.user && state.user.is_admin)) continue;
+      const link = el(
+        "button",
+        {
+          class: "nav-link",
+          "data-nav": item.id,
+          onclick: () => {
+            location.hash = "#/" + item.id;
+          },
+        },
+        item.label
+      );
+      nav.appendChild(link);
+    }
+
+    const badge = $("#user-badge");
+    badge.innerHTML = "";
+    badge.appendChild(document.createTextNode(state.user.name || state.user.id || "user"));
+    if (state.user.is_admin) {
+      badge.appendChild(el("span", { class: "admin-tag" }, "admin"));
+    }
+
+    const versionEl = $("#server-version");
+    if (state.system && state.system.version) {
+      versionEl.textContent =
+        "HuaTuo apiserver v" + state.system.version +
+        (state.system.commit ? " (" + state.system.commit + ")" : "");
+    }
+
+    $("#logout-btn").onclick = () => {
+      stopPolling();
+      state.apiKey = "";
+      state.user = null;
+      localStorage.removeItem(STORAGE_KEY);
+      renderLogin();
+    };
+  }
+
+  function route() {
+    stopPolling();
+    const hash = location.hash.replace(/^#\/?/, "") || "dashboard";
+    document.querySelectorAll(".nav-link").forEach((n) => {
+      n.classList.toggle("active", n.getAttribute("data-nav") === hash);
+    });
+    const view = $("#view");
+    view.innerHTML = "";
+    try {
+      switch (hash) {
+        case "dashboard":
+          return renderDashboard(view);
+        case "tasks":
+          return renderTasks(view);
+        case "tracing":
+          return renderTracing(view);
+        case "profiling":
+          return renderProfiling(view);
+        case "metrics":
+          return renderMetrics(view);
+        case "access":
+          if (!(state.user && state.user.is_admin)) {
+            view.appendChild(emptyState("Access Control is available to administrators only."));
+            return;
+          }
+          return renderAccess(view);
+        default:
+          return renderDashboard(view);
+      }
+    } catch (err) {
+      view.appendChild(alertBox(err.message, "error"));
+    }
+  }
+
+  window.addEventListener("hashchange", route);
+
+  /* ------------------------------------------------------------------ */
+  /* Shared UI fragments                                                 */
+  /* ------------------------------------------------------------------ */
+
+  function alertBox(message, type = "info") {
+    return el("div", { class: `alert alert-${type}` }, message);
+  }
+
+  function emptyState(message) {
+    return el("div", { class: "empty" }, message);
+  }
+
+  function pageHeader(title, subtitle) {
+    return el("div", {}, el("h2", { class: "page-title" }, title), el("p", { class: "page-subtitle" }, subtitle));
+  }
+
+  function panel(title, bodyNodes) {
+    return el("section", { class: "card" }, el("p", { class: "card-title" }, title), ...bodyNodes);
+  }
+
+  function metricCard(value, label, opts = {}) {
+    return el("div", { class: "card" }, el("div", { class: "metric-value", style: opts.color ? `color:${opts.color}` : "" }, String(value)), el("div", { class: "metric-label" }, label));
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Login view                                                          */
+  /* ------------------------------------------------------------------ */
+
+  function renderLogin() {
+    $(".topbar").hidden = true;
+    const view = $("#view");
+    view.innerHTML = "";
+    const card = el("div", { class: "login-card" });
+    card.appendChild(el("h1", {}, "HuaTuo Console"));
+    card.appendChild(el("p", {}, "Sign in with your API key. Administrators provision keys from Access Control."));
+
+    let input;
+    let submitBtn;
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      const key = input.value.trim();
+      if (!key) return;
+      submitBtn.disabled = true;
+      try {
+        state.apiKey = key;
+        localStorage.setItem(STORAGE_KEY, key);
+        state.user = await api("/v1/auth/whoami");
+        try {
+          state.system = await api("/v1/system/info");
+        } catch {
+          state.system = null;
+        }
+        showChrome();
+        location.hash = "#/dashboard";
+        route();
+      } catch (err) {
+        state.apiKey = "";
+        localStorage.removeItem(STORAGE_KEY);
+        card.insertBefore(alertBox(err.message || "Login failed", "error"), form);
+      } finally {
+        submitBtn.disabled = false;
+      }
+    } });
+
+    const field = el("div", { class: "field" }, el("label", { for: "api-key" }, "API key"), (input = el("input", { id: "api-key", type: "password", placeholder: "htk_...", autocomplete: "current-password", required: true })), el("div", { class: "hint" }, "The API key is the credential sent in the Authorization header."));
+    form.appendChild(field);
+
+    submitBtn = el("button", { class: "btn btn-primary", type: "submit" }, "Sign in");
+    form.appendChild(el("div", { class: "form-actions" }, submitBtn));
+    card.appendChild(form);
+    view.appendChild(el("div", { class: "login-wrap" }, card));
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Dashboard view                                                      */
+  /* ------------------------------------------------------------------ */
+
+  async function renderDashboard(root) {
+    root.appendChild(pageHeader("Dashboard", "Unified overview of integrated observability modules."));
+
+    let info = state.system;
+    try {
+      info = await api("/v1/system/info");
+      state.system = info;
+    } catch (err) {
+      root.appendChild(alertBox("Failed to load system info: " + err.message, "error"));
+    }
+
+    const totals = { tracing: 0, profiling: 0, running: 0 };
+    try {
+      const traces = await api("/v1/traces?limit=500");
+      totals.tracing = traces.total;
+      totals.running += countRunning(traces.items);
+    } catch {
+      /* non-fatal */
+    }
+    try {
+      const profiles = await api("/v1/profiles?limit=500");
+      totals.profiling = profiles.total;
+      totals.running += countRunning(profiles.items);
+    } catch {
+      /* non-fatal */
+    }
+
+    const cards = el("div", { class: "grid grid-4" });
+    cards.appendChild(metricCard(totals.running, "Running jobs", { color: "var(--green)" }));
+    cards.appendChild(metricCard(totals.tracing, "Tracing jobs"));
+    cards.appendChild(metricCard(totals.profiling, "Profiling jobs"));
+    cards.appendChild(metricCard(info ? info.version : "-", "Server version"));
+    root.appendChild(cards);
+
+    if (info && info.modules && info.modules.length) {
+      const grid = el("div", { class: "grid grid-3" });
+      for (const m of info.modules) {
+        const card = el("div", { class: "card module-card" });
+        card.appendChild(el("div", { class: "row" }, el("span", { class: "module-name" }, m.display_name || m.name), el("span", { class: "spacer" }), el("span", { class: m.enabled ? "badge badge-completed" : "badge badge-muted" }, m.enabled ? "enabled" : "disabled")));
+        card.appendChild(el("div", { class: "module-desc" }, m.description || ""));
+        card.appendChild(el("div", { class: "row" }, el("span", { class: "mono perm-tag" }, m.endpoint || "-"), el("a", { class: "btn btn-ghost btn-sm", href: moduleHref(m.name) }, "Open")));
+        grid.appendChild(card);
+      }
+      root.appendChild(el("div", { class: "section" }, panel("Integrated modules", [grid])));
+    }
+
+    if (info && info.limits) {
+      const limits = info.limits;
+      root.appendChild(el("div", { class: "section" }, panel("Scheduling limits", [el("div", { class: "grid grid-4" }, metricCard(limits.max_profiling_tasks_per_host, "Profiling / host"), metricCard(limits.max_tracing_tasks_per_host, "Tracing / host"), metricCard(limits.max_total_profiling_tasks, "Total profiling"), metricCard(limits.max_total_tracing_tasks, "Total tracing"))])));
+    }
+  }
+
+  function countRunning(items) {
+    if (!items) return 0;
+    return items.filter((i) => String(i.status).toLowerCase() === "running").length;
+  }
+
+  function moduleHref(name) {
+    return "#/" + (name === "tracing" ? "tracing" : name === "profiling" ? "profiling" : name === "metrics" ? "metrics" : "dashboard");
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Tasks view (unified)                                                */
+  /* ------------------------------------------------------------------ */
+
+  async function renderTasks(root) {
+    root.appendChild(pageHeader("Tasks", "All collection jobs across tracing and profiling, with live status."));
+
+    const toolbar = el("div", { class: "toolbar" });
+    const statusSel = el("select", { class: "field" });
+    for (const s of ["", "running", "pending", "completed", "failed", "stopped", "timeout"]) {
+      statusSel.appendChild(el("option", { value: s }, s || "all statuses"));
+    }
+    const hostInput = el("input", { type: "text", placeholder: "filter by host" });
+    const reload = el("button", { class: "btn btn-ghost btn-sm", onclick: () => load() }, "Refresh");
+    toolbar.appendChild(el("label", {}, "Status", statusSel));
+    toolbar.appendChild(el("label", {}, "Host", hostInput));
+    toolbar.appendChild(el("span", { class: "spacer" }));
+    toolbar.appendChild(reload);
+    root.appendChild(toolbar);
+
+    const tableHost = el("div", { class: "table-wrap" });
+    root.appendChild(tableHost);
+
+    async function load() {
+      try {
+        const params = new URLSearchParams();
+        params.set("limit", "200");
+        if (statusSel.value) params.set("status", statusSel.value);
+        if (hostInput.value.trim()) params.set("host", hostInput.value.trim());
+        const q = "?" + params.toString();
+
+        let traces = [];
+        let profiles = [];
+        try {
+          const t = await api("/v1/traces" + q);
+          traces = (t.items || []).map((i) => Object.assign({}, i, { _kind: "trace" }));
+        } catch (err) {
+          tableHost.replaceChildren(alertBox("Failed to load traces: " + err.message, "error"));
+        }
+        try {
+          const p = await api("/v1/profiles" + q);
+          profiles = (p.items || []).map((i) => Object.assign({}, i, { _kind: "profile" }));
+        } catch (err) {
+          tableHost.replaceChildren(alertBox("Failed to load profiles: " + err.message, "error"));
+        }
+
+        const all = traces.concat(profiles).sort((a, b) => (b.start_time || "").localeCompare(a.start_time || ""));
+        renderTaskTable(tableHost, all);
+      } catch (err) {
+        tableHost.replaceChildren(alertBox(err.message, "error"));
+      }
+    }
+
+    pollEvery(load, 5000);
+  }
+
+  function renderTaskTable(host, rows) {
+    if (!rows.length) {
+      host.replaceChildren(emptyState("No jobs match the current filters."));
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "Module"), el("th", {}, "ID"), el("th", {}, "Host"), el("th", {}, "Container"), el("th", {}, "Status"), el("th", {}, "Started"), el("th", {}, "Result"))));
+    const tbody = el("tbody");
+    for (const r of rows) {
+      const resultUrl = r.results && r.results.url;
+      const resultCell = resultUrl
+        ? el("a", { class: "btn btn-ghost btn-sm", href: resultUrl, target: "_blank", rel: "noopener" }, "Open")
+        : el("span", { class: "badge badge-muted" }, "-");
+      tbody.appendChild(el("tr", {}, el("td", {}, r._kind === "profile" ? "Profiling" : "Tracing"), el("td", { class: "mono" }, r.id), el("td", {}, r.hostname || "-"), el("td", {}, r.container || "-"), el("td", { html: statusBadge(r.status) }), el("td", {}, relativeTime(r.start_time)), el("td", {}, resultCell)));
+    }
+    table.appendChild(tbody);
+    host.replaceChildren(table);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Event Tracing view                                                  */
+  /* ------------------------------------------------------------------ */
+
+  async function renderTracing(root) {
+    root.appendChild(pageHeader("Event Tracing", "Create, monitor and stop on-demand tracing jobs."));
+
+    root.appendChild(buildTraceForm());
+
+    const listHost = el("div", { class: "section" });
+    root.appendChild(listHost);
+
+    async function load() {
+      try {
+        const data = await api("/v1/traces?limit=100");
+        renderJobList(listHost, "Tracing jobs", data.items || [], {
+          kind: "trace",
+          onStop: stopJob("/v1/traces"),
+          onDelete: deleteJob("/v1/traces"),
+        });
+      } catch (err) {
+        listHost.replaceChildren(alertBox(err.message, "error"));
+      }
+    }
+    pollEvery(load, 5000);
+  }
+
+  function buildTraceForm() {
+    const card = panel("Start a trace", []);
+    const host = el("input", { type: "text", placeholder: "host name", required: true });
+    const container = el("input", { type: "text", placeholder: "container (optional)" });
+    const duration = el("input", { type: "number", min: "1", max: "300", value: "30", required: true });
+    const typeSel = el("select", {});
+    for (const t of ["tracing", "syscall", "network"]) {
+      typeSel.appendChild(el("option", { value: t }, t));
+    }
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      const btn = form.querySelector("button[type=submit]");
+      btn.disabled = true;
+      try {
+        await api("/v1/traces", {
+          method: "POST",
+          body: {
+            hostname: host.value.trim(),
+            container: container.value.trim(),
+            duration: Number(duration.value),
+            type: typeSel.value,
+          },
+        });
+        toast("Trace job created", "success");
+        form.reset();
+        location.hash = "#/tracing";
+      } catch (err) {
+        toast(err.message, "error");
+      } finally {
+        btn.disabled = false;
+      }
+    } });
+
+    const grid = el("div", { class: "grid grid-4" });
+    grid.appendChild(fieldWrap("Host", host));
+    grid.appendChild(fieldWrap("Container", container));
+    grid.appendChild(fieldWrap("Duration (s)", duration, "Maximum 300 seconds."));
+    grid.appendChild(fieldWrap("Type", typeSel));
+    form.appendChild(grid);
+    form.appendChild(el("div", { class: "form-actions" }, el("button", { class: "btn btn-primary", type: "submit" }, "Start trace")));
+    card.replaceChildren(el("p", { class: "card-title" }, "Start a trace"), form);
+    return card;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Profiling view                                                      */
+  /* ------------------------------------------------------------------ */
+
+  async function renderProfiling(root) {
+    root.appendChild(pageHeader("Continuous Profiling", "CPU and memory profiling with flame-graph integration."));
+
+    let caps = null;
+    try {
+      caps = await api("/v1/profiles/capabilities");
+    } catch (err) {
+      root.appendChild(alertBox("Failed to load capabilities: " + err.message, "error"));
+    }
+
+    root.appendChild(buildProfilingForm(caps));
+
+    const listHost = el("div", { class: "section" });
+    root.appendChild(listHost);
+
+    async function load() {
+      try {
+        const data = await api("/v1/profiles?limit=100");
+        renderJobList(listHost, "Profiling jobs", data.items || [], {
+          kind: "profile",
+          onStop: stopJob("/v1/profiles"),
+          onDelete: deleteJob("/v1/profiles"),
+        });
+      } catch (err) {
+        listHost.replaceChildren(alertBox(err.message, "error"));
+      }
+    }
+    pollEvery(load, 5000);
+  }
+
+  function buildProfilingForm(caps) {
+    const card = panel("Start profiling", []);
+    const typeSel = el("select", {});
+    const profileTypes = (caps && caps.profile_types) || ["cpu", "memory"];
+    for (const t of profileTypes) {
+      typeSel.appendChild(el("option", { value: t }, t));
+    }
+
+    const host = el("input", { type: "text", placeholder: "host name", required: true });
+    const container = el("input", { type: "text", placeholder: "container (optional)" });
+    const execPath = el("input", { type: "text", placeholder: "/usr/bin/myapp" });
+    const langSel = el("select", {});
+    const modeSel = el("select", {});
+    const duration = el("input", { type: "number", min: "1", value: "60", required: true });
+
+    const cpuLangs = (caps && caps.cpu_supported_languages) || [];
+    const memLangs = (caps && caps.memory_supported_languages) || [];
+    const modes = (caps && caps.memory_modes) || {};
+
+    function refreshControls() {
+      const t = typeSel.value;
+      langSel.innerHTML = "";
+      modeSel.innerHTML = "";
+      const langs = t === "memory" ? memLangs : cpuLangs;
+      for (const l of langs) langSel.appendChild(el("option", { value: l }, l));
+      if (t === "memory") {
+        for (const [display, internal] of Object.entries(modes)) {
+          modeSel.appendChild(el("option", { value: display }, display));
+        }
+      }
+    }
+    typeSel.addEventListener("change", refreshControls);
+    refreshControls();
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      const btn = form.querySelector("button[type=submit]");
+      btn.disabled = true;
+      try {
+        const body = {
+          hostname: host.value.trim(),
+          container: container.value.trim(),
+          duration: Number(duration.value),
+          type: typeSel.value,
+        };
+        if (typeSel.value === "cpu") {
+          body.target_exec_path = execPath.value.trim();
+          body.target_process_language = langSel.value;
+        } else {
+          body.target_process_language = langSel.value;
+          body.memory_mode = modeSel.value;
+        }
+        await api("/v1/profiles", { method: "POST", body });
+        toast("Profiling job created", "success");
+        form.reset();
+        refreshControls();
+      } catch (err) {
+        toast(err.message, "error");
+      } finally {
+        btn.disabled = false;
+      }
+    } });
+
+    const grid = el("div", { class: "grid grid-4" });
+    grid.appendChild(fieldWrap("Host", host));
+    grid.appendChild(fieldWrap("Container", container));
+    grid.appendChild(fieldWrap("Profile type", typeSel));
+    grid.appendChild(fieldWrap("Duration (s)", duration));
+    grid.appendChild(fieldWrap("Executable path", execPath, "CPU profiling target executable."));
+    grid.appendChild(fieldWrap("Language", langSel));
+    grid.appendChild(fieldWrap("Memory mode", modeSel, "Only used for memory profiling."));
+    form.appendChild(grid);
+    form.appendChild(el("div", { class: "form-actions" }, el("button", { class: "btn btn-primary", type: "submit" }, "Start profiling")));
+    card.replaceChildren(el("p", { class: "card-title" }, "Start profiling"), form);
+    return card;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Shared job list with stop/delete                                    */
+  /* ------------------------------------------------------------------ */
+
+  function renderJobList(host, title, items, opts) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, title));
+    if (!items.length) {
+      card.appendChild(emptyState("No jobs yet."));
+      host.replaceChildren(card);
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "ID"), el("th", {}, "Host"), el("th", {}, "Status"), el("th", {}, "Started"), el("th", {}, "Result"), el("th", {}, "Actions"))));
+    const tbody = el("tbody");
+    for (const job of items) {
+      const status = String(job.status).toLowerCase();
+      const isActive = status === "running" || status === "pending";
+      const resultUrl = job.results && job.results.url;
+      const actions = el("div", { class: "row" });
+      if (isActive) {
+        actions.appendChild(el("button", { class: "btn btn-ghost btn-sm", onclick: () => opts.onStop(job) }, "Stop"));
+      }
+      actions.appendChild(el("button", { class: "btn btn-danger btn-sm", onclick: () => opts.onDelete(job) }, "Delete"));
+      const resultCell = resultUrl
+        ? el("a", { class: "btn btn-ghost btn-sm", href: resultUrl, target: "_blank", rel: "noopener" }, "Open")
+        : el("span", { class: "badge badge-muted" }, "-");
+      tbody.appendChild(el("tr", {}, el("td", { class: "mono" }, job.id), el("td", {}, job.hostname || "-"), el("td", { html: statusBadge(job.status) }), el("td", {}, relativeTime(job.start_time)), el("td", {}, resultCell), el("td", {}, actions)));
+    }
+    table.appendChild(tbody);
+    card.appendChild(table);
+    host.replaceChildren(card);
+  }
+
+  function stopJob(base) {
+    return async (job) => {
+      try {
+        await api(base + "/" + encodeURIComponent(job.id), { method: "PATCH", body: { status: "stopped" } });
+        toast("Job " + job.id + " stop requested", "success");
+        route();
+      } catch (err) {
+        toast(err.message, "error");
+      }
+    };
+  }
+
+  function deleteJob(base) {
+    return async (job) => {
+      if (!confirm("Delete job " + job.id + "?")) return;
+      try {
+        await api(base + "/" + encodeURIComponent(job.id), { method: "DELETE" });
+        toast("Job " + job.id + " deleted", "success");
+        route();
+      } catch (err) {
+        toast(err.message, "error");
+      }
+    };
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Metrics view                                                        */
+  /* ------------------------------------------------------------------ */
+
+  async function renderMetrics(root) {
+    root.appendChild(pageHeader("Metrics", "Prometheus exposition surface scraped from /metrics."));
+    const toolbar = el("div", { class: "toolbar" });
+    const refresh = el("button", { class: "btn btn-ghost btn-sm", onclick: load }, "Refresh");
+    const filter = el("input", { type: "text", placeholder: "filter metric families" });
+    toolbar.appendChild(el("label", {}, "Filter", filter));
+    toolbar.appendChild(el("span", { class: "spacer" }));
+    toolbar.appendChild(refresh);
+    root.appendChild(toolbar);
+
+    const host = el("div", { class: "section" });
+    root.appendChild(host);
+
+    async function load() {
+      try {
+        const text = await api("/metrics");
+        const families = parsePrometheus(text);
+        const needle = filter.value.trim().toLowerCase();
+        const rows = needle ? families.filter((f) => f.name.toLowerCase().includes(needle)) : families;
+        renderMetricsTable(host, rows, text);
+      } catch (err) {
+        host.replaceChildren(alertBox("Failed to load metrics: " + err.message, "error"));
+      }
+    }
+    filter.addEventListener("input", load);
+    pollEvery(load, 10000);
+  }
+
+  function parsePrometheus(text) {
+    const families = [];
+    let current = null;
+    for (const line of text.split("\n")) {
+      if (!line) continue;
+      if (line.startsWith("# HELP ")) {
+        const rest = line.slice(8);
+        const sp = rest.indexOf(" ");
+        const name = rest.slice(0, sp);
+        const help = rest.slice(sp + 1);
+        current = { name, help, samples: [] };
+        families.push(current);
+      } else if (line.startsWith("# TYPE ") || line.startsWith("#")) {
+        continue;
+      } else {
+        const m = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+([-+eE0-9.]+)/);
+        if (m) {
+          if (!current || current.name.split("_")[0] !== m[1].split("_")[0]) {
+            // best-effort grouping
+          }
+          const fam = families.find((f) => f.name === m[1]) || (() => {
+            const f = { name: m[1], help: "", samples: [] };
+            families.push(f);
+            return f;
+          })();
+          fam.samples.push({ labels: m[2] || "", value: m[3] });
+        }
+      }
+    }
+    return families.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  function renderMetricsTable(host, families, raw) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, families.length + " metric families"));
+    if (!families.length) {
+      card.appendChild(emptyState("No metric families match the filter."));
+      host.replaceChildren(card);
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "Metric"), el("th", {}, "Help"), el("th", {}, "Samples"))));
+    const tbody = el("tbody");
+    for (const f of families) {
+      tbody.appendChild(el("tr", {}, el("td", { class: "mono" }, f.name), el("td", {}, escapeHtml(f.help)), el("td", {}, String(f.samples.length))));
+    }
+    table.appendChild(tbody);
+    card.appendChild(table);
+    card.appendChild(el("div", { class: "row", style: "margin-top:12px;justify-content:flex-end" }, el("a", { class: "btn btn-ghost btn-sm", href: "/metrics", target: "_blank" }, "Open raw /metrics")));
+    host.replaceChildren(card);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Access Control view (RBAC)                                          */
+  /* ------------------------------------------------------------------ */
+
+  async function renderAccess(root) {
+    root.appendChild(pageHeader("Access Control", "Manage users, roles and API keys."));
+
+    root.appendChild(buildCreateUserForm());
+
+    const rolesHost = el("div", { class: "section" });
+    root.appendChild(rolesHost);
+    const usersHost = el("div", { class: "section" });
+    root.appendChild(usersHost);
+
+    async function load() {
+      try {
+        const roles = await api("/v1/roles");
+        renderRoles(rolesHost, roles || []);
+      } catch (err) {
+        rolesHost.replaceChildren(alertBox("Failed to load roles: " + err.message, "error"));
+      }
+      try {
+        const users = await api("/v1/users");
+        renderUsers(usersHost, users || []);
+      } catch (err) {
+        usersHost.replaceChildren(alertBox("Failed to load users: " + err.message, "error"));
+      }
+    }
+    load();
+  }
+
+  function renderRoles(host, roles) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, "Role catalog"));
+    if (!roles.length) {
+      card.appendChild(emptyState("No roles defined."));
+      host.replaceChildren(card);
+      return;
+    }
+    for (const r of roles) {
+      const block = el("div", { class: "section" }, el("div", { class: "row" }, el("strong", {}, r.name), r.is_admin ? el("span", { class: "badge badge-completed" }, "admin") : null), el("div", { class: "metric-label", style: "margin-top:6px" }, r.description || ""));
+      const tags = el("div", { class: "tag-list", style: "margin-top:8px" });
+      for (const p of r.permissions || []) tags.appendChild(el("span", { class: "perm-tag" }, p));
+      block.appendChild(tags);
+      card.appendChild(block);
+    }
+    host.replaceChildren(card);
+  }
+
+  function renderUsers(host, users) {
+    const card = el("section", { class: "card" });
+    card.appendChild(el("p", { class: "card-title" }, "Users & API keys (" + users.length + ")"));
+    if (!users.length) {
+      card.appendChild(emptyState("No users configured."));
+      host.replaceChildren(card);
+      return;
+    }
+    const table = el("table", { class: "data" });
+    table.appendChild(el("thead", {}, el("tr", {}, el("th", {}, "Name"), el("th", {}, "ID"), el("th", {}, "Role"), el("th", {}, "Permissions"), el("th", {}, "Actions"))));
+    const tbody = el("tbody");
+    for (const u of users) {
+      const actions = el("div", { class: "row" });
+      if (u.id !== state.user.id) {
+        actions.appendChild(el("button", { class: "btn btn-danger btn-sm", onclick: () => deleteUser(u) }, "Revoke"));
+      } else {
+        actions.appendChild(el("span", { class: "badge badge-muted" }, "you"));
+      }
+      const perms = el("div", { class: "tag-list" });
+      if (u.is_admin) {
+        perms.appendChild(el("span", { class: "perm-tag" }, "admin (all)"));
+      } else {
+        for (const p of u.permissions || []) perms.appendChild(el("span", { class: "perm-tag" }, p));
+      }
+      tbody.appendChild(el("tr", {}, el("td", {}, u.name || "-"), el("td", { class: "mono" }, maskKey(u.id)), el("td", {}, u.is_admin ? "admin" : "custom"), el("td", {}, perms), el("td", {}, actions)));
+    }
+    table.appendChild(tbody);
+    card.appendChild(table);
+    host.replaceChildren(card);
+  }
+
+  function maskKey(id) {
+    if (!id) return "-";
+    if (id.length <= 8) return id;
+    return id.slice(0, 4) + "..." + id.slice(-4);
+  }
+
+  function buildCreateUserForm() {
+    const card = panel("Provision API key", []);
+    const name = el("input", { type: "text", required: true, placeholder: "display name" });
+    const roleSel = el("select", {});
+    roleSel.appendChild(el("option", { value: "viewer" }, "viewer"));
+    roleSel.appendChild(el("option", { value: "operator" }, "operator"));
+    roleSel.appendChild(el("option", { value: "admin" }, "admin"));
+    const generate = el("input", { type: "checkbox", checked: true });
+    const resultBox = el("div");
+
+    const form = el("form", { class: "form-grid", onsubmit: async (e) => {
+      e.preventDefault();
+      resultBox.innerHTML = "";
+      const btn = form.querySelector("button[type=submit]");
+      btn.disabled = true;
+      try {
+        const role = roleSel.value;
+        const body = { name: name.value.trim(), generate_key: generate.checked };
+        if (role === "admin") {
+          body.is_admin = true;
+        } else {
+          const catalog = await loadRoleCatalog();
+          const tmpl = (catalog || []).find((r) => r.name === role);
+          body.is_admin = false;
+          body.permissions = tmpl ? tmpl.permissions : [];
+        }
+        const created = await api("/v1/users", { method: "POST", body });
+        toast("API key created", "success");
+        resultBox.appendChild(alertBox("Store this key securely. It will not be shown again.", "success"));
+        resultBox.appendChild(el("div", { class: "code-block" }, created.id));
+        form.reset();
+        generate.checked = true;
+        route();
+      } catch (err) {
+        toast(err.message, "error");
+        resultBox.appendChild(alertBox(err.message, "error"));
+      } finally {
+        btn.disabled = false;
+      }
+    } });
+
+    const grid = el("div", { class: "grid grid-3" });
+    grid.appendChild(fieldWrap("Name", name));
+    grid.appendChild(fieldWrap("Role", roleSel));
+    grid.appendChild(fieldWrap("Generate key", generate, "Generate a random secret API key."));
+    form.appendChild(grid);
+    form.appendChild(el("div", { class: "form-actions" }, el("button", { class: "btn btn-primary", type: "submit" }, "Create API key")));
+    form.appendChild(resultBox);
+    card.replaceChildren(el("p", { class: "card-title" }, "Provision API key"), form);
+    return card;
+  }
+
+  let roleCatalogCache = null;
+  async function loadRoleCatalog() {
+    if (roleCatalogCache) return roleCatalogCache;
+    try {
+      roleCatalogCache = await api("/v1/roles");
+    } catch {
+      roleCatalogCache = [];
+    }
+    return roleCatalogCache;
+  }
+
+  async function deleteUser(u) {
+    if (!confirm("Revoke API key for " + (u.name || u.id) + "?")) return;
+    try {
+      await api("/v1/users/" + encodeURIComponent(u.id), { method: "DELETE" });
+      toast("API key revoked", "success");
+      route();
+    } catch (err) {
+      toast(err.message, "error");
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Field helper                                                        */
+  /* ------------------------------------------------------------------ */
+
+  function fieldWrap(labelText, control, hint) {
+    const f = el("div", { class: "field" });
+    f.appendChild(el("label", {}, labelText));
+    f.appendChild(control);
+    if (hint) f.appendChild(el("div", { class: "hint" }, hint));
+    return f;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Go                                                                  */
+  /* ------------------------------------------------------------------ */
+
+  bootstrap();
+})();

--- a/cmd/huatuo-apiserver/handlers/console/web/index.html
+++ b/cmd/huatuo-apiserver/handlers/console/web/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HuaTuo Console</title>
+    <link rel="stylesheet" href="assets/app.css" />
+  </head>
+  <body>
+    <div id="app" class="app">
+      <header class="topbar" hidden>
+        <div class="topbar-brand">
+          <span class="logo">HuaTuo</span>
+          <span class="logo-sub">Console</span>
+        </div>
+        <nav class="nav" id="nav"></nav>
+        <div class="topbar-user">
+          <span id="user-badge" class="user-badge"></span>
+          <button id="logout-btn" class="btn btn-ghost" type="button">Sign out</button>
+        </div>
+      </header>
+
+      <main id="view" class="view"></main>
+
+      <footer class="footer">
+        <span id="server-version"></span>
+      </footer>
+    </div>
+
+    <script src="assets/app.js"></script>
+  </body>
+</html>

--- a/cmd/huatuo-apiserver/handlers/server.go
+++ b/cmd/huatuo-apiserver/handlers/server.go
@@ -15,9 +15,11 @@
 package handlers
 
 import (
+	"net/http"
 	"time"
 
 	"huatuo-bamai/cmd/huatuo-apiserver/config"
+	"huatuo-bamai/cmd/huatuo-apiserver/handlers/console"
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers/profiling"
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers/trace"
 	"huatuo-bamai/internal/job"
@@ -42,13 +44,25 @@ func ServerStart(opts ServerOptions) error {
 		EnablePProf:     false,
 		EnableRateLimit: false,
 		AuthUsers:       getUserConfigs(),
-		PromReg:         opts.PromReg,
-		VersionInfo:     opts.VersionInfo,
+		// The web console and the root redirect are reachable without a
+		// credential so the login screen can be served before authentication.
+		PublicPaths: []string{"/", "/console"},
+		PromReg:     opts.PromReg,
+		VersionInfo: opts.VersionInfo,
 	})
+
+	// Register the console routes (RBAC, system info, API-key management).
+	consoleHandler := console.NewHandler(httpServer.UserManager(), opts.VersionInfo)
+	httpServer.MustRegisterRoutes("/v1", consoleHandler.Handlers)
 
 	// Register trace routes
 	httpServer.MustRegisterRoutes("/v1/traces", trace.NewHandler(opts.TracingManager).Handlers)
 	httpServer.MustRegisterRoutes("/v1/profiles", profiling.NewHandler(opts.ProfilingManager).Handlers)
+
+	// Serve the embedded web console. The "/console" prefix is in PublicPaths,
+	// so the assets load without authentication; API calls still require a key.
+	httpServer.StaticFS("/console", console.WebFS())
+	httpServer.Redirect("/", "/console/", http.StatusFound)
 
 	_ = httpServer.Run(&server.Option{
 		Addr:          opts.Addr,

--- a/cmd/huatuo-apiserver/handlers/server.go
+++ b/cmd/huatuo-apiserver/handlers/server.go
@@ -17,7 +17,10 @@ package handlers
 import (
 	"context"
 	"errors"
+	"net/http"
 
+	v1 "huatuo-bamai/apis/v1"
+	"huatuo-bamai/cmd/huatuo-apiserver/handlers/console"
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers/profiling"
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers/trace"
 	"huatuo-bamai/internal/job"
@@ -39,6 +42,7 @@ type ServerOptions struct {
 	VersionInfo     *version.Info
 	RateLimit       *server.RateLimitConfig
 	Ready           func(context.Context) error
+	SystemLimits    v1.SystemLimits
 }
 
 // Start starts the API service with the given configuration.
@@ -54,6 +58,7 @@ func Start(opts *ServerOptions) (*server.Server, error) {
 		EnablePProf: opts.EnablePProf,
 		RateLimit:   opts.RateLimit,
 		AuthUsers:   opts.AuthUsers,
+		PublicPaths: []string{"/", "/console", "/console/**"},
 		AdminPaths: []string{
 			"/v1/profiles/flamegraph/**",
 		},
@@ -61,6 +66,10 @@ func Start(opts *ServerOptions) (*server.Server, error) {
 		VersionInfo: opts.VersionInfo,
 		Ready:       opts.Ready,
 	})
+
+	// Register the console routes (RBAC, system info, API-key management).
+	consoleHandler := console.NewHandler(httpServer.UserManager(), opts.VersionInfo, opts.SystemLimits)
+	httpServer.MustRegisterRoutes("/v1", consoleHandler.Handlers)
 
 	// Register trace routes
 	httpServer.MustRegisterRoutes(
@@ -76,6 +85,9 @@ func Start(opts *ServerOptions) (*server.Server, error) {
 		).Handlers
 	}
 	httpServer.MustRegisterRoutes("/v1/profiles", profileHandlers)
+
+	httpServer.StaticFS("/console", console.WebFS())
+	httpServer.Redirect("/", "/console/", http.StatusFound)
 
 	if err := httpServer.Start(opts.Addr); err != nil {
 		return nil, err

--- a/cmd/huatuo-apiserver/server.go
+++ b/cmd/huatuo-apiserver/server.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/cmd/huatuo-apiserver/config"
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers"
 	"huatuo-bamai/cmd/huatuo-apiserver/handlers/profiling"
@@ -36,6 +37,12 @@ func startHandlers(_ context.Context, d *Daemon) (func(context.Context) error, e
 		PromReg:        d.metrics,
 		JobManager:     d.jobManager,
 		ProfileService: profileQueryService,
+		SystemLimits: v1.SystemLimits{
+			MaxProfilingTasksPerHost: d.opts.Config.Jobs.Profiling.MaxConcurrentPerHost,
+			MaxTracingTasksPerHost:   d.opts.Config.Jobs.Tracing.MaxConcurrentPerHost,
+			MaxTotalProfilingTasks:   d.opts.Config.Jobs.Profiling.MaxConcurrent,
+			MaxTotalTracingTasks:     d.opts.Config.Jobs.Tracing.MaxConcurrent,
+		},
 		ProfilingConfig: profiling.Config{
 			AggregationIntervalSeconds:     d.opts.Config.Profiling.AggregationIntervalSeconds,
 			MaxConcurrentProfilerProcesses: d.opts.Config.Profiling.MaxConcurrentProfilerProcesses,

--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -115,6 +115,21 @@
 #     IsAdmin     = false
 #     Permissions = ["/v1/traces", "/v1/traces/**", "/v1/profiles", "/v1/profiles/**"]
 
+# Web console.
+#
+# The apiserver ships an embedded web console at /console that unifies the
+# Metrics, Event Tracing and Profiling modules and provides access control
+# (RBAC) and collection-task management. It is served without authentication
+# so the login screen can load; all API calls still require an API key.
+#
+# Provisioning API keys:
+#   - Pre-declare users in the [[Auth.users]] blocks above, or
+#   - Sign in as an administrator and use the "Access Control" view to create
+#     and revoke API keys (kept in memory for the lifetime of the process).
+#
+# To open the console, point a browser at:
+#   http://<apiserver-host>:12740/console/
+
 # Profiling configuration.
 #
 # - CPUProfilingInterval

--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -154,6 +154,21 @@
     #         "GET /v1/profiles/**",
     #     ]
 
+# Web console.
+#
+# The apiserver ships an embedded web console at /console that unifies the
+# Metrics, Event Tracing and Profiling modules and provides access control
+# (RBAC) and collection-task management. It is served without authentication
+# so the login screen can load; all API calls still require an API key.
+#
+# Provisioning API keys:
+#   - Pre-declare users in the [[Auth.users]] blocks above, or
+#   - Sign in as an administrator and use the "Access Control" view to create
+#     and revoke API keys (kept in memory for the lifetime of the process).
+#
+# To open the console, point a browser at:
+#   http://<apiserver-host>:12740/console/
+
 # Profiling subprocess configuration.
 [Profiling]
     # - AggregationIntervalSeconds

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -17,6 +17,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 
@@ -45,6 +46,17 @@ type UserConfig struct {
 // authService handles authentication and authorization.
 type authService struct {
 	users sync.Map
+}
+
+// UserManager exposes the operations the console uses to administer the
+// in-memory user/API-key registry. Methods are safe for concurrent use.
+type UserManager interface {
+	ListUsers() []User
+	Add(user User)
+	Delete(userID string)
+	GetUserById(userID string) (User, bool)
+	Validate(userID, path string) error
+	IsAdmin(userID string) bool
 }
 
 // NewService creates a new auth authService.
@@ -76,6 +88,17 @@ func (s *authService) Add(user User) {
 // Delete removes a user from the authService.
 func (s *authService) Delete(userID string) {
 	s.users.Delete(userID)
+}
+
+// ListUsers returns all registered users in a stable, id-sorted order.
+func (s *authService) ListUsers() []User {
+	users := make([]User, 0)
+	s.users.Range(func(_, value any) bool {
+		users = append(users, value.(User))
+		return true
+	})
+	sort.Slice(users, func(i, j int) bool { return users[i].ID < users[j].ID })
+	return users
 }
 
 // GetUserById gets a user by ID.
@@ -167,8 +190,15 @@ func (s *authService) matchesSegments(permission, path string) bool {
 }
 
 // NewAuthMiddleware returns a HandlerContextFunc that validates requests using the given authService.
-func NewAuthMiddleware(svc *authService) HandlerContextFunc {
+// Requests whose path matches one of publicPaths (exact match or prefix + "/")
+// bypass authentication so that public assets such as the web console can be
+// served without credentials.
+func NewAuthMiddleware(svc *authService, publicPaths []string) HandlerContextFunc {
 	return func(ctx *Context) {
+		if isPublicPath(ctx.Request().URL.Path, publicPaths) {
+			ctx.Next()
+			return
+		}
 		userID := ctx.Request().Header.Get("Authorization")
 		if userID == "" {
 			response.ErrorWithCode(ctx, http.StatusUnauthorized, response.ErrUnauthorized.Code, "missing user ID")
@@ -184,4 +214,18 @@ func NewAuthMiddleware(svc *authService) HandlerContextFunc {
 		ctx.IsAdmin = svc.IsAdmin(userID)
 		ctx.Next()
 	}
+}
+
+// isPublicPath reports whether path is exempt from authentication. A path is
+// public when it equals a configured prefix exactly or starts with prefix+"/".
+func isPublicPath(path string, publicPaths []string) bool {
+	for _, prefix := range publicPaths {
+		if prefix == "" {
+			continue
+		}
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -17,6 +17,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 
@@ -29,6 +30,7 @@ type Permission string
 // User represents a user with permissions.
 type User struct {
 	ID          string
+	Name        string
 	Permissions []Permission
 	IsAdmin     bool
 }
@@ -36,6 +38,7 @@ type User struct {
 // UserConfig represents a user configuration for initialization.
 type UserConfig struct {
 	ID          string
+	Name        string
 	BearerToken string
 	Permissions []string
 	IsAdmin     bool
@@ -44,11 +47,23 @@ type UserConfig struct {
 // authService handles authentication and authorization.
 type authService struct {
 	usersByToken sync.Map
+	usersByID    sync.Map
+	tokensByID   sync.Map
+}
+
+// UserManager exposes the operations the console uses to administer the
+// in-memory user/API-key registry. Methods are safe for concurrent use.
+type UserManager interface {
+	ListUsers() []User
+	Add(user User)
+	Delete(userID string)
+	GetUserById(userID string) (User, bool)
+	IsAdmin(userID string) bool
 }
 
 // NewService creates a new auth authService.
 func NewAuthService(users []UserConfig) *authService {
-	s := &authService{usersByToken: sync.Map{}}
+	s := &authService{}
 
 	for _, cfgUser := range users {
 		permissions := make([]Permission, 0, len(cfgUser.Permissions))
@@ -56,11 +71,19 @@ func NewAuthService(users []UserConfig) *authService {
 			permissions = append(permissions, Permission(p))
 		}
 
-		s.usersByToken.Store(cfgUser.BearerToken, User{
+		token := cfgUser.BearerToken
+		if token == "" {
+			token = cfgUser.ID
+		}
+		user := User{
 			ID:          cfgUser.ID,
+			Name:        cfgUser.Name,
 			Permissions: permissions,
 			IsAdmin:     cfgUser.IsAdmin,
-		})
+		}
+		s.usersByID.Store(user.ID, user)
+		s.usersByToken.Store(token, user)
+		s.tokensByID.Store(user.ID, token)
 	}
 
 	return s
@@ -73,6 +96,47 @@ func (s *authService) Authenticate(token string) (User, bool) {
 		return User{}, false
 	}
 	return value.(User), true
+}
+
+// Add adds a user to the authService.
+func (s *authService) Add(user User) {
+	s.usersByID.Store(user.ID, user)
+	s.usersByToken.Store(user.ID, user)
+	s.tokensByID.Store(user.ID, user.ID)
+}
+
+// Delete removes a user from the authService.
+func (s *authService) Delete(userID string) {
+	_, exists := s.usersByID.LoadAndDelete(userID)
+	if token, tokenExists := s.tokensByID.LoadAndDelete(userID); exists && tokenExists {
+		s.usersByToken.Delete(token.(string))
+	}
+}
+
+// ListUsers returns all registered users in a stable, id-sorted order.
+func (s *authService) ListUsers() []User {
+	users := make([]User, 0)
+	s.usersByID.Range(func(_, value any) bool {
+		users = append(users, value.(User))
+		return true
+	})
+	sort.Slice(users, func(i, j int) bool { return users[i].ID < users[j].ID })
+	return users
+}
+
+// GetUserById gets a user by ID.
+func (s *authService) GetUserById(userID string) (User, bool) {
+	value, exists := s.usersByID.Load(userID)
+	if !exists {
+		return User{}, false
+	}
+	return value.(User), true
+}
+
+// IsAdmin reports whether the identified user has administrator access.
+func (s *authService) IsAdmin(userID string) bool {
+	user, exists := s.GetUserById(userID)
+	return exists && user.IsAdmin
 }
 
 // Validate validates if a user has access to a specific path.
@@ -164,7 +228,7 @@ func NewAuthMiddleware(svc *authService, pathSets ...[]string) HandlerContextFun
 	}
 	return func(ctx *Context) {
 		path := ctx.Request().URL.Path
-		if matchesAnyPath(svc, publicPaths, path) {
+		if isPublicPath(path, publicPaths) {
 			ctx.Next()
 			return
 		}
@@ -208,6 +272,18 @@ func bearerToken(header string) string {
 func matchesAnyPath(svc *authService, patterns []string, path string) bool {
 	for _, pattern := range patterns {
 		if svc.matchesPath(pattern, path) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPublicPath(path string, publicPaths []string) bool {
+	for _, prefix := range publicPaths {
+		if prefix == "" {
+			continue
+		}
+		if path == prefix || (prefix != "/" && strings.HasPrefix(path, strings.TrimRight(prefix, "/")+"/")) {
 			return true
 		}
 	}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -337,7 +337,7 @@ func TestNewAuthMiddleware(t *testing.T) {
 
 			engine.GET(
 				"/v1/tasks/:taskID",
-				wrapHandler(NewAuthMiddleware(svc)),
+				wrapHandler(NewAuthMiddleware(svc, nil)),
 				wrapHandler(func(ctx *Context) {
 					handlerRan = true
 					gotUserID = ctx.UserID
@@ -347,7 +347,7 @@ func TestNewAuthMiddleware(t *testing.T) {
 			)
 			engine.GET(
 				"/v1/tasks/:taskID/result",
-				wrapHandler(NewAuthMiddleware(svc)),
+				wrapHandler(NewAuthMiddleware(svc, nil)),
 				wrapHandler(func(ctx *Context) {
 					handlerRan = true
 					gotUserID = ctx.UserID

--- a/internal/server/auth_users_test.go
+++ b/internal/server/auth_users_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httpGin "github.com/gin-gonic/gin"
+)
+
+func TestAuthServiceListUsers(t *testing.T) {
+	svc := NewAuthService([]UserConfig{
+		{ID: "beta-2026", Name: "Beta", IsAdmin: true},
+		{ID: "alpha-2026", Name: "Alpha", Permissions: []string{"/v1/traces"}},
+	})
+
+	users := svc.ListUsers()
+	if len(users) != 2 {
+		t.Fatalf("ListUsers() len = %d, want 2", len(users))
+	}
+	if users[0].ID != "alpha-2026" || users[1].ID != "beta-2026" {
+		t.Errorf("ListUsers() not sorted by ID: %+v", users)
+	}
+}
+
+func TestAuthServiceImplementsUserManager(t *testing.T) {
+	var _ UserManager = (*authService)(nil)
+}
+
+func TestIsPublicPath(t *testing.T) {
+	public := []string{"/", "/console"}
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/", true},
+		{"/console", true},
+		{"/console/", true},
+		{"/console/assets/app.css", true},
+		{"/v1/traces", false},
+		{"/consolefoo", false}, // prefix must be followed by "/"
+		{"/healthz", false},
+	}
+
+	for _, tc := range cases {
+		if got := isPublicPath(tc.path, public); got != tc.want {
+			t.Errorf("isPublicPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestIsPublicPathEmptyPrefix(t *testing.T) {
+	if isPublicPath("/anything", []string{""}) {
+		t.Errorf("empty prefix should not exempt any path")
+	}
+}
+
+func TestNewAuthMiddlewarePublicPathBypass(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	svc := NewAuthService([]UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+
+	var handlerRan bool
+	engine := httpGin.New()
+	engine.GET(
+		"/console/*filepath",
+		wrapHandler(NewAuthMiddleware(svc, []string{"/console"})),
+		wrapHandler(func(ctx *Context) {
+			handlerRan = true
+			ctx.Status(http.StatusNoContent)
+		}),
+	)
+
+	// No Authorization header, but the path is public.
+	request := httptest.NewRequest(http.MethodGet, "/console/assets/app.css", http.NoBody)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Errorf("public path status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	if !handlerRan {
+		t.Errorf("public path handler did not run")
+	}
+}
+
+func TestNewAuthMiddlewareNonPublicStillRequiresAuth(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	svc := NewAuthService([]UserConfig{
+		{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+	})
+
+	engine := httpGin.New()
+	engine.GET(
+		"/v1/users",
+		wrapHandler(NewAuthMiddleware(svc, []string{"/console"})),
+		wrapHandler(func(ctx *Context) {
+			ctx.Status(http.StatusNoContent)
+		}),
+	)
+
+	request := httptest.NewRequest(http.MethodGet, "/v1/users", http.NoBody)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Errorf("protected path without auth status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func buildMiddlewareChain(cfg *Config) []httpGin.HandlerFunc {
+func buildMiddlewareChain(cfg *Config, authService *authService) []httpGin.HandlerFunc {
 	chain := []httpGin.HandlerFunc{
 		middlewareContext(),
 		maxBodyBytesMiddleware(cfg.MaxBodyBytes),
@@ -41,7 +41,6 @@ func buildMiddlewareChain(cfg *Config) []httpGin.HandlerFunc {
 		chain = append(chain, newHTTPMetricsMiddleware(cfg.PromReg))
 	}
 	if cfg.RequireAuth || len(cfg.AuthUsers) > 0 {
-		authService := NewAuthService(cfg.AuthUsers)
 		publicPaths := append(
 			[]string{"/healthz", "/readyz", "/metrics", "/version"},
 			cfg.PublicPaths...,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"syscall"
@@ -41,9 +42,13 @@ type Config struct {
 	RateBurst       int
 	EnableRetry     bool
 	AuthUsers       []UserConfig
-	PromReg         *prometheus.Registry
-	Group           string
-	VersionInfo     *version.Info
+	// PublicPaths are URL path prefixes exempt from authentication. A path is
+	// public when it equals a configured value exactly or starts with value+"/".
+	// Used to serve the web console and other unauthenticated assets.
+	PublicPaths []string
+	PromReg     *prometheus.Registry
+	Group       string
+	VersionInfo *version.Info
 }
 
 var defaultConfig = &Config{
@@ -61,6 +66,7 @@ type server struct {
 	engine       *httpGin.Engine
 	promRegistry *prometheus.Registry
 	rootGroup    *routerGroup
+	authSvc      *authService
 }
 
 type Option struct {
@@ -94,7 +100,8 @@ func NewServer(cfg *Config) *server {
 
 	if len(cfg.AuthUsers) > 0 {
 		svc := NewAuthService(cfg.AuthUsers)
-		middleWares = append(middleWares, wrapHandler(NewAuthMiddleware(svc)))
+		s.authSvc = svc
+		middleWares = append(middleWares, wrapHandler(NewAuthMiddleware(svc, cfg.PublicPaths)))
 	}
 
 	if cfg.EnableRateLimit {
@@ -161,6 +168,36 @@ func newRateLimitMiddleware(r rate.Limit, burst int) httpGin.HandlerFunc {
 // Group return the cgroup for this httpserver
 func (s *server) Group() *routerGroup {
 	return s.rootGroup
+}
+
+// UserManager returns the user/API-key registry used for authentication, or
+// nil when authentication is disabled. Callers may type-assert against the
+// UserManager interface to administer users and API keys.
+func (s *server) UserManager() UserManager {
+	if s.authSvc == nil {
+		return nil
+	}
+	return s.authSvc
+}
+
+// StaticFS serves files from fsys at the given URL path using gin's StaticFS.
+// relativePath must not contain URL parameters. The handler is registered on
+// the root engine so it participates in the normal routing/middleware chain.
+func (s *server) StaticFS(relativePath string, fsys fs.FS) {
+	s.engine.StaticFS(relativePath, http.FS(fsys))
+}
+
+// Redirect registers a route that performs an HTTP redirect to targetPath.
+func (s *server) Redirect(relativePath, targetPath string, code int) {
+	s.engine.GET(relativePath, func(c *httpGin.Context) {
+		c.Redirect(code, targetPath)
+	})
+}
+
+// HTTPHandler returns the underlying http.Handler. Useful for embedding the
+// server in another process and for in-process testing with httptest.
+func (s *server) HTTPHandler() http.Handler {
+	return s.engine
 }
 
 const (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/http"
 	"sync"
@@ -109,6 +110,7 @@ type Server struct {
 	state           serverState
 	activeExecution *serveExecution
 	config          Config
+	authSvc         *authService
 }
 
 // Start binds addr before returning and serves requests in the background.
@@ -228,8 +230,11 @@ func NewServer(cfg *Config) *Server {
 		promRegistry: effectiveConfig.PromReg,
 		config:       effectiveConfig,
 	}
+	if effectiveConfig.RequireAuth || len(effectiveConfig.AuthUsers) > 0 {
+		s.authSvc = NewAuthService(effectiveConfig.AuthUsers)
+	}
 
-	s.engine.Use(buildMiddlewareChain(&effectiveConfig)...)
+	s.engine.Use(buildMiddlewareChain(&effectiveConfig, s.authSvc)...)
 	if effectiveConfig.EnablePProf {
 		pprof.Register(s.engine)
 	}
@@ -279,6 +284,36 @@ func (s *Server) Group() *routerGroup {
 
 // MethodAny registers a route for all HTTP methods supported by Gin.
 const MethodAny = "*"
+
+// UserManager returns the user/API-key registry used for authentication, or
+// nil when authentication is disabled. Callers may type-assert against the
+// UserManager interface to administer users and API keys.
+func (s *Server) UserManager() UserManager {
+	if s.authSvc == nil {
+		return nil
+	}
+	return s.authSvc
+}
+
+// StaticFS serves files from fsys at the given URL path using gin's StaticFS.
+// relativePath must not contain URL parameters. The handler is registered on
+// the root engine so it participates in the normal routing/middleware chain.
+func (s *Server) StaticFS(relativePath string, fsys fs.FS) {
+	s.engine.StaticFS(relativePath, http.FS(fsys))
+}
+
+// Redirect registers a route that performs an HTTP redirect to targetPath.
+func (s *Server) Redirect(relativePath, targetPath string, code int) {
+	s.engine.GET(relativePath, func(c *httpGin.Context) {
+		c.Redirect(code, targetPath)
+	})
+}
+
+// HTTPHandler returns the underlying http.Handler. Useful for embedding the
+// server in another process and for in-process testing with httptest.
+func (s *Server) HTTPHandler() http.Handler {
+	return s.engine
+}
 
 // Route defines an HTTP route.
 type Route struct {

--- a/internal/server/server_usermanager_test.go
+++ b/internal/server/server_usermanager_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServerUserManagerNilWithoutAuth(t *testing.T) {
+	s := NewServer(nil)
+	if um := s.UserManager(); um != nil {
+		t.Errorf("UserManager() = %v, want nil when auth disabled", um)
+	}
+}
+
+func TestServerUserManagerReturnsConfiguredUsers(t *testing.T) {
+	s := NewServer(&Config{
+		AuthUsers: []UserConfig{
+			{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+			{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/traces"}},
+		},
+	})
+
+	um := s.UserManager()
+	if um == nil {
+		t.Fatalf("UserManager() = nil, want non-nil")
+	}
+	users := um.ListUsers()
+	if len(users) != 2 {
+		t.Fatalf("ListUsers() len = %d, want 2", len(users))
+	}
+	if !um.IsAdmin("admin-2026") {
+		t.Errorf("IsAdmin(admin-2026) = false, want true")
+	}
+	if um.IsAdmin("viewer-2026") {
+		t.Errorf("IsAdmin(viewer-2026) = true, want false")
+	}
+}
+
+func TestServerUserManagerMutationsAreVisibleToAuth(t *testing.T) {
+	s := NewServer(&Config{
+		AuthUsers: []UserConfig{
+			{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+		},
+		PublicPaths: []string{"/console"},
+	})
+	um := s.UserManager()
+
+	// Add a new API key and confirm it is accepted by the middleware.
+	um.Add(User{
+		ID:          "operator-2026",
+		Name:        "Operator",
+		Permissions: []Permission{"/v1/traces"},
+	})
+
+	s.MustRegisterRoutes("/v1/traces", []Handle{
+		{Typ: HttpGet, Uri: "", Handle: func(ctx *Context) error {
+			ctx.Status(http.StatusNoContent)
+			return nil
+		}},
+	})
+
+	cases := []struct {
+		name       string
+		authHeader string
+		target     string
+		wantStatus int
+	}{
+		{name: "new-key-accepted", authHeader: "operator-2026", target: "/v1/traces", wantStatus: http.StatusNoContent},
+		{name: "missing-key-rejected", authHeader: "", target: "/v1/traces", wantStatus: http.StatusUnauthorized},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.target, http.NoBody)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			s.engine.ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+		})
+	}
+
+	// Deleting the key revokes access.
+	um.Delete("operator-2026")
+	req := httptest.NewRequest(http.MethodGet, "/v1/traces", http.NoBody)
+	req.Header.Set("Authorization", "operator-2026")
+	rec := httptest.NewRecorder()
+	s.engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("after delete status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestServerPublicPathServedWithoutAuth(t *testing.T) {
+	s := NewServer(&Config{
+		AuthUsers:   []UserConfig{{ID: "admin-2026", Name: "Admin", IsAdmin: true}},
+		PublicPaths: []string{"/console"},
+	})
+	s.MustRegisterRoutes("", []Handle{
+		{Typ: HttpGet, Uri: "/console", Handle: func(ctx *Context) error {
+			ctx.JSON(http.StatusOK, map[string]string{"ok": "true"})
+			return nil
+		}},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/console", http.NoBody)
+	rec := httptest.NewRecorder()
+	s.engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("public path status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}

--- a/internal/server/server_usermanager_test.go
+++ b/internal/server/server_usermanager_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServerUserManagerNilWithoutAuth(t *testing.T) {
+	s := NewServer(nil)
+	if um := s.UserManager(); um != nil {
+		t.Errorf("UserManager() = %v, want nil when auth disabled", um)
+	}
+}
+
+func TestServerUserManagerReturnsConfiguredUsers(t *testing.T) {
+	s := NewServer(&Config{
+		AuthUsers: []UserConfig{
+			{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+			{ID: "viewer-2026", Name: "Viewer", Permissions: []string{"/v1/traces"}},
+		},
+	})
+
+	um := s.UserManager()
+	if um == nil {
+		t.Fatalf("UserManager() = nil, want non-nil")
+	}
+	users := um.ListUsers()
+	if len(users) != 2 {
+		t.Fatalf("ListUsers() len = %d, want 2", len(users))
+	}
+	if !um.IsAdmin("admin-2026") {
+		t.Errorf("IsAdmin(admin-2026) = false, want true")
+	}
+	if um.IsAdmin("viewer-2026") {
+		t.Errorf("IsAdmin(viewer-2026) = true, want false")
+	}
+}
+
+func TestServerUserManagerMutationsAreVisibleToAuth(t *testing.T) {
+	s := NewServer(&Config{
+		AuthUsers: []UserConfig{
+			{ID: "admin-2026", Name: "Admin", IsAdmin: true},
+		},
+		PublicPaths: []string{"/console"},
+	})
+	um := s.UserManager()
+
+	// Add a new API key and confirm it is accepted by the middleware.
+	um.Add(User{
+		ID:          "operator-2026",
+		Name:        "Operator",
+		Permissions: []Permission{"/v1/traces"},
+	})
+
+	s.MustRegisterRoutes("/v1/traces", []Route{
+		{Method: http.MethodGet, Path: "", Handler: func(ctx *Context) error {
+			ctx.Status(http.StatusNoContent)
+			return nil
+		}},
+	})
+
+	cases := []struct {
+		name       string
+		authHeader string
+		target     string
+		wantStatus int
+	}{
+		{name: "new-key-accepted", authHeader: "Bearer operator-2026", target: "/v1/traces", wantStatus: http.StatusNoContent},
+		{name: "missing-key-rejected", authHeader: "", target: "/v1/traces", wantStatus: http.StatusUnauthorized},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.target, http.NoBody)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rec := httptest.NewRecorder()
+			s.engine.ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+		})
+	}
+
+	// Deleting the key revokes access.
+	um.Delete("operator-2026")
+	req := httptest.NewRequest(http.MethodGet, "/v1/traces", http.NoBody)
+	req.Header.Set("Authorization", "Bearer operator-2026")
+	rec := httptest.NewRecorder()
+	s.engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("after delete status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestServerPublicPathServedWithoutAuth(t *testing.T) {
+	s := NewServer(&Config{
+		AuthUsers:   []UserConfig{{ID: "admin-2026", Name: "Admin", IsAdmin: true}},
+		PublicPaths: []string{"/console"},
+	})
+	s.MustRegisterRoutes("", []Route{
+		{Method: http.MethodGet, Path: "/console", Handler: func(ctx *Context) error {
+			ctx.JSON(http.StatusOK, map[string]string{"ok": "true"})
+			return nil
+		}},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/console", http.NoBody)
+	rec := httptest.NewRecorder()
+	s.engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("public path status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
## Summary

Resolves #330 by adding an embedded web console to `huatuo-apiserver`, covering the three requested capability areas. The console is a dependency-free vanilla JS single-page app embedded into the binary via `//go:embed` (no new external dependencies, no build step), served at `/console`. Console assets are served without authentication so the login screen can load; every API call still requires an API key in the `Authorization` header.

## What's included

### 1. RBAC and API key management
- New endpoints wired under `/v1`:
  - `GET /v1/auth/whoami` — returns the identity (`id`, `name`, `is_admin`, effective permissions) of the caller; powers login verification.
  - `GET /v1/users`, `POST /v1/users`, `DELETE /v1/users/:id` — **admin only** list/provision/revoke of API keys. `POST` generates a cryptographically random, `htk_`-prefixed key (or accepts an explicit id); the current admin cannot revoke their own key.
  - `GET /v1/roles` — returns a role catalog (`admin`, `operator`, `viewer`) with permission templates.
- An **Access Control** view (admin only) lets administrators create/revoke keys, pick a role, and inspect permissions.

### 2. Collection task management
- A unified **Tasks** view aggregates tracing and profiling jobs with status/host filtering and 5s live polling.
- Dedicated **Event Tracing** and **Profiling** views provide create / stop (`PATCH ... status=stopped`) / delete with capabilities-driven form controls (profiling types, languages, memory modes from `/v1/profiles/capabilities`).

### 3. Multi-module integration
- A **Dashboard** surfaces the integrated Metrics, Event Tracing and Profiling modules, scheduling limits, and a running-job overview.
- A **Metrics** view fetches `/metrics` and parses the Prometheus exposition into metric families with a filterable table and a link to the raw endpoint.
- Unified top navigation ties the modules together.

## Backend changes
- `internal/server`: new `UserManager` interface, `server.UserManager()` accessor, configurable `PublicPaths` (exact match or `prefix + "/"`) exempt from auth, plus `StaticFS`, `Redirect`, and `HTTPHandler` helpers; `authService.ListUsers()` added; `NewAuthMiddleware` now takes public paths.
- `cmd/huatuo-apiserver/handlers/console`: new handler package implementing the RBAC/system endpoints and embedding the web assets (`web.go`).
- `cmd/huatuo-apiserver/handlers/server.go`: registers console routes, serves the SPA at `/console`, redirects `/` to `/console/`.
- `apis/v1/types.go`: wire types for users, roles, whoami, and system info.
- `huatuo-apiserver.conf`: documents the web console and API-key provisioning.

## Acceptance criteria
- [x] RBAC permission management is available (users, roles, API keys via console + API, enforced by the existing path-based auth middleware).
- [x] Collection-task CRUD is complete (unified Tasks view + per-module create/stop/delete with monitoring).
- [x] The three modules (Metrics, Event Tracing, Profiling) are integrated in a single frontend with unified navigation and a dashboard.

## Verification
- `go build ./cmd/huatuo-apiserver/... ./internal/server/... ./apis/...` — passes.
- `go vet ./cmd/huatuo-apiserver/... ./internal/server/... ./apis/...` — passes.
- `gofmt` / `goimports -local huatuo-bamai` — clean on all changed files.
- `go test ./cmd/huatuo-apiserver/... ./internal/server/... ./internal/job/...` — passes, including new tests:
  - `internal/server`: `UserManager` accessor, public-path bypass, list users, auth visibility of mutations.
  - `console`: whoami, roles, user CRUD (admin gating, conflict, self-delete guard), system info limits, embedded asset serving without auth — exercised through the real gin engine via `httptest`.

## Notes / assumptions
- The user/API-key registry remains **in-memory** for the lifetime of the process, consistent with the existing `authService`. Console-provisioned keys are therefore reset on restart; pre-declared `[[Auth.users]]` in the config are still honored. Persisting keys to storage is left as future work.
- The frontend is intentionally framework-free (vanilla HTML/CSS/JS) to avoid adding Node build tooling or new Go module dependencies.
- Console-provisioned non-admin users automatically receive the console metadata permissions (`/v1/auth/whoami`, `/v1/system/info`, `/v1/profiles/capabilities`, `/v1/roles`); config-declared users that should use the console must include these patterns explicitly.
- No DCO `Signed-off-by` line is embedded here to avoid hardcoding a personal identity; please add the appropriate sign-off when committing.

The server binary could not be launched end to end in this sandbox (no systemd/cgroups), so runtime verification was performed through in-process `httptest` against the real server engine rather than a live process.