### PR TITLE
fix: group container processes by root

### DIFF
--- a/internal/profiler/procutil/container.go
+++ b/internal/profiler/procutil/container.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -82,10 +83,9 @@ func GetPidsFromContainer(execPath, langKeyword, containerID string) ([]int, err
 }
 
 // findProcessesInCgroups groups processes in the cgroup matching langKeyword
-// (and optionally execPath) by their root PID inside the cgroup. A process
-// whose parent is also matched is grouped under that parent; otherwise it
-// becomes its own group root. Returns an empty result when both langKeyword
-// and execPath fail to match any process.
+// (and optionally execPath) by their root PID inside the cgroup. Each process
+// is placed under its highest matching ancestor. Returns an empty result when
+// both langKeyword and execPath fail to match any process.
 func findProcessesInCgroups(cgroupSuffix, langKeyword, execPath string) (map[int][]int, error) {
 	cgroup, err := cgroups.NewManager()
 	if err != nil {
@@ -97,14 +97,7 @@ func findProcessesInCgroups(cgroupSuffix, langKeyword, execPath string) (map[int
 		return nil, err
 	}
 
-	type procInfo struct {
-		pid  int
-		ppid int
-	}
-
-	validPids := make(map[int]bool)
-
-	var targetProcs []procInfo
+	parentByPID := make(map[int]int)
 
 	for _, rawPid := range pids {
 		pid := int(rawPid)
@@ -129,20 +122,58 @@ func findProcessesInCgroups(cgroupSuffix, langKeyword, execPath string) (map[int
 			return nil, err
 		}
 
-		targetProcs = append(targetProcs, procInfo{pid: pid, ppid: ppid})
-		validPids[pid] = true
+		parentByPID[pid] = ppid
 	}
 
+	return groupProcessesByRoot(parentByPID), nil
+}
+
+// groupProcessesByRoot groups matching processes under their highest matching
+// ancestor. If a malformed parent graph has a cycle, its lowest PID is used as
+// a stable group root so the caller still receives one target for that cycle.
+func groupProcessesByRoot(parentByPID map[int]int) map[int][]int {
 	result := make(map[int][]int)
-	for _, proc := range targetProcs {
-		if validPids[proc.ppid] {
-			result[proc.ppid] = append(result[proc.ppid], proc.pid)
-		} else {
-			result[proc.pid] = append(result[proc.pid], proc.pid)
-		}
+	for pid := range parentByPID {
+		root := processGroupRoot(pid, parentByPID)
+		result[root] = append(result[root], pid)
 	}
 
-	return result, nil
+	for _, pids := range result {
+		sort.Ints(pids)
+	}
+
+	return result
+}
+
+func processGroupRoot(pid int, parentByPID map[int]int) int {
+	path := make([]int, 0)
+	seen := make(map[int]int)
+	current := pid
+
+	for {
+		if cycleStart, ok := seen[current]; ok {
+			root := path[cycleStart]
+			for _, cyclePID := range path[cycleStart+1:] {
+				if cyclePID < root {
+					root = cyclePID
+				}
+			}
+			return root
+		}
+
+		seen[current] = len(path)
+		path = append(path, current)
+
+		parent, ok := parentByPID[current]
+		if !ok {
+			return current
+		}
+		if _, ok := parentByPID[parent]; !ok {
+			return current
+		}
+
+		current = parent
+	}
 }
 
 // execPathInCmdline reports whether execPath appears in any cmdline argument

--- a/internal/profiler/procutil/container_test.go
+++ b/internal/profiler/procutil/container_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGroupProcessesByRoot(t *testing.T) {
+	tests := []struct {
+		name        string
+		parentByPID map[int]int
+		want        map[int][]int
+	}{
+		{
+			name: "groups a complete matching ancestor chain under its root",
+			parentByPID: map[int]int{
+				100: 1,
+				101: 100,
+				102: 101,
+				200: 1,
+			},
+			want: map[int][]int{
+				100: {100, 101, 102},
+				200: {200},
+			},
+		},
+		{
+			name: "uses a stable root for a cyclic parent graph",
+			parentByPID: map[int]int{
+				100: 102,
+				101: 100,
+				102: 101,
+				200: 102,
+			},
+			want: map[int][]int{
+				100: {100, 101, 102, 200},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := groupProcessesByRoot(tt.parentByPID); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("groupProcessesByRoot() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Group matching container processes under their highest matching ancestor instead of only their immediate parent.
- Make the process-group selection deterministic and safely collapse malformed parent cycles.
- Add regression coverage for a three-level process chain and a cyclic parent graph.

Fixes #397.

## Validation

- `git diff --check`
- `GOOS=linux GOARCH=amd64 go test -c ./internal/profiler/procutil` — cross-compiled successfully on Windows.

The package cannot execute on this Windows host because it depends on Linux cgroup, namespace, and syscall APIs.
