### PR TITLE
fix(metrics): guard netdev_hw rx_dropped underflow and protect prog field with mutex

### DIFF
--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -133,7 +133,9 @@ func (netdev *netdevHw) Update() ([]*metric.Data, error) {
 		if count == 0 {
 			// hardware drop = rx_dropped - software_drops
 			if sw, ok := netdev.ifaceSwDroppedCounter[iface]; ok {
-				count = counters["rx_dropped"] - sw
+				if counters["rx_dropped"] >= sw {
+					count = counters["rx_dropped"] - sw
+				}
 			}
 		}
 
@@ -207,7 +209,10 @@ func (netdev *netdevHw) Start(ctx context.Context) error {
 
 	prog.WaitDetachByBreaker(childCtx, cancel)
 
+	netdev.mutex.Lock()
 	netdev.prog = prog
+	netdev.mutex.Unlock()
+
 	netdev.running.Store(true)
 
 	<-childCtx.Done()


### PR DESCRIPTION
## Problem

In `core/metrics/netdev_hw.go`, there are two bugs in the `netdevHw` collector:

### Bug 1: uint64 underflow in rx_dropped calculation

```go
if sw, ok := netdev.ifaceSwDroppedCounter[iface]; ok {
    count = counters["rx_dropped"] - sw
}
```

When the `rx_dropped` sysfs counter resets (device hotplug, driver reload), `counters["rx_dropped"]` may be smaller than `sw`. Since both are `uint64`, the subtraction underflows to a huge value, producing a **false packet loss alert**.

### Bug 2: data race on `netdev.prog` field

The `prog` field is written in `Start()` without holding the mutex:
```go
netdev.prog = prog
```

But `Update()` reads `netdev.prog` (via `updateIfaceSwDroppedStat()`) while holding `netdev.mutex`. Since `Start()` and `Update()` run in separate goroutines, the write races with the read.

## Fix

### Bug 1: Guard against underflow
```go
if counters["rx_dropped"] >= sw {
    count = counters["rx_dropped"] - sw
}
```

### Bug 2: Protect `netdev.prog` with mutex in `Start()`
```go
netdev.mutex.Lock()
netdev.prog = prog
netdev.mutex.Unlock()
```

Fixes #376