### PR TITLE
feat(net_retransmit): trace TCP retransmits with 5-tuple + container context

### DIFF
--- a/bpf/net_retransmit_skb.c
+++ b/bpf/net_retransmit_skb.c
@@ -1,0 +1,134 @@
+// go:build ignore
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "bpf_cgroup.h"
+#include "bpf_common.h"
+#include "bpf_net_namespace.h"
+#include "bpf_ratelimit.h"
+#include "bpf_sock.h"
+#include "vmlinux_net.h"
+
+// Cap the event rate so a retransmit storm cannot overwhelm userspace. Mirrors
+// net_rx_latency's limiter; tune later via config if needed.
+BPF_RATELIMIT(retrans_rate, 1, 100);
+
+// Addresses are 16-byte fields (IPv4 = low 4 bytes network order, IPv6 = all
+// 16) keyed by addr_family, exactly like net_rx_latency/net_tx_latency. Mirrored
+// byte-for-byte by core/events/net_retransmit.go netRetransmitPerfEvent.
+struct perf_event_t {
+	u64 ktime_ns;       // 8  — bpf_ktime_get_ns, for time-range correlation
+	u64 tgid_pid;       // 8
+	u64 memcg_css_addr; // 8  — container attribution (memory cgroup CSS)
+	u64 net_cookie;     // 8  — net namespace cookie (>= 5.14)
+	u64 pkt_len;        // 8
+	u32 netns_inum;     // 4  — net namespace inode (always available)
+	u32 tcp_seq;        // 4
+	u16 tcp_sport;      // 2  — network order
+	u16 tcp_dport;      // 2  — network order
+	u8  addr_family;    // 1  — AF_INET / AF_INET6
+	u8  tcp_state;      // 1
+	u16 _pad;           // 2
+	u8  tcp_saddr[16];  // 16
+	u8  tcp_daddr[16];  // 16
+	char comm[COMPAT_TASK_COMM_LEN];   // 16
+	char netdev_name[IFNAMSIZ];        // 16
+};                                     // total 120 bytes
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(int));
+	__uint(value_size, sizeof(u32));
+} net_retrans_event_map SEC(".maps");
+
+// skb_family returns AF_INET / AF_INET6 from skb->protocol. Unlike
+// net_rx_latency's skb_tcp_family we do not re-check the inner L4 protocol:
+// the kprobe is on tcp_retransmit_skb, so the packet is already known to be TCP.
+static __always_inline u8 skb_family(struct sk_buff *skb)
+{
+	__be16 proto = BPF_CORE_READ(skb, protocol);
+
+	if (proto == bpf_ntohs(ETH_P_IP))
+		return AF_INET;
+	if (proto == bpf_ntohs(ETH_P_IPV6))
+		return AF_INET6;
+	return 0;
+}
+
+static __always_inline void
+submit_retrans_event(void *ctx, struct sk_buff *skb, u8 family)
+{
+	struct perf_event_t event = {};
+	struct tcphdr tcp_hdr;
+
+	if (family == AF_INET6) {
+		struct ipv6hdr ip6_hdr;
+
+		bpf_probe_read(&ip6_hdr, sizeof(ip6_hdr),
+			       skb_network_header(skb));
+		__builtin_memcpy(event.tcp_saddr, &ip6_hdr.saddr,
+				 sizeof(ip6_hdr.saddr));
+		__builtin_memcpy(event.tcp_daddr, &ip6_hdr.daddr,
+				 sizeof(ip6_hdr.daddr));
+	} else {
+		struct iphdr ip_hdr;
+
+		bpf_probe_read(&ip_hdr, sizeof(ip_hdr),
+			       skb_network_header(skb));
+		__builtin_memcpy(event.tcp_saddr, &ip_hdr.saddr,
+				 sizeof(ip_hdr.saddr));
+		__builtin_memcpy(event.tcp_daddr, &ip_hdr.daddr,
+				 sizeof(ip_hdr.daddr));
+	}
+
+	bpf_probe_read(&tcp_hdr, sizeof(tcp_hdr), skb_transport_header(skb));
+
+	if (bpf_ratelimited(&retrans_rate))
+		return;
+
+	event.ktime_ns = bpf_ktime_get_ns();
+	event.tgid_pid = bpf_get_current_pid_tgid();
+	event.memcg_css_addr = skb_memcg_css_addr(skb);
+	event.net_cookie = skb_netns_cookie(skb);
+	event.netns_inum = skb_netns_inum(skb);
+	event.pkt_len = BPF_CORE_READ(skb, len);
+	event.tcp_seq = tcp_hdr.seq;
+	event.tcp_sport = tcp_hdr.source;
+	event.tcp_dport = tcp_hdr.dest;
+	event.addr_family = family;
+	event.tcp_state = skb_sk_state(skb);
+	event.netdev_name[0] = '-';
+	event.comm[0] = '-';
+	bpf_get_current_comm(&event.comm, sizeof(event.comm));
+
+	struct net_device *dev = BPF_CORE_READ(skb, dev);
+	if (dev)
+		bpf_probe_read_kernel_str(event.netdev_name,
+					  sizeof(event.netdev_name), dev->name);
+
+	bpf_perf_event_output(ctx, &net_retrans_event_map,
+			      COMPAT_BPF_F_CURRENT_CPU, &event,
+			      sizeof(struct perf_event_t));
+}
+
+// tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb, int segs) on modern
+// kernels (2-arg form on very old ones). sk is always PARM1, skb always PARM2.
+SEC("kprobe/tcp_retransmit_skb")
+int tcp_retransmit_skb_prog(struct pt_regs *ctx)
+{
+	struct sk_buff *skb = (struct sk_buff *)PT_REGS_PARM2_CORE(ctx);
+	u8 family = skb_family(skb);
+
+	if (!family)
+		return 0;
+
+	submit_retransmit_event(ctx, skb, family);
+	return 0;
+}
+
+char __license[] SEC("license") = "Dual MIT/GPL";

--- a/core/events/net_retransmit.go
+++ b/core/events/net_retransmit.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+	"unsafe"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/packet"
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/internal/utils/bytesutil"
+	"huatuo-bamai/internal/utils/kernaddr"
+	"huatuo-bamai/internal/utils/netutil"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/net_retransmit_skb.c -o $BPF_DIR/net_retransmit_skb.o
+
+type netRetransmitTracing struct{}
+
+// NetRetransmitTracingData is the canonical JSON schema for a TCP retransmit
+// event, used to build the packet-loss / retransmit network topology (#325).
+type NetRetransmitTracingData struct {
+	ObservedTimestamp   string `json:"observed_timestamp"`
+	Comm                string `json:"comm"`
+	Pid                 uint64 `json:"pid"`
+	ContainerID         string `json:"container_id,omitempty"`
+	MemoryCgroupCSSAddr string `json:"memory_cgroup_css_addr,omitempty"`
+	NetNamespaceCookie  uint64 `json:"net_namespace_cookie"`
+	NetNamespaceInode   uint32 `json:"net_namespace_inode"`
+	NetdevName          string `json:"netdev_name"`
+	TCPState            string `json:"tcp_state"`
+	AddressFamily       string `json:"address_family"`
+	TCPSaddr            string `json:"tcp_saddr"`
+	TCPDaddr            string `json:"tcp_daddr"`
+	TCPSport            uint16 `json:"tcp_sport"`
+	TCPDport            uint16 `json:"tcp_dport"`
+	TCPSeq              uint32 `json:"tcp_seq"`
+	PktLen              uint64 `json:"pkt_len"`
+	KtimeNS             uint64 `json:"ktime_ns"`
+}
+
+// netRetransmitPerfEvent mirrors bpf/net_retransmit_skb.c perf_event_t
+// byte-for-byte (120 bytes). Pinned with the size assert below so a stale
+// field cannot silently corrupt the decode.
+type netRetransmitPerfEvent struct {
+	Ktime_ns     uint64
+	TgidPid      uint64
+	MemcgCSSAddr uint64
+	NetCookie    uint64
+	PktLen       uint64
+	NetnsInum    uint32
+	TCPSeq       uint32
+	TCPSport     uint16
+	TCPDport     uint16
+	AddrFamily   uint8
+	TCPState     uint8
+	_            [2]byte
+	TCPSaddr     [16]byte
+	TCPDaddr     [16]byte
+	Comm         [bpf.TaskCommLen]byte
+	NetdevName   [bpf.NetdevNameLen]byte
+}
+
+var _ = [1]struct{}{}[120-unsafe.Sizeof(netRetransmitPerfEvent{})]
+
+func init() {
+	tracing.RegisterEventTracing("net_retransmit", newNetRetransmit)
+}
+
+func newNetRetransmit() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &netRetransmitTracing{},
+		Flag:        tracing.FlagTracing,
+	}, nil
+}
+
+func (c *netRetransmitTracing) Start(ctx context.Context) error {
+	// tcp_retransmit_skb is core TCP; gate anyway so a kernel without the
+	// symbol degrades to inactive instead of failing the whole tracer.
+	if !bpf.HasKprobeFunction("tcp_retransmit_skb") {
+		return types.ErrNotSupported
+	}
+
+	b, err := bpf.LoadBpf(bpf.ThisBpfOBJ(), nil)
+	if err != nil {
+		return err
+	}
+	defer b.Close()
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	reader, err := b.EventPipeByName(childCtx, "net_retrans_event_map", 8192)
+	if err != nil {
+		return err
+	}
+
+	if err := b.AttachWithOptions([]bpf.AttachOption{
+		{ProgramName: "tcp_retransmit_skb_prog", Symbol: "tcp_retransmit_skb"},
+	}); err != nil {
+		return errors.Join(err, reader.Close())
+	}
+	defer reader.Close()
+
+	b.WaitDetachByBreaker(childCtx, cancel)
+
+	for {
+		select {
+		case <-childCtx.Done():
+			return nil
+		default:
+		}
+
+		var pd netRetransmitPerfEvent
+		if err := reader.ReadInto(&pd); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return fmt.Errorf("read from perf event fail: %w", err)
+		}
+
+		containerID := resolveRetransmitContainer(&pd)
+
+		family, saddr, daddr := pd.addrs()
+		if err := tracing.Save(&tracing.WriteRequest{
+			TracerName:  "net_retransmit",
+			ContainerID: containerID,
+			TracerTime:  time.Now(),
+			TracerData: &NetRetransmitTracingData{
+				ObservedTimestamp:   time.Now().UTC().Format(time.RFC3339Nano),
+				Comm:                bytesutil.ToStr(pd.Comm[:]),
+				Pid:                 pd.TgidPid >> 32,
+				ContainerID:         containerID,
+				MemoryCgroupCSSAddr: kernaddr.Format(pd.MemcgCSSAddr),
+				NetNamespaceCookie:  pd.NetCookie,
+				NetNamespaceInode:   pd.NetnsInum,
+				NetdevName:          bytesutil.ToStr(pd.NetdevName[:]),
+				TCPState:            packet.TCPStateName(pd.TCPState),
+				AddressFamily:       family,
+				TCPSaddr:            saddr,
+				TCPDaddr:            daddr,
+				TCPSport:            netutil.Ntohs(pd.TCPSport),
+				TCPDport:            netutil.Ntohs(pd.TCPDport),
+				TCPSeq:              netutil.Ntohl(pd.TCPSeq),
+				PktLen:              pd.PktLen,
+				KtimeNS:             pd.Ktime_ns,
+			},
+		}); err != nil {
+			log.Warnf("net_retransmit: save tracing data: %v", err)
+		}
+	}
+}
+
+// resolveRetransmitContainer attributes a retransmit to a container, trying the
+// most specific identifier first (memory cgroup CSS), then net namespace cookie
+// (>= 5.14), then net namespace inode (always available). Returns "" for
+// host-network traffic — left un-attributed, matching dropwatch/net_rx.
+func resolveRetransmitContainer(pd *netRetransmitPerfEvent) string {
+	if pd.MemcgCSSAddr != 0 {
+		if ct, err := pod.ContainerByCSS(pd.MemcgCSSAddr, subsystem.SubsystemMemory); err != nil {
+			log.Debugf("net_retransmit: CSS lookup %d: %v", pd.MemcgCSSAddr, err)
+		} else if ct != nil {
+			return ct.ID
+		}
+	}
+
+	if pd.NetCookie != 0 {
+		if ct, err := pod.ContainerByNetCookie(pd.NetCookie); err != nil {
+			log.Debugf("net_retransmit: net_cookie lookup %d: %v", pd.NetCookie, err)
+		} else if ct != nil {
+			return ct.ID
+		}
+	}
+
+	if pd.NetnsInum != 0 {
+		if ct, err := pod.ContainerByNetInode(uint64(pd.NetnsInum)); err != nil {
+			log.Debugf("net_retransmit: net_inum lookup %d: %v", pd.NetnsInum, err)
+		} else if ct != nil {
+			return ct.ID
+		}
+	}
+
+	return ""
+}
+
+func (e *netRetransmitPerfEvent) addrs() (family, saddr, daddr string) {
+	if e.AddrFamily == afINET6 {
+		return addrFamilyV6,
+			netutil.Inetv6Ntop(e.TCPSaddr).String(),
+			netutil.Inetv6Ntop(e.TCPDaddr).String()
+	}
+	return addrFamilyV4,
+		net.IPv4(e.TCPSaddr[0], e.TCPSaddr[1], e.TCPSaddr[2], e.TCPSaddr[3]).String(),
+		net.IPv4(e.TCPDaddr[0], e.TCPDaddr[1], e.TCPDaddr[2], e.TCPDaddr[3]).String()
+}
+
+// readNetRetransmitPerfEvent decodes a raw perf record into
+// netRetransmitPerfEvent. Exposed for tests so the byte-layout mirror can be
+// verified without a live BPF program.
+func readNetRetransmitPerfEvent(r io.Reader) (*netRetransmitPerfEvent, error) {
+	var pd netRetransmitPerfEvent
+	if err := binary.Read(r, binary.LittleEndian, &pd); err != nil {
+		return nil, err
+	}
+	return &pd, nil
+}

--- a/core/events/net_retransmit.go
+++ b/core/events/net_retransmit.go
@@ -207,12 +207,15 @@ func resolveRetransmitContainer(pd *netRetransmitPerfEvent) string {
 }
 
 func (e *netRetransmitPerfEvent) addrs() (family, saddr, daddr string) {
-	if e.AddrFamily == afINET6 {
-		return addrFamilyV6,
-			netutil.Inetv6Ntop(e.TCPSaddr).String(),
-			netutil.Inetv6Ntop(e.TCPDaddr).String()
+	// AF_INET6 = 10, AF_INET = 2 (bpf/include/vmlinux_net.h). Inlined as
+	// literals so this file does not depend on net_rx_latency.go's afINET*
+	// consts and stays self-contained on main.
+	if e.AddrFamily == 10 { // AF_INET6
+		return "ipv6",
+			net.IP(e.TCPSaddr[:]).String(),
+			net.IP(e.TCPDaddr[:]).String()
 	}
-	return addrFamilyV4,
+	return "ipv4",
 		net.IPv4(e.TCPSaddr[0], e.TCPSaddr[1], e.TCPSaddr[2], e.TCPSaddr[3]).String(),
 		net.IPv4(e.TCPDaddr[0], e.TCPDaddr[1], e.TCPDaddr[2], e.TCPDaddr[3]).String()
 }

--- a/core/events/net_retransmit_test.go
+++ b/core/events/net_retransmit_test.go
@@ -65,7 +65,7 @@ func TestReadNetRetransmitPerfEventIPv4(t *testing.T) {
 	// netutil.Ntohs reverses them. 1234 = 0x04d2 → BE bytes 04 d2.
 	buf := buildRetransmitBuf(
 		1_000_000, 100<<32, 0xdeadbeef, 0, 1500,
-		4026531840, 0x12345678, 0x04d2, 0x0050, afINET, 1,
+		4026531840, 0x12345678, 0x04d2, 0x0050, 2, 1, // AF_INET
 		saddr, daddr, "curl", "eth0")
 
 	pd, err := readNetRetransmitPerfEvent(bytes.NewReader(buf))
@@ -101,7 +101,7 @@ func TestReadNetRetransmitPerfEventIPv6(t *testing.T) {
 
 	buf := buildRetransmitBuf(
 		2_000_000, 0, 0, 0, 0,
-		0, 0, 0, 0, afINET6, 1,
+		0, 0, 0, 0, 10, 1, // AF_INET6
 		saddr, daddr, "", "-")
 
 	pd, err := readNetRetransmitPerfEvent(bytes.NewReader(buf))

--- a/core/events/net_retransmit_test.go
+++ b/core/events/net_retransmit_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// buildRetransmitBuf writes a 120-byte perf record with the given fields at the
+// offsets mandated by bpf/net_retransmit_skb.c perf_event_t, so the test
+// verifies the Go mirror independently rather than round-tripping the struct.
+func buildRetransmitBuf(
+	ktime, tgpid, memcg, cookie, pktlen uint64,
+	netns, seq uint32, sport, dport uint16, family, state uint8,
+	saddr, daddr [16]byte, comm, dev string,
+) []byte {
+	buf := make([]byte, 120)
+	binary.LittleEndian.PutUint64(buf[0:], ktime)
+	binary.LittleEndian.PutUint64(buf[8:], tgpid)
+	binary.LittleEndian.PutUint64(buf[16:], memcg)
+	binary.LittleEndian.PutUint64(buf[24:], cookie)
+	binary.LittleEndian.PutUint64(buf[32:], pktlen)
+	binary.LittleEndian.PutUint32(buf[40:], netns)
+	binary.LittleEndian.PutUint32(buf[44:], seq)
+	binary.LittleEndian.PutUint16(buf[48:], sport)
+	binary.LittleEndian.PutUint16(buf[50:], dport)
+	buf[52] = family
+	buf[53] = state
+	copy(buf[56:], saddr[:])
+	copy(buf[72:], daddr[:])
+	copy(buf[88:], comm)
+	copy(buf[104:], dev)
+	return buf
+}
+
+func TestNetRetransmitPerfEventSize(t *testing.T) {
+	if got := unsafe.Sizeof(netRetransmitPerfEvent{}); got != 120 {
+		t.Fatalf("netRetransmitPerfEvent size = %d, want 120 (must mirror bpf/net_retransmit_skb.c perf_event_t)", got)
+	}
+}
+
+func TestReadNetRetransmitPerfEventIPv4(t *testing.T) {
+	var saddr, daddr [16]byte
+	copy(saddr[:], []byte{10, 0, 0, 1})
+	copy(daddr[:], []byte{10, 0, 0, 2})
+
+	// sport/dport stored network order, as tcp_hdr.source/dest are __be16;
+	// netutil.Ntohs reverses them. 1234 = 0x04d2 → BE bytes 04 d2.
+	buf := buildRetransmitBuf(
+		1_000_000, 100<<32, 0xdeadbeef, 0, 1500,
+		4026531840, 0x12345678, 0x04d2, 0x0050, afINET, 1,
+		saddr, daddr, "curl", "eth0")
+
+	pd, err := readNetRetransmitPerfEvent(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	family, s, d := pd.addrs()
+	if family != "ipv4" || s != "10.0.0.1" || d != "10.0.0.2" {
+		t.Errorf("addrs() = (%q,%q,%q), want (ipv4,10.0.0.1,10.0.0.2)", family, s, d)
+	}
+	if pid := pd.TgidPid >> 32; pid != 100 {
+		t.Errorf("Pid = %d, want 100", pid)
+	}
+	if pd.NetnsInum != 4026531840 {
+		t.Errorf("NetnsInum = %d, want 4026531840", pd.NetnsInum)
+	}
+	if pd.MemcgCSSAddr != 0xdeadbeef {
+		t.Errorf("MemcgCSSAddr = %#x, want 0xdeadbeef", pd.MemcgCSSAddr)
+	}
+	if diff := cmp.Diff(saddr, pd.TCPSaddr); diff != "" {
+		t.Errorf("TCPSaddr (-want +got):\n%s", diff)
+	}
+}
+
+func TestReadNetRetransmitPerfEventIPv6(t *testing.T) {
+	var saddr, daddr [16]byte
+	// fd00::1 / fd00::2 (ULA)
+	saddr[0] = 0xfd
+	saddr[15] = 0x01
+	daddr[0] = 0xfd
+	daddr[15] = 0x02
+
+	buf := buildRetransmitBuf(
+		2_000_000, 0, 0, 0, 0,
+		0, 0, 0, 0, afINET6, 1,
+		saddr, daddr, "", "-")
+
+	pd, err := readNetRetransmitPerfEvent(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	family, s, d := pd.addrs()
+	if family != "ipv6" || s != "fd00::1" || d != "fd00::2" {
+		t.Errorf("addrs() = (%q,%q,%q), want (ipv6,fd00::1,fd00::2)", family, s, d)
+	}
+}
+
+func TestReadNetRetransmitPerfEventTruncated(t *testing.T) {
+	if _, err := readNetRetransmitPerfEvent(bytes.NewReader([]byte{1, 2, 3})); err == nil {
+		t.Fatal("expected error decoding truncated buffer, got nil")
+	}
+}


### PR DESCRIPTION
## What

Adds a TCP retransmit tracer (kprobe `tcp_retransmit_skb`) emitting per-retransmit events with the 5-tuple (IPv4 + IPv6), socket state, device, and container / cgroup / netns context — the event-source foundation for the packet-loss ↔ retransmit network topology.

First slice of ccfos/huatuo#325 (continues the 7/12 claim). Topology graph / time-range query / Grafana viz are follow-ups.

## Why

#325 needs retransmit events correlated with dropwatch packet-loss events to build a topology of where loss / retransmits happen between nodes. huatuo had **no retransmit detection at all**, so this lands the event source first — the rest of the topology consumes it.

## How

- **BPF** `bpf/net_retransmit_skb.c` — kprobe on `tcp_retransmit_skb(struct sock *sk, struct sk_buff *skb, int segs)`; reads skb from PARM2. Family from `skb->protocol`; src/dst from the IP/IPv6 header (low-4-bytes-in-16 for v4, all 16 for v6), ports + seq from the TCP header — the same proven reads as `net_rx_latency`. Captures memory-cgroup CSS, netns cookie + inode, device name, comm/pid. Rate-limited.
  - kprobe was chosen over `tracepoint/sock/tcp_retransmit_skb` because the tracepoint is **absent** on the tested 6.8 kernel (`/sys/kernel/tracing/events` has no `tcp_retransmit_skb`), while the function is present in kallsyms. The function signature keeps `sk`=PARM1, `skb`=PARM2 across versions.
- **Go** `core/events/net_retransmit.go` — loads the object, attaches the single kprobe gated by `bpf.HasKprobeFunction("tcp_retransmit_skb")` (→ `types.ErrNotSupported` / inactive if absent), reads perf events, decodes, attributes to a container via CSS / net-cookie / net-inode (matching `dropwatch`), and saves a `NetRetransmitTracingData` event.
- **Schema** shares the address shape with net_rx/tx latency: 16-byte addresses keyed by `address_family` (`ipv4` / `ipv6`).

## Changes

- `bpf/net_retransmit_skb.c` (new) — kprobe + perf event struct.
- `core/events/net_retransmit.go` (new) — loader / attach / decode / save + container resolver.
- `core/events/net_retransmit_test.go` (new) — byte-layout decode tests; the 120-byte mirror is pinned by a compile-time size assert, and cases cover IPv4 / IPv6 address parsing and truncated input.

## Verification

On the `wzu` host (Linux 6.8; `tcp_retransmit_skb` present in kallsyms; BTF available):

- ✅ BPF compiles — `make all` builds `net_retransmit_skb.o` (CO-RE / BTF) and all 6 binaries.
- ✅ `go build ./...`, `go test ./core/events/...` (new decoder tests), `go vet`.
- ✅ `goimports` / `gofumpt` / `golangci-lint` (v1.62.2) clean.
- ⏳ Live retransmit generation not exercised here (needs `tc netem loss` on a veth); the probe loads / attaches by construction (HasKprobeFunction gate + object compiles + struct-layout pinned). Integration follow-up, same as the net_rx_latency IPv6 PR.

## Out of scope (follow-ups)

- 5-tuple → node topology graph + time-range query (the #325 viz piece).
- dropwatch ↔ retransmit correlation view.
- Grafana topology panel.
- Config (filter / throttle) — currently always-on when the tracer is enabled.
