### PR TITLE
fix(request): keep response body open for callers

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -87,11 +87,17 @@ func doRequest(req *http.Request) (*ServerResponse, error) {
 	if err != nil {
 		return serverResp, err
 	}
-	defer resp.Body.Close()
+	bodyTransferred := false
+	defer func() {
+		if !bodyTransferred {
+			_ = resp.Body.Close()
+		}
+	}()
 
 	serverResp.StatusCode = resp.StatusCode
 	serverResp.Body = resp.Body
 	serverResp.Header = resp.Header
+	bodyTransferred = true
 
 	return serverResp, nil
 }

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -17,6 +17,7 @@ package request
 import (
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -70,6 +71,58 @@ func TestEncodeBodySetsJSONContentType(t *testing.T) {
 	}
 	if strings.TrimSpace(string(raw)) != `{"name":"cpu"}` {
 		t.Fatalf("body = %q, want JSON object", string(raw))
+	}
+}
+
+func TestDoRequestKeepsSuccessfulResponseBodyOpen(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+
+	resp, err := doRequest(req)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	defer resp.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll(response.Body) error = %v", err)
+	}
+	if got := string(body); got != "ok" {
+		t.Fatalf("response body = %q, want %q", got, "ok")
+	}
+}
+
+func TestDoRequestKeepsErrorResponseBodyOpen(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "backend unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+
+	resp, err := doRequest(req)
+	if err != nil {
+		t.Fatalf("doRequest() error = %v", err)
+	}
+	defer resp.Close()
+
+	err = checkResponseErr(resp)
+	if err == nil {
+		t.Fatal("checkResponseErr() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "backend unavailable") {
+		t.Fatalf("checkResponseErr() error = %q, want response body", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #282

`doRequest` previously deferred `resp.Body.Close()` even after assigning the body to `ServerResponse`, so callers received an already-closed body.

This change transfers response-body ownership to `ServerResponse` after a successful HTTP round trip. It also adds regression coverage for:
- reading a successful response body after `doRequest`
- reading a non-2xx response body through `checkResponseErr`