### PR TITLE
feat(profiler): inject PID/TGID/cgroup/pgroup dimensions as pprof labels (#329 PR 1/4)

### DIFF
--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -29,6 +29,54 @@ import (
 	"github.com/shirou/gopsutil/process"
 )
 
+// dimensionLabelSeparator is the marker between the existing header frame
+// (e.g. "threadName#pid") and any injected dimension labels. Using a ';' keeps
+// the result consistent with the collapsed-stack frame separator so flamegraph
+// renderers treat the labels as part of the first frame, while pprof/Pyroscope
+// backends still parse the `key=value` pairs as labels within that frame.
+const dimensionLabelSeparator = ";"
+
+// buildDimensionLabels renders the requested dimension labels in pprof
+// canonical form (e.g. "pid=123;tgid=456;cgroup=/kubepods/..."). Returns nil
+// when no labels are requested or no values are available, so callers can
+// cheaply detect the no-op case and preserve byte-identical output.
+//
+// It takes the individual dimension values rather than a struct so it works
+// uniformly for the multi-PID path (which reads SampleOutput) and the
+// single-PID path (which reads ParseInput.SampleDimensions).
+func buildDimensionLabels(dim Dimensions, pid, tgid int, cgroupPath, processGroup string) []byte {
+	if !dim.Enabled() {
+		return nil
+	}
+	var b []byte
+	if dim.PID && pid != 0 {
+		b = appendDimension(b, "pid", strconv.Itoa(pid))
+	}
+	if dim.TGID && tgid != 0 {
+		b = appendDimension(b, "tgid", strconv.Itoa(tgid))
+	}
+	if dim.Cgroup && cgroupPath != "" {
+		b = appendDimension(b, "cgroup", cgroupPath)
+	}
+	if dim.ProcessGroup && processGroup != "" {
+		b = appendDimension(b, "pgroup", processGroup)
+	}
+	return b
+}
+
+// appendDimension appends one `key=value` pair to b, prefixed by the frame
+// separator when b already has content. Returns the (possibly reallocated)
+// buffer.
+func appendDimension(b []byte, key, value string) []byte {
+	if len(b) > 0 {
+		b = append(b, dimensionLabelSeparator...)
+	}
+	b = append(b, key...)
+	b = append(b, '=')
+	b = append(b, value...)
+	return b
+}
+
 // ParseTree parses the tree data and returns the profile data.
 //
 // The tree example:
@@ -112,7 +160,7 @@ func ParseCollapsedData(ctx context.Context, input *ParseInput) (*ProfileData, e
 	}
 
 fallback:
-	return parseCommonData(ctx, input.StartTime, input.ProfileType, input.Data, input.Opt, input.PID, extractJavaMainClassFromPid)
+	return parseCommonData(ctx, input.StartTime, input.ProfileType, input.Data, input.Opt, input.PID, input.SampleDimensions, extractJavaMainClassFromPid)
 }
 
 // ParseRawData parses a raw profile (e.g. py-spy output) into *ProfileData.
@@ -145,13 +193,20 @@ func ParseRawData(ctx context.Context, input *ParseInput) (*ProfileData, error) 
 	}
 
 fallback:
-	return parseCommonData(ctx, input.StartTime, input.ProfileType, input.Data, input.Opt, input.PID, extractPythonThreadNameFromPid)
+	return parseCommonData(ctx, input.StartTime, input.ProfileType, input.Data, input.Opt, input.PID, input.SampleDimensions, extractPythonThreadNameFromPid)
 }
 
 // Profiling output for each PID.
 type SampleOutput struct {
 	PID    int    `json:"pid"`
 	Output string `json:"output"`
+
+	// TGID, CgroupPath, and ProcessGroup are optional dimension carriers used
+	// when ParseOption.Dimensions requests label injection. Zero values are
+	// skipped — existing callers that leave these unset are unaffected.
+	TGID         int    `json:"tgid,omitempty"`
+	CgroupPath   string `json:"cgroup_path,omitempty"`
+	ProcessGroup string `json:"process_group,omitempty"`
 }
 
 // parseMultiProcessData parses profiles of multiple PIDs from SampleOutput.
@@ -173,6 +228,21 @@ func parseMultiProcessData(ctx context.Context, startTime time.Time, profileType
 			headerFrame, err = getThreadName(out.PID)
 			if err != nil {
 				return nil, fmt.Errorf("get header frame for PID %d failed: %w", out.PID, err)
+			}
+		}
+		// When the caller requests dimension labels, append them to the header
+		// frame (or synthesize a bare-label header when getThreadName is nil,
+		// which is the ParseRawData multi-PID path).
+		var dim Dimensions
+		if opt != nil {
+			dim = opt.Dimensions
+		}
+		if dimLabels := buildDimensionLabels(dim, out.PID, out.TGID, out.CgroupPath, out.ProcessGroup); dimLabels != nil {
+			if len(headerFrame) > 0 {
+				headerFrame = append(headerFrame, dimensionLabelSeparator...)
+				headerFrame = append(headerFrame, dimLabels...)
+			} else {
+				headerFrame = dimLabels
 			}
 		}
 
@@ -232,7 +302,7 @@ func parseMultiProcessData(ctx context.Context, startTime time.Time, profileType
 }
 
 // parseCommonData parses profile of single PID from raw data.
-func parseCommonData(ctx context.Context, startTime time.Time, profileType string, b []byte, opt *ParseOption, pid int, getThreadName func(int) (string, error)) (*ProfileData, error) {
+func parseCommonData(ctx context.Context, startTime time.Time, profileType string, b []byte, opt *ParseOption, pid int, sampleDims SampleDimensions, getThreadName func(int) (string, error)) (*ProfileData, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -275,8 +345,15 @@ func parseCommonData(ctx context.Context, startTime time.Time, profileType strin
 			Value: value,
 		}
 
-		// Format: threadName#pid
+		// Format: threadName#pid (optionally followed by dimension labels).
 		firstField := fmt.Sprintf("%s#%d", threadName, pid)
+		var dim Dimensions
+		if opt != nil {
+			dim = opt.Dimensions
+		}
+		if dimLabels := buildDimensionLabels(dim, pid, sampleDims.TGID, sampleDims.CgroupPath, sampleDims.ProcessGroup); dimLabels != nil {
+			firstField += dimensionLabelSeparator + string(dimLabels)
+		}
 		item.Stack = append(item.Stack, []byte(firstField))
 
 		// Append each frame in order

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDimensions_Enabled exercises the cheap gate that guards the whole
+// label-injection path. A zero-value Dimensions must report Enabled() == false
+// so existing callers (which never set it) keep byte-identical output.
+func TestDimensions_Enabled(t *testing.T) {
+	assert.False(t, Dimensions{}.Enabled(), "zero Dimensions must be disabled")
+
+	for _, tc := range []struct {
+		name string
+		dim  Dimensions
+	}{
+		{"PID only", Dimensions{PID: true}},
+		{"TGID only", Dimensions{TGID: true}},
+		{"Cgroup only", Dimensions{Cgroup: true}},
+		{"ProcessGroup only", Dimensions{ProcessGroup: true}},
+		{"all on", Dimensions{PID: true, TGID: true, Cgroup: true, ProcessGroup: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, tc.dim.Enabled())
+		})
+	}
+}
+
+// TestBuildDimensionLabels covers the canonical pprof form for every
+// combination of requested dimensions and available values.
+func TestBuildDimensionLabels(t *testing.T) {
+	cases := []struct {
+		name string
+		dim  Dimensions
+		pid  int
+		tgid int
+		cg   string
+		pg   string
+		want string // "" means nil/empty
+	}{
+		{
+			name: "disabled_returns_nil",
+			dim:  Dimensions{},
+			want: "",
+		},
+		{
+			name: "PID_only",
+			dim:  Dimensions{PID: true},
+			pid:  123,
+			want: "pid=123",
+		},
+		{
+			name: "PID_skipped_when_zero",
+			dim:  Dimensions{PID: true},
+			pid:  0,
+			want: "",
+		},
+		{
+			name: "all_dimensions",
+			dim:  Dimensions{PID: true, TGID: true, Cgroup: true, ProcessGroup: true},
+			pid:  123, tgid: 456,
+			cg: "/kubepods/burstable/pod-abc",
+			pg: "web-tier",
+			want: "pid=123;tgid=456;cgroup=/kubepods/burstable/pod-abc;pgroup=web-tier",
+		},
+		{
+			name: "requested_but_unset_values_skipped",
+			dim:  Dimensions{PID: true, TGID: true, Cgroup: true, ProcessGroup: true},
+			pid:  123, // tgid/cg/pg empty
+			want: "pid=123",
+		},
+		{
+			name: "cgroup_with_separator_in_path",
+			dim:  Dimensions{Cgroup: true},
+			cg:   "/sys/fs/cgroup/foo.slice;bar",
+			want: "cgroup=/sys/fs/cgroup/foo.slice;bar",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildDimensionLabels(tc.dim, tc.pid, tc.tgid, tc.cg, tc.pg)
+			if tc.want == "" {
+				assert.Nil(t, got)
+			} else {
+				assert.Equal(t, tc.want, string(got))
+			}
+		})
+	}
+}
+
+// renderProfile serializes a ProfileData to a textual form that contains every
+// frame (string keys), so tests can assert on injected labels without depending
+// on ptree's internal structure. Uses the same ptree -> pprof text path the
+// project itself uses for output.
+func renderProfile(t *testing.T, pd *ProfileData) string {
+	t.Helper()
+	require.NotNil(t, pd)
+	// ptree.Profile contains a sync.Mutex, so we must not copy the value via
+	// require.NotNil(pd.Profile). ParseTree always constructs the Profile via
+	// ptree.New(), so a non-nil *ProfileData is sufficient for these tests.
+	// Serialize via proto text format and scan for the injected label.
+	// Each frame appears in the string table; we just need the labels to show up.
+	var sb strings.Builder
+	// ptree.Profile has a String() via proto.Message; that captures the string table.
+	sb.WriteString(pd.Profile.String())
+	return sb.String()
+}
+
+// TestParseCommonData_DimensionInjection_Off verifies the back-compat
+// contract: when Dimensions is zero-value, no label is injected and parsing
+// succeeds unchanged.
+func TestParseCommonData_DimensionInjection_Off(t *testing.T) {
+	data := []byte("foo;bar;baz 10\n")
+	opt := &ParseOption{}
+
+	pd, err := parseCommonData(context.Background(), time.Unix(0, 0),
+		"process_cpu:cpu:nanoseconds:cpu:nanoseconds", data, opt, 4242, SampleDimensions{},
+		func(int) (string, error) { return "javaApp", nil })
+	require.NoError(t, err)
+
+	rendered := renderProfile(t, pd)
+	assert.Contains(t, rendered, "javaApp#4242")
+	assert.NotContains(t, rendered, "pid=4242")
+	assert.NotContains(t, rendered, "cgroup=")
+}
+
+// TestParseCommonData_DimensionInjection_On covers the opt-in path: with
+// Dimensions.PID and Dimensions.Cgroup set, the first frame gains the
+// pprof-style labels after the existing header, separated by ';'.
+func TestParseCommonData_DimensionInjection_On(t *testing.T) {
+	data := []byte("foo;bar;baz 10\n")
+	opt := &ParseOption{Dimensions: Dimensions{PID: true, Cgroup: true}}
+	sampleDims := SampleDimensions{
+		CgroupPath: "/kubepods/burstable/pod-abc",
+	}
+
+	pd, err := parseCommonData(context.Background(), time.Unix(0, 0),
+		"process_cpu:cpu:nanoseconds:cpu:nanoseconds", data, opt, 4242, sampleDims,
+		func(int) (string, error) { return "javaApp", nil })
+	require.NoError(t, err)
+
+	rendered := renderProfile(t, pd)
+	assert.Contains(t, rendered, "javaApp#4242;pid=4242;cgroup=/kubepods/burstable/pod-abc")
+}
+
+// TestParseCommonData_DimensionInjection_NilOpt guards against a nil
+// ParseOption — the original code already tolerated nil opt, so the new
+// dimension path must too.
+func TestParseCommonData_DimensionInjection_NilOpt(t *testing.T) {
+	data := []byte("foo;bar;baz 10\n")
+
+	pd, err := parseCommonData(context.Background(), time.Unix(0, 0),
+		"process_cpu:cpu:nanoseconds:cpu:nanoseconds", data, nil, 4242, SampleDimensions{},
+		func(int) (string, error) { return "javaApp", nil })
+	require.NoError(t, err)
+
+	rendered := renderProfile(t, pd)
+	assert.Contains(t, rendered, "javaApp#4242")
+	assert.NotContains(t, rendered, "pid=")
+}
+
+// TestParseRawData_MultiPID_DimensionInjection verifies the multi-PID path:
+// each PID's header frame picks up its own SampleOutput dimensions. Uses
+// ParseRawData (the py-spy path) because it doesn't shell out to /proc for
+// thread-name resolution, so the test is hermetic.
+func TestParseRawData_MultiPID_DimensionInjection(t *testing.T) {
+	outputs := []SampleOutput{
+		{PID: 100, Output: "foo;bar 5\n", TGID: 1000, CgroupPath: "/cg/a"},
+		{PID: 200, Output: "baz;qux 7\n", TGID: 2000, CgroupPath: "/cg/b"},
+	}
+	data, err := json.Marshal(outputs)
+	require.NoError(t, err)
+
+	opt := &ParseOption{Dimensions: Dimensions{PID: true, TGID: true, Cgroup: true}}
+	input := &ParseInput{
+		StartTime:   time.Unix(0, 0),
+		ProfileType: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Data:        data,
+		Opt:         opt,
+	}
+
+	pd, err := ParseRawData(context.Background(), input)
+	require.NoError(t, err)
+	rendered := renderProfile(t, pd)
+
+	assert.Contains(t, rendered, "pid=100;tgid=1000;cgroup=/cg/a")
+	assert.Contains(t, rendered, "pid=200;tgid=2000;cgroup=/cg/b")
+}
+
+// TestSampleOutput_JSONRoundTrip guards the JSON shape: existing fields keep
+// their names, new dimension fields are omitempty so old data unmarshals clean.
+func TestSampleOutput_JSONRoundTrip(t *testing.T) {
+	t.Run("legacy_data_unmarshals_without_new_fields", func(t *testing.T) {
+		legacy := []byte(`{"pid":42,"output":"foo;bar 1"}`)
+		var s SampleOutput
+		require.NoError(t, json.Unmarshal(legacy, &s))
+		assert.Equal(t, 42, s.PID)
+		assert.Equal(t, "foo;bar 1", s.Output)
+		assert.Zero(t, s.TGID)
+		assert.Empty(t, s.CgroupPath)
+		assert.Empty(t, s.ProcessGroup)
+	})
+
+	t.Run("new_fields_round_trip", func(t *testing.T) {
+		s := SampleOutput{PID: 42, Output: "x", TGID: 4200, CgroupPath: "/cg", ProcessGroup: "web"}
+		out, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"tgid":4200`)
+		assert.Contains(t, string(out), `"cgroup_path":"/cg"`)
+		assert.Contains(t, string(out), `"process_group":"web"`)
+	})
+
+	t.Run("zero_dimension_fields_omitted", func(t *testing.T) {
+		s := SampleOutput{PID: 42, Output: "x"}
+		out, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "tgid")
+		assert.NotContains(t, string(out), "cgroup_path")
+		assert.NotContains(t, string(out), "process_group")
+	})
+}
+
+// TestParseRawData_LegacyInput_Unchanged is the contract guard: when
+// ParseOption.Dimensions is not set, output frames are byte-for-byte what
+// they were before this change, regardless of what dimension values ride
+// along on the sample.
+func TestParseRawData_LegacyInput_Unchanged(t *testing.T) {
+	// Sample carries dimension values, but opt.Dimensions is disabled.
+	outputs := []SampleOutput{
+		{PID: 100, Output: "foo;bar 5\n", TGID: 1000, CgroupPath: "/cg/a"},
+	}
+	data, err := json.Marshal(outputs)
+	require.NoError(t, err)
+
+	opt := &ParseOption{} // Dimensions not set
+	input := &ParseInput{
+		StartTime:   time.Unix(0, 0),
+		ProfileType: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Data:        data,
+		Opt:         opt,
+	}
+
+	pd, err := ParseRawData(context.Background(), input)
+	require.NoError(t, err)
+	rendered := renderProfile(t, pd)
+
+	// No labels should appear anywhere in the output.
+	assert.NotContains(t, rendered, "pid=100")
+	assert.NotContains(t, rendered, "cgroup=")
+	assert.NotContains(t, rendered, "tgid=")
+}

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -57,12 +57,59 @@ type ParseInput struct {
 	Data         []byte
 	Opt          *ParseOption
 	PID          int
+	// SampleDimensions carries optional dimension values for the single-PID
+	// path (ParseRawData / ParseCollapsedData with a single PID). Used together
+	// with Opt.Dimensions to inject labels. Zero values are skipped. The
+	// multi-PID path carries its own per-sample dimensions via SampleOutput.
+	SampleDimensions SampleDimensions
+}
+
+// SampleDimensions carries the per-sample dimension values used by
+// ParseCollapsedData/ParseRawData when Opt.Dimensions requests label
+// injection on the single-PID path. Zero values are skipped, so existing
+// callers that don't set these remain unaffected.
+type SampleDimensions struct {
+	TGID         int
+	CgroupPath   string
+	ProcessGroup string
+}
+
+// Dimensions carries optional profiling dimensions (PID/TGID/cgroup/process
+// group) that, when set, are injected as pprof-style labels into the first
+// frame of every stack in the parsed output. A zero-value Dimensions means
+// "inject nothing" — existing output is byte-identical.
+//
+// The labels use the canonical pprof/Pyroscope form (e.g. `pid=123;cgroup=/...`)
+// so downstream backends (Pyroscope, Parca, flamegraph) can parse them without
+// per-backend branching.
+type Dimensions struct {
+	// PID controls injection of the PID label. Defaults to false; when true
+	// the PID passed to the parser is emitted as `pid=<n>`.
+	PID bool
+	// TGID controls injection of the TGID label. When true and a TGID is
+	// available on the sample, emitted as `tgid=<n>`.
+	TGID bool
+	// Cgroup controls injection of the cgroup path label. When true and the
+	// sample carries a non-empty CgroupPath, emitted as `cgroup=<path>`.
+	Cgroup bool
+	// ProcessGroup controls injection of the process-group label. When true
+	// and the sample carries a non-empty ProcessGroup, emitted as
+	// `pgroup=<name>`.
+	ProcessGroup bool
+}
+
+// Enabled reports whether any dimension injection is requested.
+func (d Dimensions) Enabled() bool {
+	return d.PID || d.TGID || d.Cgroup || d.ProcessGroup
 }
 
 // ParseOption is the option for ParseTree.
 type ParseOption struct {
 	// SampleRate is only used for CPU sample.
 	SampleRate int64
+	// Dimensions, when Enabled(), injects profiling-dimension labels into the
+	// first frame of each parsed stack. Zero value = no injection (back-compat).
+	Dimensions Dimensions
 }
 
 // TreeItem is the item in the tree.


### PR DESCRIPTION
## What

First PR toward issue #329 (multi-dimension profiling capture). Adds opt-in **dimension capture + label injection** in the Go profiler pipeline. The three lock-contention profilers (mutex/spinlock/rwlock) will follow as separate PRs once the label format is signed off here.

## Why

Closes one third of issue #329's acceptance criteria ("PID/TGID/cgroup/进程组维度采集可用" + "多维度标签正确注入"). Today profiler output has no per-sample dimension context, so aggregating or filtering profiles by cgroup/process-group downstream isn't possible. This PR adds the Go-side capture + injection; the three lock profilers will feed off the same machinery.

## How

**Opt-in by default, byte-identical when off.** A new `ParseOption.Dimensions` struct selects which labels to emit; zero value = no injection, so existing output is unchanged.

```go
type Dimensions struct {
    PID          bool
    TGID         bool
    Cgroup       bool
    ProcessGroup bool
}
```

**Carriers** (all `omitempty`, so legacy JSON/data round-trips clean):
- `SampleOutput.TGID` / `.CgroupPath` / `.ProcessGroup` — multi-PID path (`ParseCollapsedData` / `ParseRawData` with a JSON sample array)
- `ParseInput.SampleDimensions` — single-PID path

**Injection** happens at the existing first-frame construction point (`profiler.go:354` in `parseCommonData`, and the `headerFrame` block in `parseMultiProcessData`). The new helper renders the requested dimensions in canonical pprof form and appends them to the existing `threadName#pid` header via `;`:

```
javaApp#4242;pid=4242;tgid=456;cgroup=/kubepods/burstable/pod-abc;pgroup=web-tier
```

Putting labels in the first frame means every output backend (collapsed/flamegraph/raw/chrometrace/speedscope — all under `internal/profiler/output/`) picks them up **without per-backend branching**, and Pyroscope/Parca can still parse the `key=value` pairs as labels within that frame.

**Why pprof canonical form (`key=value`) over Brendan Gregg collapsed form (`key_value`)?** It's what Pyroscope and Parca natively ingest. If maintainers prefer form B from the design comment, it's a one-line change in `appendDimension`.

## API contract

| Surface | Change | Back-compat |
|---------|--------|-------------|
| `ParseOption` | adds `Dimensions Dimensions` (zero value off) | ✅ existing callers unchanged |
| `SampleOutput` JSON | adds `tgid,cgroup_path,process_group` (all omitempty) | ✅ legacy JSON unmarshals clean |
| `ParseInput` | adds `SampleDimensions SampleDimensions` (zero value off) | ✅ existing callers unchanged |
| `parseCommonData` signature | adds `sampleDims SampleDimensions` param | internal only, 2 callers updated |

## Testing

New file `internal/profiler/profiler_test.go` (first test file for this package):

- `TestDimensions_Enabled` — gate function: zero value disabled, every flag combo enabled.
- `TestBuildDimensionLabels` (6 cases) — pprof form for every dimension combo, including PID=0 skip, separator-in-cgroup-path, all-requested-but-unset skip.
- `TestParseCommonData_DimensionInjection_Off` — back-compat: zero Dimensions → no label, output unchanged.
- `TestParseCommonData_DimensionInjection_On` — opt-in path: labels appended to header.
- `TestParseCommonData_DimensionInjection_NilOpt` — `nil` ParseOption must not panic (matches existing nil-opt tolerance in `opt.SampleRate`).
- `TestParseRawData_MultiPID_DimensionInjection` — multi-PID path: each sample's own dimensions land in its own header.
- `TestSampleOutput_JSONRoundTrip` (3 cases) — legacy JSON unmarshals clean; new fields round-trip; zero values omitempty.
- `TestParseRawData_LegacyInput_Unchanged` — contract guard: even when the sample carries dimension values, opt-out produces no labels.

All passing under `go test ./internal/profiler/ -count=1` on Linux 6.8; `go vet ./internal/profiler/` clean; `go build ./cmd/...` clean.

## Verification note

BPF isn't touched in this PR — it's pure Go and fully testable on the server. The three lock-contention profilers (mutex/spinlock/rwlock) come in follow-up PRs and will reuse this label-injection machinery.

## Checklist

- [x] Zero-value Dimensions = byte-identical output (back-compat contract)
- [x] nil ParseOption tolerated
- [x] JSON shape backward compatible (omitempty on all new fields)
- [x] Labels appear in first frame → works for all output backends without per-backend changes
- [x] Pure-Go PR, no BPF touched
- [x] Tests added and passing; `go vet` clean

Refs #329.
