### PR TITLE
fix(metrics): cpu_stat deltaWaitRunSum uint64 underflow on cgroup counter reset

### DIFF
--- a/core/metrics/cpu_stat.go
+++ b/core/metrics/cpu_stat.go
@@ -145,7 +145,7 @@ func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Containe
 		stat.waitrateWaitSum = float64(deltaWaitSum) * 100 / float64(waitSumDenom)
 	}
 
-	deltaWaitRunSum := deltaHierarchyWaitSum + stat.cpuTotal - cpu.cpuTotal
+	deltaWaitRunSum := deltaHierarchyWaitSum + deltaCpuUsage
 	if deltaWaitRunSum == 0 {
 		stat.waitrateHierarchy = 0
 		stat.waitrateInner = 0


### PR DESCRIPTION
## Fix

Fixes #414

## Problem

In `core/metrics/cpu_stat.go`, `deltaWaitRunSum` is computed with a raw uint64 subtraction:

```go
deltaWaitRunSum := deltaHierarchyWaitSum + stat.cpuTotal - cpu.cpuTotal
```

When a container's cgroup is recreated (e.g., container restart), `stat.cpuTotal` can be smaller than `cpu.cpuTotal`, causing the subtraction to underflow to a near-`MaxUint64` value. This produces garbage values for all four wait-rate metrics derived from `deltaWaitRunSum`.

## Fix

Reuse the already-safe `deltaCpuUsage` variable (computed with a counter-reset guard a few lines above) instead of repeating the raw subtraction:

```go
deltaWaitRunSum := deltaHierarchyWaitSum + deltaCpuUsage
```

This is consistent with how `waitSumDenom` is already computed on line 144:

```go
waitSumDenom := deltaWaitSum + deltaCpuUsage
```

## Verification

- `go build ./core/metrics/` — pass
- `golangci-lint run ./core/metrics/... --timeout=5m --config .golangci.yaml` — pass (no warnings)
- Code review by sub-agent — pass