### PR TITLE
revert: rollback modify, use time.after for perf

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -318,14 +318,11 @@ func (c *cpuIdleTracing) Start(ctx context.Context) error {
 		return fmt.Errorf("container filter: %w", err)
 	}
 
-	ticker := time.NewTicker(time.Duration(interval) * time.Second)
-	defer ticker.Stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return types.ErrExitByCancelCtx
-		case <-ticker.C:
+		case <-time.After(time.Duration(interval) * time.Second):
 			if err := updateContainersCPUIdle(containerFilter); err != nil {
 				return err
 			}

--- a/core/autotracing/cpusys.go
+++ b/core/autotracing/cpusys.go
@@ -170,14 +170,11 @@ func (c *cpuSysTracing) Start(ctx context.Context) error {
 		usage: cfg.CPUSys.SysThreshold,
 	}
 
-	ticker := time.NewTicker(time.Duration(interval) * time.Second)
-	defer ticker.Stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return types.ErrExitByCancelCtx
-		case <-ticker.C:
+		case <-time.After(time.Duration(interval) * time.Second):
 			if err := c.updateCpuSysUsage(); err != nil {
 				return err
 			}


### PR DESCRIPTION
1. Commit f63d7cc 部分代码回退，之前的修改错误可能出现行为和预期不一致，将 cpusys 和 cpuidle 的周期调度从 time.NewTicker 改为每轮 time.After 等待，使采集完成后才开始下一次 interval，避免 perf 执行超过 interval 时消费积压 tick 并立即触发下一轮采集。
2. 保持现有 context 退出语义不变：等待期间 ctx.Done() 可立即结束循环；每轮仅创建一个 timer，timer 触发并被接收后再进入下一轮，不会因内部 continue 造成未到期 timer 堆积。