### PR TITLE
feat(autotracing): export flame graphs as folded stacks

### DIFF
--- a/internal/flamegraph/folded.go
+++ b/internal/flamegraph/folded.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// FramesToFolded converts depth-first flame graph frames to folded stacks.
+func FramesToFolded(frames []FrameData) ([]byte, error) {
+	counts := make(map[string]int64, len(frames))
+	stack := make([]string, 0, 32)
+
+	for i, frame := range frames {
+		if err := validateFoldedFrame(i, frame, len(stack)); err != nil {
+			return nil, err
+		}
+
+		stack = stack[:int(frame.Level)]
+		stack = append(stack, sanitizeFoldedLabel(frame.Label))
+		if frame.Self == 0 {
+			continue
+		}
+
+		path := strings.Join(stack, ";")
+		if counts[path] > math.MaxInt64-frame.Self {
+			return nil, fmt.Errorf(
+				"frame %d: folded count overflows for stack %q",
+				i,
+				path,
+			)
+		}
+		counts[path] += frame.Self
+	}
+
+	paths := make([]string, 0, len(counts))
+	for path := range counts {
+		paths = append(paths, path)
+	}
+	// Stable output makes exported snapshots reproducible and diffable.
+	sort.Strings(paths)
+
+	var output bytes.Buffer
+	for _, path := range paths {
+		output.Grow(len(path) + 22)
+		output.WriteString(path)
+		output.WriteByte(' ')
+		output.Write(strconv.AppendInt(nil, counts[path], 10))
+		output.WriteByte('\n')
+	}
+	return output.Bytes(), nil
+}
+
+func validateFoldedFrame(index int, frame FrameData, stackDepth int) error {
+	if frame.Level < 0 || frame.Level > int64(stackDepth) {
+		return fmt.Errorf(
+			"frame %d: invalid level %d for stack depth %d",
+			index,
+			frame.Level,
+			stackDepth,
+		)
+	}
+	if frame.Value < 0 {
+		return fmt.Errorf("frame %d: aggregate value must not be negative", index)
+	}
+	if frame.Self < 0 {
+		return fmt.Errorf("frame %d: self value must not be negative", index)
+	}
+	if frame.Self > frame.Value {
+		return fmt.Errorf(
+			"frame %d: self value %d exceeds aggregate value %d",
+			index,
+			frame.Self,
+			frame.Value,
+		)
+	}
+	return nil
+}
+
+func sanitizeFoldedLabel(label string) string {
+	label = strings.Map(func(current rune) rune {
+		switch {
+		case current == ';':
+			return '_'
+		case unicode.IsControl(current):
+			return ' '
+		default:
+			return current
+		}
+	}, label)
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return "(unknown)"
+	}
+	return label
+}

--- a/internal/flamegraph/folded_test.go
+++ b/internal/flamegraph/folded_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestFramesToFolded(t *testing.T) {
+	tests := []struct {
+		name   string
+		frames []FrameData
+		want   string
+	}{
+		{
+			name: "nested branches",
+			frames: []FrameData{
+				{Level: 0, Value: 15, Self: 1, Label: "root"},
+				{Level: 1, Value: 10, Self: 0, Label: "worker"},
+				{Level: 2, Value: 6, Self: 6, Label: "read"},
+				{Level: 2, Value: 4, Self: 4, Label: "write"},
+				{Level: 1, Value: 4, Self: 4, Label: "idle"},
+			},
+			want: "root 1\n" +
+				"root;idle 4\n" +
+				"root;worker;read 6\n" +
+				"root;worker;write 4\n",
+		},
+		{
+			name: "multiple roots",
+			frames: []FrameData{
+				{Level: 0, Value: 2, Self: 1, Label: "pid-b"},
+				{Level: 1, Value: 1, Self: 1, Label: "work-b"},
+				{Level: 0, Value: 3, Self: 1, Label: "pid-a"},
+				{Level: 1, Value: 2, Self: 2, Label: "work-a"},
+			},
+			want: "pid-a 1\npid-a;work-a 2\npid-b 1\npid-b;work-b 1\n",
+		},
+		{
+			name: "repeated paths",
+			frames: []FrameData{
+				{Level: 0, Value: 2, Self: 2, Label: "same"},
+				{Level: 0, Value: 3, Self: 3, Label: "same"},
+			},
+			want: "same 5\n",
+		},
+		{
+			name: "sanitized labels",
+			frames: []FrameData{
+				{Level: 0, Value: 1, Self: 1, Label: "main;work"},
+				{Level: 0, Value: 1, Self: 1, Label: "line\nbreak"},
+				{Level: 0, Value: 1, Self: 1, Label: "\t"},
+			},
+			want: "(unknown) 1\nline break 1\nmain_work 1\n",
+		},
+		{
+			name:   "empty profile",
+			frames: nil,
+			want:   "",
+		},
+		{
+			name: "zero self",
+			frames: []FrameData{
+				{Level: 0, Value: 1, Label: "root"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FramesToFolded(tt.frames)
+			if err != nil {
+				t.Fatalf("FramesToFolded() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("FramesToFolded() = %q, want %q", got, tt.want)
+			}
+			if gotSum := foldedSum(t, got); gotSum != positiveSelfSum(tt.frames) {
+				t.Fatalf(
+					"folded count sum = %d, want %d",
+					gotSum,
+					positiveSelfSum(tt.frames),
+				)
+			}
+		})
+	}
+}
+
+func TestFramesToFoldedRejectsInvalidFrames(t *testing.T) {
+	tests := []struct {
+		name   string
+		frames []FrameData
+		want   string
+	}{
+		{
+			name:   "negative level",
+			frames: []FrameData{{Level: -1}},
+			want:   "invalid level",
+		},
+		{
+			name: "level jump",
+			frames: []FrameData{
+				{Level: 0, Value: 1},
+				{Level: 2, Value: 1},
+			},
+			want: "invalid level",
+		},
+		{
+			name:   "negative aggregate",
+			frames: []FrameData{{Level: 0, Value: -1}},
+			want:   "aggregate value must not be negative",
+		},
+		{
+			name:   "negative self",
+			frames: []FrameData{{Level: 0, Value: 1, Self: -1}},
+			want:   "self value must not be negative",
+		},
+		{
+			name:   "self exceeds aggregate",
+			frames: []FrameData{{Level: 0, Value: 1, Self: 2}},
+			want:   "self value 2 exceeds aggregate value 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := FramesToFolded(tt.frames)
+			if err == nil {
+				t.Fatal("FramesToFolded() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("FramesToFolded() error = %q, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestFramesToFoldedRejectsCountOverflow(t *testing.T) {
+	frames := []FrameData{
+		{Level: 0, Value: math.MaxInt64, Self: math.MaxInt64, Label: "root"},
+		{Level: 0, Value: 1, Self: 1, Label: "root"},
+	}
+
+	_, err := FramesToFolded(frames)
+	if err == nil {
+		t.Fatal("FramesToFolded() error = nil, want overflow error")
+	}
+	if !strings.Contains(err.Error(), "folded count overflows") {
+		t.Fatalf("FramesToFolded() error = %q, want overflow error", err)
+	}
+}
+
+func TestFramesToFoldedSupportsMaximumCount(t *testing.T) {
+	frames := []FrameData{{
+		Level: 0,
+		Value: math.MaxInt64,
+		Self:  math.MaxInt64,
+		Label: "root",
+	}}
+	want := fmt.Sprintf("root %d\n", int64(math.MaxInt64))
+
+	got, err := FramesToFolded(frames)
+	if err != nil {
+		t.Fatalf("FramesToFolded() error = %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("FramesToFolded() = %q, want %q", got, want)
+	}
+}
+
+func foldedSum(t *testing.T, folded []byte) int64 {
+	t.Helper()
+
+	var sum int64
+	for _, line := range strings.Split(strings.TrimSpace(string(folded)), "\n") {
+		if line == "" {
+			continue
+		}
+
+		separator := strings.LastIndexByte(line, ' ')
+		if separator <= 0 || separator == len(line)-1 {
+			t.Fatalf("invalid folded line %q", line)
+		}
+		count, err := strconv.ParseInt(line[separator+1:], 10, 64)
+		if err != nil {
+			t.Fatalf("invalid folded count in %q: %v", line, err)
+		}
+		if sum > math.MaxInt64-count {
+			t.Fatalf("folded count sum overflows for %q", line)
+		}
+		sum += count
+	}
+	return sum
+}
+
+func positiveSelfSum(frames []FrameData) int64 {
+	var sum int64
+	for _, frame := range frames {
+		if frame.Self > 0 {
+			sum += frame.Self
+		}
+	}
+	return sum
+}


### PR DESCRIPTION
Part of #327.

## Summary

- convert depth-first AutoTracing flame graph frames to folded stacks
- preserve parent stacks and emit positive self samples
- aggregate repeated paths and sort output deterministically
- sanitize folded-stack delimiters and control characters
- reject malformed levels, invalid values, and count overflows

This is the format-conversion patch required by the standalone exporter.
It does not change backend selection, storage, or HTTP transport.

## Validation

- go test -race ./internal/flamegraph/...
- Linux-target full repository lint with all 26 configured linters
- git diff --check

make check was attempted but local gen-build requires the unavailable capnp
compiler. No generated files were modified or committed.