### PR TITLE
fix(profiling): preserve profile query matchers

### DIFF
--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -265,7 +265,7 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 
 func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 	query := driver.Query{
-		Filters: make([]driver.Filter, 0, 6),
+		Filters: make([]driver.Filter, 0, 8),
 	}
 
 	if filter == nil {
@@ -287,8 +287,7 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 		})
 	}
 
-	switch {
-	case filter.TracerID != "" || filter.ID != "":
+	if filter.TracerID != "" || filter.ID != "" {
 		id := filter.TracerID
 		if id == "" {
 			id = filter.ID
@@ -298,7 +297,8 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Op:    driver.OpEq,
 			Value: id,
 		})
-	case filter.Hostname != "":
+	}
+	if filter.Hostname != "" {
 		query.Filters = append(
 			query.Filters,
 			driver.Filter{
@@ -312,13 +312,15 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 				Value: "",
 			},
 		)
-	case filter.ContainerID != "":
+	}
+	if filter.ContainerID != "" {
 		query.Filters = append(query.Filters, driver.Filter{
 			Field: profileFieldContainerID + ".keyword",
 			Op:    driver.OpEq,
 			Value: filter.ContainerID,
 		})
-	case filter.ContainerHostname != "":
+	}
+	if filter.ContainerHostname != "" {
 		query.Filters = append(query.Filters, driver.Filter{
 			Field: profileFieldContainerHostname + ".keyword",
 			Op:    driver.OpEq,
@@ -331,14 +333,6 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Field: profileFieldProfileType + ".keyword",
 			Op:    driver.OpEq,
 			Value: filter.ProfileType,
-		})
-	}
-
-	if filter.TracerID != "" {
-		query.Filters = append(query.Filters, driver.Filter{
-			Field: profileFieldTracerID,
-			Op:    driver.OpEq,
-			Value: filter.TracerID,
 		})
 	}
 

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+func TestBuildProfileAggregationQueryPreservesTargetMatchers(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		ContainerID:       "containerd://4df60fc5",
+		ContainerHostname: "checkout-api-7b9f6d8c4f-k2x7m",
+	})
+	want := []driver.Filter{
+		{
+			Field: profileFieldContainerID + ".keyword",
+			Op:    driver.OpEq,
+			Value: "containerd://4df60fc5",
+		},
+		{
+			Field: profileFieldContainerHostname + ".keyword",
+			Op:    driver.OpEq,
+			Value: "checkout-api-7b9f6d8c4f-k2x7m",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{TracerID: "task-20260722-8f6a"})
+	want := []driver.Filter{
+		{
+			Field: profileFieldTracerID,
+			Op:    driver.OpEq,
+			Value: "task-20260722-8f6a",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve every supplied profile target matcher in storage queries
- remove the duplicate tracer ID predicate
- add regression coverage for combined container matchers and tracer IDs

## Why

Pyroscope label selectors can contain multiple equality matchers. The storage query used a switch, so it silently kept only the first target matcher. This could broaden a profile query beyond the requested label set.

## Testing

- `make check`
- `go test -race ./internal/profiler/service -count=1`
- `make unit` (reaches the full Go suite, but this WSL environment lacks cgroup v1 `cpuacct.stat`; the unrelated `internal/cgroups/TestCgroupInterfaces/CpuUsage` test fails for that reason)
