### PR TITLE
feat(profiling): add common external profiler tool path

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -24,6 +24,7 @@ import (
 type CreateProfilingJobRequest struct {
 	ProfilingType   string `json:"type"`              // cpu or memory
 	BinaryMatchPath string `json:"binary_match_path"` // executable path used to match target processes
+	ToolPath        string `json:"tool_path"`         // external profiler installation directory
 	Language        string `json:"language"`          // programming language of the target process
 	MemoryMode      string `json:"memory_mode"`       // memory profiling mode
 	Duration        int    `json:"duration"`          // profiling duration in seconds
@@ -46,6 +47,7 @@ type ProfilingJobResponse struct {
 	MemoryMode      string           `json:"memory_mode"`       // memory profiling mode
 	Language        string           `json:"language"`          // programming language of the target process
 	BinaryMatchPath string           `json:"binary_match_path"` // executable path used to match target processes
+	ToolPath        string           `json:"tool_path"`         // external profiler installation directory
 	Status          string           `json:"status"`            // job status
 	StartTime       string           `json:"start_time"`        // start time
 	EndTime         string           `json:"end_time"`          // end time

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -36,6 +36,7 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 			fields: []string{
 				"type",
 				"binary_match_path",
+				"tool_path",
 				"language",
 				"memory_mode",
 				"duration",
@@ -115,6 +116,7 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 			fields: []string{
 				"container_id",
 				"binary_match_path",
+				"tool_path",
 				"language",
 			},
 		},

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -207,6 +207,7 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		ErrorMessage:    jobResult.ErrorMessage,
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
+		ToolPath:        privateData.ToolPath,
 		Language:        privateData.Language,
 	}
 

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -134,6 +134,7 @@ func TestCapabilitiesReturnsIndependentMemoryModeMap(t *testing.T) {
 func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	data, err := newProfilingPrivateData(&v1.CreateProfilingJobRequest{
 		BinaryMatchPath: "/usr/bin/example",
+		ToolPath:        "/opt/profiler",
 		Duration:        60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
@@ -147,6 +148,7 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error=%v", err)
 	}
 	if fields["binary_match_path"] != "/usr/bin/example" ||
+		fields["tool_path"] != "/opt/profiler" ||
 		fields["duration"] != float64(60) ||
 		fields["language"] != "go" ||
 		fields["memory_mode"] != "object_alloc" {
@@ -160,6 +162,7 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 		Status: job.JobStatusRunning,
 		PrivateData: json.RawMessage(`{
 			"binary_match_path":"/usr/bin/example",
+			"tool_path":"/opt/profiler",
 			"duration":60,
 			"language":"go",
 			"memory_mode":"object_alloc"
@@ -171,6 +174,9 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 
 	if resp.BinaryMatchPath != "/usr/bin/example" {
 		t.Errorf("BinaryMatchPath=%q, want %q", resp.BinaryMatchPath, "/usr/bin/example")
+	}
+	if resp.ToolPath != "/opt/profiler" {
+		t.Errorf("ToolPath=%q, want %q", resp.ToolPath, "/opt/profiler")
 	}
 	if resp.Language != "go" {
 		t.Errorf("Language=%q, want %q", resp.Language, "go")

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -46,6 +46,7 @@ type patchProfilingJobRequest struct {
 
 type profilingJobPrivateData struct {
 	BinaryMatchPath string `json:"binary_match_path"`
+	ToolPath        string `json:"tool_path"`
 	Duration        int    `json:"duration"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
@@ -131,6 +132,9 @@ func buildProfilingTracerArgs(
 			)
 		}
 		taskReq.TracerArgs = append(taskReq.TracerArgs, "-l", string(language))
+		if err := appendProfilingToolPath(taskReq, req.ToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingCPU, nil
 	case string(profiling.TypeMemory):
 		language, err := profiling.ParseLanguage(req.Language)
@@ -146,15 +150,35 @@ func buildProfilingTracerArgs(
 			"--memory-mode", string(mode),
 			"-l", string(language),
 		}
+		if err := appendProfilingToolPath(taskReq, req.ToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingMemory, nil
 	default:
 		return "", fmt.Errorf("unsupported profiling type %q", req.ProfilingType)
 	}
 }
 
+func appendProfilingToolPath(
+	taskReq *job.AgentTaskRequest,
+	toolPath string,
+	language profiling.Language,
+) error {
+	toolPath = strings.TrimSpace(toolPath)
+	implementation, _ := profiling.ImplementationFor(language)
+	if implementation != profiling.ImplementationNative && toolPath == "" {
+		return fmt.Errorf("language %q requires tool_path", language)
+	}
+	if toolPath != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--tool-path", toolPath)
+	}
+	return nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
+		ToolPath:        strings.TrimSpace(req.ToolPath),
 		Duration:        req.Duration,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -73,6 +73,36 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "java profiling with external tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				ToolPath:      "/opt/async-profiler",
+				Duration:      30,
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"-l", "java",
+				"--tool-path", "/opt/async-profiler",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "java profiling requires external tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				ToolPath:      "   ",
+				Duration:      30,
+			},
+			wantErr: `language "java" requires tool_path`,
+		},
+		{
 			name: "unsupported type",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType: "offcpu",

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -89,6 +89,7 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `hostname` | Yes | Hostname of the node running the target process; used for job scheduling |
 | `container_id` | No | Target container ID; omit it to profile the host |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
+| `tool_path` | For Java/Python profiling | Tool installation directory on the Agent host: async-profiler for Java or py-spy for Python |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
@@ -120,6 +121,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "tool_path": "/opt/async-profiler",
     "duration": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -193,6 +195,7 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
+| `tool_path` | External profiler installation directory specified when the job was created |
 | `status` | Current job status |
 | `start_time`, `end_time` | Job start and end times; empty until available |
 | `tracer_args` | Command-line arguments sent by huatuo-apiserver to profiler |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -87,6 +87,7 @@ curl -sS \
 | `hostname` | 是 | 运行目标进程的节点主机名，用于任务调度 |
 | `container_id` | 否 | 目标容器 ID；不传表示对宿主机剖析 |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
+| `tool_path` | Java/Python 剖析必需 | Agent 主机上的工具安装目录：Java 使用 async-profiler，Python 使用 py-spy |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
@@ -118,6 +119,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "tool_path": "/opt/async-profiler",
     "duration": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -191,6 +193,7 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
+| `tool_path` | 创建任务时指定的外部 profiler 安装目录 |
 | `status` | 当前任务状态 |
 | `start_time`、`end_time` | 任务开始和结束时间；尚未产生时为空 |
 | `tracer_args` | huatuo-apiserver 实际下发给 profiler 的命令行参数 |


### PR DESCRIPTION
Refs #329.

## Summary

- replace Java- and Python-specific tool path fields with ToolPath
- forward the common value through API, task, and agent plumbing
- require a path only when an external profiler is selected

## Scope

This is the reviewer-requested API cleanup and is independent of lock
collection. It does not close #329.

## Validation

- API, profiler validation, and tracing task unit tests passed
- Linux cross-compilation and static analysis passed