### PR TITLE
fix(autotracing): cpuidle divide-by-zero panic when update interval < 1us

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -199,6 +199,10 @@ func (c *cpuIdleTracing) updateContainerCpuUsage(container *containerCPUInfo) er
 	}
 
 	updateElapsed := time.Since(container.updateTime).Microseconds()
+	if updateElapsed == 0 {
+		container.updateTime = time.Now()
+		return fmt.Errorf("cpu usage update interval too small")
+	}
 
 	container.nowUsagePercentage.user = 100 * delta.user / updateElapsed / cpuCores
 	container.nowUsagePercentage.sys = 100 * delta.sys / updateElapsed / cpuCores


### PR DESCRIPTION
## Fix

Fixes #418

## Problem

In `core/autotracing/cpuidle.go`, `updateContainerCpuUsage` computes `updateElapsed := time.Since(container.updateTime).Microseconds()` and immediately uses it as a divisor in integer arithmetic. When two calls occur within the same microsecond, `updateElapsed` is 0, causing `runtime error: integer divide by zero` panic.

## Fix

Add a guard clause before the division:

```go
if updateElapsed == 0 {
    container.updateTime = time.Now()
    return fmt.Errorf("cpu usage update interval too small")
}
```

This is consistent with the existing error-return pattern in the same function (first-update and no-change cases).

## Verification

- `go build ./core/autotracing/` — pass
- `golangci-lint run ./core/autotracing/... --timeout=5m --config .golangci.yaml` — pass (no warnings)
- Code review by sub-agent — pass