### PR TITLE
fix(bpf): discover kprobe symbols from mounted tracefs

### DIFF
--- a/internal/bpf/bpf_kprobe.go
+++ b/internal/bpf/bpf_kprobe.go
@@ -16,6 +16,7 @@ package bpf
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -25,21 +26,17 @@ var (
 	kprobeOnce   sync.Mutex
 	kprobeCache  map[string]struct{}
 	kprobeCached bool
+
+	// Tracefs has its own mount point on current kernels, while older systems
+	// commonly expose the same file through debugfs. Check both layouts.
+	kprobeFunctionFiles = []string{
+		"/sys/kernel/tracing/available_filter_functions",
+		"/sys/kernel/debug/tracing/available_filter_functions",
+	}
 )
 
-// loadKprobeFunctions reads /sys/kernel/debug/tracing/available_filter_functions
-// and populates kprobeCache. On success kprobeCached is set so subsequent
-// calls skip the file read; on failure the cache remains unset and the next
-// call retries.
-func loadKprobeFunctions() {
-	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	cache := make(map[string]struct{})
-	scanner := bufio.NewScanner(file)
+func scanKprobeFunctions(r io.Reader, cache map[string]struct{}) error {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -47,23 +44,41 @@ func loadKprobeFunctions() {
 		}
 		cache[strings.Fields(line)[0]] = struct{}{}
 	}
+	return scanner.Err()
+}
 
-	if err := scanner.Err(); err != nil {
-		return
+// loadKprobeFunctions reads the available function list and populates
+// kprobeCache. On success kprobeCached is set so subsequent calls skip the
+// file read; if neither tracefs nor debugfs is readable, the next call retries.
+func loadKprobeFunctions() {
+	cache := make(map[string]struct{})
+	readOK := false
+	for _, path := range kprobeFunctionFiles {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		err = scanKprobeFunctions(file, cache)
+		_ = file.Close()
+		if err == nil {
+			readOK = true
+		}
 	}
 
-	kprobeCache = cache
-	kprobeCached = true
+	if readOK {
+		kprobeCache = cache
+		kprobeCached = true
+	}
 }
 
 // HasKprobeFunction returns whether the given symbol is reported as
 // attachable in the kernel's available_filter_functions list.
 func HasKprobeFunction(name string) bool {
 	kprobeOnce.Lock()
+	defer kprobeOnce.Unlock()
 	if !kprobeCached {
 		loadKprobeFunctions()
 	}
-	kprobeOnce.Unlock()
 
 	_, ok := kprobeCache[name]
 	return ok

--- a/internal/bpf/bpf_kprobe_test.go
+++ b/internal/bpf/bpf_kprobe_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanKprobeFunctions(t *testing.T) {
+	cache := make(map[string]struct{})
+	input := "  mutex_lock\n_raw_spin_lock   [kernel]\n\n_raw_read_lock\t[kernel]\n"
+	if err := scanKprobeFunctions(strings.NewReader(input), cache); err != nil {
+		t.Fatalf("scanKprobeFunctions() error = %v", err)
+	}
+	for _, symbol := range []string{"mutex_lock", "_raw_spin_lock", "_raw_read_lock"} {
+		if _, ok := cache[symbol]; !ok {
+			t.Errorf("symbol %q missing from cache", symbol)
+		}
+	}
+}


### PR DESCRIPTION
Refs #329.

## Summary

- discover available kprobe symbols from tracefs or debugfs mounts
- avoid assuming a single kernel tracing mount layout
- keep symbol discovery reusable outside lock profiling

## Scope

This is the reviewer-requested independent prerequisite for profiler probes.
It does not close #329.

## Validation

- BPF kprobe unit tests passed
- Linux cross-compilation and static analysis passed