### PR TITLE
fix(autotracing): protect containersCPUIdle global map with mutex

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	"huatuo-bamai/internal/cgroups"
@@ -89,13 +90,19 @@ type cpuIdleThreshold struct {
 // containersCPUIdleMap is the container information
 type containersCPUIdleMap map[string]*containerCPUInfo
 
-var containersCPUIdle = make(containersCPUIdleMap)
+var (
+	containersCPUIdle   = make(containersCPUIdleMap)
+	containersCPUIdleMu sync.Mutex
+)
 
 func updateContainersCPUIdle(f *matcher.ContainerMatcher) error {
 	containers, err := pod.NormalContainers()
 	if err != nil {
 		return err
 	}
+
+	containersCPUIdleMu.Lock()
+	defer containersCPUIdleMu.Unlock()
 
 	for _, container := range containers {
 		if !f.Match(container) {
@@ -120,6 +127,9 @@ func updateContainersCPUIdle(f *matcher.ContainerMatcher) error {
 }
 
 func (c *cpuIdleTracing) detectCPUIdleContainer(threshold *cpuIdleThreshold) (*containerCPUInfo, error) {
+	containersCPUIdleMu.Lock()
+	defer containersCPUIdleMu.Unlock()
+
 	for id, container := range containersCPUIdle {
 		if !container.alive {
 			delete(containersCPUIdle, id)


### PR DESCRIPTION
## Problem

In `core/autotracing/cpuidle.go`, the package-level global map `containersCPUIdle` is accessed without synchronization:

- **Written** by `updateContainersCPUIdle()` — inserts and modifies entries
- **Iterated and deleted** by `detectCPUIdleContainer()` — `for range` + `delete()` inside the loop

Since `containersCPUIdle` is a **package-level global variable**, if the tracing framework creates multiple `cpuIdleTracing` instances or restarts tracing, concurrent goroutines will access the same map, causing:

```
fatal error: concurrent map writes
```
or
```
fatal error: concurrent map iteration and map write
```

This is a process-crashing bug.

## Fix

Add a `sync.Mutex` to protect all access to `containersCPUIdle`:

```go
var (
    containersCPUIdle   = make(containersCPUIdleMap)
    containersCPUIdleMu sync.Mutex
)
```

Both `updateContainersCPUIdle` and `detectCPUIdleContainer` now acquire `containersCPUIdleMu.Lock()` before accessing the map.

Fixes #378