### PR TITLE
fix(bpf): reject unknown map lookups

### DIFF
--- a/internal/bpf/bpf_default.go
+++ b/internal/bpf/bpf_default.go
@@ -39,6 +39,9 @@ import (
 
 var DefaultObjDir = "bpf"
 
+// ErrMapNotFound indicates that a requested BPF map is unavailable.
+var ErrMapNotFound = errors.New("bpf: map not found")
+
 // NewManager initializes the bpf manager.
 func NewManager(opt *Option) error {
 	return unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
@@ -239,7 +242,7 @@ func (b *defaultBPF) MapIDByName(name string) uint32 {
 func (b *defaultBPF) requireMapIDByName(name string) (uint32, error) {
 	mapID, ok := b.mapName2IDs[name]
 	if !ok {
-		return 0, fmt.Errorf("map %q not found", name)
+		return 0, fmt.Errorf("%w: name %q", ErrMapNotFound, name)
 	}
 
 	return mapID, nil
@@ -248,7 +251,7 @@ func (b *defaultBPF) requireMapIDByName(name string) (uint32, error) {
 func (b *defaultBPF) mapByID(mapID uint32) (*ebpf.Map, error) {
 	spec, ok := b.mapSpecs[mapID]
 	if !ok || spec.cloned == nil {
-		return nil, fmt.Errorf("map %d not found", mapID)
+		return nil, fmt.Errorf("%w: ID %d", ErrMapNotFound, mapID)
 	}
 
 	return spec.cloned, nil

--- a/internal/bpf/bpf_default.go
+++ b/internal/bpf/bpf_default.go
@@ -236,6 +236,24 @@ func (b *defaultBPF) MapIDByName(name string) uint32 {
 	return b.mapName2IDs[name]
 }
 
+func (b *defaultBPF) requireMapIDByName(name string) (uint32, error) {
+	mapID, ok := b.mapName2IDs[name]
+	if !ok {
+		return 0, fmt.Errorf("map %q not found", name)
+	}
+
+	return mapID, nil
+}
+
+func (b *defaultBPF) mapByID(mapID uint32) (*ebpf.Map, error) {
+	spec, ok := b.mapSpecs[mapID]
+	if !ok || spec.cloned == nil {
+		return nil, fmt.Errorf("map %d not found", mapID)
+	}
+
+	return spec.cloned, nil
+}
+
 // ProgIDByName gets progID by Name. Returns 0 if the name does not exist.
 func (b *defaultBPF) ProgIDByName(name string) uint32 {
 	return b.programName2IDs[name]
@@ -643,7 +661,12 @@ func (b *defaultBPF) EventPipe(ctx context.Context, mapID, perCPUBufSize uint32)
 }
 
 func (b *defaultBPF) eventPipe(ctx context.Context, mapID, perCPUBufSize uint32) (PerfEventReader, error) {
-	reader, err := newPerfEventReader(ctx, b.mapSpecs[mapID].cloned, int(perCPUBufSize))
+	m, err := b.mapByID(mapID)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := newPerfEventReader(ctx, m, int(perCPUBufSize))
 	if err != nil {
 		return nil, err
 	}
@@ -659,7 +682,12 @@ func (b *defaultBPF) EventPipeByName(ctx context.Context, mapName string, perCPU
 	}
 	defer b.mu.RUnlock()
 
-	return b.eventPipe(ctx, b.MapIDByName(mapName), perCPUBufSize)
+	mapID, err := b.requireMapIDByName(mapName)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.eventPipe(ctx, mapID, perCPUBufSize)
 }
 
 // AttachAndEventPipe attaches and event-pipe and returns a PerfEventReader.
@@ -697,7 +725,12 @@ func (b *defaultBPF) ReadMap(mapID uint32, key []byte) ([]byte, error) {
 }
 
 func (b *defaultBPF) readMap(mapID uint32, key []byte) ([]byte, error) {
-	val, err := b.mapSpecs[mapID].cloned.LookupBytes(key)
+	m, err := b.mapByID(mapID)
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := m.LookupBytes(key)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +749,10 @@ func (b *defaultBPF) WriteMapItems(mapID uint32, items []MapItem) error {
 }
 
 func (b *defaultBPF) writeMapItems(mapID uint32, items []MapItem) error {
-	m := b.mapSpecs[mapID].cloned
+	m, err := b.mapByID(mapID)
+	if err != nil {
+		return err
+	}
 
 	for _, item := range items {
 		if err := m.Update(item.Key, item.Value, ebpf.UpdateAny); err != nil {
@@ -737,7 +773,10 @@ func (b *defaultBPF) DeleteMapItems(mapID uint32, keys [][]byte) error {
 }
 
 func (b *defaultBPF) deleteMapItems(mapID uint32, keys [][]byte) error {
-	m := b.mapSpecs[mapID].cloned
+	m, err := b.mapByID(mapID)
+	if err != nil {
+		return err
+	}
 
 	for _, k := range keys {
 		if err := m.Delete(k); err != nil {
@@ -758,7 +797,10 @@ func (b *defaultBPF) DumpMap(mapID uint32) ([]MapItem, error) {
 }
 
 func (b *defaultBPF) dumpMap(mapID uint32) ([]MapItem, error) {
-	m := b.mapSpecs[mapID].cloned
+	m, err := b.mapByID(mapID)
+	if err != nil {
+		return nil, err
+	}
 
 	switch m.Type() {
 	case ebpf.PerCPUHash, ebpf.PerCPUArray, ebpf.LRUCPUHash, ebpf.PerCPUCGroupStorage:
@@ -828,7 +870,12 @@ func (b *defaultBPF) DumpMapByName(mapName string) ([]MapItem, error) {
 	}
 	defer b.mu.RUnlock()
 
-	return b.dumpMap(b.MapIDByName(mapName))
+	mapID, err := b.requireMapIDByName(mapName)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.dumpMap(mapID)
 }
 
 // WaitDetachByBreaker check the bpf's status.

--- a/internal/bpf/bpf_default_test.go
+++ b/internal/bpf/bpf_default_test.go
@@ -350,7 +350,8 @@ func TestDefaultBPF_MapOperations(t *testing.T) {
 			name: "Error_InvalidMapID",
 			fn: func(t *testing.T) {
 				err := b.WriteMapItems(99999, []MapItem{{Key: key, Value: val}})
-				assert.EqualError(t, err, "map 99999 not found")
+				require.ErrorIs(t, err, ErrMapNotFound)
+				assert.EqualError(t, err, "bpf: map not found: ID 99999")
 			},
 		},
 	}

--- a/internal/bpf/bpf_default_test.go
+++ b/internal/bpf/bpf_default_test.go
@@ -349,9 +349,8 @@ func TestDefaultBPF_MapOperations(t *testing.T) {
 		{
 			name: "Error_InvalidMapID",
 			fn: func(t *testing.T) {
-				assert.Panics(t, func() {
-					_ = b.WriteMapItems(99999, []MapItem{{Key: key, Value: val}})
-				})
+				err := b.WriteMapItems(99999, []MapItem{{Key: key, Value: val}})
+				assert.EqualError(t, err, "map 99999 not found")
 			},
 		},
 	}

--- a/internal/bpf/map_lookup_test.go
+++ b/internal/bpf/map_lookup_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !didi
+
+package bpf
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestDefaultBPFMapOperationsRejectUnknownMap(t *testing.T) {
+	b := &defaultBPF{
+		mapSpecs:    make(map[uint32]mapSpec),
+		mapName2IDs: make(map[string]uint32),
+	}
+
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{
+			name: "EventPipe",
+			run: func() error {
+				_, err := b.EventPipe(context.Background(), 42, 4096)
+				return err
+			},
+			want: "map 42 not found",
+		},
+		{
+			name: "EventPipeByName",
+			run: func() error {
+				_, err := b.EventPipeByName(context.Background(), "missing", 4096)
+				return err
+			},
+			want: `map "missing" not found`,
+		},
+		{
+			name: "ReadMap",
+			run: func() error {
+				_, err := b.ReadMap(42, nil)
+				return err
+			},
+			want: "map 42 not found",
+		},
+		{
+			name: "WriteMapItems",
+			run: func() error {
+				return b.WriteMapItems(42, nil)
+			},
+			want: "map 42 not found",
+		},
+		{
+			name: "DeleteMapItems",
+			run: func() error {
+				return b.DeleteMapItems(42, nil)
+			},
+			want: "map 42 not found",
+		},
+		{
+			name: "DumpMap",
+			run: func() error {
+				_, err := b.DumpMap(42)
+				return err
+			},
+			want: "map 42 not found",
+		},
+		{
+			name: "DumpMapByName",
+			run: func() error {
+				_, err := b.DumpMapByName("missing")
+				return err
+			},
+			want: `map "missing" not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("map operation error=%v, want error containing %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/bpf/map_lookup_test.go
+++ b/internal/bpf/map_lookup_test.go
@@ -17,8 +17,7 @@
 package bpf
 
 import (
-	"context"
-	"strings"
+	"errors"
 	"testing"
 )
 
@@ -30,70 +29,73 @@ func TestDefaultBPFMapOperationsRejectUnknownMap(t *testing.T) {
 
 	tests := []struct {
 		name string
-		run  func() error
+		run  func(*testing.T) error
 		want string
 	}{
 		{
 			name: "EventPipe",
-			run: func() error {
-				_, err := b.EventPipe(context.Background(), 42, 4096)
+			run: func(t *testing.T) error {
+				_, err := b.EventPipe(t.Context(), 42, 4096)
 				return err
 			},
-			want: "map 42 not found",
+			want: "bpf: map not found: ID 42",
 		},
 		{
 			name: "EventPipeByName",
-			run: func() error {
-				_, err := b.EventPipeByName(context.Background(), "missing", 4096)
+			run: func(t *testing.T) error {
+				_, err := b.EventPipeByName(t.Context(), "missing", 4096)
 				return err
 			},
-			want: `map "missing" not found`,
+			want: `bpf: map not found: name "missing"`,
 		},
 		{
 			name: "ReadMap",
-			run: func() error {
+			run: func(*testing.T) error {
 				_, err := b.ReadMap(42, nil)
 				return err
 			},
-			want: "map 42 not found",
+			want: "bpf: map not found: ID 42",
 		},
 		{
 			name: "WriteMapItems",
-			run: func() error {
+			run: func(*testing.T) error {
 				return b.WriteMapItems(42, nil)
 			},
-			want: "map 42 not found",
+			want: "bpf: map not found: ID 42",
 		},
 		{
 			name: "DeleteMapItems",
-			run: func() error {
+			run: func(*testing.T) error {
 				return b.DeleteMapItems(42, nil)
 			},
-			want: "map 42 not found",
+			want: "bpf: map not found: ID 42",
 		},
 		{
 			name: "DumpMap",
-			run: func() error {
+			run: func(*testing.T) error {
 				_, err := b.DumpMap(42)
 				return err
 			},
-			want: "map 42 not found",
+			want: "bpf: map not found: ID 42",
 		},
 		{
 			name: "DumpMapByName",
-			run: func() error {
+			run: func(*testing.T) error {
 				_, err := b.DumpMapByName("missing")
 				return err
 			},
-			want: `map "missing" not found`,
+			want: `bpf: map not found: name "missing"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.run()
-			if err == nil || !strings.Contains(err.Error(), tt.want) {
-				t.Errorf("map operation error=%v, want error containing %q", err, tt.want)
+			err := tt.run(t)
+			if !errors.Is(err, ErrMapNotFound) {
+				t.Fatalf("map operation error=%v, want errors.Is ErrMapNotFound", err)
+			}
+			if err.Error() != tt.want {
+				t.Errorf("map operation error=%q, want %q", err, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- validate BPF map IDs before dereferencing loaded map specs
- preserve unknown map names in by-name operation errors
- return descriptive errors from event-pipe and map operations instead of panicking
- add regression coverage for unknown name and ID lookups

## Testing

- `make check`
- `go test -race ./internal/bpf -count=1 -timeout=5m`
- `go test -race ./internal/bpf -run '^TestDefaultBPFMapOperationsRejectUnknownMap$' -count=10`
- `make unit` (`internal/bpf` passes; the full target only fails in `internal/cgroups/TestCgroupInterfaces/CpuUsage` because this WSL environment does not expose cgroup v1 `cpuacct.stat`)

Fixes #372