### PR TITLE
fix(metrics): tcp_memory NaN panic when memoryLimit is zero

### DIFF
--- a/core/metrics/net_tcp_memory.go
+++ b/core/metrics/net_tcp_memory.go
@@ -82,10 +82,15 @@ func (c *tcpMemory) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
+	usagePercent := float64(0)
+	if stats.memoryLimit > 0 {
+		usagePercent = stats.memoryPages / stats.memoryLimit
+	}
+
 	return []*metric.Data{
 		metric.NewGaugeData("usage_pages", stats.memoryPages, "tcp memory pages usage", nil),
 		metric.NewGaugeData("usage_bytes", stats.memoryBytes, "tcp memory bytes usage", nil),
 		metric.NewGaugeData("limit_pages", stats.memoryLimit, "tcp memory pages limit", nil),
-		metric.NewGaugeData("usage_percent", stats.memoryPages/stats.memoryLimit, "tcp memory usage percent", nil),
+		metric.NewGaugeData("usage_percent", usagePercent, "tcp memory usage percent", nil),
 	}, nil
 }


### PR DESCRIPTION
## Fix

Fixes #420

## Problem

In `core/metrics/net_tcp_memory.go`, `Update()` computes `stats.memoryPages/stats.memoryLimit` to produce a `usage_percent` metric. When `memoryLimit` is 0 (e.g., `sysctl net.ipv4.tcp_mem` returns 0 for the max value), this produces `+Inf` or `NaN`, causing `prometheus.MustNewConstMetric` to panic.

## Fix

Guard against `memoryLimit == 0`:

```go
usagePercent := float64(0)
if stats.memoryLimit > 0 {
    usagePercent = stats.memoryPages / stats.memoryLimit
}
```

## Verification

- `go build ./core/metrics/` — pass
- `golangci-lint run ./core/metrics/... --timeout=5m --config .golangci.yaml` — pass (no warnings)
- Code review by sub-agent — pass