### PR TITLE
feat(dropwatch): annotate drop layer and correlate hardware drops

### DIFF
--- a/core/events/dropwatch.go
+++ b/core/events/dropwatch.go
@@ -95,12 +95,120 @@ func handleDropwatchEvent(_ *toolstream.Session, ev *types.DropWatchTracing) err
 		ev.ContainerID = resolveContainerIDFromMeta(ev)
 	}
 
+	// Annotate the network-path layer from the drop-location stack frame so
+	// kernel drops can be sliced alongside netdev_hw hardware drops. Hardware
+	// events arrive with DropLayer already set; never overwrite those.
+	if ev.DropLayer == "" {
+		ev.DropLayer = classifyDropLayer(ev.Stack)
+	}
+
 	return tracing.Save(&tracing.WriteRequest{
 		TracerName:  "dropwatch",
 		ContainerID: ev.ContainerID,
 		TracerTime:  time.Now(),
 		TracerData:  ev,
 	})
+}
+
+// classifyDropLayer maps a kernel dropwatch stack to a network-path layer
+// (types.DropLayer*). The first frame is the innermost call — the function
+// that decided to free the skb (kfree_skb's location), so it identifies where
+// the drop happened.
+//
+// Hardware drops are out of scope here: they are counted by the NIC/driver
+// before an skb reaches the stack and never fire kfree_skb, so netdev_hw emits
+// them directly with DropLayerHardware.
+//
+// The taxonomy is intentionally coarse (protocol / driver / unknown); layering
+// it finer (per-L4 protocol, netfilter, socket) is a follow-up. Prefix lists
+// are matched against the bare function name, which covers the kallsyms frame
+// formats produced by internal/symbol: "fn+offset/size" and "fn/hexaddr"
+// (with an optional trailing " [module]").
+func classifyDropLayer(stack string) string {
+	fn := firstStackFunc(stack)
+	if fn == "" {
+		return types.DropLayerUnknown
+	}
+
+	switch {
+	case hasPrefix(fn, protocolFuncPrefixes):
+		return types.DropLayerProtocol
+	case hasPrefix(fn, driverFuncPrefixes):
+		return types.DropLayerDriver
+	default:
+		return types.DropLayerUnknown
+	}
+}
+
+// protocolFuncPrefixes covers drops decided inside the L3/L4 stack and the
+// socket/filter layer reached after netif_receive_skb.
+var protocolFuncPrefixes = []string{
+	"ip_", "ipv6_", "ip6_", "inet_",
+	"tcp_", "udp_", "icmp", "arp_", "sctp_",
+	"sock_queue_rcv", "sk_filter", "skb_copy_datagram", "skb_receive_datagram",
+	"nf_hook", "nf_recv", "nf_",
+}
+
+// driverFuncPrefixes covers drops at link-layer ingress and queuing before the
+// protocol stack: NAPI/GRO receive, netif_receive_skb hand-off, and qdisc.
+var driverFuncPrefixes = []string{
+	"netif_", "__netif_",
+	"napi_", "gro_",
+	"sch_", "__dev_queue_xmit", "dev_queue_xmit",
+	"netdev_", "enqueue_to_",
+}
+
+// firstStackFunc returns the bare function name of the innermost stack frame
+// that actually decided the drop. It strips the "+offset/size" or "/hexaddr"
+// suffix and any trailing " [module]", and skips the kfree_skb tracepoint
+// wrappers that occupy the top of the stack (e.g. "kfree_skb_reason",
+// "__kfree_skb") — the real drop location is the first frame after them.
+// Empty input or no frame yields "".
+func firstStackFunc(stack string) string {
+	for _, frame := range strings.Split(stack, "\n") {
+		frame = strings.TrimSpace(frame)
+		if frame == "" {
+			continue
+		}
+		// Strip a trailing module annotation first, e.g. "fn+0x1/0x2 [mlx5_core]".
+		if i := strings.LastIndex(frame, " ["); i >= 0 {
+			frame = frame[:i]
+		}
+		// Cut at the first offset/address separator.
+		fn := frame
+		for i, r := range frame {
+			if r == '+' || r == '/' {
+				fn = frame[:i]
+				break
+			}
+		}
+		if isKfreeSKBWrapper(fn) {
+			continue
+		}
+		return fn
+	}
+	return ""
+}
+
+// isKfreeSKBWrapper reports whether fn is the kfree_skb tracepoint entry point
+// itself rather than the function that decided the drop.
+func isKfreeSKBWrapper(fn string) bool {
+	switch {
+	case fn == "kfree_skb", fn == "__kfree_skb", fn == "kfree_skb_reason":
+		return true
+	case strings.HasPrefix(fn, "trace_kfree_skb"), strings.HasPrefix(fn, "perf_trace_kfree_skb"):
+		return true
+	}
+	return false
+}
+
+func hasPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveContainerIDFromMeta(ev *types.DropWatchTracing) string {

--- a/core/events/dropwatch_layer_test.go
+++ b/core/events/dropwatch_layer_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"huatuo-bamai/pkg/types"
+)
+
+func TestClassifyDropLayer(t *testing.T) {
+	cases := []struct {
+		name  string
+		stack string
+		want  string
+	}{
+		// protocol stack drops — resolved kallsyms frame "fn+offset/size"
+		{"tcp v4 receive", "kfree_skb_reason+0x40/0x60\ntcp_v4_do_rcv+0x1a2/0x3b0\ntcp_v4_rcv+0x99/0xc0", types.DropLayerProtocol},
+		{"tcp established", "__kfree_skb+0x10/0x20\ntcp_rcv_established+0x55/0x110", types.DropLayerProtocol},
+		{"udp queue", "kfree_skb_reason+0x40/0x60\nudp_queue_rcv_one_skb+0x77/0x200", types.DropLayerProtocol},
+		{"ip receive", "kfree_skb+0x10/0x20\nip_rcv+0x33/0x90", types.DropLayerProtocol},
+		{"ipv6 receive", "kfree_skb_reason+0x40/0x60\nipv6_rcv+0x21/0x80", types.DropLayerProtocol},
+		{"icmpv6", "__kfree_skb+0x10/0x20\nicmpv6_rcv+0x12/0x60", types.DropLayerProtocol},
+		{"arp", "kfree_skb_reason+0x40/0x60\narp_rcv+0x9/0x40", types.DropLayerProtocol},
+		{"socket filter", "kfree_skb+0x10/0x20\nsk_filter_trim_cap+0x44/0x120", types.DropLayerProtocol},
+		{"sock queue rcv", "kfree_skb_reason+0x40/0x60\nsock_queue_rcv_skb+0x5/0x50", types.DropLayerProtocol},
+		{"netfilter hook", "kfree_skb_reason+0x40/0x60\nnf_hook_slow+0x80/0xf0", types.DropLayerProtocol},
+
+		// driver / link-layer ingress
+		{"netif receive core", "kfree_skb_reason+0x40/0x60\n__netif_receive_skb_core+0x200/0x500", types.DropLayerDriver},
+		{"netif receive skb", "kfree_skb+0x10/0x20\nnetif_receive_skb+0x10/0x40", types.DropLayerDriver},
+		{"napi gro receive", "kfree_skb_reason+0x40/0x60\nnapi_gro_receive+0x77/0x1b0", types.DropLayerDriver},
+		{"qdisc direct xmit", "kfree_skb_reason+0x40/0x60\nsch_direct_xmit+0x120/0x200", types.DropLayerDriver},
+
+		// unknown — unclassifiable drop location
+		{"driver private func", "kfree_skb_reason+0x40/0x60\nmlx5e_rx_reporter+0x5/0x30", types.DropLayerUnknown},
+		{"arbitrary func", "kfree_skb+0x10/0x20\nsome_other_kernel_func+0x1/0x2", types.DropLayerUnknown},
+
+		// module-annotated frames
+		{"tcp with module", "kfree_skb_reason+0x40/0x60\ntcp_v4_rcv+0x99/0xc0 [kernel]", types.DropLayerProtocol},
+
+		// raw-address (unresolved) frame form "fn/hexaddr", as produced when
+		// kallsyms cannot resolve the symbol.
+		{"raw addr protocol", "kfree_skb/ffffffff963047b0\ntcp_v4_rcv/ffffffff96310000", types.DropLayerProtocol},
+		{"raw addr wrappers only", "kfree_skb/ffffffff963047b0\n__kfree_skb/ffffffff96304800", types.DropLayerUnknown},
+
+		// degenerate inputs
+		{"empty stack", "", types.DropLayerUnknown},
+		{"blank lines", "\n  \n\t", types.DropLayerUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyDropLayer(tc.stack)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("classifyDropLayer(%q) (-want +got):\n%s", tc.stack, diff)
+			}
+		})
+	}
+}
+
+func TestFirstStackFunc(t *testing.T) {
+	cases := []struct {
+		stack string
+		want  string
+	}{
+		{"kfree_skb_reason+0x40/0x60\ntcp_v4_do_rcv+0x1a2/0x3b0", "tcp_v4_do_rcv"},
+		{"tcp_v4_rcv+0x99/0xc0 [kernel]", "tcp_v4_rcv"},
+		{"kfree_skb/ffffffff963047b0", ""}, // wrapper only, nothing after
+		{"", ""},
+		{"  \n  \n", ""},
+	}
+	for _, tc := range cases {
+		got := firstStackFunc(tc.stack)
+		if diff := cmp.Diff(tc.want, got); diff != "" {
+			t.Errorf("firstStackFunc(%q) (-want +got):\n%s", tc.stack, diff)
+		}
+	}
+}

--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"huatuo-bamai/internal/bpf"
 	"huatuo-bamai/internal/log"
@@ -32,6 +33,7 @@ import (
 	"huatuo-bamai/internal/utils/parseutil"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
 
 	"github.com/safchain/ethtool"
 )
@@ -43,6 +45,10 @@ type netdevHw struct {
 	prog                  bpf.BPF
 	running               atomic.Bool
 	ifaceSwDroppedCounter map[string]uint64
+	// ifaceHwDroppedCounter holds the last emitted cumulative hardware drop
+	// count per interface, used to derive the per-interval delta emitted as a
+	// dropwatch tracing event (see emitHwDropDelta).
+	ifaceHwDroppedCounter map[string]uint64
 	ifaceList             map[string]*ethtool.DrvInfo
 	sysNetPath            string
 	mutex                 sync.Mutex
@@ -71,6 +77,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 
 	ifaceList := make(map[string]*ethtool.DrvInfo)
 	ifaceSwCounter := make(map[string]uint64)
+	ifaceHwCounter := make(map[string]uint64)
 
 	log.Infof("processing interfaces: %v", ifaces)
 	for _, iface := range ifaces {
@@ -88,6 +95,9 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 
 		ifaceList[iface] = &drv
 		ifaceSwCounter[iface] = 0
+		// ifaceHwCounter is intentionally NOT pre-populated: the first
+		// emitHwDropDelta sample baselines the cumulative counter so the
+		// boot-time accumulation is not mistaken for fresh drops.
 		log.Debugf("support iface %s [%s] hardware rx_dropped", iface, drv.Driver)
 	}
 
@@ -95,6 +105,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 		TracingData: &netdevHw{
 			ifaceList:             ifaceList,
 			ifaceSwDroppedCounter: ifaceSwCounter,
+			ifaceHwDroppedCounter: ifaceHwCounter,
 			sysNetPath:            sysfs.Path("class/net"),
 		},
 		Interval: 10,
@@ -142,9 +153,59 @@ func (netdev *netdevHw) Update() ([]*metric.Data, error) {
 			"count of packets dropped at hardware level",
 			map[string]string{"device": iface, "driver": drv.Driver},
 		))
+
+		// Correlate hardware drops with kernel dropwatch events: emit the
+		// per-interval delta as a dropwatch tracing event tagged
+		// DropLayerHardware so both sources share one schema/stream and can be
+		// sliced by drop_layer on one timeline. Must be called under mutex.
+		netdev.emitHwDropDelta(iface, count)
 	}
 
 	return data, nil
+}
+
+// emitHwDropDelta tracks the cumulative hardware-drop counter for iface and,
+// when it grows, emits a dropwatch tracing event carrying the delta. The first
+// observed sample baselines the counter (no event) so the boot-time cumulative
+// count is not mistaken for fresh drops. A decrease (driver reset / counter
+// wraparound) is treated as a fresh baseline via hwDropDelta.
+func (netdev *netdevHw) emitHwDropDelta(iface string, cur uint64) {
+	prev, exists := netdev.ifaceHwDroppedCounter[iface]
+	netdev.ifaceHwDroppedCounter[iface] = cur
+	if !exists {
+		return // first sample: baseline, nothing to report
+	}
+
+	delta := hwDropDelta(prev, cur)
+	if delta == 0 {
+		return
+	}
+
+	ev := &types.DropWatchTracing{
+		ObservedTimestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Source:            types.DropSourceTypesMetric,
+		Type:              "hw_drop",
+		NetdevName:        iface,
+		DropLayer:         types.DropLayerHardware,
+		DropCount:         delta,
+	}
+	if err := tracing.Save(&tracing.WriteRequest{
+		TracerName: "dropwatch",
+		TracerTime: time.Now(),
+		TracerData: ev,
+	}); err != nil {
+		log.Warnf("netdev_hw: save hardware drop event for %s: %v", iface, err)
+	}
+}
+
+// hwDropDelta returns the positive difference between two cumulative hardware
+// drop counters. A decrease (counter reset or wraparound) reports the current
+// value as-is so a reset never surfaces as a huge spurious delta.
+func hwDropDelta(prev, cur uint64) uint64 {
+	if cur >= prev {
+		return cur - prev
+	}
+	return cur
 }
 
 func (netdev *netdevHw) readSysNetclassStat(iface, stat string) (uint64, error) {

--- a/core/metrics/netdev_hw_test.go
+++ b/core/metrics/netdev_hw_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestHwDropDelta(t *testing.T) {
+	cases := []struct {
+		name string
+		prev uint64
+		cur  uint64
+		want uint64
+	}{
+		{"normal growth", 10, 15, 5},
+		{"no change", 42, 42, 0},
+		{"both zero", 0, 0, 0},
+		{"first sample style", 0, 100, 100}, // pure-fn behavior; emitHwDropDelta suppresses via baseline
+		{"counter reset", 1000, 5, 5},       // decrease reports current, not a spurious huge delta
+		{"wraparound to zero", math.MaxUint64, 0, 0},
+		{"wraparound small", math.MaxUint64 - 3, 2, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hwDropDelta(tc.prev, tc.cur)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("hwDropDelta(%d, %d) (-want +got):\n%s", tc.prev, tc.cur, diff)
+			}
+		})
+	}
+}

--- a/pkg/types/dropwatch.go
+++ b/pkg/types/dropwatch.go
@@ -46,10 +46,34 @@ type DropWatchTracing struct {
 	PacketLen           uint32         `json:"packet_len"`
 	Layers              *packet.Packet `json:"layers,omitempty"`
 	Stack               string         `json:"stack"`
+
+	// DropLayer annotates where in the network path the packet was lost, so
+	// kernel dropwatch events (protocol/driver stack frames) and hardware
+	// rx_dropped aggregates from netdev_hw can be correlated on one timeline.
+	// See the DropLayer* values below. Omitempty keeps legacy events unchanged.
+	DropLayer string `json:"drop_layer,omitempty"`
+
+	// DropCount carries the number of packets lost for aggregate events that
+	// do not represent a single skb — today only the netdev_hw hardware-drop
+	// event (DropLayer == DropLayerHardware) sets it to the per-interval delta.
+	// Per-packet kernel dropwatch events leave it unset.
+	DropCount uint64 `json:"drop_count,omitempty"`
 }
 
 // Values for DropWatchTracing.Source.
 const (
-	DropSourceTypesEvent = "events"
-	DropSourceTypesTool  = "tools"
+	DropSourceTypesEvent  = "events"
+	DropSourceTypesTool   = "tools"
+	DropSourceTypesMetric = "metrics" // hardware rx_dropped aggregate from netdev_hw
+)
+
+// Values for DropWatchTracing.DropLayer — the network-path layer where a drop
+// happened. Hardware drops (counted by the NIC/driver before reaching the
+// stack) never reach the kfree_skb tracepoint, so they are emitted by netdev_hw
+// directly; kernel drops are classified from the drop-location stack frame.
+const (
+	DropLayerHardware = "hardware" // NIC/driver drop counted via rx_dropped (netdev_hw)
+	DropLayerDriver   = "driver"   // link-layer ingress: netif_receive_skb, napi, qdisc...
+	DropLayerProtocol = "protocol" // L3/L4 stack: ip, ipv6, tcp, udp, icmp, arp, socket...
+	DropLayerUnknown  = "unknown"  // drop location could not be classified
 )


### PR DESCRIPTION
## What

Annotates every dropwatch packet-loss event with the network-path **layer** it occurred at, and emits **hardware** rx_dropped drops into the same event stream, so hardware (NIC/driver) and kernel (protocol-stack) drops can be correlated on one timeline.

Closes ccfos/huatuo#326.

## Why

Network packet loss happens at multiple layers — hardware (NIC ring exhaustion, driver), link-layer ingress, and the L3/L4 protocol stack. huatuo already collects both:

- **kernel drops** via the `dropwatch` tool (`tracepoint/skb/kfree_skb`), and
- **hardware drops** via `netdev_hw` (sysfs `rx_dropped` / `rx_missed_errors`, minus software drops),

… but the two live in separate streams with no shared dimension, so there is no way to see — for one device over time — where loss is actually happening. Hardware drops in particular never reach `kfree_skb` (the NIC/driver drops them before an skb is formed), so they are invisible to dropwatch entirely.

## How

**One schema, one stream, a `drop_layer` dimension.**

`types.DropWatchTracing` gains two backward-compatible fields:

- `drop_layer` — `hardware` | `driver` | `protocol` | `unknown`
- `drop_count` — number of packets, for aggregate (non-per-skb) events

Both `omitempty`, so existing events / storage / tests are unchanged.

**Kernel drops are classified by the drop-location stack frame.** The innermost frame of a `kfree_skb` event is the function that *decided* the drop, not the tracepoint wrapper — `firstStackFunc` skips `kfree_skb` / `__kfree_skb` / `kfree_skb_reason` / `trace_*` wrappers and reads the real caller, then `classifyDropLayer` maps its prefix:

- **protocol** — `ip_`, `ipv6_`, `tcp_`, `udp_`, `icmp*`, `arp_`, `sctp_`, socket filter (`sk_filter`, `sock_queue_rcv_skb`), netfilter (`nf_*`)
- **driver** — `netif_` / `__netif_`, `napi_`, `gro_`, qdisc (`sch_`, `dev_queue_xmit`)
- **unknown** — anything else

**Hardware drops become events.** `netdev_hw.Update()` already computes the cumulative hardware-drop counter per interface; it now tracks the previous value and, when the delta is non-zero, emits a `dropwatch` tracing event with `drop_layer=hardware`, `source=metrics`, `drop_count=<delta>`, saved under tracer name `dropwatch` so hardware and kernel drops land in the **same** storage stream, slicable by `drop_layer` and `netdev_name`. The first sample baselines the counter (boot-time accumulation is not mistaken for fresh drops); counter resets/wraparound report the current value rather than a spurious huge delta.

## Changes

- **`pkg/types/dropwatch.go`** — `DropLayer`, `DropCount` fields; `DropLayer*` and `DropSourceTypesMetric` constants.
- **`core/events/dropwatch.go`** — `classifyDropLayer` / `firstStackFunc` / `isKfreeSKBWrapper`; `handleDropwatchEvent` sets `DropLayer` on kernel events (never overwriting the hardware tag).
- **`core/events/dropwatch_layer_test.go`** (new) — table-driven classifier tests across stack-frame formats (`fn+offset/size`, `fn/hexaddr`, ` [module]`).
- **`core/metrics/netdev_hw.go`** — `emitHwDropDelta` + `hwDropDelta`; per-interval delta emission.
- **`core/metrics/netdev_hw_test.go`** (new) — `hwDropDelta` cases incl. reset / wraparound.

## Verification

Built and tested on the `wzu` host (Linux 6.8):

- ✅ `go build ./...`
- ✅ `go test ./core/events/... ./core/metrics/... ./pkg/types/... ./cmd/dropwatch/...` (incl. the new `TestClassifyDropLayer`, `TestFirstStackFunc`, `TestHwDropDelta`)
- ✅ `go vet ./core/events/... ./core/metrics/... ./pkg/types/... ./cmd/dropwatch/...`
- ✅ `goimports` / `gofumpt` / `golangci-lint` (v1.62.2, repo config) clean on touched packages
- ✅ `make all` — all 6 binaries + 28 BPF objects build green

## Out of scope (follow-ups)

- Grafana layered panel + alerting rules (the data model and `drop_layer` dimension now make this straightforward).
- Layer classification on the producer side (the standalone `dropwatch` tool binary) — currently consumer-side only; storage / Grafana already see `drop_layer`.
- TX-direction hardware drops (`netdev_hw` is RX-focused today).
- Finer layering (per-L4 protocol, separate netfilter vs socket) — the taxonomy is intentionally coarse for v1.
