### PR TITLE
fix(profiler): group container processes by root

### DIFF
--- a/internal/profiler/procutil/container.go
+++ b/internal/profiler/procutil/container.go
@@ -31,6 +31,11 @@ import (
 	"github.com/shirou/gopsutil/process"
 )
 
+type procInfo struct {
+	pid  int
+	ppid int
+}
+
 // ContainerPathOnHost returns the host-visible path for a container-scoped path.
 func ContainerPathOnHost(pid int, containerPath string) string {
 	if containerPath == "" {
@@ -97,13 +102,6 @@ func findProcessesInCgroups(cgroupSuffix, langKeyword, execPath string) (map[int
 		return nil, err
 	}
 
-	type procInfo struct {
-		pid  int
-		ppid int
-	}
-
-	validPids := make(map[int]bool)
-
 	var targetProcs []procInfo
 
 	for _, rawPid := range pids {
@@ -130,16 +128,38 @@ func findProcessesInCgroups(cgroupSuffix, langKeyword, execPath string) (map[int
 		}
 
 		targetProcs = append(targetProcs, procInfo{pid: pid, ppid: ppid})
-		validPids[pid] = true
+	}
+
+	return groupProcessesByRoot(targetProcs)
+}
+
+func groupProcessesByRoot(processes []procInfo) (map[int][]int, error) {
+	parents := make(map[int]int, len(processes))
+	for _, proc := range processes {
+		parents[proc.pid] = proc.ppid
 	}
 
 	result := make(map[int][]int)
-	for _, proc := range targetProcs {
-		if validPids[proc.ppid] {
-			result[proc.ppid] = append(result[proc.ppid], proc.pid)
-		} else {
-			result[proc.pid] = append(result[proc.pid], proc.pid)
+	for _, proc := range processes {
+		root := proc.pid
+		parent := proc.ppid
+		seen := map[int]struct{}{proc.pid: {}}
+
+		for {
+			next, ok := parents[parent]
+			if !ok {
+				break
+			}
+			if _, ok := seen[parent]; ok {
+				return nil, fmt.Errorf("process parent cycle at PID %d", parent)
+			}
+
+			seen[parent] = struct{}{}
+			root = parent
+			parent = next
 		}
+
+		result[root] = append(result[root], proc.pid)
 	}
 
 	return result, nil

--- a/internal/profiler/procutil/container_test.go
+++ b/internal/profiler/procutil/container_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGroupProcessesByRootTraversesAllAncestors(t *testing.T) {
+	processes := []procInfo{
+		{pid: 100, ppid: 1},
+		{pid: 101, ppid: 100},
+		{pid: 102, ppid: 101},
+		{pid: 200, ppid: 1},
+	}
+	got, err := groupProcessesByRoot(processes)
+	if err != nil {
+		t.Fatalf("groupProcessesByRoot() error = %v", err)
+	}
+	want := map[int][]int{
+		100: {100, 101, 102},
+		200: {200},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groupProcessesByRoot() = %v, want %v", got, want)
+	}
+}
+
+func TestGroupProcessesByRootRejectsParentCycle(t *testing.T) {
+	processes := []procInfo{
+		{pid: 100, ppid: 101},
+		{pid: 101, ppid: 100},
+	}
+
+	if _, err := groupProcessesByRoot(processes); err == nil {
+		t.Fatal("groupProcessesByRoot() error = nil, want parent cycle error")
+	}
+}


### PR DESCRIPTION
## Summary

- walk the complete matched parent chain when grouping container processes
- group every matched PID under the highest matched ancestor so the Java profiler receives one target per process tree
- reject malformed parent cycles and add regression coverage for nested chains

## Testing

- `make check`
- `go test -race ./internal/profiler/procutil -count=10`
- `make unit` (the relevant packages pass; the full target only fails `internal/cgroups/TestCgroupInterfaces/CpuUsage` because this WSL environment lacks the cgroup v1 `cpuacct.stat` file)

Fixes #397