### PR TITLE
feat(storage): add Pyroscope profile backend

### DIFF
--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -52,6 +52,15 @@ type BamaiConfig struct {
 			RotationSize int    `default:"100"`
 			MaxRotation  int    `default:"10"`
 		}
+
+		Pyroscope struct {
+			Address        string
+			AppNamePrefix  string
+			Username       string
+			Password       string
+			BearerToken    string
+			TimeoutSeconds int `default:"5"`
+		}
 	}
 
 	Task struct {

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -40,6 +40,12 @@ BlackList = ["netdev_hw", "metax_gpu"]
 [RuntimeCgroup]
 LimitMem = 2
 
+[Storage.Pyroscope]
+Address = "https://profiles.example.com"
+AppNamePrefix = "production.huatuo"
+BearerToken = "token-1"
+TimeoutSeconds = 8
+
 [AutoTracing]
 IssuesList = [["dload", "jbd2"]]
 
@@ -68,6 +74,24 @@ ExcludedOnContainer = "writeback"
 	}
 	if Get().RuntimeCgroup.LimitMem != 2*1024*1024 {
 		t.Errorf("LimitMem should be converted to bytes, got %d", Get().RuntimeCgroup.LimitMem)
+	}
+	if Get().Storage.Pyroscope.Address != "https://profiles.example.com" {
+		t.Errorf("unexpected Pyroscope address: %q", Get().Storage.Pyroscope.Address)
+	}
+	if Get().Storage.Pyroscope.AppNamePrefix != "production.huatuo" {
+		t.Errorf(
+			"unexpected Pyroscope app name prefix: %q",
+			Get().Storage.Pyroscope.AppNamePrefix,
+		)
+	}
+	if Get().Storage.Pyroscope.BearerToken != "token-1" {
+		t.Errorf("unexpected Pyroscope bearer token")
+	}
+	if Get().Storage.Pyroscope.TimeoutSeconds != 8 {
+		t.Errorf(
+			"unexpected Pyroscope timeout: %d",
+			Get().Storage.Pyroscope.TimeoutSeconds,
+		)
 	}
 	if len(Get().AutoTracing.IssuesList) != 1 {
 		t.Errorf("unexpected AutoTracing.IssuesList length: %d", len(Get().AutoTracing.IssuesList))

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
@@ -38,11 +39,12 @@ func setupStorage(d *Daemon) (func(context.Context) error, error) {
 
 func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 	var esStore *storage.Store[*tracing.Document]
+	esEnabled := cfg.Storage.ES.Address != "" &&
+		cfg.Storage.ES.Username != "" &&
+		cfg.Storage.ES.Password != ""
 
 	tracingMetadataStores := make([]*storage.Store[*tracing.Document], 0, 2)
-	if cfg.Storage.ES.Address != "" &&
-		cfg.Storage.ES.Username != "" &&
-		cfg.Storage.ES.Password != "" {
+	if esEnabled {
 		store, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
 			Driver:      "elasticsearch",
 			ESAddresses: strutil.SplitCommaList(cfg.Storage.ES.Address),
@@ -82,10 +84,31 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
 	}
 
-	if cfg.Storage.ES.Address != "" &&
+	profileStores, err := newProfileStores(context.Background(), cfg)
+	if err != nil {
+		return err
+	}
+	if len(profileStores) > 0 {
+		tracing.SetProfileStore(
+			profileStores,
+			tracing.DocumentOptions{Region: storageRegion},
+		)
+	}
+
+	return nil
+}
+
+func newProfileStores(
+	ctx context.Context,
+	cfg *config.BamaiConfig,
+) ([]*storage.Store[*tracing.Document], error) {
+	profileStores := make([]*storage.Store[*tracing.Document], 0, 2)
+	esEnabled := cfg.Storage.ES.Address != "" &&
 		cfg.Storage.ES.Username != "" &&
-		cfg.Storage.ES.Password != "" {
-		profileStore, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
+		cfg.Storage.ES.Password != ""
+
+	if esEnabled {
+		profileStore, err := storage.NewFromConfig[*tracing.Document](ctx, &driver.Config{
 			Driver:      "elasticsearch",
 			ESAddresses: strutil.SplitCommaList(cfg.Storage.ES.Address),
 			ESUsername:  cfg.Storage.ES.Username,
@@ -93,13 +116,43 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 			ESIndex:     cfg.Storage.ES.Index,
 		}, profiler.MetadataCollection, tracing.ProfileDocumentStoreMapper{})
 		if err != nil {
-			return fmt.Errorf("new profiling document store (elasticsearch): %w", err)
+			return nil, fmt.Errorf("new profiling document store (elasticsearch): %w", err)
 		}
-		tracing.SetProfileStore(
-			[]*storage.Store[*tracing.Document]{profileStore},
-			tracing.DocumentOptions{Region: storageRegion},
-		)
+		profileStores = append(profileStores, profileStore)
 	}
 
-	return nil
+	if cfg.Storage.Pyroscope.Address != "" {
+		profileStore, err := storage.NewFromConfig[*tracing.Document](ctx, &driver.Config{
+			Driver:                  "pyroscope",
+			PyroscopeAddress:        cfg.Storage.Pyroscope.Address,
+			PyroscopeAppNamePrefix:  cfg.Storage.Pyroscope.AppNamePrefix,
+			PyroscopeUsername:       cfg.Storage.Pyroscope.Username,
+			PyroscopePassword:       cfg.Storage.Pyroscope.Password,
+			PyroscopeBearerToken:    cfg.Storage.Pyroscope.BearerToken,
+			PyroscopeTimeoutSeconds: cfg.Storage.Pyroscope.TimeoutSeconds,
+		}, profiler.MetadataCollection, tracing.PprofDocumentStoreMapper{})
+		if err != nil {
+			cleanupErr := closeProfileStores(ctx, profileStores)
+			return nil, errors.Join(
+				fmt.Errorf("new profiling document store (pyroscope): %w", err),
+				cleanupErr,
+			)
+		}
+		profileStores = append(profileStores, profileStore)
+	}
+
+	return profileStores, nil
+}
+
+func closeProfileStores(
+	ctx context.Context,
+	stores []*storage.Store[*tracing.Document],
+) error {
+	var errs []error
+	for _, store := range stores {
+		if err := store.Close(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("close profiling document store %s: %w", store.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/huatuo-bamai/storage_test.go
+++ b/cmd/huatuo-bamai/storage_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"huatuo-bamai/cmd/huatuo-bamai/config"
+)
+
+func TestNewProfileStoresRegistersElasticsearchAndPyroscope(t *testing.T) {
+	cfg := &config.BamaiConfig{}
+	cfg.Storage.ES.Address = "http://127.0.0.1:9200"
+	cfg.Storage.ES.Username = "elastic"
+	cfg.Storage.ES.Password = "secret"
+	cfg.Storage.ES.Index = "profiles"
+	cfg.Storage.Pyroscope.Address = "http://127.0.0.1:4040"
+
+	stores, err := newProfileStores(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newProfileStores returned error: %v", err)
+	}
+	defer func() {
+		if err := closeProfileStores(context.Background(), stores); err != nil {
+			t.Errorf("closeProfileStores returned error: %v", err)
+		}
+	}()
+
+	if len(stores) != 2 {
+		t.Fatalf("store count = %d, want 2", len(stores))
+	}
+	if stores[0].Name != "elasticsearch" {
+		t.Errorf("stores[0].Name = %q, want elasticsearch", stores[0].Name)
+	}
+	if stores[1].Name != "pyroscope" {
+		t.Errorf("stores[1].Name = %q, want pyroscope", stores[1].Name)
+	}
+}
+
+func TestNewProfileStoresRejectsInvalidPyroscopeAuthentication(t *testing.T) {
+	cfg := &config.BamaiConfig{}
+	cfg.Storage.Pyroscope.Address = "http://127.0.0.1:4040"
+	cfg.Storage.Pyroscope.Username = "user"
+
+	if _, err := newProfileStores(context.Background(), cfg); err == nil {
+		t.Fatal("newProfileStores error = nil, want authentication error")
+	}
+}

--- a/core/autotracing/profiler_ingest.go
+++ b/core/autotracing/profiler_ingest.go
@@ -17,18 +17,19 @@ package autotracing
 import (
 	"time"
 
+	profctx "huatuo-bamai/internal/profiler/context"
 	"huatuo-bamai/internal/toolstream"
 	"huatuo-bamai/pkg/tracing"
 )
 
 // ProfilerEvent is the payload sent by the profiler subprocess over toolstream.
 type ProfilerEvent struct {
-	TracerID      string `json:"tracer_id,omitempty"`
-	ContainerID   string `json:"container_id,omitempty"`
-	TracerName    string `json:"tracer_name,omitempty"`
-	TracerRunType string `json:"tracer_type,omitempty"`
-	TracerTime    string `json:"tracer_time"`
-	TracerData    any    `json:"tracer_data,omitempty"`
+	TracerID      string              `json:"tracer_id,omitempty"`
+	ContainerID   string              `json:"container_id,omitempty"`
+	TracerName    string              `json:"tracer_name,omitempty"`
+	TracerRunType string              `json:"tracer_type,omitempty"`
+	TracerTime    string              `json:"tracer_time"`
+	TracerData    *profctx.TracerData `json:"tracer_data,omitempty"`
 }
 
 const profilerEventTimeLayout = "2006-01-02 15:04:05.000 -0700"

--- a/core/autotracing/profiler_ingest_test.go
+++ b/core/autotracing/profiler_ingest_test.go
@@ -15,8 +15,14 @@
 package autotracing
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
 )
 
 func TestParseProfilerEventTime(t *testing.T) {
@@ -73,10 +79,40 @@ func TestHandleProfilerEventNoStore(t *testing.T) {
 		TracerName:    "profiler",
 		TracerRunType: "autotracing",
 		TracerTime:    "2026-07-06 12:30:45.123 +0800",
-		TracerData:    map[string]any{"flamedata": map[string]any{"profile_type": "cpu"}},
+		TracerData:    &profctx.TracerData{},
 	}
 
 	if err := handleProfilerEvent(nil, ev); err != nil {
 		t.Fatalf("handleProfilerEvent() error = %v, want nil", err)
+	}
+}
+
+func TestProfilerEventPreservesPprofPayload(t *testing.T) {
+	source := &ProfilerEvent{
+		TracerID: "tracer-123",
+		TracerData: &profctx.TracerData{
+			FlameData: &profiler.ProfileData{
+				ProfileType: profiler.ProfileTypeCpuSample,
+				Profile: ptree.Profile{
+					TimeNanos:     1700000000000000000,
+					DurationNanos: int64(10 * time.Second),
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	var decoded ProfilerEvent
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	if decoded.TracerData == nil || decoded.TracerData.FlameData == nil {
+		t.Fatal("decoded profiler event is missing flamedata")
+	}
+	if got := decoded.TracerData.FlameData.Profile.TimeNanos; got != 1700000000000000000 {
+		t.Errorf("decoded TimeNanos = %d, want 1700000000000000000", got)
 	}
 }

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -210,7 +210,35 @@ BlackList = ["netdev_hw", "metax_gpu"]
 
   Default: 10.
 
-  **Description**: Oldest files are automatically deleted once the limit is reached, controlling disk usage.
+**Description**: Oldest files are automatically deleted once the limit is reached, controlling disk usage.
+
+#### 5.3 Pyroscope Profile Storage
+
+```toml
+[Storage.Pyroscope]
+    Address = "https://profiles.example.com"
+    AppNamePrefix = "huatuo"
+    # Username = "profiles-user"
+    # Password = "change-me"
+    # BearerToken = "token"
+    TimeoutSeconds = 5
+```
+
+- **Address**: Pyroscope server base URL. An empty value disables this
+  backend. The backend appends `/ingest` and accepts only HTTP or HTTPS URLs.
+- **AppNamePrefix**: Prefix for Pyroscope application names. The default is
+  `huatuo`.
+- **Username / Password**: Optional Basic Auth credentials. Both fields must
+  be set together.
+- **BearerToken**: Optional bearer token. It cannot be combined with Basic
+  Auth.
+- **TimeoutSeconds**: Timeout for each ingest request. The default is 5
+  seconds.
+
+Pyroscope stores profiling data as pprof protobuf. Elasticsearch can remain
+enabled at the same time and continues to store its existing JSON profiling
+documents. Use HTTPS when credentials leave the local host, and restrict
+configuration-file permissions because authentication fields contain secrets.
 
 ### 6. Automatic Tracing
 

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -207,7 +207,30 @@ BlackList = ["netdev_hw", "metax_gpu"]
 
   每个追踪器最多保留的历史文件数量。默认值为 10。
 
-  **说明**：超过数量后自动删除最早文件，控制磁盘空间使用。
+**说明**：超过数量后自动删除最早文件，控制磁盘空间使用。
+
+#### 5.3 Pyroscope Profile 存储
+
+```toml
+[Storage.Pyroscope]
+    Address = "https://profiles.example.com"
+    AppNamePrefix = "huatuo"
+    # Username = "profiles-user"
+    # Password = "change-me"
+    # BearerToken = "token"
+    TimeoutSeconds = 5
+```
+
+- **Address**：Pyroscope 服务的基础地址。留空时禁用该后端。后端会自动
+  追加 `/ingest`，且只接受 HTTP 或 HTTPS 地址。
+- **AppNamePrefix**：Pyroscope 应用名称前缀，默认值为 `huatuo`。
+- **Username / Password**：可选的 Basic Auth 凭据，必须同时配置。
+- **BearerToken**：可选的 Bearer Token，不能与 Basic Auth 同时配置。
+- **TimeoutSeconds**：单次写入请求的超时时间，默认值为 5 秒。
+
+Pyroscope 使用 pprof protobuf 保存 profiling 数据。可以同时启用
+Elasticsearch；Elasticsearch 会继续保存现有 JSON profiling 文档。凭据需要
+离开本机时应使用 HTTPS，并限制配置文件权限，避免认证信息泄露。
 
 ### 6. 自动追踪配置
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -90,6 +90,21 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu"]
         # RotationSize = 100
         # MaxRotation = 10
 
+    # Pyroscope profile storage
+    #
+    # Pyroscope receives pprof protobuf profiles independently of ES/OS.
+    # Leave Address empty to disable it. Address is the server base URL; the
+    # backend appends /ingest. Use either Username and Password for Basic Auth,
+    # or BearerToken, but not both.
+    #
+    [Storage.Pyroscope]
+        # Address = "http://127.0.0.1:4040"
+        # AppNamePrefix = "huatuo"
+        # Username = ""
+        # Password = ""
+        # BearerToken = ""
+        # TimeoutSeconds = 5
+
 # Autotracing configuration
 [AutoTracing]
     # IssuesList for known issue filtering in autotracing

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -70,6 +70,14 @@ type TracerData struct {
 	FlameData  *profiler.ProfileData `json:"flamedata"`
 }
 
+// ProfileData exposes the native profile without coupling storage to this envelope.
+func (d *TracerData) ProfileData() *profiler.ProfileData {
+	if d == nil {
+		return nil
+	}
+	return d.FlameData
+}
+
 func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerContext, error) {
 	ctx, cancel := context.WithCancel(cliCtx.Context)
 

--- a/internal/storage/backends.go
+++ b/internal/storage/backends.go
@@ -18,5 +18,6 @@ import (
 	// Register all built-in storage backends.
 	_ "huatuo-bamai/internal/storage/elasticsearch"
 	_ "huatuo-bamai/internal/storage/localfile"
+	_ "huatuo-bamai/internal/storage/pyroscope"
 	_ "huatuo-bamai/internal/storage/sqlite"
 )

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -57,6 +57,13 @@ type Config struct {
 	ESUsername  string
 	ESPassword  string
 	ESIndex     string
+
+	PyroscopeAddress        string
+	PyroscopeAppNamePrefix  string
+	PyroscopeUsername       string
+	PyroscopePassword       string
+	PyroscopeBearerToken    string
+	PyroscopeTimeoutSeconds int
 }
 
 // Op is a storage query operator.

--- a/internal/storage/pyroscope/pyroscope.go
+++ b/internal/storage/pyroscope/pyroscope.go
@@ -1,0 +1,405 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pyroscope implements a write-only pprof storage backend.
+package pyroscope
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+const (
+	defaultAppNamePrefix    = "huatuo"
+	defaultTimeoutSeconds   = 5
+	maxErrorResponseBytes   = 4 * 1024
+	pprofFormat             = "pprof"
+	protobufContentType     = "application/octet-stream"
+	authorizationHeaderName = "Authorization"
+)
+
+// Config contains Pyroscope backend settings.
+type Config struct {
+	Address        string
+	AppNamePrefix  string
+	Username       string
+	Password       string
+	BearerToken    string
+	TimeoutSeconds int
+}
+
+// Storage pushes protobuf-encoded pprof profiles to Pyroscope's HTTP ingest API.
+type Storage struct {
+	ingestURL     *url.URL
+	appNamePrefix string
+	username      string
+	password      string
+	bearerToken   string
+	httpClient    *http.Client
+}
+
+var _ driver.Backend = (*Storage)(nil)
+
+func init() {
+	driver.RegisterBackend("pyroscope", func(cfg *driver.Config) (driver.Backend, error) {
+		return NewBackend(&Config{
+			Address:        cfg.PyroscopeAddress,
+			AppNamePrefix:  cfg.PyroscopeAppNamePrefix,
+			Username:       cfg.PyroscopeUsername,
+			Password:       cfg.PyroscopePassword,
+			BearerToken:    cfg.PyroscopeBearerToken,
+			TimeoutSeconds: cfg.PyroscopeTimeoutSeconds,
+		})
+	})
+}
+
+// NewBackend creates a Pyroscope storage backend.
+func NewBackend(cfg *Config) (*Storage, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("pyroscope: config is nil")
+	}
+
+	endpoint, err := parseAddress(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	username, password, token, err := validateAuthentication(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	timeoutSeconds := cfg.TimeoutSeconds
+	switch {
+	case timeoutSeconds < 0:
+		return nil, fmt.Errorf("pyroscope: timeout seconds must not be negative")
+	case timeoutSeconds == 0:
+		timeoutSeconds = defaultTimeoutSeconds
+	}
+
+	appNamePrefix := sanitizeNamePart(strings.TrimSpace(cfg.AppNamePrefix))
+	if appNamePrefix == "" {
+		appNamePrefix = defaultAppNamePrefix
+	}
+
+	return newBackendWithHTTPClient(
+		endpoint,
+		appNamePrefix,
+		username,
+		password,
+		token,
+		&http.Client{
+			Timeout: time.Duration(timeoutSeconds) * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	), nil
+}
+
+func parseAddress(address string) (*url.URL, error) {
+	rawAddress := strings.TrimSpace(address)
+	if rawAddress == "" {
+		return nil, fmt.Errorf("pyroscope: address is empty")
+	}
+	endpoint, err := url.Parse(rawAddress)
+	if err != nil {
+		return nil, fmt.Errorf("pyroscope: parse address: %w", err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf(
+			"pyroscope: address scheme must be http or https, got %q",
+			endpoint.Scheme,
+		)
+	}
+	if endpoint.Host == "" || endpoint.Opaque != "" {
+		return nil, fmt.Errorf("pyroscope: address must include a host")
+	}
+	if endpoint.User != nil {
+		return nil, fmt.Errorf("pyroscope: URL credentials are not allowed; use authentication fields")
+	}
+	if endpoint.RawQuery != "" || endpoint.ForceQuery || endpoint.Fragment != "" {
+		return nil, fmt.Errorf("pyroscope: address must not include a query or fragment")
+	}
+
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/ingest"
+	endpoint.RawPath = ""
+	return endpoint, nil
+}
+
+func validateAuthentication(cfg *Config) (string, string, string, error) {
+	hasUsername := cfg.Username != ""
+	hasPassword := cfg.Password != ""
+	token := cfg.BearerToken
+	switch {
+	case hasUsername != hasPassword:
+		return "", "", "", fmt.Errorf(
+			"pyroscope: username and password must be configured together",
+		)
+	case strings.Contains(cfg.Username, ":"):
+		return "", "", "", fmt.Errorf(
+			"pyroscope: basic authentication username must not contain a colon",
+		)
+	case token != "" && hasUsername:
+		return "", "", "", fmt.Errorf(
+			"pyroscope: basic authentication and bearer token are mutually exclusive",
+		)
+	case containsControl(cfg.Username) || containsControl(cfg.Password) ||
+		containsControl(token):
+		return "", "", "", fmt.Errorf(
+			"pyroscope: authentication fields must not contain control characters",
+		)
+	case strings.TrimSpace(token) != token:
+		return "", "", "", fmt.Errorf(
+			"pyroscope: bearer token must not have surrounding whitespace",
+		)
+	default:
+		return cfg.Username, cfg.Password, token, nil
+	}
+}
+
+func containsControl(value string) bool {
+	return strings.IndexFunc(value, unicode.IsControl) >= 0
+}
+
+func newBackendWithHTTPClient(
+	endpoint *url.URL,
+	appNamePrefix string,
+	username string,
+	password string,
+	bearerToken string,
+	httpClient *http.Client,
+) *Storage {
+	return &Storage{
+		ingestURL:     endpoint,
+		appNamePrefix: appNamePrefix,
+		username:      username,
+		password:      password,
+		bearerToken:   bearerToken,
+		httpClient:    httpClient,
+	}
+}
+
+// Init is a no-op because Pyroscope owns its profile schema.
+func (b *Storage) Init(context.Context, string, []driver.Index) error {
+	return nil
+}
+
+// Save uploads one pprof protobuf payload.
+func (b *Storage) Save(ctx context.Context, rec driver.Record) error {
+	if len(rec.Data) == 0 {
+		return fmt.Errorf("pyroscope: profile data is empty")
+	}
+
+	endpoint := *b.ingestURL
+	start := profileStart(rec.Fields)
+	end := profileEnd(rec.Fields, start)
+	query := endpoint.Query()
+	query.Set("name", b.applicationName(rec.Fields))
+	query.Set("from", strconv.FormatInt(start.Unix(), 10))
+	query.Set("until", strconv.FormatInt(end.Unix(), 10))
+	query.Set("format", pprofFormat)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(
+		driver.WithContext(ctx),
+		http.MethodPost,
+		endpoint.String(),
+		bytes.NewReader(rec.Data),
+	)
+	if err != nil {
+		return fmt.Errorf("pyroscope: create ingest request: %w", err)
+	}
+	req.Header.Set("Content-Type", protobufContentType)
+	switch {
+	case b.bearerToken != "":
+		req.Header.Set(authorizationHeaderName, "Bearer "+b.bearerToken)
+	case b.username != "":
+		req.SetBasicAuth(b.username, b.password)
+	}
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("pyroscope: ingest profile: %w", err)
+	}
+
+	body, responseErr := readAndCloseResponse(resp)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		message := strings.Join(strings.Fields(string(body)), " ")
+		if message == "" {
+			message = resp.Status
+		}
+		statusErr := fmt.Errorf(
+			"pyroscope: ingest returned status %d: %s",
+			resp.StatusCode,
+			message,
+		)
+		return errors.Join(statusErr, responseErr)
+	}
+	if responseErr != nil {
+		return fmt.Errorf("pyroscope: consume ingest response: %w", responseErr)
+	}
+	return nil
+}
+
+func readAndCloseResponse(resp *http.Response) ([]byte, error) {
+	if resp.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBytes))
+	_, drainErr := io.Copy(io.Discard, resp.Body)
+	closeErr := resp.Body.Close()
+	return body, errors.Join(readErr, drainErr, closeErr)
+}
+
+// Get is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Get(context.Context, string) (driver.Record, error) {
+	return driver.Record{}, driver.ErrUnsupportedOp
+}
+
+// Delete is unsupported because Pyroscope owns profile retention.
+func (b *Storage) Delete(context.Context, string) error {
+	return driver.ErrUnsupportedOp
+}
+
+// Query is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Query(context.Context, driver.Query) ([]driver.Record, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+// Count is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Count(context.Context, driver.Query) (int64, error) {
+	return 0, driver.ErrUnsupportedOp
+}
+
+// Values is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Values(context.Context, string, driver.Query, int) ([]string, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+// Close releases no resources because the HTTP client owns no background worker.
+func (b *Storage) Close(context.Context) error {
+	return nil
+}
+
+func (b *Storage) applicationName(fields map[string]any) string {
+	name := b.appNamePrefix
+	if tracerName := sanitizeNamePart(stringField(fields, "tracer_name")); tracerName != "" {
+		name += "." + tracerName
+	}
+
+	labels := []struct {
+		name  string
+		field string
+	}{
+		{name: "tracer_id", field: "tracer_id"},
+		{name: "tracer_name", field: "tracer_name"},
+		{name: "hostname", field: "hostname"},
+		{name: "region", field: "region"},
+		{name: "container_id", field: "container_id"},
+		{name: "container_hostname", field: "container_hostname"},
+		{name: "tracer_type", field: "tracer_type"},
+		{name: "profile_type", field: "profile_type"},
+	}
+
+	values := make([]string, 0, len(labels))
+	for _, label := range labels {
+		value := sanitizeLabelValue(stringField(fields, label.field))
+		if value == "" {
+			continue
+		}
+		values = append(values, label.name+"="+value)
+	}
+	if len(values) > 0 {
+		name += "{" + strings.Join(values, ",") + "}"
+	}
+	return name
+}
+
+func profileStart(fields map[string]any) time.Time {
+	if value, ok := timeField(fields, "profile_start_time"); ok {
+		return value.UTC()
+	}
+	if value, ok := timeField(fields, "tracer_time"); ok {
+		return value.UTC()
+	}
+	if value, ok := timeField(fields, "uploaded_time"); ok {
+		return value.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func profileEnd(fields map[string]any, start time.Time) time.Time {
+	if value, ok := timeField(fields, "profile_end_time"); ok && value.After(start) {
+		return value.UTC()
+	}
+	return start.Add(time.Second)
+}
+
+func timeField(fields map[string]any, name string) (time.Time, bool) {
+	value, ok := fields[name]
+	if !ok {
+		return time.Time{}, false
+	}
+	switch typed := value.(type) {
+	case time.Time:
+		return typed, !typed.IsZero()
+	case *time.Time:
+		if typed == nil {
+			return time.Time{}, false
+		}
+		return *typed, !typed.IsZero()
+	default:
+		return time.Time{}, false
+	}
+}
+
+func stringField(fields map[string]any, name string) string {
+	value, _ := fields[name].(string)
+	return strings.TrimSpace(value)
+}
+
+func sanitizeNamePart(value string) string {
+	return sanitizeProfilePart(value, true)
+}
+
+func sanitizeLabelValue(value string) string {
+	return sanitizeProfilePart(value, false)
+}
+
+func sanitizeProfilePart(value string, allowDot bool) string {
+	var result strings.Builder
+	result.Grow(len(value))
+	for _, current := range strings.TrimSpace(value) {
+		if unicode.IsLetter(current) || unicode.IsDigit(current) ||
+			current == '_' || current == '-' || current == '/' ||
+			(allowDot && current == '.') {
+			result.WriteRune(current)
+			continue
+		}
+		result.WriteByte('_')
+	}
+	return strings.Trim(result.String(), "_")
+}

--- a/internal/storage/pyroscope/pyroscope_test.go
+++ b/internal/storage/pyroscope/pyroscope_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pyroscope
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+func TestStorageSaveIngestsPprof(t *testing.T) {
+	profile := []byte{0x0a, 0x01, 0x00}
+	start := time.Unix(1700000000, 0).UTC()
+	end := start.Add(10 * time.Second)
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/base/ingest" {
+			t.Errorf("path = %s, want /base/ingest", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("format"); got != pprofFormat {
+			t.Errorf("format = %q, want %q", got, pprofFormat)
+		}
+		if got := r.URL.Query().Get("from"); got != strconv.FormatInt(start.Unix(), 10) {
+			t.Errorf("from = %q, want %d", got, start.Unix())
+		}
+		if got := r.URL.Query().Get("until"); got != strconv.FormatInt(end.Unix(), 10) {
+			t.Errorf("until = %q, want %d", got, end.Unix())
+		}
+		wantName := "huatuo.profiler{tracer_id=trace-1,tracer_name=profiler," +
+			"hostname=node-a,region=cn-hz,container_id=container-1," +
+			"tracer_type=autotracing,profile_type=cpu}"
+		if got := r.URL.Query().Get("name"); got != wantName {
+			t.Errorf("name = %q, want %q", got, wantName)
+		}
+		if got := r.Header.Get("Content-Type"); got != protobufContentType {
+			t.Errorf("Content-Type = %q, want %q", got, protobufContentType)
+		}
+		if got := r.Header.Get(authorizationHeaderName); got != "Bearer token-1" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !bytes.Equal(body, profile) {
+			t.Errorf("body = %v, want %v", body, profile)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	endpoint, _ := url.Parse("http://pyroscope.test/base/ingest")
+	backend := newBackendWithHTTPClient(
+		endpoint,
+		"huatuo",
+		"",
+		"",
+		"token-1",
+		httpClient,
+	)
+	err := backend.Save(context.Background(), driver.Record{
+		ID:   "trace-1",
+		Data: profile,
+		Fields: map[string]any{
+			"profile_start_time": start,
+			"profile_end_time":   end,
+			"profile_type":       "cpu",
+			"tracer_id":          "trace-1",
+			"tracer_name":        "profiler",
+			"hostname":           "node-a",
+			"region":             "cn-hz",
+			"container_id":       "container-1",
+			"tracer_type":        "autotracing",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+}
+
+func TestStorageSaveUsesBasicAuthentication(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "user" || password != "secret" {
+			t.Errorf("BasicAuth = (%q, %q, %v)", username, password, ok)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	endpoint, _ := url.Parse("https://pyroscope.test/ingest")
+	backend := newBackendWithHTTPClient(endpoint, "huatuo", "user", "secret", "", httpClient)
+	if err := backend.Save(context.Background(), driver.Record{Data: []byte{1}}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+}
+
+func TestStorageSaveClosesErrorResponse(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("ingest failed")}
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	endpoint, _ := url.Parse("http://pyroscope.test/ingest")
+	backend := newBackendWithHTTPClient(endpoint, "huatuo", "", "", "", httpClient)
+	err := backend.Save(context.Background(), driver.Record{Data: []byte{1}})
+	if err == nil || !strings.Contains(err.Error(), "status 500: ingest failed") {
+		t.Fatalf("Save error = %v, want status and response", err)
+	}
+	if !body.closed.Load() {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestStorageSaveHonorsContext(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})}
+	endpoint, _ := url.Parse("http://pyroscope.test/ingest")
+	backend := newBackendWithHTTPClient(endpoint, "huatuo", "", "", "", httpClient)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := backend.Save(ctx, driver.Record{Data: []byte{1}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Save error = %v, want context.Canceled", err)
+	}
+}
+
+func TestNewBackendRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{name: "nil config", cfg: nil},
+		{name: "empty address", cfg: &Config{}},
+		{name: "missing scheme", cfg: &Config{Address: "127.0.0.1:4040"}},
+		{name: "unsupported scheme", cfg: &Config{Address: "ftp://127.0.0.1"}},
+		{name: "URL credentials", cfg: &Config{Address: "http://user:secret@127.0.0.1"}},
+		{name: "query", cfg: &Config{Address: "http://127.0.0.1?tenant=a"}},
+		{name: "fragment", cfg: &Config{Address: "http://127.0.0.1#fragment"}},
+		{
+			name: "incomplete basic authentication",
+			cfg:  &Config{Address: "http://127.0.0.1", Username: "user"},
+		},
+		{
+			name: "colon in basic authentication username",
+			cfg: &Config{
+				Address:  "http://127.0.0.1",
+				Username: "user:name",
+				Password: "secret",
+			},
+		},
+		{
+			name: "multiple authentication methods",
+			cfg: &Config{
+				Address:     "http://127.0.0.1",
+				Username:    "user",
+				Password:    "secret",
+				BearerToken: "token",
+			},
+		},
+		{
+			name: "control character in token",
+			cfg:  &Config{Address: "http://127.0.0.1", BearerToken: "a\nb"},
+		},
+		{
+			name: "surrounding whitespace in token",
+			cfg:  &Config{Address: "http://127.0.0.1", BearerToken: " token"},
+		},
+		{
+			name: "negative timeout",
+			cfg:  &Config{Address: "http://127.0.0.1", TimeoutSeconds: -1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewBackend(tt.cfg); err == nil {
+				t.Fatalf("NewBackend(%#v) error = nil", tt.cfg)
+			}
+		})
+	}
+}
+
+func TestStorageDoesNotFollowRedirects(t *testing.T) {
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetRequests.Add(1)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	backend, err := NewBackend(&Config{Address: source.URL})
+	if err != nil {
+		t.Fatalf("NewBackend returned error: %v", err)
+	}
+	err = backend.Save(context.Background(), driver.Record{Data: []byte{1}})
+	if err == nil || !strings.Contains(err.Error(), "status 307") {
+		t.Fatalf("Save error = %v, want redirect status", err)
+	}
+	if targetRequests.Load() != 0 {
+		t.Fatalf("redirect target requests = %d, want 0", targetRequests.Load())
+	}
+}
+
+func TestStorageReadOperationsAreUnsupported(t *testing.T) {
+	backend, err := NewBackend(&Config{Address: "http://127.0.0.1:4040"})
+	if err != nil {
+		t.Fatalf("NewBackend returned error: %v", err)
+	}
+	if _, err := backend.Get(context.Background(), "id"); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Get error = %v, want ErrUnsupportedOp", err)
+	}
+	if err := backend.Delete(context.Background(), "id"); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Delete error = %v, want ErrUnsupportedOp", err)
+	}
+	if _, err := backend.Query(context.Background(), driver.Query{}); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Query error = %v, want ErrUnsupportedOp", err)
+	}
+	if _, err := backend.Count(context.Background(), driver.Query{}); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Count error = %v, want ErrUnsupportedOp", err)
+	}
+	if _, err := backend.Values(context.Background(), "field", driver.Query{}, 1); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Values error = %v, want ErrUnsupportedOp", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (b *trackingReadCloser) Close() error {
+	b.closed.Store(true)
+	return nil
+}

--- a/pkg/tracing/document_pprof.go
+++ b/pkg/tracing/document_pprof.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"fmt"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	"huatuo-bamai/internal/storage/driver"
+)
+
+// PprofDocumentStoreMapper encodes profiling documents for profile-native
+// backends. Elasticsearch continues to use ProfileDocumentStoreMapper and JSON.
+type PprofDocumentStoreMapper struct {
+	ProfileDocumentStoreMapper
+}
+
+// Encode serializes the embedded pprof profile as protobuf.
+func (PprofDocumentStoreMapper) Encode(document *Document) ([]byte, error) {
+	profileData, err := profileDataFromDocument(document)
+	if err != nil {
+		return nil, err
+	}
+	return profileData.Profile.MarshalVT()
+}
+
+// Decode is unsupported because the Pyroscope backend is write-only.
+func (PprofDocumentStoreMapper) Decode([]byte) (*Document, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+// Fields adds profile timestamps and type to the document metadata.
+func (PprofDocumentStoreMapper) Fields(document *Document) (map[string]any, error) {
+	fields, err := (ProfileDocumentStoreMapper{}).Fields(document)
+	if err != nil {
+		return nil, err
+	}
+
+	profileData, err := profileDataFromDocument(document)
+	if err != nil {
+		return nil, err
+	}
+	fields["profile_type"] = profileData.ProfileType
+
+	start := time.Unix(0, profileData.Profile.TimeNanos).UTC()
+	if profileData.Profile.TimeNanos == 0 {
+		start = tracingDocumentTimeValue(document.TracerTime, document.UploadedTime)
+	}
+	fields["profile_start_time"] = start
+
+	end := start.Add(time.Duration(profileData.Profile.DurationNanos))
+	if !end.After(start) {
+		end = start.Add(time.Second)
+	}
+	fields["profile_end_time"] = end
+
+	return fields, nil
+}
+
+// Indexes lists metadata consumed by the Pyroscope ingest backend.
+func (PprofDocumentStoreMapper) Indexes() []driver.Index {
+	indexes := (ProfileDocumentStoreMapper{}).Indexes()
+	return append(indexes,
+		driver.Index{Field: "profile_type"},
+		driver.Index{Field: "profile_start_time"},
+		driver.Index{Field: "profile_end_time"},
+	)
+}
+
+func profileDataFromDocument(document *Document) (*profiler.ProfileData, error) {
+	if document == nil {
+		return nil, fmt.Errorf("pprof document is nil")
+	}
+
+	var profileData *profiler.ProfileData
+	switch value := document.TracerData.(type) {
+	case *profiler.ProfileData:
+		profileData = value
+	case profiler.ProfileData:
+		profileData = &value
+	case interface{ ProfileData() *profiler.ProfileData }:
+		profileData = value.ProfileData()
+	default:
+		return nil, fmt.Errorf(
+			"pprof document tracer_data has unsupported type %T",
+			document.TracerData,
+		)
+	}
+	if profileData == nil {
+		return nil, fmt.Errorf("pprof document is missing tracer_data.flamedata")
+	}
+	return profileData, nil
+}

--- a/pkg/tracing/document_pprof_test.go
+++ b/pkg/tracing/document_pprof_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	"huatuo-bamai/internal/storage/driver"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestPprofDocumentStoreMapperEncodesProtobuf(t *testing.T) {
+	start := time.Unix(1700000000, 123).UTC()
+	profileData := &profiler.ProfileData{
+		ProfileType: profiler.ProfileTypeCpuSample,
+		Profile: ptree.Profile{
+			StringTable:   []string{"", "cpu", "nanoseconds"},
+			TimeNanos:     start.UnixNano(),
+			DurationNanos: int64(10 * time.Second),
+		},
+	}
+	document := &Document{
+		TracerID:   "trace-1",
+		TracerTime: start.Format(tracingDocumentTimeLayout),
+		TracerData: testProfileEnvelope{profileData: profileData},
+	}
+
+	mapper := PprofDocumentStoreMapper{}
+	raw, err := mapper.Encode(document)
+	if err != nil {
+		t.Fatalf("Encode returned error: %v", err)
+	}
+	var decoded ptree.Profile
+	if err := decoded.UnmarshalVT(raw); err != nil {
+		t.Fatalf("UnmarshalVT returned error: %v", err)
+	}
+	if decoded.TimeNanos != start.UnixNano() {
+		t.Errorf("TimeNanos = %d, want %d", decoded.TimeNanos, start.UnixNano())
+	}
+
+	fields, err := mapper.Fields(document)
+	if err != nil {
+		t.Fatalf("Fields returned error: %v", err)
+	}
+	if got := fields["profile_type"]; got != profiler.ProfileTypeCpuSample {
+		t.Errorf("profile_type = %v, want %q", got, profiler.ProfileTypeCpuSample)
+	}
+	if got := fields["profile_start_time"]; got != start {
+		t.Errorf("profile_start_time = %v, want %v", got, start)
+	}
+	if got := fields["profile_end_time"]; got != start.Add(10*time.Second) {
+		t.Errorf("profile_end_time = %v, want %v", got, start.Add(10*time.Second))
+	}
+}
+
+func TestPprofDocumentStoreMapperRejectsMissingProfile(t *testing.T) {
+	mapper := PprofDocumentStoreMapper{}
+	if _, err := mapper.Encode(&Document{TracerData: testProfileEnvelope{}}); err == nil {
+		t.Fatal("Encode error = nil, want missing profile error")
+	}
+}
+
+func TestPprofDocumentStoreMapperDecodeIsUnsupported(t *testing.T) {
+	_, err := (PprofDocumentStoreMapper{}).Decode(nil)
+	if !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Fatalf("Decode error = %v, want ErrUnsupportedOp", err)
+	}
+}
+
+type testProfileEnvelope struct {
+	profileData *profiler.ProfileData
+}
+
+func (e testProfileEnvelope) ProfileData() *profiler.ProfileData {
+	return e.profileData
+}


### PR DESCRIPTION
Part of #327.

## Summary

- add a configurable Pyroscope write backend for profiling payloads
- keep Elasticsearch and Pyroscope writes independent
- bound HTTP requests and support Basic or bearer authentication

## Scope

This is the storage-only first patch. AutoTracing conversion, the
standalone compose mode, and folded-stacks export remain separate.

## Validation

- storage package unit tests passed
- Linux cross-compilation and static analysis passed