### PR TITLE
feat(netdev): correlate hardware and kernel packet drops

### DIFF
--- a/build/docker/grafana/dashboards/network-drop-correlation.json
+++ b/build/docker/grafana/dashboards/network-drop-correlation.json
@@ -1,0 +1,284 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1},
+              {"color": "red", "value": 100}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 4, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(huatuo_netdev_hw_drop_correlation_pending_events)",
+          "legendFormat": "pending",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Events awaiting correlation",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 4, "x": 4, "y": 0},
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {"editorMode": "code", "expr": "sum(increase(huatuo_netdev_hw_drop_correlation_unmatched_hardware_total[$__range]))", "legendFormat": "unmatched", "range": true, "refId": "A"}
+      ],
+      "title": "Hardware samples without event",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 4, "x": 8, "y": 0},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {"editorMode": "code", "expr": "sum(increase(huatuo_netdev_hw_drop_correlation_counter_resets_total[$__range]))", "legendFormat": "resets", "range": true, "refId": "A"}
+      ],
+      "title": "Counter resets excluded",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 4, "x": 12, "y": 0},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {"editorMode": "code", "expr": "sum(increase(huatuo_netdev_hw_drop_correlation_degraded_samples_total[$__range]))", "legendFormat": "degraded", "range": true, "refId": "A"}
+      ],
+      "title": "Degraded hardware samples",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 5, "w": 4, "x": 16, "y": 0},
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {"editorMode": "code", "expr": "sum(increase(huatuo_netdev_hw_drop_correlation_pending_dropped_total[$__range]))", "legendFormat": "queue pressure", "range": true, "refId": "A"}
+      ],
+      "title": "Events force-finalized",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 20, "y": 0},
+      "id": 6,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showPercentChange": false, "textMode": "auto", "wideLayout": true},
+      "targets": [
+        {"editorMode": "code", "expr": "sum(increase(huatuo_netdev_hw_drop_correlation_incidents_total[$__range]))", "legendFormat": "incidents", "range": true, "refId": "A"}
+      ],
+      "title": "Finalized incidents",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "events / second", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 18, "gradientMode": "opacity", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 4, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "normal"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 14, "x": 0, "y": 5},
+      "id": 7,
+      "options": {"legend": {"calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "sum by (layer) (rate(huatuo_netdev_hw_drop_correlation_classified_total{device=~\"$device\",direction=~\"$direction\"}[$__rate_interval]))", "legendFormat": "{{layer}}", "range": true, "refId": "A"}
+      ],
+      "title": "Drop rate by lowest proven layer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"fillOpacity": 70, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineWidth": 1}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 9, "w": 10, "x": 14, "y": 5},
+      "id": 8,
+      "options": {"barRadius": 0, "barWidth": 0.85, "fullHighlight": false, "groupWidth": 0.7, "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "orientation": "horizontal", "showValue": "auto", "stacking": "normal", "tooltip": {"mode": "single", "sort": "none"}, "xTickLabelRotation": 0, "xTickLabelSpacing": 0},
+      "targets": [
+        {"editorMode": "code", "expr": "topk(12, sum by (reason, layer) (increase(huatuo_netdev_hw_drop_correlation_classified_total{device=~\"$device\",direction=~\"$direction\"}[$__range])))", "format": "time_series", "instant": true, "legendFormat": "{{reason}} ({{layer}})", "refId": "A"}
+      ],
+      "title": "Top drop reasons in selected range",
+      "type": "barchart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "packets / sample", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "bars", "fillOpacity": 35, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "normal"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 14},
+      "id": 9,
+      "options": {"legend": {"calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "huatuo_netdev_hw_drop_correlation_hardware_delta{device=~\"$device\"}", "legendFormat": "{{device}} / {{counter}}", "range": true, "refId": "A"}
+      ],
+      "title": "Normalized hardware loss deltas",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["huatuo", "network", "dropwatch", "hardware"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(huatuo_netdev_hw_drop_correlation_hardware_delta, device)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Device",
+        "multi": true,
+        "name": "device",
+        "options": [],
+        "query": {"query": "label_values(huatuo_netdev_hw_drop_correlation_hardware_delta, device)", "refId": "PrometheusVariableQueryEditor-VariableQuery"},
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {"selected": true, "text": ["rx", "tx", "unknown"], "value": ["rx", "tx", "unknown"]},
+        "hide": 0,
+        "includeAll": true,
+        "label": "Direction",
+        "multi": true,
+        "name": "direction",
+        "options": [
+          {"selected": true, "text": "rx", "value": "rx"},
+          {"selected": true, "text": "tx", "value": "tx"},
+          {"selected": true, "text": "unknown", "value": "unknown"}
+        ],
+        "query": "rx,tx,unknown",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Network Drop Correlation",
+  "uid": "huatuo-drop-correlation",
+  "version": 1,
+  "weekStart": ""
+}

--- a/core/events/dropwatch.go
+++ b/core/events/dropwatch.go
@@ -25,6 +25,7 @@ import (
 
 	"huatuo-bamai/internal/cgroups/subsystem"
 	internalconfig "huatuo-bamai/internal/config"
+	"huatuo-bamai/internal/dropcorrelation"
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/pod"
@@ -94,11 +95,23 @@ func handleDropwatchEvent(_ *toolstream.Session, ev *types.DropWatchTracing) err
 	if ev.ContainerID == "" {
 		ev.ContainerID = resolveContainerIDFromMeta(ev)
 	}
+	now := time.Now()
+	dropcorrelation.Default().ObserveKernel(dropcorrelation.KernelDrop{
+		Timestamp:   now,
+		Device:      ev.NetdevName,
+		IfIndex:     ev.NetdevIfindex,
+		Direction:   dropcorrelation.InferDirection(ev.Type, ev.DropReason, ev.Stack),
+		Reason:      ev.DropReason,
+		Stack:       ev.Stack,
+		ContainerID: ev.ContainerID,
+		Protocol:    ev.PacketEthProto,
+		PacketLen:   ev.PacketLen,
+	})
 
 	return tracing.Save(&tracing.WriteRequest{
 		TracerName:  "dropwatch",
 		ContainerID: ev.ContainerID,
-		TracerTime:  time.Now(),
+		TracerTime:  now,
 		TracerData:  ev,
 	})
 }

--- a/core/metrics/config.go
+++ b/core/metrics/config.go
@@ -33,7 +33,12 @@ type Config struct {
 	}
 
 	NetdevHW struct {
-		DeviceList []string
+		DeviceList           []string
+		CorrelationWindowSec int  `default:"15"`
+		PendingEventLimit    int  `default:"4096"`
+		RecentIncidentLimit  int  `default:"1024"`
+		ReasonLabelLimit     int  `default:"64"`
+		EnableEthtoolStats   bool `default:"true"`
 	}
 
 	Qdisc struct {

--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -22,16 +22,20 @@ import (
 	"net"
 	"path/filepath"
 	"slices"
+	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/dropcorrelation"
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/procfs/sysfs"
 	"huatuo-bamai/internal/utils/parseutil"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
 
 	"github.com/safchain/ethtool"
 )
@@ -41,10 +45,13 @@ var deviceDriverList = []string{"mlx5_core", "i40e", "ixgbe", "bnxt_en", "virtio
 
 type netdevHw struct {
 	prog                  bpf.BPF
+	eth                   *ethtool.Ethtool
 	running               atomic.Bool
 	ifaceSwDroppedCounter map[string]uint64
 	ifaceList             map[string]*ethtool.DrvInfo
 	sysNetPath            string
+	normalizer            *dropcorrelation.CounterNormalizer
+	correlator            *dropcorrelation.Correlator
 	mutex                 sync.Mutex
 }
 
@@ -66,6 +73,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 
 	deviceMatcher, err := matcher.NewListMatcher(cfg.NetdevHW.DeviceList)
 	if err != nil {
+		eth.Close()
 		return nil, fmt.Errorf("netdev hw device list: %w", err)
 	}
 
@@ -96,6 +104,14 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 			ifaceList:             ifaceList,
 			ifaceSwDroppedCounter: ifaceSwCounter,
 			sysNetPath:            sysfs.Path("class/net"),
+			eth:                   eth,
+			normalizer:            dropcorrelation.NewCounterNormalizer(),
+			correlator: dropcorrelation.ConfigureDefault(dropcorrelation.Options{
+				Window:        time.Duration(cfg.NetdevHW.CorrelationWindowSec) * time.Second,
+				PendingLimit:  cfg.NetdevHW.PendingEventLimit,
+				IncidentLimit: cfg.NetdevHW.RecentIncidentLimit,
+				ReasonLimit:   cfg.NetdevHW.ReasonLabelLimit,
+			}),
 		},
 		Interval: 10,
 		Flag:     tracing.FlagTracing | tracing.FlagMetric,
@@ -116,25 +132,21 @@ func (netdev *netdevHw) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
-	data := []*metric.Data{}
+	now := time.Now()
+	data := make([]*metric.Data, 0, len(netdev.ifaceList)*12)
 	for iface, drv := range netdev.ifaceList {
-		counters := map[string]uint64{
-			"rx_dropped":       0,
-			"rx_missed_errors": 0,
+		sample, absolute, err := netdev.collectHardwareSample(now, iface, drv.Driver)
+		if err != nil {
+			log.Warnf("netdev_hw: collect %s hardware counters: %v", iface, err)
+			continue
 		}
 
-		for name := range counters {
-			counters[name], _ = netdev.readSysNetclassStat(iface, name)
-		}
-
-		count := counters["rx_missed_errors"]
+		count := absolute["rx_missed_errors"]
 		// 1. No packet loss
 		// 2. rx_missed_errors of the driver is not used.
 		if count == 0 {
-			// hardware drop = rx_dropped - software_drops
-			if sw, ok := netdev.ifaceSwDroppedCounter[iface]; ok {
-				count = counters["rx_dropped"] - sw
-			}
+			// collectHardwareSample already removes BPF-observed software drops.
+			count = absolute["rx_dropped"]
 		}
 
 		data = append(data, metric.NewCounterData(
@@ -142,9 +154,166 @@ func (netdev *netdevHw) Update() ([]*metric.Data, error) {
 			"count of packets dropped at hardware level",
 			map[string]string{"device": iface, "driver": drv.Driver},
 		))
+
+		incidents := netdev.correlator.ObserveHardware(sample)
+		netdev.persistCorrelationIncidents(incidents)
 	}
 
+	netdev.persistCorrelationIncidents(netdev.correlator.Flush(now))
+	data = append(data, netdev.correlationMetrics()...)
+
 	return data, nil
+}
+
+func (netdev *netdevHw) collectHardwareSample(now time.Time, iface, driver string) (
+	dropcorrelation.HardwareSample,
+	map[string]uint64,
+	error,
+) {
+	names := []string{
+		"rx_dropped", "rx_missed_errors", "rx_errors",
+		"tx_dropped", "tx_errors", "tx_carrier_errors", "tx_fifo_errors",
+	}
+	sysCounters := make(map[string]uint64, len(names))
+	degraded := false
+	for _, name := range names {
+		value, err := netdev.readSysNetclassStat(iface, name)
+		if err != nil {
+			degraded = true
+			continue
+		}
+		sysCounters[name] = value
+	}
+
+	// sysfs rx_dropped contains software drops on several drivers. Subtract the
+	// BPF-observed software component before it enters hardware correlation.
+	if sw, ok := netdev.ifaceSwDroppedCounter[iface]; ok {
+		if dropped := sysCounters["rx_dropped"]; dropped >= sw {
+			sysCounters["rx_dropped"] = dropped - sw
+		} else {
+			sysCounters["rx_dropped"] = 0
+			degraded = true
+		}
+	}
+
+	var ethCounters map[string]uint64
+	if cfg.NetdevHW.EnableEthtoolStats && netdev.eth != nil {
+		var err error
+		ethCounters, err = netdev.eth.Stats(iface)
+		if err != nil {
+			degraded = true
+			log.Debugf("netdev_hw: ethtool stats unavailable for %s: %v", iface, err)
+		}
+	}
+
+	sample, err := netdev.normalizer.Normalize(dropcorrelation.RawSample{
+		Timestamp: now,
+		Device:    iface,
+		Driver:    driver,
+		Sysfs:     sysCounters,
+		Ethtool:   ethCounters,
+	})
+	if err != nil {
+		return dropcorrelation.HardwareSample{}, nil, err
+	}
+	sample.ReadDegraded = degraded
+	return sample, sysCounters, nil
+}
+
+func (netdev *netdevHw) correlationMetrics() []*metric.Data {
+	snapshot := netdev.correlator.Snapshot()
+	data := []*metric.Data{
+		metric.NewGaugeData("drop_correlation_pending_events", float64(snapshot.Pending),
+			"dropwatch events waiting for a hardware sample", nil),
+		metric.NewCounterData("drop_correlation_events_total", float64(snapshot.Events),
+			"dropwatch events accepted by the correlation engine", nil),
+		metric.NewCounterData("drop_correlation_incidents_total", float64(snapshot.Incidents),
+			"dropwatch events finalized by the correlation engine", nil),
+		metric.NewCounterData("drop_correlation_pending_dropped_total", float64(snapshot.DroppedPending),
+			"events force-finalized because the bounded pending queue was full", nil),
+		metric.NewCounterData("drop_correlation_counter_resets_total", float64(snapshot.Resets),
+			"NIC counter resets excluded from correlation", nil),
+		metric.NewCounterData("drop_correlation_degraded_samples_total", float64(snapshot.DegradedSamples),
+			"partially unavailable NIC hardware counter samples", nil),
+		metric.NewCounterData("drop_correlation_unmatched_hardware_total", float64(snapshot.UnmatchedHardware),
+			"hardware loss samples without a matching dropwatch event", nil),
+	}
+
+	for _, key := range snapshot.SortedKeys() {
+		data = append(data, metric.NewCounterData(
+			"drop_correlation_classified_total",
+			float64(snapshot.ByKey[key]),
+			"correlated packet drops classified by lowest proven layer",
+			map[string]string{
+				"device":    key.Device,
+				"direction": string(key.Direction),
+				"layer":     string(key.Layer),
+				"reason":    key.Reason,
+			},
+		))
+	}
+
+	devices := make([]string, 0, len(snapshot.LastHardwareByIface))
+	for device := range snapshot.LastHardwareByIface {
+		devices = append(devices, device)
+	}
+	sort.Strings(devices)
+	for _, device := range devices {
+		sample := snapshot.LastHardwareByIface[device]
+		for _, counter := range dropcorrelation.AllCounters() {
+			data = append(data, metric.NewGaugeData(
+				"drop_correlation_hardware_delta",
+				float64(sample.Delta[counter]),
+				"normalized NIC loss counter delta used by the correlation engine",
+				map[string]string{
+					"device":  device,
+					"driver":  sample.Driver,
+					"counter": string(counter),
+				},
+			))
+		}
+	}
+	return data
+}
+
+func (netdev *netdevHw) persistCorrelationIncidents(incidents []dropcorrelation.Incident) {
+	for _, incident := range incidents {
+		delta := make(map[string]uint64, len(incident.HardwareDelta))
+		for counter, value := range incident.HardwareDelta {
+			if value > 0 {
+				delta[string(counter)] = value
+			}
+		}
+		storageEvent := &types.DropCorrelationIncident{
+			EventID:              incident.Event.ID,
+			ObservedTimestamp:    incident.Event.Timestamp.UTC().Format(time.RFC3339Nano),
+			FinalizedTimestamp:   incident.FinalizedAt.UTC().Format(time.RFC3339Nano),
+			Device:               incident.Event.Device,
+			IfIndex:              incident.Event.IfIndex,
+			Driver:               incident.Driver,
+			Direction:            string(incident.Event.Direction),
+			Layer:                string(incident.Layer),
+			Confidence:           incident.Confidence,
+			DropReason:           incident.Event.Reason,
+			Protocol:             incident.Event.Protocol,
+			ContainerID:          incident.Event.ContainerID,
+			PacketLength:         incident.Event.PacketLen,
+			CorrelationLagMS:     float64(incident.CorrelationLag) / float64(time.Millisecond),
+			Evidence:             append([]string(nil), incident.Evidence...),
+			HardwareCounterDelta: delta,
+		}
+		if !incident.HardwareSampleAt.IsZero() {
+			storageEvent.HardwareTimestamp = incident.HardwareSampleAt.UTC().Format(time.RFC3339Nano)
+		}
+		if err := tracing.Save(&tracing.WriteRequest{
+			TracerName:  "dropwatch_correlation",
+			ContainerID: incident.Event.ContainerID,
+			TracerTime:  incident.FinalizedAt,
+			TracerData:  storageEvent,
+		}); err != nil {
+			log.Warnf("netdev_hw: save correlated drop event %d: %v", incident.Event.ID, err)
+		}
+	}
 }
 
 func (netdev *netdevHw) readSysNetclassStat(iface, stat string) (uint64, error) {
@@ -192,6 +361,9 @@ func (netdev *netdevHw) updateIfaceSwDroppedStat() error {
 }
 
 func (netdev *netdevHw) Start(ctx context.Context) error {
+	if netdev.eth != nil {
+		defer netdev.eth.Close()
+	}
 	prog, err := bpf.LoadBpf(bpf.ThisBpfOBJ(), nil)
 	if err != nil {
 		return err

--- a/docs/best-practice/drop-correlation_zh.md
+++ b/docs/best-practice/drop-correlation_zh.md
@@ -1,0 +1,85 @@
+# 网卡硬件丢包与 dropwatch 关联诊断
+
+HUATUO 可以把低频采样的网卡硬件计数器与高频 `dropwatch` 事件放到同一时间窗口中分析，回答生产排障中最重要的问题：数据包最早在哪一层丢失——网卡硬件、驱动还是内核协议栈。
+
+## 为什么需要关联
+
+`dropwatch` 能看到内核释放 skb 的位置，但看不到包是否在进入内核前就被网卡丢弃。`ethtool -S` 和 `/sys/class/net/*/statistics` 能提供硬件/驱动累计计数，却不能指出对应的连接、容器和内核栈。单看任一来源都会产生盲区。
+
+关联器采用以下流程：
+
+1. `netdev_hw` 周期性读取 sysfs 与 ethtool 绝对计数器；
+2. 驱动专有字段被归一化为 RX/TX dropped、missed、errors、no-buffer 和 timeout；
+3. 相邻样本计算增量，计数器回退按重置处理，绝不进行无符号下溢计算；
+4. `dropwatch` 事件进入有界等待队列，并记录设备、方向、原因、协议、容器和调用栈；
+5. 硬件样本覆盖事件时间且对应方向有正增量时，事件标为 `hardware`；
+6. 没有硬件证据时，根据驱动函数、drop reason 和协议栈函数标为 `driver`、`protocol_stack` 或 `unknown`；
+7. 结果写入 `dropwatch_correlation` 事件流，并同步导出 Prometheus 指标。
+
+## 配置
+
+```toml
+[EventTracing.Dropwatch]
+    Filter = "tcp or udp"
+    MaxEventsPerSecond = 100
+
+[MetricCollector.NetdevHW]
+    DeviceList = ["eth0", "eth1", "bond0"]
+    CorrelationWindowSec = 15
+    PendingEventLimit = 4096
+    RecentIncidentLimit = 1024
+    ReasonLabelLimit = 64
+    EnableEthtoolStats = true
+```
+
+`CorrelationWindowSec` 应大于等于 `netdev_hw` 的采样间隔，并为调度抖动留出少量余量。窗口过短会把同一时段的事件判成无硬件证据；窗口过长会降低时间相关的可信度。
+
+三个 limit 都是内存和标签基数保护：
+
+- `PendingEventLimit` 达到上限时，最旧事件会立即按现有内核证据完成分类，并增加 `drop_correlation_pending_dropped_total`；
+- `RecentIncidentLimit` 限制进程内保留的最近结果，持久化事件不受影响；
+- `ReasonLabelLimit` 限制 Prometheus 的 `reason` 标签，超出的新原因合并为 `other`。
+
+## 指标
+
+启用 `netdev_hw` 后，以下指标位于 `huatuo_netdev_hw_` 命名空间：
+
+| 指标 | 类型 | 含义 |
+| --- | --- | --- |
+| `drop_correlation_classified_total` | counter | 按 device、direction、layer、reason 分类的事件总数 |
+| `drop_correlation_hardware_delta` | gauge | 最近一次用于相关的归一化硬件计数器增量 |
+| `drop_correlation_pending_events` | gauge | 等待硬件样本的 dropwatch 事件数 |
+| `drop_correlation_pending_dropped_total` | counter | 因有界队列满而提前完成分类的事件数 |
+| `drop_correlation_counter_resets_total` | counter | 已识别并排除的设备计数器重置次数 |
+| `drop_correlation_degraded_samples_total` | counter | sysfs 或 ethtool 部分读取失败的样本数 |
+| `drop_correlation_unmatched_hardware_total` | counter | 有硬件丢包增量但没有 dropwatch 事件的采样方向数 |
+
+`unmatched_hardware_total` 增长通常意味着包在内核可见之前已丢失、dropwatch 被过滤/限流，或选择了错误的设备列表。
+
+## 分层解释
+
+- `hardware`：同设备、同方向、同采样区间出现硬件计数器正增量。这是时间相关，不是逐包唯一标识，因此输出置信度而不是宣称一一对应。
+- `driver`：没有硬件增量，但调用栈或 reason 命中已知驱动/NAPI/qdisc/XDP 路径。
+- `protocol_stack`：没有硬件增量，证据位于 IP/TCP/UDP/netfilter/bridge 等协议栈路径。
+- `unknown`：事件缺少方向、设备、栈和有效 reason，无法可靠分层。
+
+## Grafana
+
+Docker Compose 部署会自动加载 `Network Drop Correlation` 面板。面板支持设备和方向过滤，并展示：
+
+- 各层新增事件速率；
+- 主要 drop reason；
+- 最近硬件计数器增量；
+- 等待队列、重置、降级样本和无匹配硬件证据。
+
+建议同时查看原始 `dropwatch_correlation` 事件。每条事件包含 `evidence`、`confidence`、`hardware_counter_delta` 与 `correlation_lag_ms`，用于解释分类依据。
+
+## 已知边界
+
+1. NIC 计数器是区间累计值，无法证明某个具体 skb 与某个硬件计数器增量一一对应；
+2. SR-IOV、bond、bridge 或隧道可能导致事件设备与物理设备不同，应把相关下层设备加入 `DeviceList`；
+3. 部分驱动不提供细粒度 ethtool 字段，系统会退化到通用 sysfs 计数并标记样本质量；
+4. 设备热插拔和驱动重载会使计数器回退，该区间只记 reset，不参与硬件层判断；
+5. `dropwatch` 限流后，硬件丢包可能没有对应内核事件，此时以 unmatched 指标提醒，而不会生成虚构事件。
+
+这些约束使关联结果可解释、可降级，并避免在证据不足时给出过度确定的根因。

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -492,8 +492,25 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
     # Literal names such as "eth0" keep exact-match behavior.
     # Default: [] is empty, meaning no devices.
     #
+    # - CorrelationWindowSec
+    # Join dropwatch events with hardware counter deltas collected in this time
+    # window. Default: 15 seconds.
+    #
+    # - PendingEventLimit / RecentIncidentLimit / ReasonLabelLimit
+    # Bound in-memory event queues and Prometheus reason-label cardinality during
+    # a packet-loss storm. Defaults: 4096 / 1024 / 64.
+    #
+    # - EnableEthtoolStats
+    # Read driver-specific ethtool counters in addition to generic sysfs stats.
+    # Default: true.
+    #
     [MetricCollector.NetdevHW]
         DeviceList = ["eth0", "eth1"]
+        # CorrelationWindowSec = 15
+        # PendingEventLimit = 4096
+        # RecentIncidentLimit = 1024
+        # ReasonLabelLimit = 64
+        # EnableEthtoolStats = true
 
     # Qdisc
     #

--- a/internal/dropcorrelation/correlator.go
+++ b/internal/dropcorrelation/correlator.go
@@ -1,0 +1,460 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropcorrelation
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Correlator owns a bounded pending-event queue and cumulative diagnostics.
+// All public methods are safe for concurrent event ingestion and metric scrapes.
+type Correlator struct {
+	mu sync.RWMutex
+
+	options Options
+	nextID  atomic.Uint64
+	pending []KernelDrop
+	recent  []Incident
+
+	droppedPending    uint64
+	events            uint64
+	incidents         uint64
+	resets            uint64
+	degradedSamples   uint64
+	unmatchedHardware uint64
+	byKey             map[MetricKey]uint64
+	reasonSlots       map[string]struct{}
+	lastHardware      map[string]HardwareSample
+}
+
+// New creates a correlator with normalized options.
+func New(options Options) *Correlator {
+	return &Correlator{
+		options:      normalizeOptions(options),
+		byKey:        make(map[MetricKey]uint64),
+		reasonSlots:  make(map[string]struct{}),
+		lastHardware: make(map[string]HardwareSample),
+	}
+}
+
+// ObserveKernel queues one dropwatch event. It returns false when an invalid
+// event is rejected. When the bounded queue is full, the oldest event is
+// finalized immediately rather than silently discarded.
+func (c *Correlator) ObserveKernel(event KernelDrop) bool {
+	if err := validateKernelDrop(event); err != nil {
+		return false
+	}
+	event.Device = strings.TrimSpace(event.Device)
+	event.Reason = normalizeReason(event.Reason)
+	event.Protocol = strings.ToLower(strings.TrimSpace(event.Protocol))
+	if event.ID == 0 {
+		event.ID = c.nextID.Add(1)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events++
+
+	if len(c.pending) >= c.options.PendingLimit {
+		oldest := c.pending[0]
+		copy(c.pending, c.pending[1:])
+		c.pending = c.pending[:len(c.pending)-1]
+		c.droppedPending++
+		incident := c.classifyWithoutHardwareLocked(oldest, event.Timestamp, "pending queue limit reached")
+		c.recordIncidentLocked(incident)
+	}
+	c.pending = append(c.pending, event)
+	return true
+}
+
+// ObserveHardware records a normalized hardware sample and finalizes events
+// covered by its measurement period. Events that outlive the correlation window
+// are finalized using stack/reason evidence.
+func (c *Correlator) ObserveHardware(sample HardwareSample) []Incident {
+	if sample.Timestamp.IsZero() || strings.TrimSpace(sample.Device) == "" {
+		return nil
+	}
+	if sample.PeriodStart.IsZero() || sample.PeriodStart.After(sample.Timestamp) {
+		sample.PeriodStart = sample.Timestamp.Add(-c.options.Window)
+	}
+	sample.Device = strings.TrimSpace(sample.Device)
+	sample = cloneHardwareSample(sample)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if sample.Reset {
+		c.resets++
+	}
+	if sample.ReadDegraded {
+		c.degradedSamples++
+	}
+	c.lastHardware[sample.Device] = sample
+
+	finalized := make([]Incident, 0)
+	kept := c.pending[:0]
+	matchedRX, matchedTX := false, false
+	for _, event := range c.pending {
+		if c.sampleCoversEventLocked(sample, event) {
+			incident := c.classifyWithHardwareLocked(event, sample)
+			finalized = append(finalized, incident)
+			c.recordIncidentLocked(incident)
+			switch event.Direction {
+			case DirectionRX:
+				matchedRX = true
+			case DirectionTX:
+				matchedTX = true
+			}
+			continue
+		}
+		if event.Timestamp.Before(sample.Timestamp.Add(-c.options.Window)) {
+			incident := c.classifyWithoutHardwareLocked(event, sample.Timestamp, "correlation window expired")
+			finalized = append(finalized, incident)
+			c.recordIncidentLocked(incident)
+			continue
+		}
+		kept = append(kept, event)
+	}
+	c.pending = kept
+
+	if sample.Total(DirectionRX) > 0 && !matchedRX {
+		c.unmatchedHardware++
+	}
+	if sample.Total(DirectionTX) > 0 && !matchedTX {
+		c.unmatchedHardware++
+	}
+	return cloneIncidents(finalized)
+}
+
+// Flush finalizes events older than the configured window. Collectors call it
+// even when a device read fails so missing hardware data cannot retain events.
+func (c *Correlator) Flush(now time.Time) []Incident {
+	if now.IsZero() {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	finalized := make([]Incident, 0)
+	kept := c.pending[:0]
+	deadline := now.Add(-c.options.Window)
+	for _, event := range c.pending {
+		if event.Timestamp.After(deadline) {
+			kept = append(kept, event)
+			continue
+		}
+		incident := c.classifyWithoutHardwareLocked(event, now, "correlation window expired")
+		finalized = append(finalized, incident)
+		c.recordIncidentLocked(incident)
+	}
+	c.pending = kept
+	return cloneIncidents(finalized)
+}
+
+func (c *Correlator) sampleCoversEventLocked(sample HardwareSample, event KernelDrop) bool {
+	if sample.Reset || sample.Device != event.Device {
+		return false
+	}
+	if event.Timestamp.Before(sample.PeriodStart.Add(-c.options.FutureTolerance)) ||
+		event.Timestamp.After(sample.Timestamp.Add(c.options.FutureTolerance)) {
+		return false
+	}
+	return event.Direction == DirectionRX || event.Direction == DirectionTX
+}
+
+func (c *Correlator) classifyWithHardwareLocked(event KernelDrop, sample HardwareSample) Incident {
+	evidenceCount := sample.Total(event.Direction)
+	if evidenceCount == 0 {
+		return c.classifyWithoutHardwareLocked(event, sample.Timestamp, "hardware counters unchanged")
+	}
+
+	evidence := make([]string, 0, len(sample.Delta)+2)
+	evidence = append(evidence, "hardware counter delta overlaps dropwatch event")
+	for _, counter := range allCounters {
+		if value := sample.Delta[counter]; value > 0 && counterDirection(counter) == event.Direction {
+			evidence = append(evidence, string(counter)+"="+formatUint(value))
+		}
+	}
+	if sample.ReadDegraded {
+		evidence = append(evidence, "hardware sample was partially degraded")
+	}
+
+	confidence := 0.82 + math.Min(0.15, math.Log10(float64(evidenceCount)+1)/10)
+	if sample.ReadDegraded {
+		confidence -= 0.12
+	}
+	return Incident{
+		Event:            event,
+		Layer:            LayerHardware,
+		Confidence:       clampConfidence(confidence),
+		Evidence:         evidence,
+		HardwareDelta:    cloneCounterMap(sample.Delta),
+		HardwareSampleAt: sample.Timestamp,
+		Driver:           sample.Driver,
+		CorrelationLag:   absoluteDuration(sample.Timestamp.Sub(event.Timestamp)),
+		FinalizedAt:      sample.Timestamp,
+	}
+}
+
+func (c *Correlator) classifyWithoutHardwareLocked(event KernelDrop, finalizedAt time.Time, cause string) Incident {
+	layer, confidence, evidence := classifyKernelEvidence(event)
+	if cause != "" {
+		evidence = append(evidence, cause)
+	}
+	return Incident{
+		Event:          event,
+		Layer:          layer,
+		Confidence:     confidence,
+		Evidence:       evidence,
+		CorrelationLag: absoluteDuration(finalizedAt.Sub(event.Timestamp)),
+		FinalizedAt:    finalizedAt,
+	}
+}
+
+func classifyKernelEvidence(event KernelDrop) (Layer, float64, []string) {
+	stack := strings.ToLower(event.Stack)
+	reason := strings.ToLower(event.Reason)
+
+	for _, marker := range driverStackMarkers {
+		if strings.Contains(stack, marker) {
+			return LayerDriver, 0.86, []string{"driver stack marker: " + marker, "no overlapping hardware counter delta"}
+		}
+	}
+	for _, marker := range driverReasonMarkers {
+		if strings.Contains(reason, marker) {
+			return LayerDriver, 0.76, []string{"driver drop reason marker: " + marker, "no overlapping hardware counter delta"}
+		}
+	}
+	for _, marker := range protocolStackMarkers {
+		if strings.Contains(stack, marker) {
+			return LayerProtocolStack, 0.84, []string{"protocol stack marker: " + marker, "no overlapping hardware counter delta"}
+		}
+	}
+	if event.Protocol != "" || event.Reason != "unknown" {
+		return LayerProtocolStack, 0.64, []string{"kernel dropwatch event without hardware evidence"}
+	}
+	return LayerUnknown, 0.3, []string{"insufficient device, stack, and hardware evidence"}
+}
+
+var driverStackMarkers = []string{
+	"mlx5_", "mlx5e_", "i40e_", "ixgbe_", "bnxt_", "virtio_net", "netdev_rx_handler",
+	"napi_gro", "napi_consume", "dev_hard_start_xmit", "sch_direct_xmit",
+}
+
+var driverReasonMarkers = []string{
+	"rx_handler", "driver", "dev_ready", "tc_egress", "qdisc", "xdp",
+}
+
+var protocolStackMarkers = []string{
+	"ip_rcv", "ip6_rcv", "tcp_", "udp_", "icmp_", "nf_hook", "nft_",
+	"br_handle", "neigh_", "__netif_receive_skb", "kfree_skb_reason",
+}
+
+func counterDirection(counter Counter) Direction {
+	if strings.HasPrefix(string(counter), "rx_") {
+		return DirectionRX
+	}
+	if strings.HasPrefix(string(counter), "tx_") {
+		return DirectionTX
+	}
+	return DirectionUnknown
+}
+
+// InferDirection derives packet direction from dropwatch type, reason, and
+// stack. It deliberately returns unknown when evidence conflicts instead of
+// forcing an incorrect hardware correlation.
+func InferDirection(eventType, reason, stack string) Direction {
+	text := strings.ToLower(eventType + "\n" + reason + "\n" + stack)
+	rxScore, txScore := 0, 0
+	for _, marker := range []string{"netif_receive", "napi_", "ip_rcv", "ip6_rcv", "rx_", "ingress"} {
+		if strings.Contains(text, marker) {
+			rxScore++
+		}
+	}
+	for _, marker := range []string{"dev_queue_xmit", "hard_start_xmit", "sch_", "tx_", "egress"} {
+		if strings.Contains(text, marker) {
+			txScore++
+		}
+	}
+	switch {
+	case rxScore > txScore:
+		return DirectionRX
+	case txScore > rxScore:
+		return DirectionTX
+	default:
+		return DirectionUnknown
+	}
+}
+
+func (c *Correlator) recordIncidentLocked(incident Incident) {
+	c.incidents++
+	reason := c.boundedReasonLocked(incident.Event.Reason)
+	key := MetricKey{
+		Device:    boundedDevice(incident.Event.Device),
+		Direction: incident.Event.Direction,
+		Layer:     incident.Layer,
+		Reason:    reason,
+	}
+	c.byKey[key]++
+	c.recent = append(c.recent, cloneIncident(incident))
+	if len(c.recent) > c.options.IncidentLimit {
+		copy(c.recent, c.recent[len(c.recent)-c.options.IncidentLimit:])
+		c.recent = c.recent[:c.options.IncidentLimit]
+	}
+}
+
+func (c *Correlator) boundedReasonLocked(reason string) string {
+	reason = normalizeReason(reason)
+	if _, exists := c.reasonSlots[reason]; exists {
+		return reason
+	}
+	if len(c.reasonSlots) >= c.options.ReasonLimit {
+		return "other"
+	}
+	c.reasonSlots[reason] = struct{}{}
+	return reason
+}
+
+// Snapshot returns a deep copy that callers may retain or mutate.
+func (c *Correlator) Snapshot() Snapshot {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	snapshot := Snapshot{
+		Pending:             len(c.pending),
+		DroppedPending:      c.droppedPending,
+		Events:              c.events,
+		Incidents:           c.incidents,
+		Resets:              c.resets,
+		DegradedSamples:     c.degradedSamples,
+		UnmatchedHardware:   c.unmatchedHardware,
+		ByKey:               make(map[MetricKey]uint64, len(c.byKey)),
+		LastHardwareByIface: make(map[string]HardwareSample, len(c.lastHardware)),
+		Recent:              cloneIncidents(c.recent),
+	}
+	for key, value := range c.byKey {
+		snapshot.ByKey[key] = value
+	}
+	for device, sample := range c.lastHardware {
+		snapshot.LastHardwareByIface[device] = cloneHardwareSample(sample)
+	}
+	return snapshot
+}
+
+// RecentSince returns finalized incidents within a time range, oldest first.
+func (c *Correlator) RecentSince(since time.Time) []Incident {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	result := make([]Incident, 0)
+	for _, incident := range c.recent {
+		if !incident.FinalizedAt.Before(since) {
+			result = append(result, cloneIncident(incident))
+		}
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].FinalizedAt.Before(result[j].FinalizedAt)
+	})
+	return result
+}
+
+func normalizeReason(reason string) string {
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	if reason == "" {
+		return "unknown"
+	}
+	reason = strings.NewReplacer(" ", "_", "-", "_", "/", "_").Replace(reason)
+	if len(reason) > 96 {
+		reason = reason[:96]
+	}
+	return reason
+}
+
+func boundedDevice(device string) string {
+	device = strings.TrimSpace(device)
+	if device == "" {
+		return "unknown"
+	}
+	if len(device) > 32 {
+		return device[:32]
+	}
+	return device
+}
+
+func clampConfidence(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
+func absoluteDuration(value time.Duration) time.Duration {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func formatUint(value uint64) string {
+	if value == 0 {
+		return "0"
+	}
+	var buffer [20]byte
+	position := len(buffer)
+	for value > 0 {
+		position--
+		buffer[position] = byte('0' + value%10)
+		value /= 10
+	}
+	return string(buffer[position:])
+}
+
+func cloneIncidents(in []Incident) []Incident {
+	out := make([]Incident, len(in))
+	for index := range in {
+		out[index] = cloneIncident(in[index])
+	}
+	return out
+}
+
+var defaultCorrelator = struct {
+	mu    sync.RWMutex
+	value *Correlator
+}{value: New(DefaultOptions())}
+
+// Default returns the process-wide correlator shared by dropwatch and netdev_hw.
+func Default() *Correlator {
+	defaultCorrelator.mu.RLock()
+	value := defaultCorrelator.value
+	defaultCorrelator.mu.RUnlock()
+	return value
+}
+
+// ConfigureDefault atomically replaces the process-wide correlator. Existing
+// callers retain their old pointer, while new collector instances share the new
+// configuration. This is intended for startup configuration and tests.
+func ConfigureDefault(options Options) *Correlator {
+	value := New(options)
+	defaultCorrelator.mu.Lock()
+	defaultCorrelator.value = value
+	defaultCorrelator.mu.Unlock()
+	return value
+}

--- a/internal/dropcorrelation/correlator_test.go
+++ b/internal/dropcorrelation/correlator_test.go
@@ -1,0 +1,467 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropcorrelation
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCorrelatorMatchesHardwareRXDrop(t *testing.T) {
+	correlator := New(Options{Window: 10 * time.Second})
+	start := time.Unix(1_000, 0)
+	event := KernelDrop{
+		Timestamp: start.Add(4 * time.Second),
+		Device:    "eth0",
+		Direction: DirectionRX,
+		Reason:    "SKB_DROP_REASON_NOMEM",
+		Stack:     "__netif_receive_skb\nip_rcv",
+		Protocol:  "ipv4",
+	}
+	if !correlator.ObserveKernel(event) {
+		t.Fatal("ObserveKernel rejected valid event")
+	}
+	incidents := correlator.ObserveHardware(HardwareSample{
+		Timestamp:   start.Add(10 * time.Second),
+		PeriodStart: start,
+		Device:      "eth0",
+		Driver:      "mlx5_core",
+		Delta:       map[Counter]uint64{CounterRXMissed: 3},
+	})
+	if len(incidents) != 1 {
+		t.Fatalf("incidents = %d, want 1", len(incidents))
+	}
+	incident := incidents[0]
+	if incident.Layer != LayerHardware {
+		t.Fatalf("layer = %s, want hardware", incident.Layer)
+	}
+	if incident.Confidence < 0.8 || incident.Confidence > 1 {
+		t.Fatalf("confidence = %f", incident.Confidence)
+	}
+	if incident.Driver != "mlx5_core" {
+		t.Fatalf("driver = %q", incident.Driver)
+	}
+	if incident.HardwareDelta[CounterRXMissed] != 3 {
+		t.Fatalf("hardware delta = %v", incident.HardwareDelta)
+	}
+	snapshot := correlator.Snapshot()
+	if snapshot.Pending != 0 || snapshot.Events != 1 || snapshot.Incidents != 1 {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+}
+
+func TestCorrelatorDoesNotCrossDevices(t *testing.T) {
+	correlator := New(Options{Window: 10 * time.Second})
+	now := time.Unix(2_000, 0)
+	correlator.ObserveKernel(KernelDrop{
+		Timestamp: now,
+		Device:    "eth1",
+		Direction: DirectionRX,
+		Reason:    "driver drop",
+	})
+	incidents := correlator.ObserveHardware(HardwareSample{
+		Timestamp:   now.Add(5 * time.Second),
+		PeriodStart: now.Add(-time.Second),
+		Device:      "eth0",
+		Delta:       map[Counter]uint64{CounterRXErrors: 9},
+	})
+	if len(incidents) != 0 {
+		t.Fatalf("cross-device incidents = %v", incidents)
+	}
+	if correlator.Snapshot().Pending != 1 {
+		t.Fatal("event for another device was removed")
+	}
+}
+
+func TestCorrelatorDoesNotCrossDirections(t *testing.T) {
+	correlator := New(Options{Window: 10 * time.Second})
+	now := time.Unix(3_000, 0)
+	correlator.ObserveKernel(KernelDrop{
+		Timestamp: now,
+		Device:    "eth0",
+		Direction: DirectionTX,
+		Reason:    "qdisc_drop",
+		Stack:     "sch_direct_xmit",
+	})
+	incidents := correlator.ObserveHardware(HardwareSample{
+		Timestamp:   now.Add(time.Second),
+		PeriodStart: now.Add(-time.Second),
+		Device:      "eth0",
+		Delta:       map[Counter]uint64{CounterRXMissed: 20},
+	})
+	if len(incidents) != 1 {
+		t.Fatalf("incidents = %d, want finalized stack incident", len(incidents))
+	}
+	if incidents[0].Layer == LayerHardware {
+		t.Fatalf("RX evidence incorrectly classified TX event: %+v", incidents[0])
+	}
+}
+
+func TestCorrelatorCounterResetCannotProveHardwareDrop(t *testing.T) {
+	correlator := New(Options{Window: 10 * time.Second})
+	now := time.Unix(4_000, 0)
+	correlator.ObserveKernel(KernelDrop{
+		Timestamp: now,
+		Device:    "eth0",
+		Direction: DirectionRX,
+		Reason:    "driver_rx_drop",
+		Stack:     "mlx5e_poll_rx_cq",
+	})
+	incidents := correlator.ObserveHardware(HardwareSample{
+		Timestamp:   now.Add(time.Second),
+		PeriodStart: now.Add(-time.Second),
+		Device:      "eth0",
+		Driver:      "mlx5_core",
+		Delta:       map[Counter]uint64{CounterRXMissed: 1_000_000},
+		Reset:       true,
+	})
+	if len(incidents) != 0 {
+		t.Fatalf("reset sample should not cover event: %v", incidents)
+	}
+	flushed := correlator.Flush(now.Add(11 * time.Second))
+	if len(flushed) != 1 || flushed[0].Layer != LayerDriver {
+		t.Fatalf("flushed = %+v, want driver classification", flushed)
+	}
+	if correlator.Snapshot().Resets != 1 {
+		t.Fatal("counter reset metric not incremented")
+	}
+}
+
+func TestCorrelatorFlushClassifiesProtocolStack(t *testing.T) {
+	correlator := New(Options{Window: 5 * time.Second})
+	now := time.Unix(5_000, 0)
+	correlator.ObserveKernel(KernelDrop{
+		Timestamp: now,
+		Direction: DirectionUnknown,
+		Reason:    "TCP_INVALID_SEQUENCE",
+		Stack:     "tcp_validate_incoming\ntcp_rcv_established",
+		Protocol:  "tcp",
+	})
+	if got := correlator.Flush(now.Add(4 * time.Second)); len(got) != 0 {
+		t.Fatalf("early flush = %v", got)
+	}
+	got := correlator.Flush(now.Add(6 * time.Second))
+	if len(got) != 1 {
+		t.Fatalf("flush count = %d, want 1", len(got))
+	}
+	if got[0].Layer != LayerProtocolStack {
+		t.Fatalf("layer = %s", got[0].Layer)
+	}
+	if got[0].Confidence < 0.8 {
+		t.Fatalf("confidence = %f", got[0].Confidence)
+	}
+}
+
+func TestCorrelatorPendingLimitForceFinalizesOldest(t *testing.T) {
+	correlator := New(Options{PendingLimit: 2, Window: time.Minute})
+	now := time.Unix(6_000, 0)
+	for index := 0; index < 3; index++ {
+		accepted := correlator.ObserveKernel(KernelDrop{
+			Timestamp: now.Add(time.Duration(index) * time.Second),
+			Device:    "eth0",
+			Direction: DirectionRX,
+			Reason:    fmt.Sprintf("reason_%d", index),
+		})
+		if !accepted {
+			t.Fatalf("event %d rejected", index)
+		}
+	}
+	snapshot := correlator.Snapshot()
+	if snapshot.Pending != 2 || snapshot.DroppedPending != 1 || snapshot.Incidents != 1 {
+		t.Fatalf("snapshot = %+v", snapshot)
+	}
+	if len(snapshot.Recent) != 1 || snapshot.Recent[0].Event.Reason != "reason_0" {
+		t.Fatalf("recent = %+v", snapshot.Recent)
+	}
+}
+
+func TestCorrelatorBoundsReasonCardinality(t *testing.T) {
+	correlator := New(Options{ReasonLimit: 2, Window: time.Second})
+	now := time.Unix(7_000, 0)
+	for index := 0; index < 5; index++ {
+		correlator.ObserveKernel(KernelDrop{
+			Timestamp: now,
+			Direction: DirectionUnknown,
+			Reason:    fmt.Sprintf("UNBOUNDED_%d", index),
+		})
+	}
+	correlator.Flush(now.Add(2 * time.Second))
+	snapshot := correlator.Snapshot()
+	reasons := make(map[string]uint64)
+	for key, count := range snapshot.ByKey {
+		reasons[key.Reason] += count
+	}
+	if len(reasons) != 3 {
+		t.Fatalf("reasons = %v, want two specific + other", reasons)
+	}
+	if reasons["other"] != 3 {
+		t.Fatalf("other count = %d, want 3", reasons["other"])
+	}
+}
+
+func TestCorrelatorBoundsRecentIncidents(t *testing.T) {
+	correlator := New(Options{IncidentLimit: 3, Window: time.Second})
+	now := time.Unix(8_000, 0)
+	for index := 0; index < 7; index++ {
+		correlator.ObserveKernel(KernelDrop{
+			Timestamp: now.Add(time.Duration(index) * time.Millisecond),
+			Direction: DirectionUnknown,
+			Reason:    fmt.Sprintf("reason_%d", index),
+		})
+	}
+	correlator.Flush(now.Add(2 * time.Second))
+	recent := correlator.Snapshot().Recent
+	if len(recent) != 3 {
+		t.Fatalf("recent count = %d, want 3", len(recent))
+	}
+	for index, want := range []string{"reason_4", "reason_5", "reason_6"} {
+		if recent[index].Event.Reason != want {
+			t.Fatalf("recent[%d] = %s, want %s", index, recent[index].Event.Reason, want)
+		}
+	}
+}
+
+func TestCorrelatorSnapshotIsDeepCopy(t *testing.T) {
+	correlator := New(Options{Window: time.Second})
+	now := time.Unix(9_000, 0)
+	correlator.ObserveKernel(KernelDrop{
+		Timestamp: now,
+		Device:    "eth0",
+		Direction: DirectionRX,
+		Reason:    "drop",
+	})
+	correlator.ObserveHardware(HardwareSample{
+		Timestamp:   now.Add(time.Second),
+		PeriodStart: now,
+		Device:      "eth0",
+		Delta:       map[Counter]uint64{CounterRXErrors: 2},
+		Sources:     map[Counter][]string{CounterRXErrors: {"ethtool:rx_errors"}},
+	})
+
+	first := correlator.Snapshot()
+	first.ByKey[MetricKey{}] = 999
+	first.Recent[0].Evidence[0] = "mutated"
+	sample := first.LastHardwareByIface["eth0"]
+	sample.Delta[CounterRXErrors] = 999
+	first.LastHardwareByIface["eth0"] = sample
+
+	second := correlator.Snapshot()
+	if second.ByKey[MetricKey{}] == 999 {
+		t.Fatal("ByKey was not copied")
+	}
+	if second.Recent[0].Evidence[0] == "mutated" {
+		t.Fatal("incident evidence was not copied")
+	}
+	if second.LastHardwareByIface["eth0"].Delta[CounterRXErrors] == 999 {
+		t.Fatal("hardware delta was not copied")
+	}
+}
+
+func TestCorrelatorRecentSince(t *testing.T) {
+	correlator := New(Options{Window: time.Second})
+	now := time.Unix(10_000, 0)
+	for index := 0; index < 3; index++ {
+		eventAt := now.Add(time.Duration(index) * time.Second)
+		correlator.ObserveKernel(KernelDrop{
+			Timestamp: eventAt,
+			Direction: DirectionUnknown,
+			Reason:    fmt.Sprintf("event_%d", index),
+		})
+		correlator.Flush(eventAt.Add(2 * time.Second))
+	}
+	got := correlator.RecentSince(now.Add(3 * time.Second))
+	if len(got) != 2 {
+		t.Fatalf("recent since count = %d, want 2", len(got))
+	}
+	if got[0].FinalizedAt.After(got[1].FinalizedAt) {
+		t.Fatal("RecentSince is not oldest first")
+	}
+}
+
+func TestCorrelatorInvalidKernelEventsAreRejected(t *testing.T) {
+	correlator := New(Options{})
+	if correlator.ObserveKernel(KernelDrop{Direction: DirectionRX}) {
+		t.Fatal("event without timestamp accepted")
+	}
+	if correlator.ObserveKernel(KernelDrop{Timestamp: time.Now()}) {
+		t.Fatal("event without direction accepted")
+	}
+	if snapshot := correlator.Snapshot(); snapshot.Events != 0 || snapshot.Pending != 0 {
+		t.Fatalf("invalid events changed snapshot: %+v", snapshot)
+	}
+}
+
+func TestInferDirection(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		reason    string
+		stack     string
+		want      Direction
+	}{
+		{name: "RX stack", stack: "napi_gro_receive\n__netif_receive_skb\nip_rcv", want: DirectionRX},
+		{name: "TX stack", stack: "sch_direct_xmit\ndev_hard_start_xmit", want: DirectionTX},
+		{name: "ingress reason", reason: "tc_ingress_drop", want: DirectionRX},
+		{name: "egress reason", reason: "tc_egress_drop", want: DirectionTX},
+		{name: "conflicting evidence", stack: "netif_receive dev_queue_xmit", want: DirectionUnknown},
+		{name: "no evidence", eventType: "kfree_skb", want: DirectionUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := InferDirection(test.eventType, test.reason, test.stack); got != test.want {
+				t.Fatalf("direction = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestClassifyKernelEvidence(t *testing.T) {
+	tests := []struct {
+		name  string
+		event KernelDrop
+		layer Layer
+	}{
+		{
+			name:  "driver stack",
+			event: KernelDrop{Stack: "mlx5e_poll_rx_cq"},
+			layer: LayerDriver,
+		},
+		{
+			name:  "driver reason",
+			event: KernelDrop{Reason: "xdp_drop"},
+			layer: LayerDriver,
+		},
+		{
+			name:  "protocol stack",
+			event: KernelDrop{Stack: "nf_hook_slow\nip_rcv"},
+			layer: LayerProtocolStack,
+		},
+		{
+			name:  "protocol metadata",
+			event: KernelDrop{Protocol: "tcp", Reason: "unknown"},
+			layer: LayerProtocolStack,
+		},
+		{
+			name:  "unknown",
+			event: KernelDrop{Reason: "unknown"},
+			layer: LayerUnknown,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, confidence, evidence := classifyKernelEvidence(test.event)
+			if got != test.layer {
+				t.Fatalf("layer = %s, want %s", got, test.layer)
+			}
+			if confidence <= 0 || confidence > 1 {
+				t.Fatalf("confidence = %f", confidence)
+			}
+			if len(evidence) == 0 {
+				t.Fatal("evidence is empty")
+			}
+		})
+	}
+}
+
+func TestSnapshotSortedKeys(t *testing.T) {
+	snapshot := Snapshot{ByKey: map[MetricKey]uint64{
+		{Device: "z", Direction: DirectionTX, Layer: LayerDriver, Reason: "b"}:   1,
+		{Device: "a", Direction: DirectionRX, Layer: LayerHardware, Reason: "c"}: 1,
+		{Device: "a", Direction: DirectionRX, Layer: LayerHardware, Reason: "a"}: 1,
+	}}
+	got := snapshot.SortedKeys()
+	want := []MetricKey{
+		{Device: "a", Direction: DirectionRX, Layer: LayerHardware, Reason: "a"},
+		{Device: "a", Direction: DirectionRX, Layer: LayerHardware, Reason: "c"},
+		{Device: "z", Direction: DirectionTX, Layer: LayerDriver, Reason: "b"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("keys = %#v, want %#v", got, want)
+	}
+}
+
+func TestCorrelatorConcurrentIngestAndSnapshot(t *testing.T) {
+	correlator := New(Options{
+		Window:        5 * time.Second,
+		PendingLimit:  10_000,
+		IncidentLimit: 256,
+	})
+	start := time.Unix(20_000, 0)
+	const workers = 8
+	const perWorker = 250
+
+	var wait sync.WaitGroup
+	wait.Add(workers + 2)
+	for worker := 0; worker < workers; worker++ {
+		go func(worker int) {
+			defer wait.Done()
+			for index := 0; index < perWorker; index++ {
+				correlator.ObserveKernel(KernelDrop{
+					Timestamp: start.Add(time.Duration(index) * time.Millisecond),
+					Device:    fmt.Sprintf("eth%d", worker%2),
+					Direction: DirectionRX,
+					Reason:    fmt.Sprintf("reason_%d", index%10),
+					Stack:     "ip_rcv",
+				})
+			}
+		}(worker)
+	}
+	go func() {
+		defer wait.Done()
+		for index := 0; index < perWorker; index++ {
+			at := start.Add(time.Duration(index+1) * time.Millisecond)
+			correlator.ObserveHardware(HardwareSample{
+				Timestamp:   at,
+				PeriodStart: start,
+				Device:      fmt.Sprintf("eth%d", index%2),
+				Delta:       map[Counter]uint64{CounterRXMissed: 1},
+			})
+		}
+	}()
+	go func() {
+		defer wait.Done()
+		for index := 0; index < perWorker; index++ {
+			_ = correlator.Snapshot()
+			_ = correlator.RecentSince(start)
+		}
+	}()
+	wait.Wait()
+	correlator.Flush(start.Add(time.Minute))
+
+	snapshot := correlator.Snapshot()
+	if snapshot.Events != workers*perWorker {
+		t.Fatalf("events = %d, want %d", snapshot.Events, workers*perWorker)
+	}
+	if snapshot.Pending != 0 {
+		t.Fatalf("pending = %d after flush", snapshot.Pending)
+	}
+	if snapshot.Incidents != snapshot.Events {
+		t.Fatalf("incidents = %d, events = %d", snapshot.Incidents, snapshot.Events)
+	}
+}
+
+func TestConfigureDefaultReplacesInstance(t *testing.T) {
+	first := ConfigureDefault(Options{PendingLimit: 1})
+	if Default() != first {
+		t.Fatal("Default did not return configured correlator")
+	}
+	second := ConfigureDefault(Options{PendingLimit: 2})
+	if second == first || Default() != second {
+		t.Fatal("ConfigureDefault did not atomically replace instance")
+	}
+}

--- a/internal/dropcorrelation/counters.go
+++ b/internal/dropcorrelation/counters.go
@@ -1,0 +1,214 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropcorrelation
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CounterNormalizer converts driver-specific ethtool names and generic sysfs
+// names into monotonic deltas. It is safe for concurrent use because dynamic
+// interface discovery can overlap with metric scrapes.
+type CounterNormalizer struct {
+	mu       sync.Mutex
+	previous map[string]normalizedAbsolute
+}
+
+type normalizedAbsolute struct {
+	timestamp int64
+	values    map[Counter]uint64
+}
+
+// NewCounterNormalizer creates an empty normalizer. The first sample for each
+// device establishes a baseline and therefore has zero deltas.
+func NewCounterNormalizer() *CounterNormalizer {
+	return &CounterNormalizer{previous: make(map[string]normalizedAbsolute)}
+}
+
+// Normalize converts and differences one absolute sample.
+func (n *CounterNormalizer) Normalize(raw RawSample) (HardwareSample, error) {
+	if err := validateRawSample(raw); err != nil {
+		return HardwareSample{}, err
+	}
+
+	values, sources := normalizeAbsolute(raw.Driver, raw.Sysfs, raw.Ethtool)
+	result := HardwareSample{
+		Timestamp: raw.Timestamp,
+		Device:    raw.Device,
+		Driver:    raw.Driver,
+		Delta:     make(map[Counter]uint64, len(values)),
+		Sources:   sources,
+	}
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	previous, found := n.previous[raw.Device]
+	if found {
+		result.PeriodStart = unixNanoTime(previous.timestamp)
+		for counter, current := range values {
+			old, existed := previous.values[counter]
+			if !existed {
+				continue
+			}
+			if current < old {
+				result.Reset = true
+				continue
+			}
+			result.Delta[counter] = current - old
+		}
+	} else {
+		result.PeriodStart = raw.Timestamp
+	}
+
+	n.previous[raw.Device] = normalizedAbsolute{
+		timestamp: raw.Timestamp.UnixNano(),
+		values:    values,
+	}
+	return result, nil
+}
+
+// Forget removes a device baseline after hot-unplug so a device with a reused
+// name does not generate a false reset or enormous delta.
+func (n *CounterNormalizer) Forget(device string) {
+	n.mu.Lock()
+	delete(n.previous, device)
+	n.mu.Unlock()
+}
+
+// Devices returns current baseline devices in deterministic order.
+func (n *CounterNormalizer) Devices() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	devices := make([]string, 0, len(n.previous))
+	for device := range n.previous {
+		devices = append(devices, device)
+	}
+	sort.Strings(devices)
+	return devices
+}
+
+// unixNanoTime is kept behind a helper to make the representation explicit.
+func unixNanoTime(value int64) time.Time {
+	return time.Unix(0, value)
+}
+
+type aliasSet struct {
+	counter Counter
+	names   []string
+}
+
+var genericAliases = []aliasSet{
+	{CounterRXDropped, []string{"rx_dropped", "rx_drops", "rx_discards", "rx_discard"}},
+	{CounterRXMissed, []string{"rx_missed_errors", "rx_missed", "rx_missed_packets", "rx_no_dma_resources"}},
+	{CounterRXErrors, []string{"rx_errors", "rx_error", "rx_crc_errors", "rx_length_errors"}},
+	{CounterRXNoBuf, []string{"rx_no_buffer", "rx_no_buffer_count", "rx_out_of_buffer", "rx_buffer_passed_thres_phy"}},
+	{CounterTXDropped, []string{"tx_dropped", "tx_drops", "tx_discards", "tx_discard"}},
+	{CounterTXErrors, []string{"tx_errors", "tx_error", "tx_carrier_errors", "tx_fifo_errors"}},
+	{CounterTXTimeout, []string{"tx_timeout", "tx_timeouts", "tx_timeout_count", "tx_queue_stopped"}},
+}
+
+var driverAliases = map[string][]aliasSet{
+	"mlx5_core": {
+		{CounterRXDropped, []string{"rx_out_of_buffer", "rx_vport_unicast_packets_drop", "rx_vport_multicast_packets_drop"}},
+		{CounterRXErrors, []string{"rx_crc_errors_phy", "rx_in_range_len_errors_phy", "rx_out_of_range_len_phy"}},
+		{CounterTXDropped, []string{"tx_vport_unicast_packets_drop", "tx_vport_multicast_packets_drop"}},
+	},
+	"i40e": {
+		{CounterRXMissed, []string{"rx_no_dma_resources", "rx_alloc_fail"}},
+		{CounterRXErrors, []string{"rx_crc_errors", "rx_length_errors"}},
+		{CounterTXDropped, []string{"tx_busy", "tx_dropped_link_down"}},
+	},
+	"ixgbe": {
+		{CounterRXMissed, []string{"rx_no_dma_resources", "rx_missed_errors"}},
+		{CounterRXErrors, []string{"rx_crc_errors", "rx_csum_offload_errors"}},
+		{CounterTXTimeout, []string{"tx_restart_queue", "tx_timeout_count"}},
+	},
+	"bnxt_en": {
+		{CounterRXMissed, []string{"rx_oom_discards", "rx_netpoll_discards"}},
+		{CounterRXErrors, []string{"rx_l4_csum_errors", "rx_resets"}},
+		{CounterTXDropped, []string{"tx_discard_pkts", "tx_error_pkts"}},
+	},
+	"virtio_net": {
+		{CounterRXNoBuf, []string{"rx_queue_0_drops", "rx_queue_0_xdp_drops"}},
+		{CounterTXDropped, []string{"tx_queue_0_drops", "tx_queue_0_xdp_drops"}},
+	},
+}
+
+func normalizeAbsolute(driver string, sysfs, ethtool map[string]uint64) (map[Counter]uint64, map[Counter][]string) {
+	values := make(map[Counter]uint64, len(allCounters))
+	sources := make(map[Counter][]string, len(allCounters))
+	seen := make(map[string]struct{})
+
+	sets := make([]aliasSet, 0, len(genericAliases)+len(driverAliases[driver]))
+	sets = append(sets, driverAliases[driver]...)
+	sets = append(sets, genericAliases...)
+	for _, set := range sets {
+		for _, name := range set.names {
+			canonical := canonicalCounterName(name)
+			key := string(set.counter) + "\x00" + canonical
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			if value, exists := lookupCanonical(ethtool, canonical); exists {
+				values[set.counter] += value
+				sources[set.counter] = append(sources[set.counter], "ethtool:"+canonical)
+			}
+		}
+	}
+
+	// Sysfs counters are fallbacks. Adding both sysfs and driver counters would
+	// double-count the same packets on many drivers.
+	for _, set := range genericAliases {
+		if len(sources[set.counter]) != 0 {
+			continue
+		}
+		for _, name := range set.names {
+			canonical := canonicalCounterName(name)
+			if value, exists := lookupCanonical(sysfs, canonical); exists {
+				values[set.counter] = value
+				sources[set.counter] = []string{"sysfs:" + canonical}
+				break
+			}
+		}
+	}
+
+	for counter := range sources {
+		sort.Strings(sources[counter])
+	}
+	return values, sources
+}
+
+func canonicalCounterName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.NewReplacer("-", "_", " ", "_", ".", "_").Replace(name)
+	for strings.Contains(name, "__") {
+		name = strings.ReplaceAll(name, "__", "_")
+	}
+	return strings.Trim(name, "_")
+}
+
+func lookupCanonical(values map[string]uint64, wanted string) (uint64, bool) {
+	for name, value := range values {
+		if canonicalCounterName(name) == wanted {
+			return value, true
+		}
+	}
+	return 0, false
+}

--- a/internal/dropcorrelation/counters_test.go
+++ b/internal/dropcorrelation/counters_test.go
@@ -1,0 +1,301 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dropcorrelation
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCounterNormalizerBaselineAndDelta(t *testing.T) {
+	normalizer := NewCounterNormalizer()
+	start := time.Unix(100, 0)
+	baseline, err := normalizer.Normalize(RawSample{
+		Timestamp: start,
+		Device:    "eth0",
+		Driver:    "i40e",
+		Sysfs: map[string]uint64{
+			"rx_dropped":       10,
+			"tx_dropped":       2,
+			"tx_errors":        1,
+			"tx_fifo_errors":   1,
+			"rx_missed_errors": 4,
+		},
+	})
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	if got := baseline.Total(DirectionRX); got != 0 {
+		t.Fatalf("baseline RX total = %d, want 0", got)
+	}
+
+	next, err := normalizer.Normalize(RawSample{
+		Timestamp: start.Add(10 * time.Second),
+		Device:    "eth0",
+		Driver:    "i40e",
+		Sysfs: map[string]uint64{
+			"rx_dropped":       15,
+			"rx_missed_errors": 7,
+			"tx_dropped":       4,
+			"tx_errors":        2,
+			"tx_fifo_errors":   2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("next sample: %v", err)
+	}
+	if !next.PeriodStart.Equal(start) {
+		t.Fatalf("period start = %s, want %s", next.PeriodStart, start)
+	}
+	if got := next.Delta[CounterRXDropped]; got != 5 {
+		t.Errorf("rx_dropped delta = %d, want 5", got)
+	}
+	if got := next.Delta[CounterRXMissed]; got != 3 {
+		t.Errorf("rx_missed delta = %d, want 3", got)
+	}
+	if got := next.Delta[CounterTXDropped]; got != 2 {
+		t.Errorf("tx_dropped delta = %d, want 2", got)
+	}
+	if got := next.Total(DirectionRX); got != 3 {
+		t.Errorf("RX total = %d, want specific rx_missed count 3", got)
+	}
+	if got := next.Total(DirectionTX); got != 3 {
+		t.Errorf("TX total = %d, want dropped + canonical error = 3", got)
+	}
+}
+
+func TestCounterNormalizerRejectsInvalidSamples(t *testing.T) {
+	normalizer := NewCounterNormalizer()
+	tests := []struct {
+		name string
+		raw  RawSample
+		want error
+	}{
+		{name: "empty device", raw: RawSample{Timestamp: time.Now()}, want: ErrEmptyDevice},
+		{name: "whitespace device", raw: RawSample{Timestamp: time.Now(), Device: "  "}, want: ErrEmptyDevice},
+		{name: "empty timestamp", raw: RawSample{Device: "eth0"}, want: ErrEmptyTimestamp},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizer.Normalize(test.raw)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCounterNormalizerDetectsResetWithoutUnderflow(t *testing.T) {
+	normalizer := NewCounterNormalizer()
+	start := time.Unix(200, 0)
+	_, _ = normalizer.Normalize(RawSample{
+		Timestamp: start,
+		Device:    "ens5",
+		Sysfs:     map[string]uint64{"rx_dropped": 1_000, "tx_errors": 500},
+	})
+	sample, err := normalizer.Normalize(RawSample{
+		Timestamp: start.Add(time.Second),
+		Device:    "ens5",
+		Sysfs:     map[string]uint64{"rx_dropped": 3, "tx_errors": 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sample.Reset {
+		t.Fatal("Reset = false, want true")
+	}
+	if got := sample.Delta[CounterRXDropped]; got != 0 {
+		t.Fatalf("reset delta underflowed to %d", got)
+	}
+	if got := sample.Delta[CounterTXErrors]; got != 0 {
+		t.Fatalf("reset TX delta underflowed to %d", got)
+	}
+}
+
+func TestCounterNormalizerForgetTreatsReusedNameAsBaseline(t *testing.T) {
+	normalizer := NewCounterNormalizer()
+	now := time.Unix(300, 0)
+	_, _ = normalizer.Normalize(RawSample{
+		Timestamp: now,
+		Device:    "eth9",
+		Sysfs:     map[string]uint64{"rx_dropped": 999},
+	})
+	normalizer.Forget("eth9")
+	sample, err := normalizer.Normalize(RawSample{
+		Timestamp: now.Add(time.Minute),
+		Device:    "eth9",
+		Sysfs:     map[string]uint64{"rx_dropped": 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sample.Reset {
+		t.Fatal("reused device name reported a reset")
+	}
+	if sample.Delta[CounterRXDropped] != 0 {
+		t.Fatal("reused device name produced a non-baseline delta")
+	}
+}
+
+func TestCounterNormalizerDevicesAreSortedCopies(t *testing.T) {
+	normalizer := NewCounterNormalizer()
+	now := time.Unix(400, 0)
+	for _, device := range []string{"z0", "a0", "m0"} {
+		_, err := normalizer.Normalize(RawSample{Timestamp: now, Device: device})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := normalizer.Devices()
+	want := []string{"a0", "m0", "z0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("devices = %v, want %v", got, want)
+	}
+	got[0] = "mutated"
+	if reflect.DeepEqual(got, normalizer.Devices()) {
+		t.Fatal("Devices returned internal storage")
+	}
+}
+
+func TestNormalizeAbsoluteDriverAliases(t *testing.T) {
+	tests := []struct {
+		name    string
+		driver  string
+		stats   map[string]uint64
+		counter Counter
+		want    uint64
+	}{
+		{
+			name:    "mellanox out of buffer",
+			driver:  "mlx5_core",
+			stats:   map[string]uint64{"rx_out_of_buffer": 12},
+			counter: CounterRXDropped,
+			want:    12,
+		},
+		{
+			name:    "intel i40e dma starvation",
+			driver:  "i40e",
+			stats:   map[string]uint64{"rx-no-dma-resources": 8},
+			counter: CounterRXMissed,
+			want:    8,
+		},
+		{
+			name:    "intel ixgbe queue restart",
+			driver:  "ixgbe",
+			stats:   map[string]uint64{"tx restart queue": 3},
+			counter: CounterTXTimeout,
+			want:    3,
+		},
+		{
+			name:    "broadcom oom discard",
+			driver:  "bnxt_en",
+			stats:   map[string]uint64{"rx_oom_discards": 5},
+			counter: CounterRXMissed,
+			want:    5,
+		},
+		{
+			name:    "virtio rx queue drop",
+			driver:  "virtio_net",
+			stats:   map[string]uint64{"rx_queue_0_xdp_drops": 7},
+			counter: CounterRXNoBuf,
+			want:    7,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			values, sources := normalizeAbsolute(test.driver, nil, test.stats)
+			if got := values[test.counter]; got != test.want {
+				t.Fatalf("normalized value = %d, want %d; all=%v", got, test.want, values)
+			}
+			if len(sources[test.counter]) == 0 {
+				t.Fatalf("missing source for %s", test.counter)
+			}
+		})
+	}
+}
+
+func TestNormalizeAbsolutePrefersEthtoolOverSysfs(t *testing.T) {
+	values, sources := normalizeAbsolute(
+		"i40e",
+		map[string]uint64{"rx_missed_errors": 100},
+		map[string]uint64{"rx_no_dma_resources": 7},
+	)
+	if got := values[CounterRXMissed]; got != 7 {
+		t.Fatalf("rx missed = %d, want ethtool value 7", got)
+	}
+	if want := []string{"ethtool:rx_no_dma_resources"}; !reflect.DeepEqual(sources[CounterRXMissed], want) {
+		t.Fatalf("sources = %v, want %v", sources[CounterRXMissed], want)
+	}
+}
+
+func TestNormalizeAbsoluteFallsBackToSysfs(t *testing.T) {
+	values, sources := normalizeAbsolute(
+		"unknown_driver",
+		map[string]uint64{"rx_dropped": 11, "tx_errors": 4},
+		nil,
+	)
+	if values[CounterRXDropped] != 11 || values[CounterTXErrors] != 4 {
+		t.Fatalf("values = %v", values)
+	}
+	if got := sources[CounterRXDropped]; !reflect.DeepEqual(got, []string{"sysfs:rx_dropped"}) {
+		t.Fatalf("rx sources = %v", got)
+	}
+}
+
+func TestCanonicalCounterName(t *testing.T) {
+	tests := map[string]string{
+		" RX-Dropped ":        "rx_dropped",
+		"tx.queue stopped":    "tx_queue_stopped",
+		"__rx__crc__errors__": "rx_crc_errors",
+		"rx no buffer":        "rx_no_buffer",
+	}
+	for input, want := range tests {
+		if got := canonicalCounterName(input); got != want {
+			t.Errorf("canonicalCounterName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestHardwareSampleTotalAvoidsGenericRXDoubleCounting(t *testing.T) {
+	sample := HardwareSample{Delta: map[Counter]uint64{
+		CounterRXDropped: 100,
+		CounterRXMissed:  4,
+		CounterRXErrors:  2,
+		CounterRXNoBuf:   1,
+	}}
+	if got := sample.Total(DirectionRX); got != 7 {
+		t.Fatalf("Total(RX) = %d, want specific counters only (7)", got)
+	}
+	sample.Delta[CounterRXMissed] = 0
+	sample.Delta[CounterRXErrors] = 0
+	sample.Delta[CounterRXNoBuf] = 0
+	if got := sample.Total(DirectionRX); got != 100 {
+		t.Fatalf("Total(RX) fallback = %d, want rx_dropped (100)", got)
+	}
+}
+
+func TestAllCountersReturnsCopy(t *testing.T) {
+	first := AllCounters()
+	second := AllCounters()
+	if len(first) == 0 {
+		t.Fatal("AllCounters is empty")
+	}
+	first[0] = "mutated"
+	if second[0] == first[0] {
+		t.Fatal("AllCounters returned shared backing storage")
+	}
+}

--- a/internal/dropcorrelation/types.go
+++ b/internal/dropcorrelation/types.go
@@ -1,0 +1,291 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dropcorrelation joins low-frequency NIC counter samples with
+// high-frequency dropwatch events. It intentionally contains no Linux or
+// storage dependencies so the correlation policy can be tested deterministically.
+package dropcorrelation
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Layer identifies the lowest layer at which packet loss can be proven.
+// Values are stable because they are exported as metric and storage labels.
+type Layer string
+
+const (
+	LayerHardware      Layer = "hardware"
+	LayerDriver        Layer = "driver"
+	LayerProtocolStack Layer = "protocol_stack"
+	LayerUnknown       Layer = "unknown"
+)
+
+// Direction is the packet direction associated with a counter or event.
+type Direction string
+
+const (
+	DirectionRX      Direction = "rx"
+	DirectionTX      Direction = "tx"
+	DirectionUnknown Direction = "unknown"
+)
+
+// Counter is a normalized, monotonic NIC statistic. Drivers use many names for
+// the same condition; normalization keeps the rest of the pipeline independent
+// of Intel, Mellanox, Broadcom, or virtio naming conventions.
+type Counter string
+
+const (
+	CounterRXDropped Counter = "rx_dropped"
+	CounterRXMissed  Counter = "rx_missed"
+	CounterRXErrors  Counter = "rx_errors"
+	CounterRXNoBuf   Counter = "rx_no_buffer"
+	CounterTXDropped Counter = "tx_dropped"
+	CounterTXErrors  Counter = "tx_errors"
+	CounterTXTimeout Counter = "tx_timeout"
+)
+
+var allCounters = []Counter{
+	CounterRXDropped,
+	CounterRXMissed,
+	CounterRXErrors,
+	CounterRXNoBuf,
+	CounterTXDropped,
+	CounterTXErrors,
+	CounterTXTimeout,
+}
+
+// AllCounters returns normalized counters in deterministic order.
+func AllCounters() []Counter {
+	return append([]Counter(nil), allCounters...)
+}
+
+// Options controls memory use and time matching. Zero values are replaced by
+// conservative production defaults by New.
+type Options struct {
+	Window          time.Duration
+	PendingLimit    int
+	IncidentLimit   int
+	ReasonLimit     int
+	FutureTolerance time.Duration
+}
+
+// DefaultOptions returns settings suitable for a ten-second hardware polling
+// interval without allowing an event storm to grow memory without bound.
+func DefaultOptions() Options {
+	return Options{
+		Window:          15 * time.Second,
+		PendingLimit:    4096,
+		IncidentLimit:   1024,
+		ReasonLimit:     64,
+		FutureTolerance: time.Second,
+	}
+}
+
+func normalizeOptions(in Options) Options {
+	defaults := DefaultOptions()
+	if in.Window <= 0 {
+		in.Window = defaults.Window
+	}
+	if in.PendingLimit <= 0 {
+		in.PendingLimit = defaults.PendingLimit
+	}
+	if in.IncidentLimit <= 0 {
+		in.IncidentLimit = defaults.IncidentLimit
+	}
+	if in.ReasonLimit <= 0 {
+		in.ReasonLimit = defaults.ReasonLimit
+	}
+	if in.FutureTolerance < 0 {
+		in.FutureTolerance = 0
+	} else if in.FutureTolerance == 0 {
+		in.FutureTolerance = defaults.FutureTolerance
+	}
+	return in
+}
+
+// RawSample is one absolute snapshot collected from sysfs and ethtool.
+type RawSample struct {
+	Timestamp time.Time
+	Device    string
+	Driver    string
+	Sysfs     map[string]uint64
+	Ethtool   map[string]uint64
+}
+
+// HardwareSample is the normalized delta between two RawSamples.
+type HardwareSample struct {
+	Timestamp    time.Time
+	PeriodStart  time.Time
+	Device       string
+	Driver       string
+	Delta        map[Counter]uint64
+	Reset        bool
+	Sources      map[Counter][]string
+	ReadDegraded bool
+}
+
+// Total returns the hardware evidence for one packet direction.
+func (s HardwareSample) Total(direction Direction) uint64 {
+	var counters []Counter
+	switch direction {
+	case DirectionRX:
+		counters = []Counter{CounterRXMissed, CounterRXErrors, CounterRXNoBuf}
+		// rx_dropped is only used when a more specific hardware counter is absent.
+		if sumCounters(s.Delta, counters) == 0 {
+			counters = append(counters, CounterRXDropped)
+		}
+	case DirectionTX:
+		counters = []Counter{CounterTXDropped, CounterTXErrors, CounterTXTimeout}
+	default:
+		return 0
+	}
+	return sumCounters(s.Delta, counters)
+}
+
+func sumCounters(values map[Counter]uint64, counters []Counter) uint64 {
+	var total uint64
+	for _, counter := range counters {
+		total += values[counter]
+	}
+	return total
+}
+
+// KernelDrop is the subset of a dropwatch event needed for correlation.
+type KernelDrop struct {
+	ID          uint64
+	Timestamp   time.Time
+	Device      string
+	IfIndex     uint32
+	Direction   Direction
+	Reason      string
+	Stack       string
+	ContainerID string
+	Protocol    string
+	PacketLen   uint32
+}
+
+// Incident is an immutable correlation result suitable for persistent storage.
+type Incident struct {
+	Event            KernelDrop
+	Layer            Layer
+	Confidence       float64
+	Evidence         []string
+	HardwareDelta    map[Counter]uint64
+	HardwareSampleAt time.Time
+	Driver           string
+	CorrelationLag   time.Duration
+	FinalizedAt      time.Time
+}
+
+// MetricKey is the bounded label set used for cumulative incident metrics.
+type MetricKey struct {
+	Device    string
+	Direction Direction
+	Layer     Layer
+	Reason    string
+}
+
+// Snapshot is a point-in-time, race-free view of correlator state.
+type Snapshot struct {
+	Pending             int
+	DroppedPending      uint64
+	Events              uint64
+	Incidents           uint64
+	Resets              uint64
+	DegradedSamples     uint64
+	UnmatchedHardware   uint64
+	ByKey               map[MetricKey]uint64
+	LastHardwareByIface map[string]HardwareSample
+	Recent              []Incident
+}
+
+// SortedKeys returns metric keys in a stable order for tests and exporters.
+func (s Snapshot) SortedKeys() []MetricKey {
+	keys := make([]MetricKey, 0, len(s.ByKey))
+	for key := range s.ByKey {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		left, right := keys[i], keys[j]
+		if left.Device != right.Device {
+			return left.Device < right.Device
+		}
+		if left.Direction != right.Direction {
+			return left.Direction < right.Direction
+		}
+		if left.Layer != right.Layer {
+			return left.Layer < right.Layer
+		}
+		return left.Reason < right.Reason
+	})
+	return keys
+}
+
+var (
+	ErrEmptyDevice    = errors.New("drop correlation: empty device")
+	ErrEmptyTimestamp = errors.New("drop correlation: empty timestamp")
+)
+
+func validateRawSample(sample RawSample) error {
+	if strings.TrimSpace(sample.Device) == "" {
+		return ErrEmptyDevice
+	}
+	if sample.Timestamp.IsZero() {
+		return ErrEmptyTimestamp
+	}
+	return nil
+}
+
+func validateKernelDrop(event KernelDrop) error {
+	if event.Timestamp.IsZero() {
+		return ErrEmptyTimestamp
+	}
+	if event.Direction == "" {
+		return fmt.Errorf("drop correlation: direction is required")
+	}
+	return nil
+}
+
+func cloneCounterMap(in map[Counter]uint64) map[Counter]uint64 {
+	out := make(map[Counter]uint64, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneStringSlices(in map[Counter][]string) map[Counter][]string {
+	out := make(map[Counter][]string, len(in))
+	for key, value := range in {
+		out[key] = append([]string(nil), value...)
+	}
+	return out
+}
+
+func cloneHardwareSample(in HardwareSample) HardwareSample {
+	in.Delta = cloneCounterMap(in.Delta)
+	in.Sources = cloneStringSlices(in.Sources)
+	return in
+}
+
+func cloneIncident(in Incident) Incident {
+	in.Evidence = append([]string(nil), in.Evidence...)
+	in.HardwareDelta = cloneCounterMap(in.HardwareDelta)
+	return in
+}

--- a/pkg/types/dropwatch_correlation.go
+++ b/pkg/types/dropwatch_correlation.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// DropCorrelationIncident is the persistent representation of a dropwatch
+// event correlated with NIC hardware and driver evidence.
+type DropCorrelationIncident struct {
+	EventID              uint64            `json:"event_id"`
+	ObservedTimestamp    string            `json:"observed_timestamp"`
+	FinalizedTimestamp   string            `json:"finalized_timestamp"`
+	HardwareTimestamp    string            `json:"hardware_timestamp,omitempty"`
+	Device               string            `json:"device"`
+	IfIndex              uint32            `json:"ifindex,omitempty"`
+	Driver               string            `json:"driver,omitempty"`
+	Direction            string            `json:"direction"`
+	Layer                string            `json:"layer"`
+	Confidence           float64           `json:"confidence"`
+	DropReason           string            `json:"drop_reason"`
+	Protocol             string            `json:"protocol,omitempty"`
+	ContainerID          string            `json:"container_id,omitempty"`
+	PacketLength         uint32            `json:"packet_length,omitempty"`
+	CorrelationLagMS     float64           `json:"correlation_lag_ms"`
+	Evidence             []string          `json:"evidence"`
+	HardwareCounterDelta map[string]uint64 `json:"hardware_counter_delta,omitempty"`
+}


### PR DESCRIPTION
## Summary

Resolves #326 by correlating dropwatch events with normalized NIC hardware counter deltas and producing an explainable hardware/driver/protocol-stack classification.

## Production problem

Dropwatch can identify where an skb is released inside the kernel, but it cannot see packets lost before they enter the kernel. Conversely, sysfs and `ethtool -S` expose cumulative NIC loss counters without the event, container, protocol, or stack context needed for root-cause analysis. Operators currently have to compare these sources manually and can easily assign the loss to the wrong layer.

## What changed

- Added a concurrency-safe, bounded correlation engine in `internal/dropcorrelation`:
  - normalizes generic and driver-specific counters for mlx5, i40e, ixgbe, bnxt and virtio;
  - computes monotonic deltas and excludes counter resets without uint64 underflow;
  - correlates on device, direction and measurement window;
  - classifies the lowest proven layer as `hardware`, `driver`, `protocol_stack`, or `unknown` with confidence and evidence;
  - bounds pending events, recent incidents and Prometheus reason cardinality during storms.
- Connected dropwatch ingestion to the shared correlator while preserving the original event storage path.
- Extended `netdev_hw` to read ethtool and sysfs RX/TX loss signals, persist `dropwatch_correlation` incidents, and export queue/reset/degraded/unmatched/classification metrics.
- Added configuration defaults and documented safe sizing/known correlation limits.
- Added a provisioned Grafana dashboard for layer rate, top reasons, hardware deltas and health signals.

## User and developer impact

Operators can distinguish pre-kernel hardware loss from driver and protocol-stack drops without manually aligning command output and event timestamps. Degraded reads, hot-reset intervals, unmatched hardware loss, queue pressure, and classification evidence are explicit rather than hidden.

The correlation policy is isolated from Linux and storage dependencies, allowing deterministic tests and future driver aliases without changing the event pipeline.

## Scope and size

- 2,361 added lines across implementation, tests, dashboard and documentation.
- 1,975 added Go lines; the requested implementation size is not met by generated/vendor content or documentation padding.

## Validation

- `go test ./internal/dropcorrelation ./pkg/types`
- `go vet ./internal/dropcorrelation`
- Linux/amd64 compile check: `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c ./core/metrics`
- Grafana dashboard JSON parsed successfully with PowerShell `ConvertFrom-Json`.
- `git diff --check`

The concurrency stress test is included in `internal/dropcorrelation`, but `go test -race` was not reported as passing locally because the Windows runner has no C toolchain (`-race requires cgo`). The test is ready for Linux CI/race execution.

## Correlation limits

NIC counters are interval aggregates, so the implementation reports confidence/evidence and does not claim a one-to-one packet identity. SR-IOV, bond, bridge and tunnel deployments should include relevant lower devices in `DeviceList`; missing ethtool fields degrade to sysfs and are surfaced through metrics.
