### PR TITLE
test(server): cover auth service permissions

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -15,12 +15,20 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"sync"
 
 	"huatuo-bamai/internal/server/response"
+)
+
+var (
+	// ErrUserNotFound indicates that authentication was attempted for an unknown user.
+	ErrUserNotFound = errors.New("not found")
+	// ErrPermissionDenied indicates that a known user lacks access to the requested path.
+	ErrPermissionDenied = errors.New("does not have permission")
 )
 
 // Permission represents a permission string.
@@ -91,7 +99,7 @@ func (s *authService) GetUserById(userID string) (User, bool) {
 func (s *authService) Validate(userID, path string) error {
 	value, exists := s.users.Load(userID)
 	if !exists {
-		return fmt.Errorf("user %s not found", userID)
+		return fmt.Errorf("user %s %w", userID, ErrUserNotFound)
 	}
 
 	user := value.(User)
@@ -108,7 +116,7 @@ func (s *authService) Validate(userID, path string) error {
 		}
 	}
 
-	return fmt.Errorf("user %s does not have permission to access %s", userID, path)
+	return fmt.Errorf("user %s %w to access %s", userID, ErrPermissionDenied, path)
 }
 
 // IsAdmin checks if a user is an admin.

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -394,20 +395,20 @@ func TestAuthServiceValidatePermissions(t *testing.T) {
 		name    string
 		userID  string
 		path    string
-		wantErr bool
+		wantErr error
 	}{
-		{name: "admin can access every path", userID: "admin", path: "/private"},
-		{name: "path parameter matches one segment", userID: "reader", path: "/tasks/42"},
-		{name: "wildcard matches nested path", userID: "reader", path: "/metrics/host/cpu"},
-		{name: "path parameter does not match extra segment", userID: "reader", path: "/tasks/42/logs", wantErr: true},
-		{name: "unknown user is denied", userID: "missing", path: "/tasks/42", wantErr: true},
+		{name: "admin can access every path", userID: "admin", path: "/private", wantErr: nil},
+		{name: "path parameter matches one segment", userID: "reader", path: "/tasks/42", wantErr: nil},
+		{name: "wildcard matches nested path", userID: "reader", path: "/metrics/host/cpu", wantErr: nil},
+		{name: "path parameter does not match extra segment", userID: "reader", path: "/tasks/42/logs", wantErr: ErrPermissionDenied},
+		{name: "unknown user is denied", userID: "missing", path: "/tasks/42", wantErr: ErrUserNotFound},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := service.Validate(tt.userID, tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Validate(%q, %q) error = %v, wantErr %v", tt.userID, tt.path, err, tt.wantErr)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate(%q, %q) error = %v, want %v", tt.userID, tt.path, err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -176,7 +176,6 @@ func TestAuthServiceValidate(t *testing.T) {
 		})
 	}
 }
-
 func TestAuthServiceIsAdmin(t *testing.T) {
 	svc := NewAuthService([]UserConfig{
 		{ID: "admin-2026", Name: "Admin User", IsAdmin: true},
@@ -380,6 +379,35 @@ func TestNewAuthMiddleware(t *testing.T) {
 				if gotIsAdmin != tc.wantIsAdmin {
 					t.Errorf("ctx.IsAdmin = %v, want %v", gotIsAdmin, tc.wantIsAdmin)
 				}
+			}
+		})
+	}
+}
+
+func TestAuthServiceValidatePermissions(t *testing.T) {
+	service := NewAuthService([]UserConfig{
+		{ID: "admin", IsAdmin: true},
+		{ID: "reader", Permissions: []string{"/tasks/:id", "/metrics/**"}},
+	})
+
+	tests := []struct {
+		name    string
+		userID  string
+		path    string
+		wantErr bool
+	}{
+		{name: "admin can access every path", userID: "admin", path: "/private"},
+		{name: "path parameter matches one segment", userID: "reader", path: "/tasks/42"},
+		{name: "wildcard matches nested path", userID: "reader", path: "/metrics/host/cpu"},
+		{name: "path parameter does not match extra segment", userID: "reader", path: "/tasks/42/logs", wantErr: true},
+		{name: "unknown user is denied", userID: "missing", path: "/tasks/42", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := service.Validate(tt.userID, tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate(%q, %q) error = %v, wantErr %v", tt.userID, tt.path, err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add authorization regression coverage for administrator access, path parameters, recursive wildcards, and denial paths.

## Validation

- `git diff --check`
