### PR TITLE
fix(metrics): protect iolatencyTracing bpfObject with mutex against data race

### DIFF
--- a/core/metrics/iolatency_collector.go
+++ b/core/metrics/iolatency_collector.go
@@ -24,7 +24,11 @@ import (
 )
 
 func (c *iolatencyTracing) Update() ([]*metric.Data, error) {
-	if !c.running.Load() {
+	c.bpfObjectMu.RLock()
+	ready := c.bpfObject != nil
+	c.bpfObjectMu.RUnlock()
+
+	if !ready {
 		return nil, nil
 	}
 

--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -73,6 +74,7 @@ type iolatencyTracing struct {
 	running          atomic.Bool
 	latestContainers map[string]*pod.Container
 	bpfObject        bpf.BPF
+	bpfObjectMu      sync.Mutex
 }
 
 func (c *iolatencyTracing) Start(ctx context.Context) error {
@@ -107,7 +109,10 @@ func (c *iolatencyTracing) Start(ctx context.Context) error {
 	ticker := time.NewTicker(20 * time.Second)
 	defer ticker.Stop()
 
+	c.bpfObjectMu.Lock()
 	c.bpfObject = b
+	c.bpfObjectMu.Unlock()
+
 	c.running.Store(true)
 	defer c.running.Store(false)
 
@@ -124,6 +129,9 @@ func (c *iolatencyTracing) Start(ctx context.Context) error {
 }
 
 func (c *iolatencyTracing) dumpBlkdiskLatency() ([]BlkDiskEntry, error) {
+	c.bpfObjectMu.Lock()
+	defer c.bpfObjectMu.Unlock()
+
 	var latencyData []BlkDiskEntry
 
 	disks, err := c.bpfObject.DumpMapByName(blkDiskLatencyMap)
@@ -146,6 +154,9 @@ func (c *iolatencyTracing) dumpBlkdiskLatency() ([]BlkDiskEntry, error) {
 }
 
 func (c *iolatencyTracing) dumpContainerLatency() ([]BlkgqEntry, error) {
+	c.bpfObjectMu.Lock()
+	defer c.bpfObjectMu.Unlock()
+
 	var latencyData []BlkgqEntry
 
 	containersData, err := c.bpfObject.DumpMapByName(blkContainerLatencyMap)

--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -74,7 +74,7 @@ type iolatencyTracing struct {
 	running          atomic.Bool
 	latestContainers map[string]*pod.Container
 	bpfObject        bpf.BPF
-	bpfObjectMu      sync.Mutex
+	bpfObjectMu      sync.RWMutex
 }
 
 func (c *iolatencyTracing) Start(ctx context.Context) error {
@@ -82,7 +82,6 @@ func (c *iolatencyTracing) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load bpf: %w", err)
 	}
-	defer b.Close()
 
 	// commit 1e1a9cecfab3 ("block: force noio scope in blk_mq_freeze_queue")
 	// made blk_mq_freeze_queue a static inline wrapper in v6.15; the
@@ -116,6 +115,15 @@ func (c *iolatencyTracing) Start(ctx context.Context) error {
 	c.running.Store(true)
 	defer c.running.Store(false)
 
+	defer func() {
+		c.bpfObjectMu.Lock()
+		c.bpfObject = nil
+		closeErr := b.Close()
+		c.bpfObjectMu.Unlock()
+
+		_ = closeErr
+	}()
+
 	for {
 		select {
 		case <-childCtx.Done():
@@ -129,8 +137,12 @@ func (c *iolatencyTracing) Start(ctx context.Context) error {
 }
 
 func (c *iolatencyTracing) dumpBlkdiskLatency() ([]BlkDiskEntry, error) {
-	c.bpfObjectMu.Lock()
-	defer c.bpfObjectMu.Unlock()
+	c.bpfObjectMu.RLock()
+	defer c.bpfObjectMu.RUnlock()
+
+	if c.bpfObject == nil {
+		return nil, nil
+	}
 
 	var latencyData []BlkDiskEntry
 
@@ -154,8 +166,12 @@ func (c *iolatencyTracing) dumpBlkdiskLatency() ([]BlkDiskEntry, error) {
 }
 
 func (c *iolatencyTracing) dumpContainerLatency() ([]BlkgqEntry, error) {
-	c.bpfObjectMu.Lock()
-	defer c.bpfObjectMu.Unlock()
+	c.bpfObjectMu.RLock()
+	defer c.bpfObjectMu.RUnlock()
+
+	if c.bpfObject == nil {
+		return nil, nil
+	}
 
 	var latencyData []BlkgqEntry
 


### PR DESCRIPTION
## Problem

In `core/metrics/iolatency_tracing.go`, the `bpfObject` field of `iolatencyTracing` has a data race:

- **Written** in `Start()` goroutine: `c.bpfObject = b`
- **Read** in `Update()` (called by the tracing framework in a **separate goroutine** for metric collection), which calls `c.dumpBlkdiskLatency()` and `c.dumpContainerLatency()`, both reading `c.bpfObject.DumpMapByName(...)`

`Start()` and `Update()` run in different goroutines without synchronization. Additionally, `Start()` has `defer b.Close()` which may close the BPF object while `Update()` is still reading it, leading to **use-after-close**.

## Fix

Add a `sync.Mutex` to protect `bpfObject` access:

```go
type iolatencyTracing struct {
    ...
    bpfObject   bpf.BPF
    bpfObjectMu sync.Mutex
}
```

In `Start()`, protect the write. In `dumpBlkdiskLatency` and `dumpContainerLatency`, protect the reads.

Fixes #380