### PR TITLE
fix(autotracing): extend buildDiskMetric counter reset guard to cover all delta fields

### DIFF
--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -210,7 +210,10 @@ func buildDiskMetric(prev, curr *blockdevice.Diskstats, intervalSeconds uint64) 
 	// this guard the reset causes uint64 underflow in the delta below,
 	// producing a fake metric that triggers a false IO alert.
 	if curr.ReadIOs < prev.ReadIOs || curr.WriteIOs < prev.WriteIOs ||
-		curr.IOsTotalTicks < prev.IOsTotalTicks {
+		curr.IOsTotalTicks < prev.IOsTotalTicks ||
+		curr.ReadSectors < prev.ReadSectors || curr.WriteSectors < prev.WriteSectors ||
+		curr.ReadTicks < prev.ReadTicks || curr.WriteTicks < prev.WriteTicks ||
+		curr.WeightedIOTicks < prev.WeightedIOTicks {
 		return DiskStatus{}
 	}
 


### PR DESCRIPTION
## Problem

In `core/autotracing/iotracing.go`, the `buildDiskMetric()` function guards against kernel counter resets (caused by device hotplug, driver rebind, LVM rebuild) by checking if `ReadIOs`, `WriteIOs`, or `IOsTotalTicks` have decreased since the last sample. If any of these reset, it returns an empty `DiskStatus{}` to avoid uint64 underflow.

However, the guard is **incomplete** — it misses 5 other fields that are also used in delta calculations:

| Field | Used at | Underflow risk |
|-------|---------|----------------|
| `ReadSectors` | `curr.ReadSectors - prev.ReadSectors` | Yes → inflated `ReadBps` |
| `WriteSectors` | `curr.WriteSectors - prev.WriteSectors` | Yes → inflated `WriteBps` |
| `ReadTicks` | `curr.ReadTicks - prev.ReadTicks` | Yes → inflated `ReadAwait` |
| `WriteTicks` | `curr.WriteTicks - prev.WriteTicks` | Yes → inflated `WriteAwait` |
| `WeightedIOTicks` | `curr.WeightedIOTicks - prev.WeightedIOTicks` | Yes → inflated `QueueSize` |

When a device is removed and re-registered under the same name, the kernel resets **all** counters to zero. The incomplete guard allows the five unchecked fields to underflow, producing astronomically large values that trigger **false IO alerts**.

## Fix

Extend the existing reset guard to cover all 8 counter fields used in delta calculations:

```go
if curr.ReadIOs < prev.ReadIOs || curr.WriteIOs < prev.WriteIOs ||
    curr.IOsTotalTicks < prev.IOsTotalTicks ||
    curr.ReadSectors < prev.ReadSectors || curr.WriteSectors < prev.WriteSectors ||
    curr.ReadTicks < prev.ReadTicks || curr.WriteTicks < prev.WriteTicks ||
    curr.WeightedIOTicks < prev.WeightedIOTicks {
    return DiskStatus{}
}
```

Fixes #374