### PR TITLE
fix(pod): kubeletSyncContainers nil deref panic on missing ContainerStatus

### DIFF
--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -254,7 +254,10 @@ func kubeletSyncContainers() error {
 		}
 
 		for _, c := range m {
-			containerStatus := c[1].(*corev1.ContainerStatus)
+			containerStatus, ok := c[1].(*corev1.ContainerStatus)
+			if !ok || containerStatus == nil {
+				continue
+			}
 			containerID, err := parseContainerIDInPodStatus(containerStatus.ContainerID)
 			if err != nil {
 				log.Warnf("failed to parse container id %s in pod %s status: %v", containerStatus.ContainerID, pod.Name, err)


### PR DESCRIPTION
## Fix

Fixes #416

## Problem

In `internal/pod/container_kubelet_sync.go`, `kubeletSyncContainers` builds a map from `pod.Spec.Containers` with `nil` as the second element, then fills in `ContainerStatus` from `pod.Status.ContainerStatuses`. If a container in `Spec.Containers` has no matching entry in `ContainerStatuses`, `c[1]` remains `nil`, and the bare type assertion panics:

```go
containerStatus := c[1].(*corev1.ContainerStatus)  // panic on nil
```

`isRuningPod` only checks that existing `ContainerStatuses` are all `Running`, but does not verify that the count matches `Spec.Containers`. A pod in `PodRunning` phase can have fewer `ContainerStatuses` than `Spec.Containers` during a startup race.

## Fix

Use a comma-ok type assertion and skip containers with nil status:

```go
containerStatus, ok := c[1].(*corev1.ContainerStatus)
if !ok || containerStatus == nil {
    continue
}
```

## Verification

- `go build ./internal/pod/` — pass
- `golangci-lint run ./internal/pod/... --timeout=5m --config .golangci.yaml` — pass (no warnings)
- Code review by sub-agent — pass