### PR TITLE
fix(flamegraph): guard malformed input data

### DIFF
--- a/internal/flamegraph/flamegraph.go
+++ b/internal/flamegraph/flamegraph.go
@@ -58,7 +58,11 @@ type ProfileTree struct {
 
 // LevelsToTree converts flamebearer format into a tree. This is needed to then convert it into nested set format
 func LevelsToTree(levels []*Level, names []string) *ProfileTree {
-	if len(levels) == 0 {
+	if len(levels) == 0 || levels[0] == nil || len(levels[0].Values) < ItemOffest {
+		return nil
+	}
+	rootName, ok := flamebearerName(names, levels[0].Values[NameOffest])
+	if !ok {
 		return nil
 	}
 
@@ -67,7 +71,7 @@ func LevelsToTree(levels []*Level, names []string) *ProfileTree {
 		Value: levels[0].Values[ValueOffest],
 		Self:  levels[0].Values[SelfOffest],
 		Level: 0,
-		Name:  names[levels[0].Values[NameOffest]],
+		Name:  rootName,
 	}
 
 	parentsStack := []*ProfileTree{tree}
@@ -84,6 +88,10 @@ func LevelsToTree(levels []*Level, names []string) *ProfileTree {
 			break
 		}
 
+		if levels[currentLevel] == nil {
+			break
+		}
+
 		var nextParentsStack []*ProfileTree
 		currentParent := parentsStack[:1][0]
 		parentsStack = parentsStack[1:]
@@ -93,7 +101,7 @@ func LevelsToTree(levels []*Level, names []string) *ProfileTree {
 
 		// Cycle through bar in a level
 		for {
-			if itemIndex >= len(levels[currentLevel].Values) {
+			if itemIndex+ItemOffest > len(levels[currentLevel].Values) {
 				break
 			}
 
@@ -104,13 +112,17 @@ func LevelsToTree(levels []*Level, names []string) *ProfileTree {
 			parentEnd := currentParent.Start + currentParent.Value
 
 			if itemStart >= currentParent.Start && itemEnd <= parentEnd {
+				name, ok := flamebearerName(names, levels[currentLevel].Values[itemIndex+NameOffest])
+				if !ok {
+					break
+				}
 				// We have an item that is in the bounds of current parent item, so it should be its child
 				treeItem := &ProfileTree{
 					Start: itemStart,
 					Value: itemValue,
 					Self:  selfValue,
 					Level: currentLevel,
-					Name:  names[levels[currentLevel].Values[itemIndex+NameOffest]],
+					Name:  name,
 				}
 				// Add to parent
 				currentParent.Nodes = append(currentParent.Nodes, treeItem)
@@ -136,6 +148,14 @@ func LevelsToTree(levels []*Level, names []string) *ProfileTree {
 	}
 
 	return tree
+}
+
+func flamebearerName(names []string, index int64) (string, bool) {
+	if index < 0 || index >= int64(len(names)) {
+		return "", false
+	}
+
+	return names[index], true
 }
 
 // TreeToNestedSetDataFrame walks the tree depth first and adds items into the dataframe. This is a nested set format

--- a/internal/flamegraph/flamegraph_invalid_input_test.go
+++ b/internal/flamegraph/flamegraph_invalid_input_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import "testing"
+
+func TestLevelsToTreeRejectsMalformedRoot(t *testing.T) {
+	tests := []struct {
+		name   string
+		levels []*Level
+		names  []string
+	}{
+		{
+			name:   "truncated root item",
+			levels: []*Level{{Values: []int64{0, 10, 1}}},
+			names:  []string{"root"},
+		},
+		{
+			name:   "invalid root name index",
+			levels: []*Level{{Values: []int64{0, 10, 1, 1}}},
+			names:  []string{"root"},
+		},
+		{
+			name:   "nil root level",
+			levels: []*Level{nil},
+			names:  []string{"root"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LevelsToTree(tt.levels, tt.names); got != nil {
+				t.Fatalf("LevelsToTree() = %#v, want nil", got)
+			}
+		})
+	}
+}
+
+func TestLevelsToTreeSkipsMalformedChildLevel(t *testing.T) {
+	levels := []*Level{
+		{Values: []int64{0, 10, 1, 0}},
+		{Values: []int64{0, 5, 1}},
+	}
+
+	tree := LevelsToTree(levels, []string{"root"})
+	if tree == nil {
+		t.Fatal("LevelsToTree() = nil, want root tree")
+	}
+	if len(tree.Nodes) != 0 {
+		t.Fatalf("root child count = %d, want 0", len(tree.Nodes))
+	}
+}


### PR DESCRIPTION
## Summary

- Reject truncated, nil, and invalid-name Flamebearer root entries before indexing them.
- Skip malformed child records rather than panicking while rendering profile data.
- Add regression coverage for malformed root and child levels.

## Validation

- `git diff --check`

The local Windows host does not provide a Linux Go test environment; the new cases are pure Go unit tests intended for the repository CI matrix.
