### PR TITLE
fix(profiler): guard unexpected timing store values

### DIFF
--- a/internal/profiler/timings.go
+++ b/internal/profiler/timings.go
@@ -56,14 +56,18 @@ func SetSymbolizeToPprofTimeStamp(profilerName string, t time.Time) {
 
 func GetSampleSerializeTimeStamp(profilerName string) time.Time {
 	if v, ok := SampleSerializeTimeStore.Load(profilerName); ok {
-		return v.(time.Time)
+		if timestamp, ok := v.(time.Time); ok {
+			return timestamp
+		}
 	}
 	return time.Time{}
 }
 
 func GetSymbolizeToPprofTimeStamp(profilerName string) time.Time {
 	if v, ok := SymbolizeToPprofTimeStore.Load(profilerName); ok {
-		return v.(time.Time)
+		if timestamp, ok := v.(time.Time); ok {
+			return timestamp
+		}
 	}
 	return time.Time{}
 }

--- a/internal/profiler/timings_test.go
+++ b/internal/profiler/timings_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimingStoresIgnoreUnexpectedValueType(t *testing.T) {
+	const profilerName = "unexpected-timing-value"
+	SampleSerializeTimeStore.Store(profilerName, "not a timestamp")
+	SymbolizeToPprofTimeStore.Store(profilerName, 1)
+	t.Cleanup(func() {
+		SampleSerializeTimeStore.Delete(profilerName)
+		SymbolizeToPprofTimeStore.Delete(profilerName)
+	})
+
+	if got := GetSampleSerializeTimeStamp(profilerName); !got.IsZero() {
+		t.Fatalf("GetSampleSerializeTimeStamp() = %v, want zero time", got)
+	}
+	if got := GetSymbolizeToPprofTimeStamp(profilerName); !got.IsZero() {
+		t.Fatalf("GetSymbolizeToPprofTimeStamp() = %v, want zero time", got)
+	}
+}
+
+func TestTimingStoresReturnTimestamp(t *testing.T) {
+	const profilerName = "timing-value"
+	want := time.Date(2026, time.July, 21, 8, 0, 0, 0, time.UTC)
+	SetSampleSerializeTimeStamp(profilerName, want)
+	SetSymbolizeToPprofTimeStamp(profilerName, want)
+	t.Cleanup(func() {
+		SampleSerializeTimeStore.Delete(profilerName)
+		SymbolizeToPprofTimeStore.Delete(profilerName)
+	})
+
+	if got := GetSampleSerializeTimeStamp(profilerName); !got.Equal(want) {
+		t.Fatalf("GetSampleSerializeTimeStamp() = %v, want %v", got, want)
+	}
+	if got := GetSymbolizeToPprofTimeStamp(profilerName); !got.Equal(want) {
+		t.Fatalf("GetSymbolizeToPprofTimeStamp() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Treat unexpected values in the exported profiler timing stores as absent instead of panicking.
- Preserve valid timestamp retrieval.
- Add regression tests for both cases.

## Validation

- `git diff --check`
