### PR TITLE
fix(dropwatch): correct packet metadata layout

### DIFF
--- a/cmd/dropwatch/bpf_records.go
+++ b/cmd/dropwatch/bpf_records.go
@@ -32,10 +32,10 @@ type packetMeta struct {
 	NetdevFlags         uint32
 	NetdevQueueMapping  uint32
 	DropReason          uint32
-	Type                uint32
 	NetInode            uint32
 	NetdevName          [bpf.NetdevNameLen]byte
 	Comm                [bpf.TaskCommLen]byte
+	_                   [4]byte // tail padding of struct packet_meta (92 -> 96)
 }
 
 type packetRaw struct {
@@ -55,8 +55,16 @@ type dropPacketEvent struct {
 	Stack     [symbol.KsymStackMaxDepth]uint64
 }
 
+// Size checks alone cannot catch a stale field: dropping one u32 while the
+// total stays 96 (absorbed by the C tail padding) shifts every later field,
+// so the per-field offsets are pinned to struct packet_meta in
+// bpf/dropwatch.c as well.
 var (
 	_ = [1]struct{}{}[96-unsafe.Sizeof(packetMeta{})]
+	_ = [1]struct{}{}[52-unsafe.Offsetof(packetMeta{}.DropReason)]
+	_ = [1]struct{}{}[56-unsafe.Offsetof(packetMeta{}.NetInode)]
+	_ = [1]struct{}{}[60-unsafe.Offsetof(packetMeta{}.NetdevName)]
+	_ = [1]struct{}{}[76-unsafe.Offsetof(packetMeta{}.Comm)]
 	_ = [1]struct{}{}[136-unsafe.Sizeof(packetRaw{})]
 	_ = [1]struct{}{}[240-unsafe.Offsetof(dropPacketEvent{}.Stack)]
 )

--- a/cmd/dropwatch/bpf_records_test.go
+++ b/cmd/dropwatch/bpf_records_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The HuaTuo Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"huatuo-bamai/internal/utils/bytesutil"
+)
+
+// TestPacketMetaParse decodes a perf sample laid out exactly like struct
+// packet_meta in bpf/dropwatch.c and checks that every field lands where the
+// kernel wrote it. It fails if the Go mirror drifts from the C layout, e.g.
+// the stale 4-byte Type field that shifted net_inum, dev_name and comm.
+func TestPacketMetaParse(t *testing.T) {
+	buf := make([]byte, 96)
+
+	le := binary.LittleEndian
+	le.PutUint64(buf[0:], 1111)        // ktime_ns
+	le.PutUint64(buf[8:], 2222)        // tgid_pid
+	le.PutUint64(buf[16:], 3333)       // net_cookie
+	le.PutUint64(buf[24:], 4444)       // kfree_skb_addr
+	le.PutUint64(buf[32:], 5555)       // memcg_css_addr
+	le.PutUint32(buf[40:], 7)          // ifindex
+	le.PutUint32(buf[44:], 0x1003)     // dev_flags
+	le.PutUint32(buf[48:], 2)          // queue_mapping
+	le.PutUint32(buf[52:], 6)          // drop_reason
+	le.PutUint32(buf[56:], 4026531840) // net_inum
+	copy(buf[60:], "eth0")             // dev_name[16]
+	copy(buf[76:], "nginx-worker")     // comm[16]
+	// buf[92:96] is the C tail padding, zero.
+
+	var meta packetMeta
+	if err := binary.Read(bytes.NewReader(buf), binary.NativeEndian, &meta); err != nil {
+		t.Fatalf("binary.Read: %v", err)
+	}
+
+	if meta.DropReason != 6 {
+		t.Errorf("DropReason = %d, want 6", meta.DropReason)
+	}
+	if meta.NetInode != 4026531840 {
+		t.Errorf("NetInode = %d, want 4026531840", meta.NetInode)
+	}
+	if got := bytesutil.ToStr(meta.NetdevName[:]); got != "eth0" {
+		t.Errorf("NetdevName = %q, want \"eth0\"", got)
+	}
+	if got := bytesutil.ToStr(meta.Comm[:]); got != "nginx-worker" {
+		t.Errorf("Comm = %q, want \"nginx-worker\"", got)
+	}
+	if meta.KtimeNS != 1111 || meta.TgidPid != 2222 || meta.NetCookie != 3333 ||
+		meta.SkbAddr != 4444 || meta.MemoryCgroupCSSAddr != 5555 {
+		t.Errorf("u64 header fields misparsed: %+v", meta)
+	}
+	if meta.NetdevIfindex != 7 || meta.NetdevFlags != 0x1003 || meta.NetdevQueueMapping != 2 {
+		t.Errorf("netdev fields misparsed: %+v", meta)
+	}
+}

--- a/cmd/dropwatch/bpf_records_test.go
+++ b/cmd/dropwatch/bpf_records_test.go
@@ -29,19 +29,19 @@ import (
 func TestPacketMetaParse(t *testing.T) {
 	buf := make([]byte, 96)
 
-	le := binary.LittleEndian
-	le.PutUint64(buf[0:], 1111)        // ktime_ns
-	le.PutUint64(buf[8:], 2222)        // tgid_pid
-	le.PutUint64(buf[16:], 3333)       // net_cookie
-	le.PutUint64(buf[24:], 4444)       // kfree_skb_addr
-	le.PutUint64(buf[32:], 5555)       // memcg_css_addr
-	le.PutUint32(buf[40:], 7)          // ifindex
-	le.PutUint32(buf[44:], 0x1003)     // dev_flags
-	le.PutUint32(buf[48:], 2)          // queue_mapping
-	le.PutUint32(buf[52:], 6)          // drop_reason
-	le.PutUint32(buf[56:], 4026531840) // net_inum
-	copy(buf[60:], "eth0")             // dev_name[16]
-	copy(buf[76:], "nginx-worker")     // comm[16]
+	native := binary.NativeEndian
+	native.PutUint64(buf[0:], 1111)        // ktime_ns
+	native.PutUint64(buf[8:], 2222)        // tgid_pid
+	native.PutUint64(buf[16:], 3333)       // net_cookie
+	native.PutUint64(buf[24:], 4444)       // kfree_skb_addr
+	native.PutUint64(buf[32:], 5555)       // memcg_css_addr
+	native.PutUint32(buf[40:], 7)          // ifindex
+	native.PutUint32(buf[44:], 0x1003)     // dev_flags
+	native.PutUint32(buf[48:], 2)          // queue_mapping
+	native.PutUint32(buf[52:], 6)          // drop_reason
+	native.PutUint32(buf[56:], 4026531840) // net_inum
+	copy(buf[60:], "eth0")                 // dev_name[16]
+	copy(buf[76:], "nginx-worker")         // comm[16]
 	// buf[92:96] is the C tail padding, zero.
 
 	var meta packetMeta

--- a/cmd/dropwatch/bpf_records_test.go
+++ b/cmd/dropwatch/bpf_records_test.go
@@ -27,21 +27,36 @@ import (
 // kernel wrote it. It fails if the Go mirror drifts from the C layout, e.g.
 // the stale 4-byte Type field that shifted net_inum, dev_name and comm.
 func TestPacketMetaParse(t *testing.T) {
+	const (
+		wantKtimeNS             uint64 = 12_345_678_901_234_567
+		wantTgidPid             uint64 = uint64(4321)<<32 | 8765
+		wantNetCookie           uint64 = 0x0123_4567_89ab_cdef
+		wantSkbAddr             uint64 = 0xffff_8880_1234_5678
+		wantMemoryCgroupCSSAddr uint64 = 0xffff_8880_abcd_ef00
+		wantNetdevIfindex       uint32 = 42
+		wantNetdevFlags         uint32 = 0x1003
+		wantNetdevQueueMapping  uint32 = 17
+		wantDropReason          uint32 = 6
+		wantNetInode            uint32 = 0xf000_0000
+		wantNetdevName                 = "eth0"
+		wantComm                       = "nginx-worker"
+	)
+
 	buf := make([]byte, 96)
 
 	native := binary.NativeEndian
-	native.PutUint64(buf[0:], 1111)        // ktime_ns
-	native.PutUint64(buf[8:], 2222)        // tgid_pid
-	native.PutUint64(buf[16:], 3333)       // net_cookie
-	native.PutUint64(buf[24:], 4444)       // kfree_skb_addr
-	native.PutUint64(buf[32:], 5555)       // memcg_css_addr
-	native.PutUint32(buf[40:], 7)          // ifindex
-	native.PutUint32(buf[44:], 0x1003)     // dev_flags
-	native.PutUint32(buf[48:], 2)          // queue_mapping
-	native.PutUint32(buf[52:], 6)          // drop_reason
-	native.PutUint32(buf[56:], 4026531840) // net_inum
-	copy(buf[60:], "eth0")                 // dev_name[16]
-	copy(buf[76:], "nginx-worker")         // comm[16]
+	native.PutUint64(buf[0:], wantKtimeNS)              // ktime_ns
+	native.PutUint64(buf[8:], wantTgidPid)              // tgid_pid
+	native.PutUint64(buf[16:], wantNetCookie)           // net_cookie
+	native.PutUint64(buf[24:], wantSkbAddr)             // kfree_skb_addr
+	native.PutUint64(buf[32:], wantMemoryCgroupCSSAddr) // memcg_css_addr
+	native.PutUint32(buf[40:], wantNetdevIfindex)       // ifindex
+	native.PutUint32(buf[44:], wantNetdevFlags)         // dev_flags
+	native.PutUint32(buf[48:], wantNetdevQueueMapping)  // queue_mapping
+	native.PutUint32(buf[52:], wantDropReason)          // drop_reason
+	native.PutUint32(buf[56:], wantNetInode)            // net_inum
+	copy(buf[60:], wantNetdevName)                      // dev_name[16]
+	copy(buf[76:], wantComm)                            // comm[16]
 	// buf[92:96] is the C tail padding, zero.
 
 	var meta packetMeta
@@ -49,23 +64,24 @@ func TestPacketMetaParse(t *testing.T) {
 		t.Fatalf("binary.Read: %v", err)
 	}
 
-	if meta.DropReason != 6 {
-		t.Errorf("DropReason = %d, want 6", meta.DropReason)
+	if meta.DropReason != wantDropReason {
+		t.Errorf("DropReason = %d, want %d", meta.DropReason, wantDropReason)
 	}
-	if meta.NetInode != 4026531840 {
-		t.Errorf("NetInode = %d, want 4026531840", meta.NetInode)
+	if meta.NetInode != wantNetInode {
+		t.Errorf("NetInode = %d, want %d", meta.NetInode, wantNetInode)
 	}
-	if got := bytesutil.ToStr(meta.NetdevName[:]); got != "eth0" {
-		t.Errorf("NetdevName = %q, want \"eth0\"", got)
+	if got := bytesutil.ToStr(meta.NetdevName[:]); got != wantNetdevName {
+		t.Errorf("NetdevName = %q, want %q", got, wantNetdevName)
 	}
-	if got := bytesutil.ToStr(meta.Comm[:]); got != "nginx-worker" {
-		t.Errorf("Comm = %q, want \"nginx-worker\"", got)
+	if got := bytesutil.ToStr(meta.Comm[:]); got != wantComm {
+		t.Errorf("Comm = %q, want %q", got, wantComm)
 	}
-	if meta.KtimeNS != 1111 || meta.TgidPid != 2222 || meta.NetCookie != 3333 ||
-		meta.SkbAddr != 4444 || meta.MemoryCgroupCSSAddr != 5555 {
+	if meta.KtimeNS != wantKtimeNS || meta.TgidPid != wantTgidPid || meta.NetCookie != wantNetCookie ||
+		meta.SkbAddr != wantSkbAddr || meta.MemoryCgroupCSSAddr != wantMemoryCgroupCSSAddr {
 		t.Errorf("u64 header fields misparsed: %+v", meta)
 	}
-	if meta.NetdevIfindex != 7 || meta.NetdevFlags != 0x1003 || meta.NetdevQueueMapping != 2 {
+	if meta.NetdevIfindex != wantNetdevIfindex || meta.NetdevFlags != wantNetdevFlags ||
+		meta.NetdevQueueMapping != wantNetdevQueueMapping {
 		t.Errorf("netdev fields misparsed: %+v", meta)
 	}
 }


### PR DESCRIPTION
## Summary

- remove the stale Go-only `Type` field that shifts every packet metadata field after `drop_reason` by four bytes
- mirror the C struct's tail padding explicitly and add compile-time field-offset checks
- add a regression test that decodes a perf sample laid out like `struct packet_meta`

This restores correct `net_namespace_inode`, device name, and task command values, allowing container lookup by network namespace inode to work again.

## Testing

- `go test ./cmd/dropwatch`
- `make check`
- `make unit` *(WSL baseline limitation: `internal/cgroups/TestCgroupInterfaces/CpuUsage` expects cgroup v1 `cpuacct.stat`; the same test fails on unmodified upstream `main` in this environment)*
