### PR TITLE
feat(profiler): profile targeted mutex contention

### DIFF
--- a/bpf/native_mutex_profiler.c
+++ b/bpf/native_mutex_profiler.c
@@ -1,0 +1,136 @@
+#include "vmlinux.h"
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "bpf_profiler.h"
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+/* Flags exported by lock:contention_begin since Linux 5.19. */
+#define LCB_F_MUTEX (1U << 5)
+
+static volatile const u64 mutex_wait_threshold_ns = 1000;
+
+struct mutex_wait_start_t {
+	u64 started_ns;
+	u64 lock;
+};
+
+struct mutex_event_t {
+	struct profiler_event_base_t base;
+	u64 lock;
+};
+
+/*
+ * A task can migrate between CPUs while blocked. Keying in-flight waits by
+ * pid_tgid in an LRU hash keeps enter/exit correlation correct across that
+ * migration; a per-CPU map would lose or mismatch the start record.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 65536);
+	__type(key, u64);
+	__type(value, struct mutex_wait_start_t);
+} mutex_wait_starts SEC(".maps");
+
+DEFINE_PROFILER_MAPS(struct mutex_event_t);
+
+static __always_inline int mutex_wait_begin(u64 pid_tgid, u64 lock)
+{
+	u64 cpu_css = current_task_cpu_css_addr();
+	if (!profiler_should_trace(pid_tgid, cpu_css))
+		return 0;
+
+	struct mutex_wait_start_t start = {
+		.started_ns = bpf_ktime_get_ns(),
+		.lock = lock,
+	};
+	bpf_map_update_elem(&mutex_wait_starts, &pid_tgid, &start,
+			    COMPAT_BPF_ANY);
+	return 0;
+}
+
+static __always_inline int mutex_wait_end(void *ctx, u64 pid_tgid, bool success)
+{
+	struct mutex_wait_start_t *found =
+		bpf_map_lookup_elem(&mutex_wait_starts, &pid_tgid);
+	if (!found)
+		return 0;
+
+	struct mutex_wait_start_t start = *found;
+	bpf_map_delete_elem(&mutex_wait_starts, &pid_tgid);
+	if (!success)
+		return 0;
+
+	u64 wait_ns = bpf_ktime_get_ns() - start.started_ns;
+	if (wait_ns < mutex_wait_threshold_ns)
+		return 0;
+
+	u64 *transfer_count_ptr;
+	u64 *sample_count_ptrs[2];
+	void *select_profiler_stack_map;
+	void *select_profiler_output;
+	u64 *select_profiler_sample_count_ptr;
+
+	if (!profiler_init_state(&profiler_state_map, &transfer_count_ptr,
+				 sample_count_ptrs))
+		return 0;
+
+	SELECT_PROFILER_AB();
+
+	u32 idx = 0;
+	struct mutex_event_t *event = bpf_map_lookup_elem(&event_buf, &idx);
+	if (!event)
+		return 0;
+
+	__builtin_memset(event, 0, sizeof(*event));
+	event->base.value = wait_ns;
+	event->lock = start.lock;
+	if (profiler_fill_event_base(&event->base, pid_tgid, ctx,
+				     select_profiler_stack_map) < 0)
+		return 0;
+
+	profiler_emit_event(ctx, select_profiler_output,
+			    select_profiler_sample_count_ptr, event,
+			    sizeof(*event));
+	return 0;
+}
+
+SEC("kprobe/huatuo_mutex_lock_slowpath")
+int trace_mutex_lock_slowpath(struct pt_regs *ctx)
+{
+	return mutex_wait_begin(bpf_get_current_pid_tgid(), PT_REGS_PARM1(ctx));
+}
+
+SEC("kretprobe/huatuo_mutex_lock_slowpath")
+int trace_mutex_lock_slowpath_return(struct pt_regs *ctx)
+{
+	return mutex_wait_end(ctx, bpf_get_current_pid_tgid(), true);
+}
+
+struct lock_contention_begin_ctx {
+	u64 common;
+	u64 lock_addr;
+	u32 flags;
+};
+
+struct lock_contention_end_ctx {
+	u64 common;
+	u64 lock_addr;
+	s32 ret;
+};
+
+SEC("tracepoint/lock/contention_begin")
+int trace_mutex_contention_begin(struct lock_contention_begin_ctx *ctx)
+{
+	if (!(ctx->flags & LCB_F_MUTEX))
+		return 0;
+	return mutex_wait_begin(bpf_get_current_pid_tgid(), ctx->lock_addr);
+}
+
+SEC("tracepoint/lock/contention_end")
+int trace_mutex_contention_end(struct lock_contention_end_ctx *ctx)
+{
+	return mutex_wait_end(ctx, bpf_get_current_pid_tgid(), ctx->ret == 0);
+}

--- a/cmd/profiler/flags.go
+++ b/cmd/profiler/flags.go
@@ -14,13 +14,17 @@
 
 package main
 
-import "github.com/urfave/cli/v2"
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
 
 var appFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "type",
 		Aliases: []string{"t"},
-		Usage:   "Profiling type: cpu|memory",
+		Usage:   "Profiling type: cpu|memory|lock",
 	},
 	&cli.StringFlag{
 		Name:    "language",
@@ -47,6 +51,11 @@ var appFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  "thread-group",
 		Usage: "Profile the target thread group; supported only by native profiling",
+	},
+	&cli.DurationFlag{
+		Name:  "lock-wait-threshold",
+		Usage: "Minimum mutex contention wait to record",
+		Value: time.Microsecond,
 	},
 	&cli.IntFlag{
 		Name:    "freq",

--- a/cmd/profiler/provider/native_aggregator.go
+++ b/cmd/profiler/provider/native_aggregator.go
@@ -70,7 +70,7 @@ type lockStackEntry struct {
 	User      string
 	Kernel    string
 	WaitTime  uint64
-	Contended uint32
+	Contended uint64
 }
 
 type nativeAggregator struct {
@@ -128,7 +128,14 @@ func (a *nativeAggregator) Aggregate(rec any) {
 		}
 
 	case *lockStackEntry:
-		key := fmt.Sprintf("%s\x00%d", v.User, v.Proc.Lock)
+		key := fmt.Sprintf(
+			"%d\x00%s\x00%s\x00%s\x00%d",
+			v.Proc.Pid,
+			v.Proc.Name,
+			v.User,
+			v.Kernel,
+			v.Proc.Lock,
+		)
 		if existed, ok := a.lockAggrMap[key]; ok {
 			existed.Contended += v.Contended
 			existed.WaitTime += v.WaitTime
@@ -329,7 +336,15 @@ func profileTypeOptions(pctx *pcontext.ProfilerContext) (*profiler.ParseOption, 
 	case profiling.TypeMemory:
 		return &profiler.ParseOption{SampleRate: profiler.NoSampleRate}, profiler.ProfileTypeMemSample, nil
 	case profiling.TypeLock:
-		return &profiler.ParseOption{SampleRate: profiler.NoSampleRate}, profiler.ProfileTypeLockTimeSample, nil
+		if pctx.LockMode != profiling.LockModeUnknown &&
+			pctx.LockMode != profiling.LockModeWaitTime {
+			return nil, "", fmt.Errorf(
+				"unsupported lock mode %q",
+				pctx.LockMode,
+			)
+		}
+		return &profiler.ParseOption{SampleRate: profiler.NoSampleRate},
+			profiler.ProfileTypeLockTimeSample, nil
 	default:
 		return nil, "", fmt.Errorf("unsupported profile type %q", pctx.Type)
 	}

--- a/cmd/profiler/provider/native_aggregator_test.go
+++ b/cmd/profiler/provider/native_aggregator_test.go
@@ -47,7 +47,44 @@ func TestNativeAggregatorAggregatesLockTime(t *testing.T) {
 	}
 }
 
-func requireSingleLockRecord(t *testing.T, aggregator *nativeAggregator, waitTime uint64, contended uint32) {
+func TestNativeAggregatorKeepsDistinctLockMetadata(t *testing.T) {
+	aggregator := &nativeAggregator{
+		aggrMap:     map[string]*stackEntry{},
+		lockAggrMap: map[string]*lockStackEntry{},
+	}
+	base := &lockStackEntry{
+		Proc:      &processIDNameLock{Pid: 12, Name: "app", Lock: 0xab},
+		User:      "foo;bar",
+		Kernel:    "mutex_lock",
+		WaitTime:  10,
+		Contended: 1,
+	}
+	differentPID := *base
+	differentPID.Proc = &processIDNameLock{
+		Pid:  13,
+		Name: "app",
+		Lock: 0xab,
+	}
+	differentKernel := *base
+	differentKernel.Kernel = "mutex_lock_nested"
+
+	aggregator.Aggregate(base)
+	aggregator.Aggregate(&differentPID)
+	aggregator.Aggregate(&differentKernel)
+
+	if len(aggregator.lockAggrMap) != 3 {
+		t.Fatalf(
+			"lock records = %d, want 3 distinct metadata groups",
+			len(aggregator.lockAggrMap),
+		)
+	}
+}
+
+func requireSingleLockRecord(
+	t *testing.T,
+	aggregator *nativeAggregator,
+	waitTime, contended uint64,
+) {
 	t.Helper()
 	if len(aggregator.lockAggrMap) != 1 {
 		t.Fatalf("lock records = %d, want 1", len(aggregator.lockAggrMap))

--- a/cmd/profiler/provider/native_mutex_profiler.go
+++ b/cmd/profiler/provider/native_mutex_profiler.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler/aggregator"
+	"huatuo-bamai/internal/profiler/bpfmap"
+	pcontext "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/profiler/procutil"
+	"huatuo-bamai/internal/profiler/registry"
+	"huatuo-bamai/pkg/profiling"
+	"huatuo-bamai/pkg/types"
+)
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/native_mutex_profiler.c -o $BPF_DIR/native_mutex_profiler.o
+
+const (
+	mutexBackendContentionTracepoints = "contention tracepoints"
+	mutexBackendSlowpathKprobe        = "mutex slowpath"
+	mutexSlowpathSymbol               = "__mutex_lock_slowpath"
+)
+
+type mutexEvent struct {
+	ProfilerEventBase
+	Lock uint64
+}
+
+type mutexAggregateKey struct {
+	Pid       uint32
+	Comm      [TaskCommLen]byte
+	Kernstack int32
+	Userstack int32
+	Lock      uint64
+}
+
+type mutexAggregateValue struct {
+	WaitTime  uint64
+	Contended uint64
+}
+
+type mutexNativeProfiler struct {
+	bpf bpf.BPF
+}
+
+var (
+	hasMutexKprobeFunction        = bpf.HasKprobeFunction
+	hasMutexContentionTracepoints = mutexContentionTracepointsAvailable
+)
+
+func init() {
+	impl := &mutexNativeProfiler{}
+	registry.Register(registry.ProfilerMeta{
+		Type:           profiling.TypeLock,
+		Implementation: profiling.ImplementationNative,
+		Description:    "Native kernel mutex contention profiler using eBPF",
+		Impl:           impl,
+		NewAggregator:  impl.NewAggregator,
+	})
+}
+
+func (p *mutexNativeProfiler) NewAggregator(
+	pctx *pcontext.ProfilerContext,
+) (aggregator.Aggregator, error) {
+	return newNativeAggregator(pctx)
+}
+
+func (p *mutexNativeProfiler) Start(pctx *pcontext.ProfilerContext) error {
+	if err := validateMutexTarget(pctx); err != nil {
+		return err
+	}
+	if err := requireRoot(); err != nil {
+		return err
+	}
+	if pctx.LockType != profiling.LockTypeMutex {
+		return fmt.Errorf("native lock profiler supports only mutex contention")
+	}
+	if pctx.LockMode != profiling.LockModeWaitTime {
+		return fmt.Errorf("native lock profiler supports only wait-time mode")
+	}
+
+	cssAddr, err := resolveContainerCgroupCss(
+		pctx,
+		subsystem.SubsystemCPU,
+	)
+	if err != nil {
+		return err
+	}
+	constants := newNativeBPFConstants(
+		pctx.PID(),
+		cssAddr,
+		pctx.ThreadGroup,
+	)
+	constants["mutex_wait_threshold_ns"] = uint64(pctx.LockWaitThreshold.Nanoseconds())
+
+	attachOptions, backend, err := mutexAttachOptions()
+	if err != nil {
+		return err
+	}
+
+	loaded, err := bpf.LoadBpf("native_mutex_profiler.o", constants)
+	if err != nil {
+		return fmt.Errorf("load native mutex profiler BPF: %w", err)
+	}
+	if err := loaded.AttachWithOptions(attachOptions); err != nil {
+		_ = loaded.Close()
+		return fmt.Errorf("attach mutex contention probes: %w", err)
+	}
+
+	p.bpf = loaded
+	log.Infof("native mutex contention profiler attached via %s", backend)
+	return nil
+}
+
+func (p *mutexNativeProfiler) Stop(*pcontext.ProfilerContext) error {
+	return closeBpfSafe(p.bpf)
+}
+
+func (p *mutexNativeProfiler) ReadDataLoop(
+	ctx context.Context,
+	enqueue func(any),
+) error {
+	log.Infof("data reading loop started")
+	defer log.Infof("data reading loop ended")
+
+	ringCtx, err := newRingBufferContext(
+		p.bpf,
+		ctx,
+		4096*257,
+		false,
+	)
+	if err != nil {
+		return err
+	}
+	defer ringCtx.Close()
+
+	ticker := time.NewTicker(drainTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := drainMutexEvents(ringCtx, enqueue); err != nil {
+			if errors.Is(err, types.ErrExitByCancelCtx) {
+				return nil
+			}
+			log.Warnf("drain mutex contention events: %v", err)
+		}
+	}
+}
+
+func validateMutexTarget(pctx *pcontext.ProfilerContext) error {
+	if err := validateNativePIDs("lock", pctx.PIDs); err != nil {
+		return err
+	}
+	hasPID := len(pctx.PIDs) == 1
+	hasContainer := pctx.ContainerID != ""
+	if hasPID == hasContainer {
+		return fmt.Errorf(
+			"native lock profiler requires exactly one PID or container target",
+		)
+	}
+	return nil
+}
+
+func mutexContentionTracepointsAvailable() bool {
+	for _, root := range []string{
+		"/sys/kernel/tracing/events/lock",
+		"/sys/kernel/debug/tracing/events/lock",
+	} {
+		if _, err := os.Stat(root + "/contention_begin/id"); err != nil {
+			continue
+		}
+		if _, err := os.Stat(root + "/contention_end/id"); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func mutexAttachOptions() ([]bpf.AttachOption, string, error) {
+	if hasMutexContentionTracepoints() {
+		return []bpf.AttachOption{
+			{
+				ProgramName: "trace_mutex_contention_begin",
+				Symbol:      "lock/contention_begin",
+			},
+			{
+				ProgramName: "trace_mutex_contention_end",
+				Symbol:      "lock/contention_end",
+			},
+		}, mutexBackendContentionTracepoints, nil
+	}
+
+	if !hasMutexKprobeFunction(mutexSlowpathSymbol) {
+		return nil, "", fmt.Errorf(
+			"kernel exposes neither lock contention tracepoints nor %s",
+			mutexSlowpathSymbol,
+		)
+	}
+	return []bpf.AttachOption{
+		{
+			ProgramName: "trace_mutex_lock_slowpath",
+			Symbol:      mutexSlowpathSymbol,
+		},
+		{
+			ProgramName: "trace_mutex_lock_slowpath_return",
+			Symbol:      mutexSlowpathSymbol,
+		},
+	}, mutexBackendSlowpathKprobe, nil
+}
+
+func drainMutexEvents(
+	ringCtx *ringBufferContext,
+	enqueue func(any),
+) error {
+	ring, err := ringCtx.advanceSwapParity()
+	if err != nil {
+		return err
+	}
+
+	aggregates := make(map[mutexAggregateKey]mutexAggregateValue)
+	totalRead := uint64(0)
+	for {
+		batch, err := ring.reader.ReadBatch(&mutexEvent{})
+		if err != nil {
+			return err
+		}
+		totalRead += uint64(len(batch))
+		aggregateMutexBatch(aggregates, batch)
+		if len(batch) == 0 {
+			break
+		}
+
+		count, err := bpfmap.ReadUint64(
+			ringCtx.bpf,
+			ringCtx.transferStateMapID,
+			ring.sampleCountIdx,
+		)
+		if err != nil {
+			return fmt.Errorf("read mutex event count: %w", err)
+		}
+		if totalRead >= count {
+			break
+		}
+	}
+	if err := bpfmap.WriteUint64(
+		ringCtx.bpf,
+		ringCtx.transferStateMapID,
+		ring.sampleCountIdx,
+		0,
+	); err != nil {
+		return fmt.Errorf("reset mutex event count: %w", err)
+	}
+
+	enqueueMutexAggregates(ringCtx, ring, aggregates, enqueue)
+	return nil
+}
+
+func aggregateMutexBatch(
+	aggregates map[mutexAggregateKey]mutexAggregateValue,
+	batch []any,
+) {
+	for _, raw := range batch {
+		event, ok := raw.(*mutexEvent)
+		if !ok || event.Value <= 0 {
+			continue
+		}
+		key := mutexAggregateKey{
+			Pid:       uint32(event.PidTgid >> 32),
+			Comm:      event.Comm,
+			Kernstack: event.Kernstack,
+			Userstack: event.Userstack,
+			Lock:      event.Lock,
+		}
+		value := aggregates[key]
+		value.WaitTime += uint64(event.Value)
+		value.Contended++
+		aggregates[key] = value
+	}
+}
+
+func enqueueMutexAggregates(
+	ringCtx *ringBufferContext,
+	ring activeRingBuffer,
+	aggregates map[mutexAggregateKey]mutexAggregateValue,
+	enqueue func(any),
+) {
+	kstackCache := make(map[int32]string)
+	ustackCache := make(map[struct {
+		id  int32
+		pid uint32
+	}]string)
+	for key, value := range aggregates {
+		if key.Kernstack >= 0 {
+			if _, ok := kstackCache[key.Kernstack]; !ok {
+				kstackCache[key.Kernstack] = ringCtx.resolveKstackWithFallback(ring, key.Kernstack)
+			}
+		}
+		ukey := struct {
+			id  int32
+			pid uint32
+		}{key.Userstack, key.Pid}
+		if key.Userstack >= 0 {
+			if _, ok := ustackCache[ukey]; !ok {
+				ustackCache[ukey] = ringCtx.resolveUstackWithFallback(
+					ring,
+					key.Userstack,
+					key.Pid,
+				)
+			}
+		}
+		if key.Kernstack < 0 && key.Userstack < 0 {
+			continue
+		}
+
+		enqueue(&lockStackEntry{
+			Proc: &processIDNameLock{
+				Pid:  key.Pid,
+				Name: procutil.CommToString(key.Comm),
+				Lock: key.Lock,
+			},
+			User:      ustackCache[ukey],
+			Kernel:    kstackCache[key.Kernstack],
+			WaitTime:  value.WaitTime,
+			Contended: value.Contended,
+		})
+	}
+}

--- a/cmd/profiler/provider/native_mutex_profiler_test.go
+++ b/cmd/profiler/provider/native_mutex_profiler_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	pcontext "huatuo-bamai/internal/profiler/context"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMutexTarget(t *testing.T) {
+	require.NoError(t, validateMutexTarget(&pcontext.ProfilerContext{
+		PIDs: []int{42},
+	}))
+	require.NoError(t, validateMutexTarget(&pcontext.ProfilerContext{
+		ContainerID: "container",
+	}))
+	require.EqualError(
+		t,
+		validateMutexTarget(&pcontext.ProfilerContext{}),
+		"native lock profiler requires exactly one PID or container target",
+	)
+	require.EqualError(
+		t,
+		validateMutexTarget(&pcontext.ProfilerContext{
+			PIDs:        []int{42},
+			ContainerID: "container",
+		}),
+		"native lock profiler requires exactly one PID or container target",
+	)
+}
+
+func TestMutexAttachOptions(t *testing.T) {
+	oldTracepoints := hasMutexContentionTracepoints
+	oldKprobe := hasMutexKprobeFunction
+	t.Cleanup(func() {
+		hasMutexContentionTracepoints = oldTracepoints
+		hasMutexKprobeFunction = oldKprobe
+	})
+
+	hasMutexContentionTracepoints = func() bool { return true }
+	hasMutexKprobeFunction = func(string) bool { return false }
+	options, backend, err := mutexAttachOptions()
+	require.NoError(t, err)
+	require.Equal(t, mutexBackendContentionTracepoints, backend)
+	require.Len(t, options, 2)
+	require.Equal(t, "trace_mutex_contention_begin", options[0].ProgramName)
+
+	hasMutexContentionTracepoints = func() bool { return false }
+	hasMutexKprobeFunction = func(symbol string) bool {
+		return symbol == mutexSlowpathSymbol
+	}
+	options, backend, err = mutexAttachOptions()
+	require.NoError(t, err)
+	require.Equal(t, mutexBackendSlowpathKprobe, backend)
+	require.Len(t, options, 2)
+	require.Equal(t, mutexSlowpathSymbol, options[0].Symbol)
+
+	hasMutexKprobeFunction = func(string) bool { return false }
+	_, _, err = mutexAttachOptions()
+	require.EqualError(
+		t,
+		err,
+		"kernel exposes neither lock contention tracepoints nor "+
+			mutexSlowpathSymbol,
+	)
+}
+
+func TestAggregateMutexBatch(t *testing.T) {
+	comm := [TaskCommLen]byte{'a', 'p', 'p'}
+	first := &mutexEvent{
+		ProfilerEventBase: ProfilerEventBase{
+			PidTgid:   uint64(42) << 32,
+			Comm:      comm,
+			Kernstack: 0,
+			Userstack: 1,
+			Value:     15,
+		},
+		Lock: 0xab,
+	}
+	second := *first
+	second.Value = 5
+
+	aggregates := make(map[mutexAggregateKey]mutexAggregateValue)
+	aggregateMutexBatch(aggregates, []any{
+		first,
+		&second,
+		&mutexEvent{ProfilerEventBase: ProfilerEventBase{Value: 0}},
+		"unexpected",
+	})
+
+	require.Equal(t, map[mutexAggregateKey]mutexAggregateValue{
+		{
+			Pid:       42,
+			Comm:      comm,
+			Kernstack: 0,
+			Userstack: 1,
+			Lock:      0xab,
+		}: {
+			WaitTime:  20,
+			Contended: 2,
+		},
+	}, aggregates)
+}

--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -122,7 +123,7 @@ func validateLanguageOptions(ctx *cli.Context, lang profiling.Language, typ prof
 		if err := validateSinglePID(ctx, "native"); err != nil {
 			return err
 		}
-		if typ == profiling.TypeMemory {
+		if typ == profiling.TypeMemory || typ == profiling.TypeLock {
 			return validateExactlyOneTarget(ctx)
 		}
 
@@ -267,6 +268,7 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	native := implementation == profiling.ImplementationNative
 	nativeCPU := native && typ == profiling.TypeCPU
 	nativeMemory := native && typ == profiling.TypeMemory
+	nativeLock := native && typ == profiling.TypeLock
 
 	if lang == profiling.LanguageJava && typ == profiling.TypeCPU && ctx.Int("freq") > 1000 {
 		return fmt.Errorf("Java profiler frequency must not exceed 1000 samples per second")
@@ -280,6 +282,11 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	if ctx.Bool("thread-group") && !native {
 		return fmt.Errorf("--thread-group is supported only by native profiling")
 	}
+	if ctx.IsSet("lock-wait-threshold") && !nativeLock {
+		return fmt.Errorf(
+			"--lock-wait-threshold is supported only by native lock profiling",
+		)
+	}
 	if ctx.String("binary-match-path") != "" && native {
 		return fmt.Errorf("--binary-match-path is not supported by native profilers")
 	}
@@ -292,6 +299,14 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 		probability := ctx.Uint("physical-memory-probability")
 		if probability < 1 || probability > 100 {
 			return fmt.Errorf("physical memory probability must be between 1 and 100")
+		}
+	}
+	if nativeLock {
+		threshold := ctx.Duration("lock-wait-threshold")
+		if threshold < 0 || threshold > time.Hour {
+			return fmt.Errorf(
+				"--lock-wait-threshold must be between 0 and 1h",
+			)
 		}
 	}
 	return nil

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -55,6 +55,20 @@ func TestCLIProfileTypeAndRemovedFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "native mutex contention",
+			args: []string{
+				"--type", "lock",
+				"--language", "c",
+				"--pid", strconv.Itoa(os.Getpid()),
+				"--lock-wait-threshold", "10us",
+			},
+		},
+		{
+			name:      "native mutex contention requires a target",
+			args:      []string{"--type", "lock", "--language", "c"},
+			wantError: "exactly one of --container-id or --pid must be provided",
+		},
+		{
 			name: "tracer ID",
 			args: []string{
 				"--type", "cpu",
@@ -66,7 +80,7 @@ func TestCLIProfileTypeAndRemovedFlags(t *testing.T) {
 		{
 			name:      "legacy mem type",
 			args:      []string{"--type", "mem", "--language", "c"},
-			wantError: `unsupported profiling type "mem" (expected: cpu or memory)`,
+			wantError: `unsupported profiling type "mem" (expected: cpu, memory, or lock)`,
 		},
 		{
 			name:      "removed flags option",
@@ -273,6 +287,19 @@ func TestValidateProfilerFlagCompatibility(t *testing.T) {
 		},
 		{name: "native CPU thread group", language: "go", typ: "cpu", args: []string{"--thread-group"}},
 		{name: "native memory thread group", language: "c", typ: "memory", args: []string{"--thread-group"}},
+		{
+			name:     "native mutex wait threshold",
+			language: "c",
+			typ:      "lock",
+			args:     []string{"--lock-wait-threshold", "10us"},
+		},
+		{
+			name:      "CPU mutex wait threshold",
+			language:  "c",
+			typ:       "cpu",
+			args:      []string{"--lock-wait-threshold", "10us"},
+			wantError: "--lock-wait-threshold is supported only by native lock profiling",
+		},
 		{
 			name:      "native exec path",
 			language:  "c",

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -302,7 +302,7 @@ The basic command structure is:
 
 ```bash
 sudo _output/bin/profiler \
-  --type <cpu|memory> \
+  --type <cpu|memory|lock> \
   --language <c|c++|go|java|python> \
   --pid <pid> \
   --duration 30 \
@@ -311,13 +311,13 @@ sudo _output/bin/profiler \
   --output-path ./profiles
 ```
 
-`--type` and `--language` are required. Java, Python, and native memory profiling require exactly one target specified with either `--pid` or `--container-id`. Native CPU profiling can sample the entire host when neither target is specified.
+`--type` and `--language` are required. Java, Python, native memory, and native lock profiling require exactly one target specified with either `--pid` or `--container-id`. Native CPU profiling can sample the entire host when neither target is specified.
 
 ### 2. General CLI Options
 
 | Option | Default | Scope | Description |
 | --- | --- | --- | --- |
-| `--type`, `-t` | None | All | Profile type: `cpu` or `memory`; required |
+| `--type`, `-t` | None | All | Profile type: `cpu`, `memory`, or `lock`; required |
 | `--language`, `-l` | None | All | Target language: `c`, `c++`, `go`, `java`, or `python`; required |
 | `--pid`, `-p` | None | All | Target PID; Java and Python accept comma-separated PIDs, while native profiling accepts at most one PID |
 | `--container-id` | None | All | Target container ID; mutually exclusive with `--pid` |
@@ -344,6 +344,7 @@ Native profiling options:
 | `--memory-mode` | None | Native memory, Java memory | Memory profiling mode; required with `--type memory` |
 | `--cpuid` | All CPUs | Native CPU | Comma-separated CPU list or ranges, for example `1,3,5-10` |
 | `--thread-group` | `false` | Native | Also profile other threads in the target PID's thread group |
+| `--lock-wait-threshold` | `1us` | Native lock | Minimum mutex contention wait included in the profile |
 | `--physical-memory-probability` | `100` | Native physical memory | Physical memory event sampling probability from 1 to 100 |
 | `--log-bpf-debug` | `false` | Native | Emit BPF debug events; not recommended for normal profiling |
 
@@ -411,6 +412,24 @@ sudo _output/bin/profiler \
 ```
 
 `--physical-memory-probability` applies only to `physical_alloc` and `physical_usage`. Lowering it reduces processing for high-frequency memory events, but flame-graph values are then estimates based on sampled events rather than counts of every event.
+
+Native lock profiling currently records mutex wait time only. It attaches to the
+kernel lock contention tracepoints when available and otherwise uses the mutex
+slow path. A PID or container target is mandatory to prevent accidental
+host-wide lock instrumentation.
+
+```bash
+sudo _output/bin/profiler \
+  --type lock \
+  --language c \
+  --pid 12345 \
+  --thread-group \
+  --lock-wait-threshold 10us \
+  --duration 30 \
+  --aggr-interval 10 \
+  --output-format flamegraph \
+  --output-path ./profiles/mutex-wait
+```
 
 ### 4. Observing Java
 

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -300,7 +300,7 @@ _output/bin/profiler --help
 
 ```bash
 sudo _output/bin/profiler \
-  --type <cpu|memory> \
+  --type <cpu|memory|lock> \
   --language <c|c++|go|java|python> \
   --pid <pid> \
   --duration 30 \
@@ -309,13 +309,13 @@ sudo _output/bin/profiler \
   --output-path ./profiles
 ```
 
-`--type` 和 `--language` 为必填参数。Java、Python 和原生内存采集必须在 `--pid` 与 `--container-id` 中指定且仅指定一个目标；原生 CPU 采集未指定目标时可进行宿主机级采样。
+`--type` 和 `--language` 为必填参数。Java、Python、原生内存和原生锁采集必须在 `--pid` 与 `--container-id` 中指定且仅指定一个目标；原生 CPU 采集未指定目标时可进行宿主机级采样。
 
 ### 2. 通用命令参数
 
 | 参数 | 默认值 | 适用范围 | 说明 |
 | --- | --- | --- | --- |
-| `--type`, `-t` | 无 | 全部 | 观测类型：`cpu` 或 `memory`，必填 |
+| `--type`, `-t` | 无 | 全部 | 观测类型：`cpu`、`memory` 或 `lock`，必填 |
 | `--language`, `-l` | 无 | 全部 | 目标语言：`c`、`c++`、`go`、`java` 或 `python`，必填 |
 | `--pid`, `-p` | 无 | 全部 | 目标 PID；Java、Python 可使用逗号分隔多个 PID，原生采集最多一个 PID |
 | `--container-id` | 无 | 全部 | 目标容器 ID；不能与 `--pid` 同时使用 |
@@ -342,6 +342,7 @@ sudo _output/bin/profiler \
 | `--memory-mode` | 无 | 原生内存、Java 内存 | 内存观测维度；使用 `--type memory` 时必填 |
 | `--cpuid` | 全部 CPU | 原生 CPU | CPU 列表或范围，例如 `1,3,5-10` |
 | `--thread-group` | `false` | 原生 | 同时采集目标 PID 所在线程组中的其他线程 |
+| `--lock-wait-threshold` | `1us` | 原生锁 | 纳入结果的最小 mutex 竞争等待时间 |
 | `--physical-memory-probability` | `100` | 原生物理内存 | 物理内存事件采样概率，范围为 1～100 |
 | `--log-bpf-debug` | `false` | 原生 | 输出 BPF 调试事件，常规采集不建议启用 |
 
@@ -409,6 +410,23 @@ sudo _output/bin/profiler \
 ```
 
 `--physical-memory-probability` 仅适用于 `physical_alloc` 和 `physical_usage`。降低该值可减少高频内存事件的处理量，但火焰图中的值由采样事件估算，不再是逐事件统计。
+
+原生锁采集当前仅统计 mutex 等待时间。内核支持时使用锁竞争
+tracepoint，否则使用 mutex 慢路径。必须指定 PID 或容器，避免意外启用
+宿主机级锁插桩。
+
+```bash
+sudo _output/bin/profiler \
+  --type lock \
+  --language c \
+  --pid 12345 \
+  --thread-group \
+  --lock-wait-threshold 10us \
+  --duration 30 \
+  --aggr-interval 10 \
+  --output-format flamegraph \
+  --output-path ./profiles/mutex-wait
+```
 
 ### 4. Java 观测
 

--- a/integration/test_profiler_native_mutex.sh
+++ b/integration/test_profiler_native_mutex.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+
+is_container && skip "native mutex profiler requires bare-metal BPF access"
+[[ ${EUID} -eq 0 ]] || skip "native mutex profiler requires root"
+
+readonly PROFILER_BIN="${ROOT_DIR}/_output/bin/profiler"
+readonly PROFILER_BPF="${ROOT_DIR}/_output/bpf/native_mutex_profiler.o"
+readonly FIXTURE_DIR="${ROOT_DIR}/integration/testdata/mutexprof_fixture"
+readonly KERNEL_BUILD_DIR="/lib/modules/$(uname -r)/build"
+
+[[ -x "${PROFILER_BIN}" ]] || fatal "profiler binary missing: ${PROFILER_BIN}"
+[[ -r "${PROFILER_BPF}" ]] || fatal "BPF object missing: ${PROFILER_BPF}"
+[[ -d "${KERNEL_BUILD_DIR}" ]] || skip "matching kernel headers unavailable"
+command -v timeout > /dev/null || skip "timeout(1) not in PATH"
+command -v insmod > /dev/null || skip "insmod(8) not in PATH"
+command -v rmmod > /dev/null || skip "rmmod(8) not in PATH"
+command -v mknod > /dev/null || skip "mknod(1) not in PATH"
+
+if [[ ! -r /sys/kernel/tracing/events/lock/contention_begin/id ]] \
+	&& [[ ! -r /sys/kernel/debug/tracing/events/lock/contention_begin/id ]] \
+	&& ! kprobe_available __mutex_lock_slowpath; then
+	skip "kernel exposes no supported mutex contention hook"
+fi
+
+WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/profiler-mutex.XXXXXX")
+MODULE_DIR="${WORK_DIR}/module"
+MODULE_NAME="huatuo_mutexprof_test"
+DEVICE_PATH="${WORK_DIR}/huatuo_mutexprof_fixture"
+WORKLOAD_BIN="${WORK_DIR}/mutexprof_workload"
+PROFILER_PID=""
+TARGET_PID=""
+
+cleanup() {
+	[[ -n "${PROFILER_PID}" ]] && stop_by_pid "${PROFILER_PID}" 5 || true
+	[[ -n "${TARGET_PID}" ]] && stop_by_pid "${TARGET_PID}" 5 || true
+	rmmod "${MODULE_NAME}" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+mkdir -p "${MODULE_DIR}"
+cp "${FIXTURE_DIR}/Makefile" "${MODULE_DIR}/"
+cp "${FIXTURE_DIR}/huatuo_mutexprof_test.kernel.c" \
+	"${MODULE_DIR}/huatuo_mutexprof_test.c"
+if ! make -s -C "${KERNEL_BUILD_DIR}" M="${MODULE_DIR}" modules \
+	> "${WORK_DIR}/module-build.log" 2>&1; then
+	fatal "failed to build kernel mutex fixture"
+fi
+
+rmmod "${MODULE_NAME}" > /dev/null 2>&1 || true
+insmod "${MODULE_DIR}/${MODULE_NAME}.ko" \
+	|| fatal "failed to load ${MODULE_NAME}.ko"
+
+readonly DEVICE_SYSFS="/sys/class/misc/huatuo_mutexprof_fixture/dev"
+wait_until 5 1 test -r "${DEVICE_SYSFS}" \
+	|| fatal "fixture miscdevice did not appear"
+readonly DEVICE_NUMBER=$(< "${DEVICE_SYSFS}")
+mknod "${DEVICE_PATH}" c "${DEVICE_NUMBER%:*}" "${DEVICE_NUMBER#*:}"
+chmod 600 "${DEVICE_PATH}"
+
+compile_user_fixture \
+	"${FIXTURE_DIR}/mutexprof_workload.user.c" \
+	"${WORKLOAD_BIN}" \
+	-pthread
+
+readonly DMESG_START=$(dmesg 2> /dev/null | wc -l)
+"${WORKLOAD_BIN}" "${DEVICE_PATH}" \
+	> "${WORK_DIR}/workload.out" 2> "${WORK_DIR}/workload.err" &
+TARGET_PID=$!
+
+timeout --signal=TERM --kill-after=5s 20s \
+	"${PROFILER_BIN}" \
+	--type lock \
+	--language c \
+	--pid "${TARGET_PID}" \
+	--thread-group \
+	--lock-wait-threshold 1us \
+	--duration 8 \
+	--aggr-interval 2 \
+	--output-format collapsed \
+	--output-path "${WORK_DIR}" \
+	--verbose \
+	> "${WORK_DIR}/profiler.out" 2> "${WORK_DIR}/profiler.err" &
+PROFILER_PID=$!
+
+wait_until 10 1 profiler_ready "${WORK_DIR}/profiler.out" \
+	|| fatal "mutex profiler did not enter its read loop"
+if ! wait "${PROFILER_PID}"; then
+	PROFILER_PID=""
+	fatal "mutex profiler failed or timed out"
+fi
+PROFILER_PID=""
+
+stop_by_pid "${TARGET_PID}" 5
+wait "${TARGET_PID}" || fatal "mutex workload exited non-zero"
+TARGET_PID=""
+
+mapfile -t folded_files < <(
+	find "${WORK_DIR}" -maxdepth 1 -name 'perf_*.folded' -type f
+)
+[[ ${#folded_files[@]} -gt 0 ]] || fatal "no folded output produced"
+grep -q "lock:" "${folded_files[@]}" \
+	|| fatal "mutex lock frame not found"
+awk 'NF && $NF ~ /^[0-9]+$/ && $NF > 0 { found=1 } END { exit !found }' \
+	"${folded_files[@]}" \
+	|| fatal "no positive mutex wait value found"
+
+if dmesg 2> /dev/null | tail -n "+$((DMESG_START + 1))" \
+	| grep -Eiq 'soft lockup|rcu[^:]*stall|hung task|watchdog: BUG'; then
+	fatal "kernel reported a stall while profiling mutex contention"
+fi
+
+log_info "native mutex contention profile passed without kernel stalls"

--- a/integration/testdata/mutexprof_fixture/Makefile
+++ b/integration/testdata/mutexprof_fixture/Makefile
@@ -1,0 +1,1 @@
+obj-m += huatuo_mutexprof_test.o

--- a/integration/testdata/mutexprof_fixture/huatuo_mutexprof_test.kernel.c
+++ b/integration/testdata/mutexprof_fixture/huatuo_mutexprof_test.kernel.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Deterministic mutex contention fixture for the Huatuo integration test. */
+
+#include <linux/delay.h>
+#include <linux/fs.h>
+#include <linux/ioctl.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+
+#define HUATUO_MUTEXPROF_IOC_MAGIC 0xb7
+#define HUATUO_MUTEXPROF_CONTEND _IO(HUATUO_MUTEXPROF_IOC_MAGIC, 1)
+
+static DEFINE_MUTEX(fixture_mutex);
+
+static long huatuo_mutexprof_ioctl(struct file *file, unsigned int cmd,
+				   unsigned long arg)
+{
+	(void)file;
+	(void)arg;
+
+	if (cmd != HUATUO_MUTEXPROF_CONTEND)
+		return -ENOTTY;
+
+	mutex_lock(&fixture_mutex);
+	usleep_range(1000, 1500);
+	mutex_unlock(&fixture_mutex);
+	return 0;
+}
+
+static const struct file_operations huatuo_mutexprof_fops = {
+	.owner = THIS_MODULE,
+	.unlocked_ioctl = huatuo_mutexprof_ioctl,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl = huatuo_mutexprof_ioctl,
+#endif
+};
+
+static struct miscdevice huatuo_mutexprof_device = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = "huatuo_mutexprof_fixture",
+	.fops = &huatuo_mutexprof_fops,
+	.mode = 0600,
+};
+
+static int __init huatuo_mutexprof_init(void)
+{
+	return misc_register(&huatuo_mutexprof_device);
+}
+
+static void __exit huatuo_mutexprof_exit(void)
+{
+	misc_deregister(&huatuo_mutexprof_device);
+}
+
+module_init(huatuo_mutexprof_init);
+module_exit(huatuo_mutexprof_exit);
+
+MODULE_AUTHOR("The HuaTuo Authors");
+MODULE_DESCRIPTION("Kernel mutex contention integration fixture");
+MODULE_LICENSE("GPL");

--- a/integration/testdata/mutexprof_fixture/mutexprof_workload.user.c
+++ b/integration/testdata/mutexprof_fixture/mutexprof_workload.user.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define HUATUO_MUTEXPROF_IOC_MAGIC 0xb7
+#define HUATUO_MUTEXPROF_CONTEND _IO(HUATUO_MUTEXPROF_IOC_MAGIC, 1)
+#define WORKER_COUNT 8
+
+static volatile sig_atomic_t stopping;
+static volatile sig_atomic_t failed;
+static volatile sig_atomic_t failure_errno;
+
+static void stop_workload(int signo)
+{
+	(void)signo;
+	stopping = 1;
+}
+
+static void *worker(void *opaque)
+{
+	const int fd = *(int *)opaque;
+
+	while (!stopping) {
+		if (ioctl(fd, HUATUO_MUTEXPROF_CONTEND, 0) == 0)
+			continue;
+		if (errno == EINTR)
+			continue;
+		failure_errno = errno;
+		failed = 1;
+		stopping = 1;
+	}
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	pthread_t threads[WORKER_COUNT];
+	struct sigaction action = {.sa_handler = stop_workload};
+	int fd;
+	int i;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <device>\n", argv[0]);
+		return 2;
+	}
+
+	sigemptyset(&action.sa_mask);
+	sigaction(SIGTERM, &action, NULL);
+	sigaction(SIGINT, &action, NULL);
+
+	fd = open(argv[1], O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		perror("open fixture device");
+		return 1;
+	}
+
+	for (i = 0; i < WORKER_COUNT; i++) {
+		if (pthread_create(&threads[i], NULL, worker, &fd) == 0)
+			continue;
+		perror("pthread_create");
+		stopping = 1;
+		failed = 1;
+		break;
+	}
+
+	while (!stopping)
+		sleep(1);
+	for (int joined = 0; joined < i; joined++)
+		pthread_join(threads[joined], NULL);
+	close(fd);
+	if (failed && failure_errno != 0)
+		fprintf(stderr, "ioctl failed: %s\n", strerror(failure_errno));
+	return failed ? 1 : 0;
+}

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/output"
@@ -46,6 +47,7 @@ type ProfilerContext struct {
 	AggrInterval         int
 	IsOneShotAgg         bool
 	CPUIDs               []int
+	LockWaitThreshold    time.Duration
 
 	ServerAddress             string
 	OutputFormat              output.OutputFormat
@@ -59,6 +61,8 @@ type ProfilerContext struct {
 	LogBpfDebug               bool
 	MemoryMode                profiling.MemoryMode
 	PhysicalMemoryProbability uint
+	LockMode                  profiling.LockMode
+	LockType                  profiling.LockType
 
 	TracerID string
 
@@ -155,6 +159,7 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 		MaxProfilerProcesses: cliCtx.Int("max-concurrent-procs"),
 		AggrInterval:         cliCtx.Int("aggr-interval"),
 		CPUIDs:               cpuIDs,
+		LockWaitThreshold:    cliCtx.Duration("lock-wait-threshold"),
 
 		ServerAddress:             cliCtx.String("huatuo-api-address"),
 		Type:                      typ,
@@ -168,6 +173,8 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 		OutputFormat:              outputFormat,
 		MemoryMode:                mode,
 		PhysicalMemoryProbability: cliCtx.Uint("physical-memory-probability"),
+		LockMode:                  lockModeForType(typ),
+		LockType:                  lockTypeForType(typ),
 
 		TracerID: cliCtx.String("tracer-id"),
 
@@ -175,6 +182,20 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 	}
 	succeeded = true
 	return profilerContext, nil
+}
+
+func lockModeForType(typ profiling.Type) profiling.LockMode {
+	if typ == profiling.TypeLock {
+		return profiling.LockModeWaitTime
+	}
+	return profiling.LockModeUnknown
+}
+
+func lockTypeForType(typ profiling.Type) profiling.LockType {
+	if typ == profiling.TypeLock {
+		return profiling.LockTypeMutex
+	}
+	return profiling.LockTypeUnknown
 }
 
 func initToolstreamClient(cliCtx *cli.Context, format output.OutputFormat) (*toolstream.Client, error) {

--- a/pkg/profiling/capability.go
+++ b/pkg/profiling/capability.go
@@ -88,7 +88,7 @@ func newNativeCapability(language Language) capability {
 	return capability{
 		Language:       language,
 		Implementation: ImplementationNative,
-		Types:          []Type{TypeCPU, TypeMemory},
+		Types:          []Type{TypeCPU, TypeMemory, TypeLock},
 		MemoryModes: []MemoryMode{
 			MemoryModeVirtualAlloc,
 			MemoryModePhysicalAlloc,
@@ -99,10 +99,13 @@ func newNativeCapability(language Language) capability {
 
 func ParseType(value string) (Type, error) {
 	typ := Type(value)
-	if typ == TypeCPU || typ == TypeMemory {
+	if typ == TypeCPU || typ == TypeMemory || typ == TypeLock {
 		return typ, nil
 	}
-	return TypeUnknown, fmt.Errorf("unsupported profiling type %q (expected: cpu or memory)", value)
+	return TypeUnknown, fmt.Errorf(
+		"unsupported profiling type %q (expected: cpu, memory, or lock)",
+		value,
+	)
 }
 
 func ParseLanguage(value string) (Language, error) {

--- a/pkg/profiling/capability_test.go
+++ b/pkg/profiling/capability_test.go
@@ -33,9 +33,9 @@ func TestCapabilities(t *testing.T) {
 		types          []Type
 		memoryModes    []MemoryMode
 	}{
-		{LanguageC, ImplementationNative, []Type{TypeCPU, TypeMemory}, nativeModes},
-		{LanguageCPP, ImplementationNative, []Type{TypeCPU, TypeMemory}, nativeModes},
-		{LanguageGo, ImplementationNative, []Type{TypeCPU, TypeMemory}, nativeModes},
+		{LanguageC, ImplementationNative, []Type{TypeCPU, TypeMemory, TypeLock}, nativeModes},
+		{LanguageCPP, ImplementationNative, []Type{TypeCPU, TypeMemory, TypeLock}, nativeModes},
+		{LanguageGo, ImplementationNative, []Type{TypeCPU, TypeMemory, TypeLock}, nativeModes},
 		{
 			LanguageJava,
 			ImplementationJava,
@@ -75,7 +75,7 @@ func TestCapabilities(t *testing.T) {
 		[]Language{LanguageC, LanguageCPP, LanguageGo, LanguageJava},
 		LanguagesFor(TypeMemory),
 	)
-	require.Empty(t, LanguagesFor(TypeLock))
+	require.Equal(t, []Language{LanguageC, LanguageCPP, LanguageGo}, LanguagesFor(TypeLock))
 }
 
 func TestMemoryModesForReturnsCopy(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCapabilityDefinitionsAreUnique(t *testing.T) {
 }
 
 func TestParsers(t *testing.T) {
-	for _, typ := range []Type{TypeCPU, TypeMemory} {
+	for _, typ := range []Type{TypeCPU, TypeMemory, TypeLock} {
 		parsed, err := ParseType(string(typ))
 		require.NoError(t, err)
 		require.Equal(t, typ, parsed)
@@ -128,7 +128,11 @@ func TestParsers(t *testing.T) {
 
 func TestParseTypeRejectsLegacyMemoryValue(t *testing.T) {
 	_, err := ParseType("mem")
-	require.EqualError(t, err, `unsupported profiling type "mem" (expected: cpu or memory)`)
+	require.EqualError(
+		t,
+		err,
+		`unsupported profiling type "mem" (expected: cpu, memory, or lock)`,
+	)
 }
 
 func allMemoryModes() []MemoryMode {

--- a/pkg/profiling/lock.go
+++ b/pkg/profiling/lock.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+// LockMode identifies the value represented by a lock profile.
+type LockMode string
+
+const (
+	LockModeUnknown  LockMode = ""
+	LockModeWaitTime LockMode = "wait_time"
+)
+
+// LockType identifies the kernel lock primitive being profiled.
+type LockType string
+
+const (
+	LockTypeUnknown LockType = ""
+	LockTypeMutex   LockType = "mutex"
+)


### PR DESCRIPTION
Part of #329.

## Summary

- add contention-only mutex wait-time profiling
- use typed lock modes and lock-wait-threshold terminology
- reuse shared profiler buffers and native target selectors
- use an LRU in-flight map because tasks can migrate across CPUs
- keep the BPF fixture in a .kernel.c source

## Scope

This intentionally delivers mutex first. Spinlock, rwlock, count aggregation,
and profile-label injection remain open.

## Validation

- BPF build and targeted Go tests passed
- runtime test passed on Ubuntu 22.04, kernel 5.15.0-106
- 1,251 contentions were sampled without soft lockups or hung tasks