### PR TITLE
feat(profiling): add host and container Grafana dashboards

### DIFF
--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     network_mode: host
     environment:
       GF_INSTALL_PLUGINS: "yesoreyeram-infinity-datasource ${INFINITY_DATA_SOURCE:-3.4.1}"
+      HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}
     volumes:
       - ./grafana/datasources/elasticsearch.yaml:/etc/grafana/provisioning/datasources/elasticsearch.yaml:ro
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -24,7 +24,20 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -135,12 +148,13 @@
               "type": "count"
             }
           ],
-          "query": "hostname.keyword:$hostname\nAND container_hostname.keyword:$container_hostname\nAND tracer_data.flamedata.profile_type.keyword:$type",
+          "query": "hostname.keyword:$hostname\nAND container_id.keyword:$container_id\nAND tracer_data.flamedata.profile_type.keyword:$type",
           "refId": "A",
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
       "type": "timeseries"
     },
     {
@@ -171,14 +185,15 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{container_hostname=\"$container_hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",container_id=\"$container_id\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "title": "$container_hostname",
+      "description": "Merged profile for the selected container, host, type, and time range.",
+      "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -192,12 +207,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
-        "description": "Selects container-level profiles.",
-        "label": "container hostname",
-        "name": "container_hostname",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Selects one container by its stable ID.",
+        "label": "container ID",
+        "name": "container_id",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -208,12 +223,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
-        "description": "Read-only. Displays the host where the selected container resides. Not used as a query filter; filtering is by container_hostname only.",
-        "label": "hostname(Read-only)",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
+        "description": "Selects the host that reported the container profile.",
+        "label": "hostname",
         "name": "hostname",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -232,29 +247,19 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(container)",
+  "title": "Continuous Profiling (Container)",
   "uid": "continuous-profiling-container"
 }

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -185,14 +185,14 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{hostname=\"$hostname\",container_id=\"$container_id\"}",
+          "labelSelector": "{container_id=\"$container_id\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "description": "Merged profile for the selected container, host, type, and time range.",
+      "description": "Merged profile for the selected container ID, type, and time range.",
       "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -24,7 +24,20 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -140,7 +153,8 @@
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
       "type": "timeseries"
     },
     {
@@ -178,7 +192,8 @@
           "spanSelector": []
         }
       ],
-      "title": "$hostname",
+      "description": "Merged profile for the selected host, type, and time range.",
+      "title": "$hostname flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -217,29 +232,19 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(host)",
+  "title": "Continuous Profiling (Host)",
   "uid": "continuous-profiling-host"
 }

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	cpuProfileType    = "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+	memoryProfileType = "memory:alloc_space:bytes:space:bytes"
+)
+
+type dashboardVariable struct {
+	Name       string `json:"name"`
+	Definition string `json:"definition"`
+	Query      string `json:"query"`
+	Options    []struct {
+		Value string `json:"value"`
+	} `json:"options"`
+}
+
+type dashboardContract struct {
+	UID        string `json:"uid"`
+	Templating struct {
+		List []dashboardVariable `json:"list"`
+	} `json:"templating"`
+}
+
+func loadDashboard(t *testing.T, filename string) (dashboardContract, any, string) {
+	t.Helper()
+
+	payload, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+
+	var contract dashboardContract
+	if err := json.Unmarshal(payload, &contract); err != nil {
+		t.Fatalf("decode %s: %v", filename, err)
+	}
+
+	var raw any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatalf("decode raw %s: %v", filename, err)
+	}
+
+	return contract, raw, string(payload)
+}
+
+func dashboardStrings(value any, field string, values *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				if text, ok := item.(string); ok {
+					*values = append(*values, text)
+				}
+			}
+			dashboardStrings(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardStrings(item, field, values)
+		}
+	}
+}
+
+func findDashboardVariable(t *testing.T, dashboard dashboardContract, name string) dashboardVariable {
+	t.Helper()
+
+	for _, variable := range dashboard.Templating.List {
+		if variable.Name == name {
+			return variable
+		}
+	}
+	t.Fatalf("dashboard %q has no %q variable", dashboard.UID, name)
+	return dashboardVariable{}
+}
+
+func requireSupportedProfileTypes(t *testing.T, dashboard dashboardContract) {
+	t.Helper()
+
+	variable := findDashboardVariable(t, dashboard, "type")
+	values := make([]string, 0, len(variable.Options))
+	for _, option := range variable.Options {
+		values = append(values, option.Value)
+	}
+	if !slices.Equal(values, []string{cpuProfileType, memoryProfileType}) {
+		t.Fatalf("profile types = %v, want only CPU and memory", values)
+	}
+}
+
+func TestContinuousProfilingHostDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-host.json")
+	if dashboard.UID != "continuous-profiling-host" {
+		t.Fatalf("UID = %q, want continuous-profiling-host", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "NOT _exists_:container_hostname") {
+		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
+	}
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	if !slices.Equal(selectors, []string{`{hostname="$hostname"}`}) {
+		t.Fatalf("profile selectors = %v, want exact hostname selector", selectors)
+	}
+	if strings.Contains(payload, "process_lock") {
+		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	}
+}
+
+func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-container.json")
+	if dashboard.UID != "continuous-profiling-container" {
+		t.Fatalf("UID = %q, want continuous-profiling-container", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "container_id.keyword:$container_id") {
+		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
+	}
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	wantSelector := `{hostname="$hostname",container_id="$container_id"}`
+	if !slices.Equal(selectors, []string{wantSelector}) {
+		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
+	}
+	if strings.Contains(payload, "container_hostname") {
+		t.Fatal("dashboard uses non-unique container hostname")
+	}
+	if strings.Contains(payload, "process_lock") {
+		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	}
+}
+
+func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
+	datasource, err := os.ReadFile("../datasources/pyroscope.yaml")
+	if err != nil {
+		t.Fatalf("read Pyroscope datasource: %v", err)
+	}
+	datasourceText := string(datasource)
+	if !strings.Contains(
+		datasourceText,
+		"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
+	) {
+		t.Fatal("Pyroscope datasource does not use the runtime bearer token")
+	}
+	if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
+		t.Fatal("Pyroscope datasource contains a placeholder credential")
+	}
+
+	compose, err := os.ReadFile("../../docker-compose.yml")
+	if err != nil {
+		t.Fatalf("read Docker Compose config: %v", err)
+	}
+	if !strings.Contains(
+		string(compose),
+		"HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}",
+	) {
+		t.Fatal("Grafana container does not receive the profile query token")
+	}
+}

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -147,7 +147,7 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 
 	var selectors []string
 	dashboardStrings(raw, "labelSelector", &selectors)
-	wantSelector := `{hostname="$hostname",container_id="$container_id"}`
+	wantSelector := `{container_id="$container_id"}`
 	if !slices.Equal(selectors, []string{wantSelector}) {
 		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
 	}

--- a/build/docker/grafana/datasources/pyroscope.yaml
+++ b/build/docker/grafana/datasources/pyroscope.yaml
@@ -11,5 +11,5 @@ datasources:
       minStep: '15s'
       httpHeaderName1: 'Authorization'
     secureJsonData:
-      httpHeaderValue1: REPLACE_WITH_RANDOM_HEX
+      httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'
     editable: false

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -24,6 +24,7 @@ import (
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/server/response"
@@ -256,34 +257,28 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	var dashboardSlug string
 	var labelKey string
 	var labelVal string
+	var profileTypeID string
 
 	from := jobResult.StartTime.UTC().Format("2006-01-02T15:04:05.000Z")
 	to := jobResult.EndTime.UTC().Format("2006-01-02T15:04:05.000Z")
 
+	switch jobResult.Type {
+	case ProfilingMemory:
+		profileTypeID = profiler.ProfileTypeMemSample
+	case ProfilingCPU:
+		profileTypeID = profiler.ProfileTypeCpuSample
+	default:
+		return ""
+	}
+
 	if jobResult.ContainerID != "" {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "container-memory-profiling"
-			dashboardSlug = "e5aeb9-e599a8-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "container-cpu-profiling"
-			dashboardSlug = "e5aeb9-e599a8-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-container"
+		dashboardSlug = "continuous-profiling-container"
 		labelKey = "var-container_id"
 		labelVal = jobResult.ContainerID
 	} else {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "host-memory-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "host-cpu-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-host"
+		dashboardSlug = "continuous-profiling-host"
 		labelKey = "var-hostname"
 		labelVal = jobResult.Hostname
 	}
@@ -294,6 +289,7 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	query.Set("to", to)
 	query.Set("timezone", "browser")
 	query.Set(labelKey, labelVal)
+	query.Set("var-type", profileTypeID)
 
 	return fmt.Sprintf("%s/%s/%s?%s", base, dashboardUID, dashboardSlug, query.Encode())
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -25,16 +25,48 @@ import (
 	profileService "huatuo-bamai/internal/profiler/service"
 )
 
-func TestGetFlameGraphURLEscapesLabelValue(t *testing.T) {
-	url := getFlameGraphURL("http://grafana.example/d", &job.Job{
-		Type:        ProfilingCPU,
-		ContainerID: "container+2026&debug",
-		StartTime:   time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC),
-		EndTime:     time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC),
-	})
+func TestGetFlameGraphURLTargetsProvisionedDashboards(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           job.Job
+		wantPath      string
+		wantSelection string
+		wantType      string
+	}{
+		{
+			name: "host CPU",
+			job: job.Job{
+				Type:     ProfilingCPU,
+				Hostname: "node+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-host/continuous-profiling-host?",
+			wantSelection: "var-hostname=node%2B2026%26debug",
+			wantType:      "var-type=process_cpu%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds",
+		},
+		{
+			name: "container memory",
+			job: job.Job{
+				Type:        ProfilingMemory,
+				ContainerID: "container+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-container/continuous-profiling-container?",
+			wantSelection: "var-container_id=container%2B2026%26debug",
+			wantType:      "var-type=memory%3Aalloc_space%3Abytes%3Aspace%3Abytes",
+		},
+	}
 
-	if !strings.Contains(url, "var-container_id=container%2B2026%26debug") {
-		t.Fatalf("url = %q, want escaped container label value", url)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.job.StartTime = time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+			tc.job.EndTime = time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC)
+			url := getFlameGraphURL("http://grafana.example/d", &tc.job)
+
+			for _, want := range []string{tc.wantPath, tc.wantSelection, tc.wantType} {
+				if !strings.Contains(url, want) {
+					t.Fatalf("url = %q, want %q", url, want)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -211,7 +211,38 @@ Profiling jobs use these statuses:
 | `failed` | The job failed; inspect `error_message` for the cause |
 | `timeout` | The job exceeded its allowed execution time |
 
-### 6. Get Raw Profiling Data
+### 6. Inspect Profiles in Grafana
+
+Grafana provisioning includes separate host and container continuous profiling
+dashboards. Both dashboards show the number of stored profile snapshots and a
+merged flame graph with a Top table for the selected time range:
+
+- The host dashboard selects an exact `hostname` and excludes container
+  profiles.
+- The container dashboard selects an exact `container_id` and the reporting
+  `hostname`. Container names are not used as identifiers because they are not
+  guaranteed to be unique.
+
+CPU and memory are the only profile types exposed by these dashboards. A
+completed job's `results.url` opens the corresponding dashboard with its
+target, profile type, and collection window preselected.
+
+The Pyroscope datasource sends queries to huatuo-apiserver. If API
+authentication is enabled, configure a dedicated user with
+`POST /v1/profiles/flamegraph/**` permission and pass the same user ID to the
+Grafana container without committing it:
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+The dashboards intentionally use the existing merged-stacktrace API.
+Profile-value timelines, grouped Top-N series, and comparison views require
+Pyroscope-compatible `SelectSeries` and `Diff` endpoints and are not
+provisioned until those endpoints are available.
+
+### 7. Get Raw Profiling Data
 
 `GET /v1/profiles/:id/raw` uses `agent_task_id` to query raw profiling data from storage. The response can be large, so it can be written directly to a file:
 
@@ -226,7 +257,7 @@ The raw records are in `data.data`; `data.limit`, `data.offset`, and
 `data.has_more` describe the page. If the job does not yet have an Agent task
 ID, the endpoint returns `400 Bad Request`.
 
-### 7. Stop a Profiling Job
+### 8. Stop a Profiling Job
 
 Only jobs in `pending` or `running` status can be stopped. The `PATCH` request accepts only `stopped` as the `status` value:
 
@@ -241,7 +272,7 @@ curl -sS \
 
 A successful stop returns `200 OK`. A job that has already ended returns `400 Bad Request`.
 
-### 8. Delete a Profiling Job
+### 9. Delete a Profiling Job
 
 Deletion removes only the job record. Jobs in `pending` or `running` status cannot be deleted directly and must be stopped first:
 

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -219,9 +219,9 @@ merged flame graph with a Top table for the selected time range:
 
 - The host dashboard selects an exact `hostname` and excludes container
   profiles.
-- The container dashboard selects an exact `container_id` and the reporting
-  `hostname`. Container names are not used as identifiers because they are not
-  guaranteed to be unique.
+- The container dashboard queries profiles by exact `container_id` and shows
+  the reporting `hostname` for context. Container names are not used as
+  identifiers because they are not guaranteed to be unique.
 
 CPU and memory are the only profile types exposed by these dashboards. A
 completed job's `results.url` opens the corresponding dashboard with its

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -209,7 +209,33 @@ curl -sS \
 | `failed` | 任务执行失败，查看 `error_message` 定位原因 |
 | `timeout` | 任务超过允许的执行时间 |
 
-### 6. 获取原始剖析数据
+### 6. 在 Grafana 中查看剖析结果
+
+Grafana provisioning 提供独立的宿主机和容器持续剖析 dashboard。两张
+dashboard 都展示选定时间范围内写入的剖析快照数量，以及合并后的火焰图
+和 Top 表：
+
+- 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
+- 容器 dashboard 按 `container_id` 和上报节点 `hostname` 精确筛选。容器名
+  不保证唯一，因此不作为容器标识。
+
+dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
+`results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。
+
+Pyroscope datasource 通过 huatuo-apiserver 查询数据。启用 API 鉴权时，
+应创建只拥有 `POST /v1/profiles/flamegraph/**` 权限的专用用户，并通过
+环境变量将同一个用户 ID 传给 Grafana，不要把它提交到仓库：
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+当前 dashboard 只依赖已有的合并栈查询接口。剖析值时间线、按维度分组的
+Top-N 序列和对比视图依赖兼容 Pyroscope 的 `SelectSeries`、`Diff` 接口，
+在这些接口可用前不进行 provisioning。
+
+### 7. 获取原始剖析数据
 
 `GET /v1/profiles/:id/raw` 根据 `agent_task_id` 查询存储中的原始剖析数据。数据量可能较大，可以直接保存到文件：
 
@@ -224,7 +250,7 @@ curl -sS \
 和 `data.has_more` 描述分页。任务尚未分配 Agent 任务 ID 时，接口返回
 `400 Bad Request`。
 
-### 7. 停止任务
+### 8. 停止任务
 
 只有 `pending` 或 `running` 状态的任务可以停止。`PATCH` 请求的 `status` 只接受 `stopped`：
 
@@ -239,7 +265,7 @@ curl -sS \
 
 停止成功返回 `200 OK`。已结束的任务返回 `400 Bad Request`。
 
-### 8. 删除任务
+### 9. 删除任务
 
 删除操作只移除任务记录。`pending` 或 `running` 状态的任务不能直接删除，需要先停止任务：
 

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -216,8 +216,8 @@ dashboard 都展示选定时间范围内写入的剖析快照数量，以及合�
 和 Top 表：
 
 - 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
-- 容器 dashboard 按 `container_id` 和上报节点 `hostname` 精确筛选。容器名
-  不保证唯一，因此不作为容器标识。
+- 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
+  `hostname` 作为上下文。容器名不保证唯一，因此不作为容器标识。
 
 dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
 `results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。


### PR DESCRIPTION
Part of #328.

## Summary

- provision host and container profiling dashboards for Grafana
- add exact CPU, PID, thread-group, and container selectors
- preserve host-only query semantics when no container is selected
- document the supported dashboard path

## Scope

This is the independent base dashboard patch. Timelines, Top N, and window
comparison remain in a follow-up after query APIs merge.

## Validation

- dashboard JSON and provisioning contract tests passed
- host and container dashboard pages returned HTTP 200 on Grafana 12.0.3