### PR TITLE
fix(request): reject raw reads before connection

### DIFF
--- a/internal/request/rawhttp.go
+++ b/internal/request/rawhttp.go
@@ -18,12 +18,15 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
 	"runtime"
 	"syscall"
 )
+
+var errRawHTTPNotConnected = errors.New("raw HTTP connection is not established")
 
 const (
 	cmsgDataMax = 200 * 4
@@ -201,6 +204,10 @@ func readCmsgAndResponse(fd int) ([]byte, []byte, error) {
 
 // ReadResponse Provide a standard interface for reading http response to the security agent
 func (h *RawHTTP) ReadResponse() (*http.Response, error) {
+	if h == nil || h.conn == nil {
+		return nil, errRawHTTPNotConnected
+	}
+
 	connFile, err := h.conn.File()
 	if err != nil {
 		return nil, err

--- a/internal/request/rawhttp_test.go
+++ b/internal/request/rawhttp_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package request
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRawHTTPReadResponseWithoutConnection(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *RawHTTP
+	}{
+		{name: "nil receiver"},
+		{name: "unconnected client", raw: &RawHTTP{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response, err := tt.raw.ReadResponse()
+			if response != nil {
+				t.Fatalf("ReadResponse() response = %v, want nil", response)
+			}
+			if !errors.Is(err, errRawHTTPNotConnected) {
+				t.Fatalf("ReadResponse() error = %v, want %v", err, errRawHTTPNotConnected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Return a descriptive error when `RawHTTP.ReadResponse` is called without a connected Unix socket.
- Guard both nil and zero-value receivers.
- Add focused regression coverage.

## Validation

- `git diff --check`
