### PR TITLE
refactor(server): remove Run/Option, use Start/Done/Wait/Shutdown

### DIFF
--- a/cmd/huatuo-bamai/handlers/server.go
+++ b/cmd/huatuo-bamai/handlers/server.go
@@ -15,7 +15,8 @@
 package handlers
 
 import (
-	"time"
+	"context"
+	"net"
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
 	"huatuo-bamai/internal/server"
@@ -33,14 +34,21 @@ type ServerOptions struct {
 	VersionInfo    *version.Info
 }
 
+// RunningServer exposes the lifecycle of the HTTP listener.
+type RunningServer interface {
+	Shutdown(ctx context.Context) error
+	Done() <-chan struct{}
+	Wait(ctx context.Context) error
+	Addr() net.Addr
+}
+
 // Start starts the HTTP server with all handlers registered.
-func Start(opts ServerOptions) {
+func Start(opts ServerOptions) (RunningServer, error) {
 	s := server.NewServer(&server.Config{
 		EnablePProf:     true,
 		EnableRateLimit: true,
 		RateLimit:       200,
 		RateBurst:       200,
-		EnableRetry:     true,
 		PromReg:         opts.PromReg,
 		VersionInfo:     opts.VersionInfo,
 	})
@@ -54,9 +62,9 @@ func Start(opts ServerOptions) {
 	evtCfg := config.Get().EventsWatch
 	s.MustRegisterRoutes("/v1/events", NewEventsHandler(evtCfg.MaxClients, evtCfg.KeepAliveInterval).Handlers)
 
-	_ = s.Run(&server.Option{
-		Addr:          opts.Addr,
-		RetryMaxTime:  5 * time.Minute,
-		RetryInterval: 1 * time.Minute,
-	})
+	if err := s.Start(opts.Addr); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }

--- a/cmd/huatuo-bamai/handlers/server.go
+++ b/cmd/huatuo-bamai/handlers/server.go
@@ -15,8 +15,6 @@
 package handlers
 
 import (
-	"time"
-
 	"huatuo-bamai/cmd/huatuo-bamai/config"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/version"
@@ -34,7 +32,7 @@ type ServerOptions struct {
 }
 
 // Start starts the HTTP server with all handlers registered.
-func Start(opts ServerOptions) {
+func Start(opts ServerOptions) (*server.Server, error) {
 	s := server.NewServer(&server.Config{
 		EnablePProf: true,
 		RateLimit: &server.RateLimitConfig{
@@ -61,9 +59,9 @@ func Start(opts ServerOptions) {
 		).Handlers,
 	)
 
-	_ = s.Run(&server.Option{
-		Addr:          opts.Addr,
-		RetryMaxTime:  5 * time.Minute,
-		RetryInterval: 1 * time.Minute,
-	})
+	if err := s.Start(opts.Addr); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }

--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -75,9 +75,13 @@ func mainAction(opts *Options) error {
 type Daemon struct {
 	opts *Options
 
-	cgr     cgroups.Cgroup
-	metrics *prometheus.Registry
-	tracer  *tracing.Manager
+	cgr       cgroups.Cgroup
+	metrics   *prometheus.Registry
+	tracer    *tracing.Manager
+	apiServer interface {
+		Done() <-chan struct{}
+		Wait(ctx context.Context) error
+	}
 }
 
 func NewDaemon(opts *Options) *Daemon {
@@ -140,8 +144,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	log.Infof("huatuo-bamai started successfully")
-	s := d.waitForSignal(ctx)
-	log.Infof("huatuo-bamai received signal %v, shutting down", s)
+	s, serveErr := d.waitForSignal(ctx)
+	if serveErr != nil {
+		log.WithError(serveErr).Error("api server stopped unexpectedly")
+	} else {
+		log.Infof("huatuo-bamai received signal %v, shutting down", s)
+	}
 
 	if err := shutdown(); err != nil {
 		log.Warnf("shutdown completed with errors: %v", err)
@@ -150,7 +158,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	return nil
 }
 
-func (d *Daemon) waitForSignal(ctx context.Context) os.Signal {
+func (d *Daemon) waitForSignal(ctx context.Context) (os.Signal, error) {
 	waitCh := make(chan os.Signal, 1)
 	signal.Notify(waitCh, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGUSR1, syscall.SIGINT, syscall.SIGTERM)
 
@@ -160,11 +168,22 @@ func (d *Daemon) waitForSignal(ctx context.Context) os.Signal {
 		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	}
 
+	if d.apiServer == nil {
+		select {
+		case <-ctx.Done():
+			return nil, nil
+		case s := <-waitCh:
+			return s, nil
+		}
+	}
+
 	select {
 	case <-ctx.Done():
-		return nil
+		return nil, nil
 	case s := <-waitCh:
-		return s
+		return s, nil
+	case <-d.apiServer.Done():
+		return nil, d.apiServer.Wait(context.WithoutCancel(ctx))
 	}
 }
 

--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -26,6 +26,7 @@ import (
 	"huatuo-bamai/internal/cgroups"
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/pidfile"
+	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/version"
 	"huatuo-bamai/pkg/tracing"
 
@@ -75,9 +76,10 @@ func mainAction(opts *Options) error {
 type Daemon struct {
 	opts *Options
 
-	cgr     cgroups.Cgroup
-	metrics *prometheus.Registry
-	tracer  *tracing.Manager
+	cgr       cgroups.Cgroup
+	metrics   *prometheus.Registry
+	tracer    *tracing.Manager
+	apiServer *server.Server
 }
 
 func NewDaemon(opts *Options) *Daemon {
@@ -140,8 +142,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	log.Infof("huatuo-bamai started successfully")
-	s := d.waitForSignal(ctx)
-	log.Infof("huatuo-bamai received signal %v, shutting down", s)
+	s, serveErr := d.waitForSignal(ctx)
+	if serveErr != nil {
+		log.WithError(serveErr).Error("api server stopped unexpectedly")
+	} else {
+		log.Infof("huatuo-bamai received signal %v, shutting down", s)
+	}
 
 	if err := shutdown(); err != nil {
 		log.Warnf("shutdown completed with errors: %v", err)
@@ -150,7 +156,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	return nil
 }
 
-func (d *Daemon) waitForSignal(ctx context.Context) os.Signal {
+func (d *Daemon) waitForSignal(ctx context.Context) (os.Signal, error) {
 	waitCh := make(chan os.Signal, 1)
 	signal.Notify(waitCh, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGUSR1, syscall.SIGINT, syscall.SIGTERM)
 
@@ -160,11 +166,22 @@ func (d *Daemon) waitForSignal(ctx context.Context) os.Signal {
 		_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	}
 
+	if d.apiServer == nil {
+		select {
+		case <-ctx.Done():
+			return nil, nil
+		case s := <-waitCh:
+			return s, nil
+		}
+	}
+
 	select {
 	case <-ctx.Done():
-		return nil
+		return nil, nil
 	case s := <-waitCh:
-		return s
+		return s, nil
+	case <-d.apiServer.Done():
+		return nil, d.apiServer.Wait(context.WithoutCancel(ctx))
 	}
 }
 

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -73,11 +73,16 @@ func startTracing(d *Daemon) (func(context.Context) error, error) {
 }
 
 func startHandlers(d *Daemon) (func(context.Context) error, error) {
-	handlers.Start(handlers.ServerOptions{
+	runningServer, err := handlers.Start(handlers.ServerOptions{
 		Addr:           config.Get().APIServer.TCPAddr,
 		TracingManager: d.tracer,
 		PromReg:        d.metrics,
 		VersionInfo:    &d.opts.VersionInfo,
 	})
-	return nil, nil
+	if err != nil {
+		return nil, fmt.Errorf("start handlers: %w", err)
+	}
+	d.apiServer = runningServer
+
+	return runningServer.Shutdown, nil
 }

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -74,10 +74,10 @@ func startTracing(d *Daemon) (func(context.Context) error, error) {
 
 func startHandlers(d *Daemon) (func(context.Context) error, error) {
 	runningServer, err := handlers.Start(handlers.ServerOptions{
-		Addr:            config.Get().HTTPServer.ListenAddress,
+		Addr:           config.Get().HTTPServer.ListenAddress,
 		TracingManager: d.tracer,
-		PromReg:         d.metrics,
-		VersionInfo:     &d.opts.VersionInfo,
+		PromReg:        d.metrics,
+		VersionInfo:    &d.opts.VersionInfo,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("start handlers: %w", err)

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -73,11 +73,16 @@ func startTracing(d *Daemon) (func(context.Context) error, error) {
 }
 
 func startHandlers(d *Daemon) (func(context.Context) error, error) {
-	handlers.Start(handlers.ServerOptions{
-		Addr:           config.Get().HTTPServer.ListenAddress,
+	runningServer, err := handlers.Start(handlers.ServerOptions{
+		Addr:            config.Get().HTTPServer.ListenAddress,
 		TracingManager: d.tracer,
-		PromReg:        d.metrics,
-		VersionInfo:    &d.opts.VersionInfo,
+		PromReg:         d.metrics,
+		VersionInfo:     &d.opts.VersionInfo,
 	})
-	return nil, nil
+	if err != nil {
+		return nil, fmt.Errorf("start handlers: %w", err)
+	}
+	d.apiServer = runningServer
+
+	return runningServer.Shutdown, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,13 +22,11 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/version"
 
-	"github.com/cloudflare/backoff"
 	"github.com/gin-contrib/pprof"
 	httpGin "github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -184,12 +182,6 @@ func (s *server) Wait(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-}
-
-type Option struct {
-	RetryMaxTime  time.Duration
-	RetryInterval time.Duration
-	Addr          string
 }
 
 // NewServer creates a new HTTP server with the given configuration.
@@ -451,41 +443,4 @@ func (s *server) MustRegisterRoutes(subGroup string, handlers []Handle) {
 			panic("unknown type")
 		}
 	}
-}
-
-func (s *server) run(addr string) error {
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("listen %w", err)
-	}
-
-	return s.engine.RunListener(listener)
-}
-
-// Run starts the TCP server with retry mechanism.
-func (s *server) Run(option *Option) error {
-	if option.RetryMaxTime > 0 && option.RetryInterval > 0 {
-		go func() {
-			b := backoff.New(option.RetryMaxTime, option.RetryInterval)
-			for {
-				err := s.run(option.Addr)
-				if err == nil {
-					return
-				}
-
-				retryInterval := b.Duration()
-				if errors.Is(err, syscall.EADDRINUSE) {
-					log.WithError(err).WithField("retry_interval", retryInterval).
-						Info("tcp api address is in use; retrying")
-				} else if err != nil {
-					log.WithError(err).WithField("retry_interval", retryInterval).
-						Warn("tcp api server failed; retrying")
-				}
-				time.Sleep(retryInterval)
-			}
-		}()
-		return fmt.Errorf("init err")
-	}
-
-	return s.run(option.Addr)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,14 +20,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
-	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/version"
 
-	"github.com/cloudflare/backoff"
 	"github.com/gin-contrib/pprof"
 	httpGin "github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -207,12 +205,6 @@ func (s *Server) Wait(ctx context.Context) error {
 	return execution.wait(ctx)
 }
 
-type Option struct {
-	RetryMaxTime  time.Duration
-	RetryInterval time.Duration
-	Addr          string
-}
-
 // NewServer creates a new HTTP server with the given configuration.
 func NewServer(cfg *Config) *Server {
 	httpGin.SetMode(httpGin.ReleaseMode)
@@ -304,41 +296,4 @@ func (s *Server) MustRegisterRoutes(subGroup string, routes []Route) {
 			g.Handle(route.Method, route.Path, route.Handler)
 		}
 	}
-}
-
-func (s *Server) run(addr string) error {
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("listen %w", err)
-	}
-
-	return s.engine.RunListener(listener)
-}
-
-// Run starts the TCP server with retry mechanism.
-func (s *Server) Run(option *Option) error {
-	if option.RetryMaxTime > 0 && option.RetryInterval > 0 {
-		go func() {
-			b := backoff.New(option.RetryMaxTime, option.RetryInterval)
-			for {
-				err := s.run(option.Addr)
-				if err == nil {
-					return
-				}
-
-				retryInterval := b.Duration()
-				if errors.Is(err, syscall.EADDRINUSE) {
-					log.WithError(err).WithField("retry_interval", retryInterval).
-						Info("tcp api address is in use; retrying")
-				} else if err != nil {
-					log.WithError(err).WithField("retry_interval", retryInterval).
-						Warn("tcp api server failed; retrying")
-				}
-				time.Sleep(retryInterval)
-			}
-		}()
-		return fmt.Errorf("init err")
-	}
-
-	return s.run(option.Addr)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 


### PR DESCRIPTION
## Summary

Per @hao022 feedback on #311, this PR removes the legacy `Run` function and `Option` type from `internal/server`, aligning `huatuo-bamai` with the same `Start → Done/Wait → Shutdown` pattern used by `huatuo-apiserver`.

Rebased onto latest `main` (`bb19c1c5`) with a single clean commit.

## Changes

### `internal/server/server.go`
- Remove `Run`, `run`, and `Option` type
- Remove unused `backoff`, `log`, and `syscall` imports

### `cmd/huatuo-bamai/handlers/server.go`
- `Start` now returns `(*server.Server, error)` instead of nothing
- Uses `s.Start(opts.Addr)` instead of `s.Run(&Option{...})`
- Remove `time` import (no longer needed)

### `cmd/huatuo-bamai/tracing.go`
- `startHandlers` saves the returned `*server.Server` to `d.apiServer`
- Registers `runningServer.Shutdown` as daemon cleanup
- Returns `fmt.Errorf` on start failure

### `cmd/huatuo-bamai/main.go`
- Add `apiServer *server.Server` field to `Daemon` struct
- `waitForSignal` now monitors `apiServer.Done()` for unexpected exits
- Returns `(os.Signal, error)` to propagate serve errors
- Logs serve error if api server stops unexpectedly

## Verification

- `make check` — PASS (golangci-lint, gofumpt, goimports, mockery, capnp)
- `make unit` — PASS (all tests pass except upstream `TestInitAndShutdown` which requires `CAP_BPF`/root; verified PASS with `sudo`)
- `make integration` — PASS (build succeeds; integration tests require root and skip cleanly for unprivileged users)

Signed-off-by: wc4440222 <199748891+wc4440222@users.noreply.github.com>