### PR TITLE
fix(profiler): account folio rmap page count

### DIFF
--- a/bpf/native_physical_usage.c
+++ b/bpf/native_physical_usage.c
@@ -9,9 +9,58 @@ char __license[] SEC("license") = "GPL";
 DEFINE_PROFILER_PAGE_TRACKING_MAP();
 DEFINE_PROFILER_MAPS(struct profiler_event_base_t);
 
+#define COMPAT_PG_HEAD_BIT 6
+
+struct folio___compat {
+	unsigned long _flags_1;
+	unsigned int _folio_nr_pages;
+	unsigned int _nr_pages;
+} __attribute__((preserve_access_index));
+
+static volatile const bool profiler_folio_npages = false;
+
+static __always_inline s64 profiler_folio_nr_pages(struct folio___compat *folio)
+{
+	unsigned long folio_flags;
+	unsigned long flags_1;
+	u32 nr_pages;
+	u32 order;
+
+	/*
+	 * Upstream v5.10-v6.2 uses page/page hooks and v6.3-v6.7 uses a
+	 * folio/page pair, so the loader only enables this helper for v6.8+.
+	 */
+	/* All v6.8+ layouts keep flags at offset 0; its type changes in v6.18. */
+	if (bpf_probe_read(&folio_flags, sizeof(folio_flags), folio))
+		return 0;
+	/* Every supported layout represents an order-0 folio as one page. */
+	if (!(folio_flags & (1UL << COMPAT_PG_HEAD_BIT)))
+		return 1;
+
+	if (bpf_core_field_exists(folio->_nr_pages)) {
+		/* v6.15-v7.2 with CONFIG_MEMCG or CONFIG_SLAB_OBJ_EXT. */
+		nr_pages = BPF_CORE_READ(folio, _nr_pages);
+	} else if (bpf_core_field_exists(folio->_folio_nr_pages)) {
+		/* v6.8-v6.14 on 64-bit kernels. */
+		nr_pages = BPF_CORE_READ(folio, _folio_nr_pages);
+	} else {
+		/*
+		 * v6.8-v6.14 on 32-bit kernels, or v6.15-v7.2 without
+		 * CONFIG_MEMCG and CONFIG_SLAB_OBJ_EXT.
+		 */
+		if (!bpf_core_field_exists(folio->_flags_1))
+			return 0;
+
+		flags_1 = BPF_CORE_READ(folio, _flags_1);
+		order = flags_1 & 0xff;
+		return 1ULL << order;
+	}
+
+	return nr_pages;
+}
+
 SEC("kprobe/page_add_new_anon_rmap")
-int BPF_KPROBE(trace_page_alloc, struct page *page,
-               struct vm_area_struct *vma, unsigned long address, bool compound)
+int BPF_KPROBE(trace_page_alloc, void *page_or_folio)
 {
 	u64 *transfer_count_ptr;
 	u64 *sample_count_ptrs[2];
@@ -39,9 +88,15 @@ int BPF_KPROBE(trace_page_alloc, struct page *page,
 	if (!event)
 		return 0;
 
-	event->value = 1;
+	if (profiler_folio_npages) {
+		event->value = profiler_folio_nr_pages(page_or_folio);
+		if (event->value <= 0)
+			return 0;
+	} else {
+		event->value = 1;
+	}
 
-	u64 page_addr = (u64)page;
+	u64 page_addr = (u64)page_or_folio;
 	/*
 	 * The hash map stores a value copy, so later event_buf reuse does not
 	 * overwrite the allocation stack saved for this page address.
@@ -55,7 +110,7 @@ int BPF_KPROBE(trace_page_alloc, struct page *page,
 }
 
 SEC("kprobe/page_remove_rmap")
-int BPF_KPROBE(trace_page_free, struct page *page, bool compound)
+int BPF_KPROBE(trace_page_free, void *page_or_folio)
 {
 	u64 *transfer_count_ptr;
 	u64 *sample_count_ptrs[2];
@@ -73,7 +128,7 @@ int BPF_KPROBE(trace_page_free, struct page *page, bool compound)
 	if (!profiler_should_trace(pid_tgid, mem_css))
 		return 0;
 
-	u64 page_addr = (u64)page;
+	u64 page_addr = (u64)page_or_folio;
 	struct profiler_event_base_t *stack_info =
 		bpf_map_lookup_elem(&page_to_stackid, &page_addr);
 	if (!stack_info)
@@ -87,9 +142,27 @@ int BPF_KPROBE(trace_page_free, struct page *page, bool compound)
 	__builtin_memset(event, 0, sizeof(*event));
 
 	profiler_copy_event_base(event, stack_info);
-	event->value = -1;
+	if (profiler_folio_npages) {
+		s64 remaining_pages = stack_info->value;
+		s64 nr_pages = (s32)PT_REGS_PARM3(ctx);
 
-	bpf_map_delete_elem(&page_to_stackid, &page_addr);
+		remaining_pages -= nr_pages;
+		/*
+		 * A large folio can be unmapped in multiple PTE batches. Keep
+		 * its allocation stack until all base pages have been removed.
+		 */
+		if (remaining_pages == 0) {
+			event->value = -nr_pages;
+			bpf_map_delete_elem(&page_to_stackid, &page_addr);
+		} else {
+			event->value = remaining_pages;
+			bpf_map_update_elem(&page_to_stackid, &page_addr, event, COMPAT_BPF_ANY);
+			event->value = -nr_pages;
+		}
+	} else {
+		event->value = -1;
+		bpf_map_delete_elem(&page_to_stackid, &page_addr);
+	}
 
 	SELECT_PROFILER_AB();
 

--- a/cmd/profiler/provider/native_mem_profiler.go
+++ b/cmd/profiler/provider/native_mem_profiler.go
@@ -45,6 +45,11 @@ const (
 	symbolFolioRemoveRmapPtes = "folio_remove_rmap_ptes"
 )
 
+type physicalUsageAttachConfig struct {
+	AttachOpts      []bpf.AttachOption
+	CountFolioPages bool
+}
+
 type memNativeProfiler struct {
 	bpf bpf.BPF
 
@@ -166,16 +171,17 @@ func newNativeMemoryBPFLoadConfig(internalMode profiling.MemoryMode, pid int, cs
 			},
 		}, nil
 	case profiling.MemoryModePhysicalUsage:
-		attachOpts, err := newPhysicalUsageAttachOptions()
+		attachCfg, err := newPhysicalUsageAttachConfig()
 		if err != nil {
 			return nil, err
 		}
 
 		constants["profiler_sampling_prob"] = uint8(probability)
+		constants["profiler_folio_npages"] = attachCfg.CountFolioPages
 		return &nativeMemoryBPFLoadConfig{
 			ObjectFile: "native_physical_usage.o",
 			Constants:  constants,
-			AttachOpts: attachOpts,
+			AttachOpts: attachCfg.AttachOpts,
 		}, nil
 	case profiling.MemoryModePhysicalAlloc:
 		attachOpt, err := newPhysicalAllocAttachOption()
@@ -195,13 +201,6 @@ func newNativeMemoryBPFLoadConfig(internalMode profiling.MemoryMode, pid int, cs
 }
 
 func newPhysicalAllocAttachOption() (bpf.AttachOption, error) {
-	if hasKprobeFunction(symbolPageAddNewAnonRmap) {
-		return bpf.AttachOption{
-			ProgramName: programTracePageAlloc,
-			Symbol:      symbolPageAddNewAnonRmap,
-		}, nil
-	}
-
 	if hasKprobeFunction(symbolFolioAddNewAnonRmap) {
 		return bpf.AttachOption{
 			ProgramName: programTracePageAlloc,
@@ -209,30 +208,50 @@ func newPhysicalAllocAttachOption() (bpf.AttachOption, error) {
 		}, nil
 	}
 
+	if hasKprobeFunction(symbolPageAddNewAnonRmap) {
+		return bpf.AttachOption{
+			ProgramName: programTracePageAlloc,
+			Symbol:      symbolPageAddNewAnonRmap,
+		}, nil
+	}
+
 	return bpf.AttachOption{}, fmt.Errorf("no supported physical alloc kprobe found: tried %s, %s",
 		symbolPageAddNewAnonRmap, symbolFolioAddNewAnonRmap)
 }
 
-func newPhysicalUsageAttachOptions() ([]bpf.AttachOption, error) {
-	if hasKprobeFunction(symbolPageAddNewAnonRmap) && hasKprobeFunction(symbolPageRemoveRmap) {
-		return []bpf.AttachOption{
-			{ProgramName: programTracePageAlloc, Symbol: symbolPageAddNewAnonRmap},
-			{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
-		}, nil
-	}
-
+func newPhysicalUsageAttachConfig() (physicalUsageAttachConfig, error) {
 	if hasKprobeFunction(symbolFolioAddNewAnonRmap) && hasKprobeFunction(symbolFolioRemoveRmapPtes) {
-		return []bpf.AttachOption{
-			{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
-			// folio_remove_rmap_ptes can cover multiple pages; parse nr_pages before
-			// treating a single free event as more than one page.
-			{ProgramName: programTracePageFree, Symbol: symbolFolioRemoveRmapPtes},
+		return physicalUsageAttachConfig{
+			AttachOpts: []bpf.AttachOption{
+				{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+				{ProgramName: programTracePageFree, Symbol: symbolFolioRemoveRmapPtes},
+			},
+			CountFolioPages: true,
 		}, nil
 	}
 
-	return nil, fmt.Errorf("no supported physical usage kprobe pair found: tried %s/%s, %s/%s",
-		symbolPageAddNewAnonRmap, symbolPageRemoveRmap,
-		symbolFolioAddNewAnonRmap, symbolFolioRemoveRmapPtes)
+	if hasKprobeFunction(symbolFolioAddNewAnonRmap) && hasKprobeFunction(symbolPageRemoveRmap) {
+		return physicalUsageAttachConfig{
+			AttachOpts: []bpf.AttachOption{
+				{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+				{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
+			},
+		}, nil
+	}
+
+	if hasKprobeFunction(symbolPageAddNewAnonRmap) && hasKprobeFunction(symbolPageRemoveRmap) {
+		return physicalUsageAttachConfig{
+			AttachOpts: []bpf.AttachOption{
+				{ProgramName: programTracePageAlloc, Symbol: symbolPageAddNewAnonRmap},
+				{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
+			},
+		}, nil
+	}
+
+	return physicalUsageAttachConfig{}, fmt.Errorf("no supported physical usage kprobe pair found: tried %s/%s, %s/%s, %s/%s",
+		symbolFolioAddNewAnonRmap, symbolFolioRemoveRmapPtes,
+		symbolFolioAddNewAnonRmap, symbolPageRemoveRmap,
+		symbolPageAddNewAnonRmap, symbolPageRemoveRmap)
 }
 
 func (p *memNativeProfiler) ReadDataLoop(ctx context.Context, enqueue func(any)) error {

--- a/cmd/profiler/provider/native_mem_profiler_test.go
+++ b/cmd/profiler/provider/native_mem_profiler_test.go
@@ -23,21 +23,13 @@ import (
 )
 
 func TestNewBpfLoadConfigAttachOpts(t *testing.T) {
-	restore := stubHasKprobeFunction(func(name string) bool {
-		switch name {
-		case symbolPageAddNewAnonRmap, symbolPageRemoveRmap:
-			return true
-		default:
-			return false
-		}
-	})
-	defer restore()
-
 	tests := []struct {
 		name            string
 		mode            profiling.MemoryMode
+		available       map[string]bool
 		wantObject      string
 		wantAttach      []bpf.AttachOption
+		wantConstants   map[string]any
 		wantProbability bool
 	}{
 		{
@@ -49,18 +41,45 @@ func TestNewBpfLoadConfigAttachOpts(t *testing.T) {
 			},
 		},
 		{
-			name:            "physical usage",
-			mode:            profiling.MemoryModePhysicalUsage,
+			name: "physical usage",
+			mode: profiling.MemoryModePhysicalUsage,
+			available: map[string]bool{
+				symbolPageAddNewAnonRmap: true,
+				symbolPageRemoveRmap:     true,
+			},
 			wantObject:      "native_physical_usage.o",
 			wantProbability: true,
 			wantAttach: []bpf.AttachOption{
 				{ProgramName: programTracePageAlloc, Symbol: symbolPageAddNewAnonRmap},
 				{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
 			},
+			wantConstants: map[string]any{
+				"profiler_folio_npages": false,
+			},
 		},
 		{
-			name:            "physical alloc",
-			mode:            profiling.MemoryModePhysicalAlloc,
+			name: "physical usage folio",
+			mode: profiling.MemoryModePhysicalUsage,
+			available: map[string]bool{
+				symbolFolioAddNewAnonRmap: true,
+				symbolFolioRemoveRmapPtes: true,
+			},
+			wantObject:      "native_physical_usage.o",
+			wantProbability: true,
+			wantAttach: []bpf.AttachOption{
+				{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+				{ProgramName: programTracePageFree, Symbol: symbolFolioRemoveRmapPtes},
+			},
+			wantConstants: map[string]any{
+				"profiler_folio_npages": true,
+			},
+		},
+		{
+			name: "physical alloc",
+			mode: profiling.MemoryModePhysicalAlloc,
+			available: map[string]bool{
+				symbolPageAddNewAnonRmap: true,
+			},
 			wantObject:      "native_physical_alloc.o",
 			wantProbability: true,
 			wantAttach: []bpf.AttachOption{
@@ -72,6 +91,11 @@ func TestNewBpfLoadConfigAttachOpts(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			restore := stubHasKprobeFunction(func(name string) bool {
+				return tc.available[name]
+			})
+			defer restore()
+
 			cfg, err := newNativeMemoryBPFLoadConfig(tc.mode, 123, 456, true, 42)
 			if err != nil {
 				t.Fatalf("newNativeMemoryBPFLoadConfig() error = %v", err)
@@ -91,6 +115,21 @@ func TestNewBpfLoadConfigAttachOpts(t *testing.T) {
 			}
 			if tc.wantProbability && probability != uint8(42) {
 				t.Fatalf("profiler_sampling_prob = %v, want 42", probability)
+			}
+			for key, want := range tc.wantConstants {
+				if got := cfg.Constants[key]; !reflect.DeepEqual(got, want) {
+					t.Fatalf("Constants[%q] = %#v, want %#v", key, got, want)
+				}
+			}
+			if tc.mode == profiling.MemoryModePhysicalUsage {
+				for _, key := range []string{
+					"profiler_alloc_reads_folio_nr_pages",
+					"profiler_free_has_nr_pages",
+				} {
+					if _, ok := cfg.Constants[key]; ok {
+						t.Fatalf("unexpected obsolete constant %q", key)
+					}
+				}
 			}
 		})
 	}
@@ -133,8 +172,16 @@ func TestNewPhysicalAllocAttachOption(t *testing.T) {
 			want: bpf.AttachOption{ProgramName: programTracePageAlloc, Symbol: symbolPageAddNewAnonRmap},
 		},
 		{
-			name: "folio rmap fallback",
+			name: "folio rmap",
 			available: map[string]bool{
+				symbolFolioAddNewAnonRmap: true,
+			},
+			want: bpf.AttachOption{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+		},
+		{
+			name: "mixed rmap",
+			available: map[string]bool{
+				symbolPageAddNewAnonRmap:  true,
 				symbolFolioAddNewAnonRmap: true,
 			},
 			want: bpf.AttachOption{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
@@ -170,11 +217,11 @@ func TestNewPhysicalAllocAttachOption(t *testing.T) {
 	}
 }
 
-func TestNewPhysicalUsageAttachOptions(t *testing.T) {
+func TestNewPhysicalUsageAttachConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		available map[string]bool
-		want      []bpf.AttachOption
+		want      physicalUsageAttachConfig
 		wantErr   bool
 	}{
 		{
@@ -183,20 +230,67 @@ func TestNewPhysicalUsageAttachOptions(t *testing.T) {
 				symbolPageAddNewAnonRmap: true,
 				symbolPageRemoveRmap:     true,
 			},
-			want: []bpf.AttachOption{
-				{ProgramName: programTracePageAlloc, Symbol: symbolPageAddNewAnonRmap},
-				{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
+			want: physicalUsageAttachConfig{
+				AttachOpts: []bpf.AttachOption{
+					{ProgramName: programTracePageAlloc, Symbol: symbolPageAddNewAnonRmap},
+					{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
+				},
 			},
 		},
 		{
-			name: "folio rmap pair fallback",
+			name: "folio rmap pair",
 			available: map[string]bool{
 				symbolFolioAddNewAnonRmap: true,
 				symbolFolioRemoveRmapPtes: true,
 			},
-			want: []bpf.AttachOption{
-				{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
-				{ProgramName: programTracePageFree, Symbol: symbolFolioRemoveRmapPtes},
+			want: physicalUsageAttachConfig{
+				AttachOpts: []bpf.AttachOption{
+					{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+					{ProgramName: programTracePageFree, Symbol: symbolFolioRemoveRmapPtes},
+				},
+				CountFolioPages: true,
+			},
+		},
+		{
+			name: "mixed folio alloc page free",
+			available: map[string]bool{
+				symbolFolioAddNewAnonRmap: true,
+				symbolPageRemoveRmap:      true,
+			},
+			want: physicalUsageAttachConfig{
+				AttachOpts: []bpf.AttachOption{
+					{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+					{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
+				},
+			},
+		},
+		{
+			name: "prefer folio rmap pair",
+			available: map[string]bool{
+				symbolFolioAddNewAnonRmap: true,
+				symbolFolioRemoveRmapPtes: true,
+				symbolPageRemoveRmap:      true,
+			},
+			want: physicalUsageAttachConfig{
+				AttachOpts: []bpf.AttachOption{
+					{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+					{ProgramName: programTracePageFree, Symbol: symbolFolioRemoveRmapPtes},
+				},
+				CountFolioPages: true,
+			},
+		},
+		{
+			name: "prefer mixed rmap over page rmap",
+			available: map[string]bool{
+				symbolPageAddNewAnonRmap:  true,
+				symbolFolioAddNewAnonRmap: true,
+				symbolPageRemoveRmap:      true,
+			},
+			want: physicalUsageAttachConfig{
+				AttachOpts: []bpf.AttachOption{
+					{ProgramName: programTracePageAlloc, Symbol: symbolFolioAddNewAnonRmap},
+					{ProgramName: programTracePageFree, Symbol: symbolPageRemoveRmap},
+				},
 			},
 		},
 		{
@@ -216,18 +310,18 @@ func TestNewPhysicalUsageAttachOptions(t *testing.T) {
 			})
 			defer restore()
 
-			got, err := newPhysicalUsageAttachOptions()
+			got, err := newPhysicalUsageAttachConfig()
 			if tc.wantErr {
 				if err == nil {
-					t.Fatal("newPhysicalUsageAttachOptions() error = nil, want non-nil")
+					t.Fatal("newPhysicalUsageAttachConfig() error = nil, want non-nil")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("newPhysicalUsageAttachOptions() error = %v", err)
+				t.Fatalf("newPhysicalUsageAttachConfig() error = %v", err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("newPhysicalUsageAttachOptions() = %#v, want %#v", got, tc.want)
+				t.Fatalf("newPhysicalUsageAttachConfig() = %#v, want %#v", got, tc.want)
 			}
 		})
 	}

--- a/integration/test_profiler_native_mem_physical_usage.sh
+++ b/integration/test_profiler_native_mem_physical_usage.sh
@@ -30,10 +30,12 @@ readonly PROFILER_READY_INTERVAL=1
 [[ -x "${TOOL_BIN}" ]] || fatal "profiler binary missing: ${TOOL_BIN}"
 [[ -r "${ROOT_DIR}/_output/bpf/native_physical_alloc.o" ]] || fatal "native physical alloc bpf object missing"
 [[ -r "${ROOT_DIR}/_output/bpf/native_physical_usage.o" ]] || fatal "native physical usage bpf object missing"
-if kprobe_available page_add_new_anon_rmap && kprobe_available page_remove_rmap; then
-	log_info "using page rmap kprobes"
-elif kprobe_available folio_add_new_anon_rmap && kprobe_available folio_remove_rmap_ptes; then
+if kprobe_available folio_add_new_anon_rmap && kprobe_available folio_remove_rmap_ptes; then
 	log_info "using folio rmap kprobes"
+elif kprobe_available folio_add_new_anon_rmap && kprobe_available page_remove_rmap; then
+	log_info "using mixed folio/page rmap kprobes"
+elif kprobe_available page_add_new_anon_rmap && kprobe_available page_remove_rmap; then
+	log_info "using page rmap kprobes"
 else
 	skip "no supported physical usage kprobe pair found"
 fi


### PR DESCRIPTION
## Summary

  Fix native physical memory profiling across newer rmap hook ABIs by supporting folio page-count accounting and
  mixed folio/page hook pairs.

  ## Problem

  Native physical memory profiling has two rmap ABI compatibility issues:

  ### 1. Folio hooks may represent multiple base pages

  On newer kernels, folio_add_new_anon_rmap() and folio_remove_rmap_ptes() may account for multiple base pages in
  a single event. The previous physical_usage implementation always emitted:

```c
  event->value = 1;
  event->value = -1;
```

  This undercounts large folios and may leave physical usage deltas unbalanced.

  ### 2. Allocation and free hooks may use different ABIs

  Some kernels allocate through folio_add_new_anon_rmap() but still free through page_remove_rmap().

  The previous provider only supported these hook pairs:
  - folio_add_new_anon_rmap() + folio_remove_rmap_ptes()

  As a result, mixed folio/page environments could miss the active allocation hook or fail to select an otherwise
  supported profiling path.

  ## Fix

  ### physical_usage

  physical_usage: Add a loader-selected BPF constant to select folio
  page-count accounting.

  - Folio alloc/free pair:
    - read the folio base-page count on allocation
    - read `nr_pages` from `folio_remove_rmap_ptes()`
    - retain the allocation stack and remaining page count across
      multiple PTE removal batches

  - Mixed folio/page pair:
    - attach `folio_add_new_anon_rmap()` and `page_remove_rmap()`
    - preserve historical `+1/-1` accounting

  - Page/page pair:
    - preserve historical `+1/-1` accounting

  This change covers PTE removal through `folio_remove_rmap_ptes()`.
  PMD/PUD removal hooks are outside the scope of this change.

  The provider now selects the first available hook pair in this order:

  1. folio_add_new_anon_rmap() + folio_remove_rmap_ptes()
  2. folio_add_new_anon_rmap() + page_remove_rmap()
  3. page_add_new_anon_rmap() + page_remove_rmap()

  ### physical_alloc

  Prefer folio_add_new_anon_rmap() when available so allocation events are not missed, while preserving the
  existing single-event accounting behavior.

  ### Tests and integration

  - Add provider unit coverage for folio/folio, folio/page, and page/page hook selection.
  - Update physical usage integration hook detection to follow the provider selection order.

  ## Testing

  - `go test ./cmd/profiler/provider`
  - Rebuilt the BPF objects and profiler binary
  - Linux 7.2 mainline:
    - folio/folio hook pair
    - physical usage integration test passed
  - Linux 6.6.8:
    - mixed folio/page hook pair
    - physical usage integration test passed
  - Ubuntu 24.04 with the 5.10 test kernel:
    - page/page hook pair
    - physical usage integration test passed