### PR TITLE
fix(tracing): allow stop before the first run

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -105,7 +105,9 @@ func (c *EventTracing) doStart() {
 // Stop stop tracing
 func (c *EventTracing) Stop() {
 	c.exit = true
-	c.cancelCtx()
+	if c.cancelCtx != nil {
+		c.cancelCtx()
+	}
 }
 
 // EventTracingInfo represents tracing information

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -165,3 +165,26 @@ func TestEventTracingStartStopAndInfo(t *testing.T) {
 		t.Errorf("tracing did not stop in time")
 	}
 }
+
+func TestEventTracingStopBeforeFirstStartDoesNotPanic(t *testing.T) {
+	tracing := &EventTracing{}
+
+	tracing.Stop()
+
+	if !tracing.exit {
+		t.Fatal("Stop() did not mark tracing as exited")
+	}
+}
+
+func TestEventTracingStopCancelsActiveRun(t *testing.T) {
+	cancelled := false
+	tracing := &EventTracing{
+		cancelCtx: func() { cancelled = true },
+	}
+
+	tracing.Stop()
+
+	if !cancelled {
+		t.Fatal("Stop() did not cancel active tracing")
+	}
+}


### PR DESCRIPTION
## Summary

- Avoid calling a nil cancellation function when tracing is stopped before its first run starts.
- Preserve cancellation for active tracing runs.
- Add regression coverage for both lifecycles.

## Validation

- `git diff --check`
