### PR TITLE
feat(profiling): complete continuous profiling visualization

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -22,13 +22,16 @@ import (
 
 // CreateProfilingJobRequest represents a request to create a profiling job.
 type CreateProfilingJobRequest struct {
-	ProfilingType   string `json:"type"`              // cpu or memory
-	BinaryMatchPath string `json:"binary_match_path"` // executable path used to match target processes
-	Language        string `json:"language"`          // programming language of the target process
-	MemoryMode      string `json:"memory_mode"`       // memory profiling mode
-	Duration        int    `json:"duration"`          // profiling duration in seconds
-	ContainerID     string `json:"container_id"`      // container ID
-	Hostname        string `json:"hostname"`          // host name
+	ProfilingType   string `json:"type"`                   // cpu or memory
+	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
+	Language        string `json:"language"`               // programming language of the target process
+	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
+	Duration        int    `json:"duration"`               // profiling duration in seconds
+	ContainerID     string `json:"container_id"`           // container ID
+	Hostname        string `json:"hostname"`               // host name
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	PID             int    `json:"pid,omitempty"`          // exact PID selected for native profiling
+	ThreadGroup     bool   `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // CreateProfilingJobResponse represents a response to create a profiling job.
@@ -38,21 +41,24 @@ type CreateProfilingJobResponse struct {
 
 // ProfilingJobResponse represents a profiling job response.
 type ProfilingJobResponse struct {
-	ID              string           `json:"id"`                // profiling job ID
-	AgentTaskID     string           `json:"agent_task_id"`     // agent task ID
-	ContainerID     string           `json:"container_id"`      // container ID
-	Hostname        string           `json:"hostname"`          // host name
-	Type            string           `json:"type"`              // cpu or memory
-	MemoryMode      string           `json:"memory_mode"`       // memory profiling mode
-	Language        string           `json:"language"`          // programming language of the target process
-	BinaryMatchPath string           `json:"binary_match_path"` // executable path used to match target processes
-	Status          string           `json:"status"`            // job status
-	StartTime       string           `json:"start_time"`        // start time
-	EndTime         string           `json:"end_time"`          // end time
-	TracerArgs      []string         `json:"tracer_args"`       // tracer arguments
-	Duration        int              `json:"duration"`          // profiling duration
-	Results         ProfilingResults `json:"results"`           // profiling results
-	ErrorMessage    string           `json:"error_message"`     // error message if any
+	ID              string           `json:"id"`                     // profiling job ID
+	AgentTaskID     string           `json:"agent_task_id"`          // agent task ID
+	ContainerID     string           `json:"container_id"`           // container ID
+	Hostname        string           `json:"hostname"`               // host name
+	Type            string           `json:"type"`                   // cpu or memory
+	MemoryMode      string           `json:"memory_mode"`            // memory profiling mode
+	Language        string           `json:"language"`               // programming language of the target process
+	BinaryMatchPath string           `json:"binary_match_path"`      // executable path used to match target processes
+	Status          string           `json:"status"`                 // job status
+	StartTime       string           `json:"start_time"`             // start time
+	EndTime         string           `json:"end_time"`               // end time
+	TracerArgs      []string         `json:"tracer_args"`            // tracer arguments
+	Duration        int              `json:"duration"`               // profiling duration
+	Results         ProfilingResults `json:"results"`                // profiling results
+	ErrorMessage    string           `json:"error_message"`          // error message if any
+	CPUIDs          []int            `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	PID             int              `json:"pid,omitempty"`          // exact PID selected for native profiling
+	ThreadGroup     bool             `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // ProfilingResults represents profiling results

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -32,6 +32,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				BinaryMatchPath: "/usr/bin/example",
 				Language:        "go",
 				ContainerID:     "container-id",
+				CPUIDs:          []int{1},
+				PID:             4242,
+				ThreadGroup:     true,
 			},
 			fields: []string{
 				"type",
@@ -41,6 +44,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				"duration",
 				"container_id",
 				"hostname",
+				"cpu_ids",
+				"pid",
+				"thread_group",
 			},
 		},
 		{
@@ -110,12 +116,19 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 		fields []string
 	}{
 		{
-			name:  "profiling response",
-			value: ProfilingJobResponse{},
+			name: "profiling response",
+			value: ProfilingJobResponse{
+				CPUIDs:      []int{1},
+				PID:         4242,
+				ThreadGroup: true,
+			},
 			fields: []string{
 				"container_id",
 				"binary_match_path",
 				"language",
+				"cpu_ids",
+				"pid",
+				"thread_group",
 			},
 		},
 		{

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     network_mode: host
     environment:
       GF_INSTALL_PLUGINS: "yesoreyeram-infinity-datasource ${INFINITY_DATA_SOURCE:-3.4.1}"
+      HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}
     volumes:
       - ./grafana/datasources/elasticsearch.yaml:/etc/grafana/provisioning/datasources/elasticsearch.yaml:ro
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro
       - ./grafana/datasources/infinity.yaml:/etc/grafana/provisioning/datasources/infinity.yaml:ro
       - ./grafana/datasources/pyroscope.yaml:/etc/grafana/provisioning/datasources/pyroscope.yaml:ro
+      - ./grafana/datasources/profiling-json.yaml:/etc/grafana/provisioning/datasources/profiling-json.yaml:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
     depends_on:
       - prometheus

--- a/build/docker/grafana/dashboards/continuous-profiling-compare.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-compare.json
@@ -145,7 +145,7 @@
           "url_options": {
             "body_content_type": "application/json",
             "body_type": "raw",
-            "data": "{\n  \"profile_type_id\": ${type:json},\n  \"hostname\": ${hostname:json},\n  \"container_id\": ${container_id:json},\n  \"start\": ${__from},\n  \"end\": ${__to},\n  \"max_nodes\": 5000\n}",
+            "data": "{\n  \"profile_type_id\": ${type:json},\n  \"hostname\": ${hostname:json},\n  \"container_id\": ${container_id:json},\n  \"profiling_scope\": ${profiling_scope:json},\n  \"cpu\": ${cpu:json},\n  \"pid\": ${pid:json},\n  \"tgid\": ${tgid:json},\n  \"start\": ${__from},\n  \"end\": ${__to},\n  \"max_nodes\": 5000\n}",
             "method": "POST"
           }
         }
@@ -211,6 +211,82 @@
         "name": "container_id",
         "options": [],
         "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact collection-scope filter.",
+        "includeAll": true,
+        "label": "scope",
+        "multi": false,
+        "name": "profiling_scope",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact logical CPU-set filter.",
+        "includeAll": true,
+        "label": "CPU set",
+        "multi": false,
+        "name": "cpu",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact process or thread target filter.",
+        "includeAll": true,
+        "label": "PID",
+        "multi": false,
+        "name": "pid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact thread-group target filter.",
+        "includeAll": true,
+        "label": "TGID",
+        "multi": false,
+        "name": "tgid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"

--- a/build/docker/grafana/dashboards/continuous-profiling-compare.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-compare.json
@@ -1,0 +1,230 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "The selected Grafana time range is the current (right) window. It is compared with the immediately preceding window of the same duration. Select a container ID for container profiles; otherwise the exact hostname is used.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.3",
+      "title": "Comparison window",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "huatuo-apiserver-profile-json"
+      },
+      "description": "Compares the selected window with the immediately preceding window of the same duration.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {},
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "level",
+              "text": "level",
+              "type": "number"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "self",
+              "text": "self",
+              "type": "number"
+            },
+            {
+              "selector": "valueRight",
+              "text": "valueRight",
+              "type": "number"
+            },
+            {
+              "selector": "selfRight",
+              "text": "selfRight",
+              "type": "number"
+            },
+            {
+              "selector": "label",
+              "text": "label",
+              "type": "string"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "huatuo-apiserver-profile-json"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/profiles/flamegraph/diff-rows",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{\n  \"profile_type_id\": ${type:json},\n  \"hostname\": ${hostname:json},\n  \"container_id\": ${container_id:json},\n  \"start\": ${__from},\n  \"end\": ${__to},\n  \"max_nodes\": 5000\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Current versus previous window",
+      "type": "flamegraph"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [
+    "profiling",
+    "continuous profiling"
+  ],
+  "templating": {
+    "list": [
+      {
+        "description": "profiling type",
+        "label": "type",
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+            "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+          },
+          {
+            "selected": false,
+            "text": "memory:alloc_space:bytes:space:bytes",
+            "value": "memory:alloc_space:bytes:space:bytes"
+          }
+        ],
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "description": "Used when no container ID is selected.",
+        "label": "hostname",
+        "name": "hostname",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Overrides hostname when a stable container ID is selected.",
+        "includeAll": true,
+        "label": "container ID",
+        "multi": false,
+        "name": "container_id",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Continuous profiling comparison",
+  "uid": "continuous-profiling-compare",
+  "version": 1,
+  "weekStart": ""
+}

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -24,7 +24,20 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -135,12 +148,13 @@
               "type": "count"
             }
           ],
-          "query": "hostname.keyword:$hostname\nAND container_hostname.keyword:$container_hostname\nAND tracer_data.flamedata.profile_type.keyword:$type",
+          "query": "hostname.keyword:$hostname\nAND container_id.keyword:$container_id\nAND tracer_data.flamedata.profile_type.keyword:$type",
           "refId": "A",
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
       "type": "timeseries"
     },
     {
@@ -171,14 +185,15 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{container_hostname=\"$container_hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",container_id=\"$container_id\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "title": "$container_hostname",
+      "description": "Merged profile for the selected container, host, type, and time range.",
+      "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -192,12 +207,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
-        "description": "Selects container-level profiles.",
-        "label": "container hostname",
-        "name": "container_hostname",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Selects one container by its stable ID.",
+        "label": "container ID",
+        "name": "container_id",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -208,12 +223,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
-        "description": "Read-only. Displays the host where the selected container resides. Not used as a query filter; filtering is by container_hostname only.",
-        "label": "hostname(Read-only)",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
+        "description": "Selects the host that reported the container profile.",
+        "label": "hostname",
         "name": "hostname",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -232,29 +247,19 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(container)",
+  "title": "Continuous Profiling (Container)",
   "uid": "continuous-profiling-container"
 }

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -210,7 +210,7 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{container_id=\"$container_id\"}",
+          "labelSelector": "{container_id=\"$container_id\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "limit": 1,
           "profileTypeId": "$type",
           "queryType": "metrics",
@@ -263,9 +263,9 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [
-            "tracer"
+            "$group_by"
           ],
-          "labelSelector": "{container_id=\"$container_id\"}",
+          "labelSelector": "{container_id=\"$container_id\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "limit": 10,
           "profileTypeId": "$type",
           "queryType": "metrics",
@@ -303,7 +303,7 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{container_id=\"$container_id\"}",
+          "labelSelector": "{container_id=\"$container_id\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
@@ -368,6 +368,121 @@
           }
         ],
         "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact collection-scope filter.",
+        "includeAll": true,
+        "label": "scope",
+        "multi": false,
+        "name": "profiling_scope",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact logical CPU-set filter.",
+        "includeAll": true,
+        "label": "CPU set",
+        "multi": false,
+        "name": "cpu",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact process or thread target filter.",
+        "includeAll": true,
+        "label": "PID",
+        "multi": false,
+        "name": "pid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact thread-group target filter.",
+        "includeAll": true,
+        "label": "TGID",
+        "multi": false,
+        "name": "tgid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "description": "Dimension used by the bounded Top 10 series.",
+        "label": "Top 10 group",
+        "name": "group_by",
+        "options": [
+          {
+            "selected": true,
+            "text": "tracer",
+            "value": "tracer"
+          },
+          {
+            "selected": false,
+            "text": "profiling_scope",
+            "value": "profiling_scope"
+          },
+          {
+            "selected": false,
+            "text": "cpu",
+            "value": "cpu"
+          },
+          {
+            "selected": false,
+            "text": "pid",
+            "value": "pid"
+          },
+          {
+            "selected": false,
+            "text": "tgid",
+            "value": "tgid"
+          },
+          {
+            "selected": false,
+            "text": "container_id",
+            "value": "container_id"
+          }
+        ],
+        "query": "tracer,profiling_scope,cpu,pid,tgid,container_id",
         "type": "custom"
       }
     ]

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -185,14 +185,14 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{hostname=\"$hostname\",container_id=\"$container_id\"}",
+          "labelSelector": "{container_id=\"$container_id\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "description": "Merged profile for the selected container, host, type, and time range.",
+      "description": "Merged profile for the selected container ID, type, and time range.",
       "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -36,6 +36,18 @@
       "tooltip": "Open the host profiling dashboard.",
       "type": "link",
       "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Compare windows",
+      "tooltip": "Compare the selected window with its preceding window.",
+      "type": "link",
+      "url": "/d/continuous-profiling-compare/continuous-profiling-compare"
     }
   ],
   "panels": [
@@ -162,6 +174,112 @@
         "type": "grafana-pyroscope-datasource",
         "uid": "huatuo-apiserver-pyroscope"
       },
+      "description": "Total profile value in each time bucket for the selected container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{container_id=\"$container_id\"}",
+          "limit": 1,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Profile value over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Ten highest-value profiling jobs in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [
+            "tracer"
+          ],
+          "labelSelector": "{container_id=\"$container_id\"}",
+          "limit": 10,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 by tracer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -170,7 +288,7 @@
         "h": 20,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 12
       },
       "id": 1,
       "maxPerRow": 2,

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -24,7 +24,20 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -140,7 +153,8 @@
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
       "type": "timeseries"
     },
     {
@@ -178,7 +192,8 @@
           "spanSelector": []
         }
       ],
-      "title": "$hostname",
+      "description": "Merged profile for the selected host, type, and time range.",
+      "title": "$hostname flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -217,29 +232,19 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(host)",
+  "title": "Continuous Profiling (Host)",
   "uid": "continuous-profiling-host"
 }

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -36,6 +36,18 @@
       "tooltip": "Open the container profiling dashboard.",
       "type": "link",
       "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Compare windows",
+      "tooltip": "Compare the selected window with its preceding window.",
+      "type": "link",
+      "url": "/d/continuous-profiling-compare/continuous-profiling-compare"
     }
   ],
   "panels": [
@@ -162,6 +174,112 @@
         "type": "grafana-pyroscope-datasource",
         "uid": "huatuo-apiserver-pyroscope"
       },
+      "description": "Total profile value in each time bucket for the selected host.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{hostname=\"$hostname\"}",
+          "limit": 1,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Profile value over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Ten highest-value profiling jobs in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [
+            "tracer"
+          ],
+          "labelSelector": "{hostname=\"$hostname\"}",
+          "limit": 10,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 by tracer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -170,7 +288,7 @@
         "h": 20,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 12
       },
       "id": 1,
       "maxPerRow": 2,

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -210,7 +210,7 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{hostname=\"$hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "limit": 1,
           "profileTypeId": "$type",
           "queryType": "metrics",
@@ -263,9 +263,9 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [
-            "tracer"
+            "$group_by"
           ],
-          "labelSelector": "{hostname=\"$hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "limit": 10,
           "profileTypeId": "$type",
           "queryType": "metrics",
@@ -303,7 +303,7 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{hostname=\"$hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
@@ -353,6 +353,121 @@
           }
         ],
         "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact collection-scope filter.",
+        "includeAll": true,
+        "label": "scope",
+        "multi": false,
+        "name": "profiling_scope",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact logical CPU-set filter.",
+        "includeAll": true,
+        "label": "CPU set",
+        "multi": false,
+        "name": "cpu",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact process or thread target filter.",
+        "includeAll": true,
+        "label": "PID",
+        "multi": false,
+        "name": "pid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact thread-group target filter.",
+        "includeAll": true,
+        "label": "TGID",
+        "multi": false,
+        "name": "tgid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "description": "Dimension used by the bounded Top 10 series.",
+        "label": "Top 10 group",
+        "name": "group_by",
+        "options": [
+          {
+            "selected": true,
+            "text": "tracer",
+            "value": "tracer"
+          },
+          {
+            "selected": false,
+            "text": "profiling_scope",
+            "value": "profiling_scope"
+          },
+          {
+            "selected": false,
+            "text": "cpu",
+            "value": "cpu"
+          },
+          {
+            "selected": false,
+            "text": "pid",
+            "value": "pid"
+          },
+          {
+            "selected": false,
+            "text": "tgid",
+            "value": "tgid"
+          },
+          {
+            "selected": false,
+            "text": "container_id",
+            "value": "container_id"
+          }
+        ],
+        "query": "tracer,profiling_scope,cpu,pid,tgid,container_id",
         "type": "custom"
       }
     ]

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	cpuProfileType    = "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+	memoryProfileType = "memory:alloc_space:bytes:space:bytes"
+)
+
+type dashboardVariable struct {
+	Name       string `json:"name"`
+	Definition string `json:"definition"`
+	Query      string `json:"query"`
+	Options    []struct {
+		Value string `json:"value"`
+	} `json:"options"`
+}
+
+type dashboardContract struct {
+	UID        string `json:"uid"`
+	Templating struct {
+		List []dashboardVariable `json:"list"`
+	} `json:"templating"`
+}
+
+func loadDashboard(t *testing.T, filename string) (dashboardContract, any, string) {
+	t.Helper()
+
+	payload, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+
+	var contract dashboardContract
+	if err := json.Unmarshal(payload, &contract); err != nil {
+		t.Fatalf("decode %s: %v", filename, err)
+	}
+
+	var raw any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatalf("decode raw %s: %v", filename, err)
+	}
+
+	return contract, raw, string(payload)
+}
+
+func dashboardStrings(value any, field string, values *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				if text, ok := item.(string); ok {
+					*values = append(*values, text)
+				}
+			}
+			dashboardStrings(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardStrings(item, field, values)
+		}
+	}
+}
+
+func findDashboardVariable(t *testing.T, dashboard dashboardContract, name string) dashboardVariable {
+	t.Helper()
+
+	for _, variable := range dashboard.Templating.List {
+		if variable.Name == name {
+			return variable
+		}
+	}
+	t.Fatalf("dashboard %q has no %q variable", dashboard.UID, name)
+	return dashboardVariable{}
+}
+
+func requireSupportedProfileTypes(t *testing.T, dashboard dashboardContract) {
+	t.Helper()
+
+	variable := findDashboardVariable(t, dashboard, "type")
+	values := make([]string, 0, len(variable.Options))
+	for _, option := range variable.Options {
+		values = append(values, option.Value)
+	}
+	if !slices.Equal(values, []string{cpuProfileType, memoryProfileType}) {
+		t.Fatalf("profile types = %v, want only CPU and memory", values)
+	}
+}
+
+func TestContinuousProfilingHostDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-host.json")
+	if dashboard.UID != "continuous-profiling-host" {
+		t.Fatalf("UID = %q, want continuous-profiling-host", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "NOT _exists_:container_hostname") {
+		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
+	}
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	if !slices.Equal(selectors, []string{`{hostname="$hostname"}`}) {
+		t.Fatalf("profile selectors = %v, want exact hostname selector", selectors)
+	}
+	if strings.Contains(payload, "process_lock") {
+		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	}
+}
+
+func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-container.json")
+	if dashboard.UID != "continuous-profiling-container" {
+		t.Fatalf("UID = %q, want continuous-profiling-container", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "container_id.keyword:$container_id") {
+		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
+	}
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	wantSelector := `{hostname="$hostname",container_id="$container_id"}`
+	if !slices.Equal(selectors, []string{wantSelector}) {
+		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
+	}
+	if strings.Contains(payload, "container_hostname") {
+		t.Fatal("dashboard uses non-unique container hostname")
+	}
+	if strings.Contains(payload, "process_lock") {
+		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	}
+}
+
+func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
+	datasource, err := os.ReadFile("../datasources/pyroscope.yaml")
+	if err != nil {
+		t.Fatalf("read Pyroscope datasource: %v", err)
+	}
+	datasourceText := string(datasource)
+	if !strings.Contains(
+		datasourceText,
+		"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
+	) {
+		t.Fatal("Pyroscope datasource does not use the runtime bearer token")
+	}
+	if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
+		t.Fatal("Pyroscope datasource contains a placeholder credential")
+	}
+
+	compose, err := os.ReadFile("../../docker-compose.yml")
+	if err != nil {
+		t.Fatalf("read Docker Compose config: %v", err)
+	}
+	if !strings.Contains(
+		string(compose),
+		"HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}",
+	) {
+		t.Fatal("Grafana container does not receive the profile query token")
+	}
+}

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -82,6 +82,22 @@ func dashboardStrings(value any, field string, values *[]string) {
 	}
 }
 
+func dashboardValues(value any, field string, values *[]any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				*values = append(*values, item)
+			}
+			dashboardValues(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardValues(item, field, values)
+		}
+	}
+}
+
 func findDashboardVariable(t *testing.T, dashboard dashboardContract, name string) dashboardVariable {
 	t.Helper()
 
@@ -107,6 +123,67 @@ func requireSupportedProfileTypes(t *testing.T, dashboard dashboardContract) {
 	}
 }
 
+func requireExactProfileQueries(
+	t *testing.T,
+	raw any,
+	selector string,
+) {
+	t.Helper()
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	if !slices.Equal(selectors, []string{selector, selector, selector}) {
+		t.Fatalf("profile selectors = %v, want exact %s selectors", selectors, selector)
+	}
+
+	var queryTypes []string
+	dashboardStrings(raw, "queryType", &queryTypes)
+	if !slices.Equal(queryTypes, []string{"metrics", "metrics", "profile"}) {
+		t.Fatalf("query types = %v, want two series and one profile query", queryTypes)
+	}
+
+	var groupBys []any
+	dashboardValues(raw, "groupBy", &groupBys)
+	if len(groupBys) != 3 {
+		t.Fatalf("profile groupBy values = %v, want three", groupBys)
+	}
+	if grouped, ok := groupBys[1].([]any); !ok ||
+		len(grouped) != 1 ||
+		grouped[0] != "tracer" {
+		t.Fatalf("Top series groupBy = %v, want tracer", groupBys[1])
+	}
+
+	var limits []any
+	dashboardValues(raw, "limit", &limits)
+	profileLimits := make([]float64, 0, len(limits))
+	for _, limit := range limits {
+		if number, ok := limit.(float64); ok {
+			profileLimits = append(profileLimits, number)
+		}
+	}
+	if !slices.Contains(profileLimits, float64(10)) {
+		t.Fatalf("dashboard limits = %v, want Top 10 bound", profileLimits)
+	}
+}
+
+func requireNoUnsupportedSelectors(t *testing.T, payload string) {
+	t.Helper()
+
+	for _, unsupported := range []string{
+		"profiling_scope",
+		"cgroup",
+		"process_group",
+		"process_lock",
+		"lock_type",
+		`=~`,
+		`!~`,
+	} {
+		if strings.Contains(payload, unsupported) {
+			t.Fatalf("dashboard contains unsupported selector %q", unsupported)
+		}
+	}
+}
+
 func TestContinuousProfilingHostDashboardContract(t *testing.T) {
 	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-host.json")
 	if dashboard.UID != "continuous-profiling-host" {
@@ -119,14 +196,8 @@ func TestContinuousProfilingHostDashboardContract(t *testing.T) {
 		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
 	}
 
-	var selectors []string
-	dashboardStrings(raw, "labelSelector", &selectors)
-	if !slices.Equal(selectors, []string{`{hostname="$hostname"}`}) {
-		t.Fatalf("profile selectors = %v, want exact hostname selector", selectors)
-	}
-	if strings.Contains(payload, "process_lock") {
-		t.Fatal("dashboard exposes lock profiling before the backend supports it")
-	}
+	requireExactProfileQueries(t, raw, `{hostname="$hostname"}`)
+	requireNoUnsupportedSelectors(t, payload)
 }
 
 func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
@@ -145,34 +216,76 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
 	}
 
-	var selectors []string
-	dashboardStrings(raw, "labelSelector", &selectors)
-	wantSelector := `{container_id="$container_id"}`
-	if !slices.Equal(selectors, []string{wantSelector}) {
-		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
-	}
+	requireExactProfileQueries(t, raw, `{container_id="$container_id"}`)
 	if strings.Contains(payload, "container_hostname") {
 		t.Fatal("dashboard uses non-unique container hostname")
 	}
-	if strings.Contains(payload, "process_lock") {
-		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	requireNoUnsupportedSelectors(t, payload)
+}
+
+func TestContinuousProfilingComparisonDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(
+		t,
+		"continuous-profiling-compare.json",
+	)
+	if dashboard.UID != "continuous-profiling-compare" {
+		t.Fatalf("UID = %q, want continuous-profiling-compare", dashboard.UID)
 	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+
+	var urls []string
+	dashboardStrings(raw, "url", &urls)
+	if !slices.Contains(urls, "/v1/profiles/flamegraph/diff-rows") {
+		t.Fatalf("comparison URLs = %v, want bounded diff adapter", urls)
+	}
+	var roots []string
+	dashboardStrings(raw, "root_selector", &roots)
+	if !slices.Equal(roots, []string{"data"}) {
+		t.Fatalf("root selectors = %v, want data", roots)
+	}
+	var columns []string
+	dashboardStrings(raw, "selector", &columns)
+	if !slices.Equal(
+		columns,
+		[]string{"level", "value", "self", "valueRight", "selfRight", "label"},
+	) {
+		t.Fatalf("comparison columns = %v", columns)
+	}
+	var bodies []string
+	dashboardStrings(raw, "data", &bodies)
+	if len(bodies) != 1 ||
+		!strings.Contains(bodies[0], `"max_nodes": 5000`) ||
+		!strings.Contains(bodies[0], `${hostname:json}`) ||
+		!strings.Contains(bodies[0], `${container_id:json}`) {
+		t.Fatalf("comparison request is not bounded or JSON-escaped: %v", bodies)
+	}
+	requireNoUnsupportedSelectors(t, payload)
 }
 
 func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
-	datasource, err := os.ReadFile("../datasources/pyroscope.yaml")
-	if err != nil {
-		t.Fatalf("read Pyroscope datasource: %v", err)
-	}
-	datasourceText := string(datasource)
-	if !strings.Contains(
-		datasourceText,
-		"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
-	) {
-		t.Fatal("Pyroscope datasource does not use the runtime bearer token")
-	}
-	if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
-		t.Fatal("Pyroscope datasource contains a placeholder credential")
+	for _, filename := range []string{
+		"../datasources/pyroscope.yaml",
+		"../datasources/profiling-json.yaml",
+	} {
+		datasource, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("read %s: %v", filename, err)
+		}
+		datasourceText := string(datasource)
+		if !strings.Contains(
+			datasourceText,
+			"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
+		) {
+			t.Fatalf("%s does not use the runtime bearer token", filename)
+		}
+		if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
+			t.Fatalf("%s contains a placeholder credential", filename)
+		}
 	}
 
 	compose, err := os.ReadFile("../../docker-compose.yml")
@@ -184,5 +297,11 @@ func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
 		"HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}",
 	) {
 		t.Fatal("Grafana container does not receive the profile query token")
+	}
+	if !strings.Contains(
+		string(compose),
+		"./grafana/datasources/profiling-json.yaml:",
+	) {
+		t.Fatal("Grafana does not provision the profile JSON datasource")
 	}
 }

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -31,6 +31,8 @@ type dashboardVariable struct {
 	Name       string `json:"name"`
 	Definition string `json:"definition"`
 	Query      string `json:"query"`
+	AllValue   string `json:"allValue"`
+	IncludeAll bool   `json:"includeAll"`
 	Options    []struct {
 		Value string `json:"value"`
 	} `json:"options"`
@@ -149,8 +151,8 @@ func requireExactProfileQueries(
 	}
 	if grouped, ok := groupBys[1].([]any); !ok ||
 		len(grouped) != 1 ||
-		grouped[0] != "tracer" {
-		t.Fatalf("Top series groupBy = %v, want tracer", groupBys[1])
+		grouped[0] != "$group_by" {
+		t.Fatalf("Top series groupBy = %v, want dashboard dimension", groupBys[1])
 	}
 
 	var limits []any
@@ -166,11 +168,34 @@ func requireExactProfileQueries(
 	}
 }
 
+func requireDimensionVariables(
+	t *testing.T,
+	dashboard dashboardContract,
+) {
+	t.Helper()
+
+	fields := map[string]string{
+		"profiling_scope": "tracer_data.flamedata.labels.profiling_scope.keyword",
+		"cpu":             "tracer_data.flamedata.labels.cpu.keyword",
+		"pid":             "tracer_data.flamedata.labels.pid.keyword",
+		"tgid":            "tracer_data.flamedata.labels.tgid.keyword",
+	}
+	for name, field := range fields {
+		variable := findDashboardVariable(t, dashboard, name)
+		if !variable.IncludeAll || variable.AllValue != "" {
+			t.Fatalf("%s must provide an empty exact-match All value", name)
+		}
+		if !strings.Contains(variable.Definition, field) ||
+			!strings.Contains(variable.Definition, `"size": 500`) {
+			t.Fatalf("%s query is unbounded or uses the wrong field: %s", name, variable.Definition)
+		}
+	}
+}
+
 func requireNoUnsupportedSelectors(t *testing.T, payload string) {
 	t.Helper()
 
 	for _, unsupported := range []string{
-		"profiling_scope",
 		"cgroup",
 		"process_group",
 		"process_lock",
@@ -190,13 +215,19 @@ func TestContinuousProfilingHostDashboardContract(t *testing.T) {
 		t.Fatalf("UID = %q, want continuous-profiling-host", dashboard.UID)
 	}
 	requireSupportedProfileTypes(t, dashboard)
+	requireDimensionVariables(t, dashboard)
 
 	hostname := findDashboardVariable(t, dashboard, "hostname")
 	if !strings.Contains(hostname.Definition, "NOT _exists_:container_hostname") {
 		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
 	}
 
-	requireExactProfileQueries(t, raw, `{hostname="$hostname"}`)
+	requireExactProfileQueries(
+		t,
+		raw,
+		`{hostname="$hostname",profiling_scope="$profiling_scope",`+
+			`cpu="$cpu",pid="$pid",tgid="$tgid"}`,
+	)
 	requireNoUnsupportedSelectors(t, payload)
 }
 
@@ -206,6 +237,7 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 		t.Fatalf("UID = %q, want continuous-profiling-container", dashboard.UID)
 	}
 	requireSupportedProfileTypes(t, dashboard)
+	requireDimensionVariables(t, dashboard)
 
 	containerID := findDashboardVariable(t, dashboard, "container_id")
 	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
@@ -216,7 +248,12 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
 	}
 
-	requireExactProfileQueries(t, raw, `{container_id="$container_id"}`)
+	requireExactProfileQueries(
+		t,
+		raw,
+		`{container_id="$container_id",profiling_scope="$profiling_scope",`+
+			`cpu="$cpu",pid="$pid",tgid="$tgid"}`,
+	)
 	if strings.Contains(payload, "container_hostname") {
 		t.Fatal("dashboard uses non-unique container hostname")
 	}
@@ -232,6 +269,7 @@ func TestContinuousProfilingComparisonDashboardContract(t *testing.T) {
 		t.Fatalf("UID = %q, want continuous-profiling-compare", dashboard.UID)
 	}
 	requireSupportedProfileTypes(t, dashboard)
+	requireDimensionVariables(t, dashboard)
 
 	containerID := findDashboardVariable(t, dashboard, "container_id")
 	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
@@ -261,7 +299,11 @@ func TestContinuousProfilingComparisonDashboardContract(t *testing.T) {
 	if len(bodies) != 1 ||
 		!strings.Contains(bodies[0], `"max_nodes": 5000`) ||
 		!strings.Contains(bodies[0], `${hostname:json}`) ||
-		!strings.Contains(bodies[0], `${container_id:json}`) {
+		!strings.Contains(bodies[0], `${container_id:json}`) ||
+		!strings.Contains(bodies[0], `${profiling_scope:json}`) ||
+		!strings.Contains(bodies[0], `${cpu:json}`) ||
+		!strings.Contains(bodies[0], `${pid:json}`) ||
+		!strings.Contains(bodies[0], `${tgid:json}`) {
 		t.Fatalf("comparison request is not bounded or JSON-escaped: %v", bodies)
 	}
 	requireNoUnsupportedSelectors(t, payload)
@@ -285,6 +327,21 @@ func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
 		}
 		if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
 			t.Fatalf("%s contains a placeholder credential", filename)
+		}
+	}
+	pyroscope, err := os.ReadFile("../datasources/pyroscope.yaml")
+	if err != nil {
+		t.Fatalf("read Pyroscope datasources: %v", err)
+	}
+	pyroscopeText := string(pyroscope)
+	for _, expected := range []string{
+		"uid: huatuo-apiserver-pyroscope",
+		"url: http://127.0.0.1:12740/v1/profiles/flamegraph/",
+		"uid: huatuo-bamai-pyroscope",
+		"url: http://127.0.0.1:4040",
+	} {
+		if !strings.Contains(pyroscopeText, expected) {
+			t.Fatalf("Pyroscope datasources missing %q", expected)
 		}
 	}
 

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -147,7 +147,7 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 
 	var selectors []string
 	dashboardStrings(raw, "labelSelector", &selectors)
-	wantSelector := `{hostname="$hostname",container_id="$container_id"}`
+	wantSelector := `{container_id="$container_id"}`
 	if !slices.Equal(selectors, []string{wantSelector}) {
 		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
 	}

--- a/build/docker/grafana/datasources/profiling-json.yaml
+++ b/build/docker/grafana/datasources/profiling-json.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+datasources:
+  - name: huatuo-apiserver-profile-json
+    type: yesoreyeram-infinity-datasource
+    uid: huatuo-apiserver-profile-json
+    access: proxy
+    orgId: 1
+    url: http://127.0.0.1:12740
+    jsonData:
+      allowedHosts:
+        - http://127.0.0.1:12740
+      httpHeaderName1: 'Authorization'
+    secureJsonData:
+      httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'
+    editable: false

--- a/build/docker/grafana/datasources/pyroscope.yaml
+++ b/build/docker/grafana/datasources/pyroscope.yaml
@@ -13,3 +13,13 @@ datasources:
     secureJsonData:
       httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'
     editable: false
+
+  - name: huatuo-bamai-pyroscope
+    type: grafana-pyroscope-datasource
+    uid: huatuo-bamai-pyroscope
+    access: proxy
+    orgId: 1
+    url: http://127.0.0.1:4040
+    jsonData:
+      minStep: '1s'
+    editable: false

--- a/build/docker/grafana/datasources/pyroscope.yaml
+++ b/build/docker/grafana/datasources/pyroscope.yaml
@@ -11,5 +11,5 @@ datasources:
       minStep: '15s'
       httpHeaderName1: 'Authorization'
     secureJsonData:
-      httpHeaderValue1: REPLACE_WITH_RANDOM_HEX
+      httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'
     editable: false

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
@@ -1,0 +1,380 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/server/response"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	diffFlamegraphNodeWidth     = 7
+	defaultProfileDiffMaxNodes  = 5000
+	maxProfileDiffMaxNodes      = 10000
+	maxProfileDiffTargetLength  = 512
+	maxProfileDiffTypeLength    = 256
+	maxProfileDiffResponseBytes = 8 << 20
+)
+
+type profileDiffRowsRequest struct {
+	ProfileTypeID string `json:"profile_type_id"`
+	Hostname      string `json:"hostname"`
+	ContainerID   string `json:"container_id"`
+	Start         int64  `json:"start"`
+	End           int64  `json:"end"`
+	MaxNodes      int64  `json:"max_nodes"`
+}
+
+type profileDiffRow struct {
+	Level      int    `json:"level"`
+	Value      int64  `json:"value"`
+	Self       int64  `json:"self"`
+	ValueRight int64  `json:"valueRight"`
+	SelfRight  int64  `json:"selfRight"`
+	Label      string `json:"label"`
+}
+
+type profileDiffNode struct {
+	row        profileDiffRow
+	leftStart  int64
+	rightStart int64
+	children   []*profileDiffNode
+}
+
+func (h *Handler) displayDiffRows(ctx *server.Context) error {
+	var request profileDiffRowsRequest
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		return response.ErrInvalidRequest.WithMessage(
+			"invalid profile diff request",
+		)
+	}
+
+	diffRequest, err := buildAdjacentProfileDiffRequest(request)
+	if err != nil {
+		return response.ErrInvalidRequest.WithMessage(err.Error())
+	}
+	diffResponse, err := h.profileService.Diff(
+		ctx.Request().Context(),
+		diffRequest,
+	)
+	if err != nil {
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField(
+				"operation",
+				"display_diff_rows",
+			).Error("profile query failed")
+		}
+		ctx.JSON(status, map[string]any{"message": message})
+		return nil
+	}
+
+	rows, err := profileDiffRows(diffResponse.GetFlamegraph())
+	if err != nil {
+		log.WithError(err).Error("invalid profile diff response")
+		ctx.JSON(
+			http.StatusInternalServerError,
+			map[string]any{"message": "internal error"},
+		)
+		return nil
+	}
+	tooLarge, err := profileDiffResponseExceedsLimit(rows)
+	if err != nil {
+		log.WithError(err).Error("encode profile diff response")
+		ctx.JSON(
+			http.StatusInternalServerError,
+			map[string]any{"message": "internal error"},
+		)
+		return nil
+	}
+	if tooLarge {
+		ctx.JSON(http.StatusUnprocessableEntity, map[string]any{
+			"message": fmt.Sprintf(
+				"profile diff response exceeds %d bytes",
+				maxProfileDiffResponseBytes,
+			),
+		})
+		return nil
+	}
+	response.Success(ctx, rows)
+	return nil
+}
+
+func profileDiffResponseExceedsLimit(rows []profileDiffRow) (bool, error) {
+	payload, err := json.Marshal(response.Response{
+		Code:    0,
+		Message: "success",
+		Data:    rows,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(payload) > maxProfileDiffResponseBytes, nil
+}
+
+func buildAdjacentProfileDiffRequest(
+	request profileDiffRowsRequest,
+) (*querierv1.DiffRequest, error) {
+	if request.ProfileTypeID == "" {
+		return nil, fmt.Errorf("profile_type_id is required")
+	}
+	if len(request.ProfileTypeID) > maxProfileDiffTypeLength {
+		return nil, fmt.Errorf(
+			"profile_type_id must not exceed %d bytes",
+			maxProfileDiffTypeLength,
+		)
+	}
+	if request.Start < 0 || request.End <= request.Start {
+		return nil, fmt.Errorf("end must be later than a non-negative start")
+	}
+	window := request.End - request.Start
+	if window > request.Start {
+		return nil, fmt.Errorf("selected range has no preceding window")
+	}
+	if request.MaxNodes < 0 ||
+		request.MaxNodes > maxProfileDiffMaxNodes {
+		return nil, fmt.Errorf(
+			"max_nodes must be between 0 and %d",
+			maxProfileDiffMaxNodes,
+		)
+	}
+
+	targetName := "hostname"
+	targetValue := request.Hostname
+	if request.ContainerID != "" {
+		targetName = "container_id"
+		targetValue = request.ContainerID
+	}
+	if strings.TrimSpace(targetValue) == "" {
+		return nil, fmt.Errorf("hostname or container_id is required")
+	}
+	if len(targetValue) > maxProfileDiffTargetLength {
+		return nil, fmt.Errorf(
+			"%s must not exceed %d bytes",
+			targetName,
+			maxProfileDiffTargetLength,
+		)
+	}
+	matcher, err := labels.NewMatcher(labels.MatchEqual, targetName, targetValue)
+	if err != nil {
+		return nil, fmt.Errorf("build target selector: %w", err)
+	}
+	selector := "{" + matcher.String() + "}"
+
+	maxNodesValue := request.MaxNodes
+	if maxNodesValue == 0 {
+		maxNodesValue = defaultProfileDiffMaxNodes
+	}
+	maxNodes := &maxNodesValue
+	return &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: request.ProfileTypeID,
+			LabelSelector: selector,
+			Start:         request.Start - window,
+			End:           request.Start - 1,
+			MaxNodes:      maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: request.ProfileTypeID,
+			LabelSelector: selector,
+			Start:         request.Start,
+			End:           request.End,
+			MaxNodes:      maxNodes,
+		},
+	}, nil
+}
+
+func profileDiffRows(graph *querierv1.FlameGraphDiff) ([]profileDiffRow, error) {
+	if graph == nil || len(graph.Levels) == 0 {
+		return []profileDiffRow{}, nil
+	}
+
+	levels := make([][]*profileDiffNode, len(graph.Levels))
+	nodeCount := 0
+	for levelIndex, level := range graph.Levels {
+		if level == nil ||
+			len(level.Values)%diffFlamegraphNodeWidth != 0 {
+			return nil, fmt.Errorf(
+				"invalid diff flame graph level %d",
+				levelIndex,
+			)
+		}
+		nodeCount += len(level.Values) / diffFlamegraphNodeWidth
+		if nodeCount > maxProfileDiffMaxNodes {
+			return nil, fmt.Errorf(
+				"diff flame graph exceeds %d nodes",
+				maxProfileDiffMaxNodes,
+			)
+		}
+		nodes := make(
+			[]*profileDiffNode,
+			0,
+			len(level.Values)/diffFlamegraphNodeWidth,
+		)
+		var leftOffset int64
+		var rightOffset int64
+		for index := 0; index < len(level.Values); index += diffFlamegraphNodeWidth {
+			leftStart, ok := addProfileDiffValue(
+				leftOffset,
+				level.Values[index],
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"invalid left offset in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			rightStart, ok := addProfileDiffValue(
+				rightOffset,
+				level.Values[index+3],
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"invalid right offset in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			nameIndex := level.Values[index+6]
+			if nameIndex < 0 || nameIndex >= int64(len(graph.Names)) {
+				return nil, fmt.Errorf(
+					"invalid diff flame graph name index %d",
+					nameIndex,
+				)
+			}
+			node := &profileDiffNode{
+				row: profileDiffRow{
+					Level:      levelIndex,
+					Value:      level.Values[index+1],
+					Self:       level.Values[index+2],
+					ValueRight: level.Values[index+4],
+					SelfRight:  level.Values[index+5],
+					Label:      graph.Names[nameIndex],
+				},
+				leftStart:  leftStart,
+				rightStart: rightStart,
+			}
+			if node.row.Value < 0 ||
+				node.row.Self < 0 ||
+				node.row.ValueRight < 0 ||
+				node.row.SelfRight < 0 ||
+				node.row.Self > node.row.Value ||
+				node.row.SelfRight > node.row.ValueRight {
+				return nil, fmt.Errorf(
+					"invalid values in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			nodes = append(nodes, node)
+			leftOffset, ok = addProfileDiffValue(leftStart, node.row.Value)
+			if !ok {
+				return nil, fmt.Errorf(
+					"left range overflows in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			rightOffset, ok = addProfileDiffValue(
+				rightStart,
+				node.row.ValueRight,
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"right range overflows in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+		}
+		levels[levelIndex] = nodes
+	}
+	if len(levels[0]) != 1 {
+		return nil, fmt.Errorf("diff flame graph must have one root")
+	}
+
+	for levelIndex := 1; levelIndex < len(levels); levelIndex++ {
+		for _, node := range levels[levelIndex] {
+			parent := profileDiffParent(levels[levelIndex-1], node)
+			if parent == nil {
+				return nil, fmt.Errorf(
+					"diff flame graph level %d node %q has no parent",
+					levelIndex,
+					node.row.Label,
+				)
+			}
+			parent.children = append(parent.children, node)
+		}
+	}
+
+	rows := make([]profileDiffRow, 0, nodeCount)
+	var appendNode func(*profileDiffNode)
+	appendNode = func(node *profileDiffNode) {
+		rows = append(rows, node.row)
+		for _, child := range node.children {
+			appendNode(child)
+		}
+	}
+	appendNode(levels[0][0])
+	return rows, nil
+}
+
+func profileDiffParent(
+	parents []*profileDiffNode,
+	child *profileDiffNode,
+) *profileDiffNode {
+	for _, parent := range parents {
+		if profileDiffRangeContains(
+			parent.leftStart,
+			parent.row.Value,
+			child.leftStart,
+			child.row.Value,
+		) || profileDiffRangeContains(
+			parent.rightStart,
+			parent.row.ValueRight,
+			child.rightStart,
+			child.row.ValueRight,
+		) {
+			return parent
+		}
+	}
+	return nil
+}
+
+func profileDiffRangeContains(
+	parentStart, parentValue, childStart, childValue int64,
+) bool {
+	parentEnd, parentOK := addProfileDiffValue(parentStart, parentValue)
+	childEnd, childOK := addProfileDiffValue(childStart, childValue)
+	return childValue > 0 &&
+		parentValue >= childValue &&
+		parentOK &&
+		childOK &&
+		childStart >= parentStart &&
+		childEnd <= parentEnd
+}
+
+func addProfileDiffValue(left, right int64) (int64, bool) {
+	if left < 0 || right < 0 || left > math.MaxInt64-right {
+		return 0, false
+	}
+	return left + right, true
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
@@ -39,12 +39,16 @@ const (
 )
 
 type profileDiffRowsRequest struct {
-	ProfileTypeID string `json:"profile_type_id"`
-	Hostname      string `json:"hostname"`
-	ContainerID   string `json:"container_id"`
-	Start         int64  `json:"start"`
-	End           int64  `json:"end"`
-	MaxNodes      int64  `json:"max_nodes"`
+	ProfileTypeID  string `json:"profile_type_id"`
+	Hostname       string `json:"hostname"`
+	ContainerID    string `json:"container_id"`
+	ProfilingScope string `json:"profiling_scope"`
+	CPU            string `json:"cpu"`
+	PID            string `json:"pid"`
+	TGID           string `json:"tgid"`
+	Start          int64  `json:"start"`
+	End            int64  `json:"end"`
+	MaxNodes       int64  `json:"max_nodes"`
 }
 
 type profileDiffRow struct {
@@ -71,7 +75,7 @@ func (h *Handler) displayDiffRows(ctx *server.Context) error {
 		)
 	}
 
-	diffRequest, err := buildAdjacentProfileDiffRequest(request)
+	diffRequest, err := buildAdjacentProfileDiffRequest(&request)
 	if err != nil {
 		return response.ErrInvalidRequest.WithMessage(err.Error())
 	}
@@ -135,8 +139,11 @@ func profileDiffResponseExceedsLimit(rows []profileDiffRow) (bool, error) {
 }
 
 func buildAdjacentProfileDiffRequest(
-	request profileDiffRowsRequest,
+	request *profileDiffRowsRequest,
 ) (*querierv1.DiffRequest, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is required")
+	}
 	if request.ProfileTypeID == "" {
 		return nil, fmt.Errorf("profile_type_id is required")
 	}
@@ -170,18 +177,43 @@ func buildAdjacentProfileDiffRequest(
 	if strings.TrimSpace(targetValue) == "" {
 		return nil, fmt.Errorf("hostname or container_id is required")
 	}
-	if len(targetValue) > maxProfileDiffTargetLength {
-		return nil, fmt.Errorf(
-			"%s must not exceed %d bytes",
-			targetName,
-			maxProfileDiffTargetLength,
+	selectors := []struct {
+		name  string
+		value string
+	}{
+		{name: targetName, value: targetValue},
+		{name: "profiling_scope", value: request.ProfilingScope},
+		{name: "cpu", value: request.CPU},
+		{name: "pid", value: request.PID},
+		{name: "tgid", value: request.TGID},
+	}
+	matchers := make([]string, 0, len(selectors))
+	for _, selector := range selectors {
+		if selector.value == "" {
+			continue
+		}
+		if len(selector.value) > maxProfileDiffTargetLength {
+			return nil, fmt.Errorf(
+				"%s must not exceed %d bytes",
+				selector.name,
+				maxProfileDiffTargetLength,
+			)
+		}
+		matcher, err := labels.NewMatcher(
+			labels.MatchEqual,
+			selector.name,
+			selector.value,
 		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build %s selector: %w",
+				selector.name,
+				err,
+			)
+		}
+		matchers = append(matchers, matcher.String())
 	}
-	matcher, err := labels.NewMatcher(labels.MatchEqual, targetName, targetValue)
-	if err != nil {
-		return nil, fmt.Errorf("build target selector: %w", err)
-	}
-	selector := "{" + matcher.String() + "}"
+	selector := "{" + strings.Join(matchers, ",") + "}"
 
 	maxNodesValue := request.MaxNodes
 	if maxNodesValue == 0 {

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+)
+
+func TestBuildAdjacentProfileDiffRequest(t *testing.T) {
+	request, err := buildAdjacentProfileDiffRequest(profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node-a",
+		ContainerID:   `container\"a`,
+		Start:         2000,
+		End:           3000,
+		MaxNodes:      500,
+	})
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+
+	if request.Left.Start != 1000 || request.Left.End != 1999 {
+		t.Fatalf(
+			"left range = %d..%d, want 1000..1999",
+			request.Left.Start,
+			request.Left.End,
+		)
+	}
+	if request.Right.Start != 2000 || request.Right.End != 3000 {
+		t.Fatalf(
+			"right range = %d..%d, want 2000..3000",
+			request.Right.Start,
+			request.Right.End,
+		)
+	}
+	wantSelector := `{container_id="container\\\"a"}`
+	if request.Left.LabelSelector != wantSelector ||
+		request.Right.LabelSelector != wantSelector {
+		t.Fatalf(
+			"selectors = %q and %q, want %q",
+			request.Left.LabelSelector,
+			request.Right.LabelSelector,
+			wantSelector,
+		)
+	}
+	if request.Left.GetMaxNodes() != 500 || request.Right.GetMaxNodes() != 500 {
+		t.Fatal("max_nodes was not forwarded to both selections")
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestRequiresTargetAndPreviousWindow(t *testing.T) {
+	tests := []profileDiffRowsRequest{
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         500,
+			End:           1500,
+		},
+	}
+	for _, request := range tests {
+		if _, err := buildAdjacentProfileDiffRequest(request); err == nil {
+			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
+		}
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestDefaultsAndBounds(t *testing.T) {
+	valid := profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node-a",
+		Start:         2000,
+		End:           3000,
+	}
+	request, err := buildAdjacentProfileDiffRequest(valid)
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+	if request.Left.GetMaxNodes() != defaultProfileDiffMaxNodes ||
+		request.Right.GetMaxNodes() != defaultProfileDiffMaxNodes {
+		t.Fatal("default max_nodes was not applied to both selections")
+	}
+
+	tests := []profileDiffRowsRequest{
+		{ProfileTypeID: "", Hostname: "node-a", Start: 2000, End: 3000},
+		{
+			ProfileTypeID: strings.Repeat("p", maxProfileDiffTypeLength+1),
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      strings.Repeat("h", maxProfileDiffTargetLength+1),
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         -1,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           2000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+			MaxNodes:      -1,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+			MaxNodes:      maxProfileDiffMaxNodes + 1,
+		},
+	}
+	for _, request := range tests {
+		if _, err := buildAdjacentProfileDiffRequest(request); err == nil {
+			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
+		}
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestEscapesSelectorInput(t *testing.T) {
+	request, err := buildAdjacentProfileDiffRequest(profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node\n\"a\\b",
+		Start:         2000,
+		End:           3000,
+	})
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+	if request.Left.LabelSelector != `{hostname="node\n\"a\\b"}` {
+		t.Fatalf("selector = %q", request.Left.LabelSelector)
+	}
+}
+
+func TestProfileDiffRowsBuildsNestedSetOrder(t *testing.T) {
+	graph := &querierv1.FlameGraphDiff{
+		Names: []string{"total", "a", "b", "a-child"},
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 30, 0, 0, 40, 0, 0}},
+			{Values: []int64{
+				0, 10, 5, 0, 30, 10, 1,
+				0, 20, 20, 0, 10, 10, 2,
+			}},
+			{Values: []int64{5, 5, 5, 10, 20, 20, 3}},
+		},
+	}
+
+	rows, err := profileDiffRows(graph)
+	if err != nil {
+		t.Fatalf("profileDiffRows() error = %v", err)
+	}
+	want := []profileDiffRow{
+		{Level: 0, Value: 30, ValueRight: 40, Label: "total"},
+		{
+			Level: 1, Value: 10, Self: 5,
+			ValueRight: 30, SelfRight: 10, Label: "a",
+		},
+		{
+			Level: 2, Value: 5, Self: 5,
+			ValueRight: 20, SelfRight: 20, Label: "a-child",
+		},
+		{
+			Level: 1, Value: 20, Self: 20,
+			ValueRight: 10, SelfRight: 10, Label: "b",
+		},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %#v, want %#v", rows, want)
+	}
+}
+
+func TestProfileDiffRowsRejectsMalformedLevel(t *testing.T) {
+	_, err := profileDiffRows(&querierv1.FlameGraphDiff{
+		Names:  []string{"total"},
+		Levels: []*querierv1.Level{{Values: []int64{0, 1}}},
+	})
+	if err == nil {
+		t.Fatal("profileDiffRows() succeeded for a malformed level")
+	}
+}
+
+func TestProfileDiffRowsRejectsMaliciousValues(t *testing.T) {
+	tests := []*querierv1.FlameGraphDiff{
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, -1, 0, 0, 1, 0, 0}}},
+		},
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, 1, 2, 0, 1, 0, 0}}},
+		},
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, 1, 0, 0, 1, 0, 1}}},
+		},
+		{
+			Names: []string{"total", "orphan"},
+			Levels: []*querierv1.Level{
+				{Values: []int64{0, 1, 0, 0, 1, 0, 0}},
+				{Values: []int64{2, 1, 0, 2, 1, 0, 1}},
+			},
+		},
+		{
+			Names: []string{"total", "overflow"},
+			Levels: []*querierv1.Level{
+				{Values: []int64{0, math.MaxInt64, 0, 0, 1, 0, 0}},
+				{Values: []int64{math.MaxInt64, 1, 0, 0, 1, 0, 1}},
+			},
+		},
+	}
+	for index, graph := range tests {
+		if _, err := profileDiffRows(graph); err == nil {
+			t.Fatalf("profileDiffRows(test %d) succeeded", index)
+		}
+	}
+}
+
+func TestProfileDiffRowsLimitsTotalNodes(t *testing.T) {
+	level := &querierv1.Level{
+		Values: make([]int64, 0, maxProfileDiffMaxNodes*diffFlamegraphNodeWidth),
+	}
+	for range maxProfileDiffMaxNodes {
+		level.Values = append(level.Values, 0, 0, 0, 0, 0, 0, 0)
+	}
+
+	_, err := profileDiffRows(&querierv1.FlameGraphDiff{
+		Names: []string{"total"},
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 1, 0, 0, 1, 0, 0}},
+			level,
+		},
+	})
+	if err == nil {
+		t.Fatal("profileDiffRows() accepted more than the node limit")
+	}
+}
+
+func TestProfileDiffResponseSizeLimit(t *testing.T) {
+	tooLarge, err := profileDiffResponseExceedsLimit([]profileDiffRow{{
+		Label: strings.Repeat("x", maxProfileDiffResponseBytes),
+	}})
+	if err != nil {
+		t.Fatalf("profileDiffResponseExceedsLimit() error = %v", err)
+	}
+	if !tooLarge {
+		t.Fatal("profile diff response exceeded the byte limit")
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
@@ -26,13 +26,17 @@ import (
 )
 
 func TestBuildAdjacentProfileDiffRequest(t *testing.T) {
-	request, err := buildAdjacentProfileDiffRequest(profileDiffRowsRequest{
-		ProfileTypeID: profiler.ProfileTypeCpuSample,
-		Hostname:      "node-a",
-		ContainerID:   `container\"a`,
-		Start:         2000,
-		End:           3000,
-		MaxNodes:      500,
+	request, err := buildAdjacentProfileDiffRequest(&profileDiffRowsRequest{
+		ProfileTypeID:  profiler.ProfileTypeCpuSample,
+		Hostname:       "node-a",
+		ContainerID:    `container\"a`,
+		ProfilingScope: "container",
+		CPU:            "2,4-7",
+		PID:            "4242",
+		TGID:           "4200",
+		Start:          2000,
+		End:            3000,
+		MaxNodes:       500,
 	})
 	if err != nil {
 		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
@@ -52,7 +56,8 @@ func TestBuildAdjacentProfileDiffRequest(t *testing.T) {
 			request.Right.End,
 		)
 	}
-	wantSelector := `{container_id="container\\\"a"}`
+	wantSelector := `{container_id="container\\\"a",` +
+		`profiling_scope="container",cpu="2,4-7",pid="4242",tgid="4200"}`
 	if request.Left.LabelSelector != wantSelector ||
 		request.Right.LabelSelector != wantSelector {
 		t.Fatalf(
@@ -68,6 +73,9 @@ func TestBuildAdjacentProfileDiffRequest(t *testing.T) {
 }
 
 func TestBuildAdjacentProfileDiffRequestRequiresTargetAndPreviousWindow(t *testing.T) {
+	if _, err := buildAdjacentProfileDiffRequest(nil); err == nil {
+		t.Fatal("buildAdjacentProfileDiffRequest(nil) succeeded")
+	}
 	tests := []profileDiffRowsRequest{
 		{
 			ProfileTypeID: profiler.ProfileTypeCpuSample,
@@ -82,7 +90,7 @@ func TestBuildAdjacentProfileDiffRequestRequiresTargetAndPreviousWindow(t *testi
 		},
 	}
 	for _, request := range tests {
-		if _, err := buildAdjacentProfileDiffRequest(request); err == nil {
+		if _, err := buildAdjacentProfileDiffRequest(&request); err == nil {
 			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
 		}
 	}
@@ -95,7 +103,7 @@ func TestBuildAdjacentProfileDiffRequestDefaultsAndBounds(t *testing.T) {
 		Start:         2000,
 		End:           3000,
 	}
-	request, err := buildAdjacentProfileDiffRequest(valid)
+	request, err := buildAdjacentProfileDiffRequest(&valid)
 	if err != nil {
 		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
 	}
@@ -115,6 +123,13 @@ func TestBuildAdjacentProfileDiffRequestDefaultsAndBounds(t *testing.T) {
 		{
 			ProfileTypeID: profiler.ProfileTypeCpuSample,
 			Hostname:      strings.Repeat("h", maxProfileDiffTargetLength+1),
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			CPU:           strings.Repeat("1", maxProfileDiffTargetLength+1),
 			Start:         2000,
 			End:           3000,
 		},
@@ -146,14 +161,14 @@ func TestBuildAdjacentProfileDiffRequestDefaultsAndBounds(t *testing.T) {
 		},
 	}
 	for _, request := range tests {
-		if _, err := buildAdjacentProfileDiffRequest(request); err == nil {
+		if _, err := buildAdjacentProfileDiffRequest(&request); err == nil {
 			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
 		}
 	}
 }
 
 func TestBuildAdjacentProfileDiffRequestEscapesSelectorInput(t *testing.T) {
-	request, err := buildAdjacentProfileDiffRequest(profileDiffRowsRequest{
+	request, err := buildAdjacentProfileDiffRequest(&profileDiffRowsRequest{
 		ProfileTypeID: profiler.ProfileTypeCpuSample,
 		Hostname:      "node\n\"a\\b",
 		Start:         2000,

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -44,6 +44,8 @@ type Config struct {
 // ProfileQueryService defines profile query operations consumed by the handler.
 type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
+	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
+	Diff(ctx context.Context, req *querierv1.DiffRequest) (*querierv1.DiffResponse, error)
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -81,6 +83,8 @@ func NewHandler(
 		{Typ: server.HttpDelete, Uri: "/:id", Handle: h.delete},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces", Handle: h.displaySelectMergeStacktraces},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
+		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},
+		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/Diff", Handle: h.displayDiff},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelNames", Handle: h.displayLabelNames},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelValues", Handle: h.displayLabelValues},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -85,6 +85,7 @@ func NewHandler(
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/Diff", Handle: h.displayDiff},
+		{Typ: server.HttpPost, Uri: "/flamegraph/diff-rows", Handle: h.displayDiffRows},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelNames", Handle: h.displayLabelNames},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelValues", Handle: h.displayLabelValues},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -16,6 +16,7 @@ package profiling
 
 import (
 	"context"
+	"io"
 
 	"huatuo-bamai/internal/job"
 	profileService "huatuo-bamai/internal/profiler/service"
@@ -46,6 +47,8 @@ type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
 	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
 	Diff(ctx context.Context, req *querierv1.DiffRequest) (*querierv1.DiffResponse, error)
+	MarshalPprof(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) ([]byte, error)
+	RenderProfileSVG(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest, writer io.Writer) error
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -81,6 +84,8 @@ func NewHandler(
 		{Typ: server.HttpGet, Uri: "/:id/raw", Handle: h.getRawData},
 		{Typ: server.HttpPatch, Uri: "/:id", Handle: h.patchOne},
 		{Typ: server.HttpDelete, Uri: "/:id", Handle: h.delete},
+		{Typ: server.HttpGet, Uri: "/flamegraph/export/pprof", Handle: h.displayPprofExport},
+		{Typ: server.HttpGet, Uri: "/flamegraph/export/svg", Handle: h.displaySVGExport},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces", Handle: h.displaySelectMergeStacktraces},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -24,6 +24,7 @@ import (
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/server/response"
@@ -259,34 +260,28 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	var dashboardSlug string
 	var labelKey string
 	var labelVal string
+	var profileTypeID string
 
 	from := jobResult.StartTime.UTC().Format("2006-01-02T15:04:05.000Z")
 	to := jobResult.EndTime.UTC().Format("2006-01-02T15:04:05.000Z")
 
+	switch jobResult.Type {
+	case ProfilingMemory:
+		profileTypeID = profiler.ProfileTypeMemSample
+	case ProfilingCPU:
+		profileTypeID = profiler.ProfileTypeCpuSample
+	default:
+		return ""
+	}
+
 	if jobResult.ContainerID != "" {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "container-memory-profiling"
-			dashboardSlug = "e5aeb9-e599a8-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "container-cpu-profiling"
-			dashboardSlug = "e5aeb9-e599a8-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-container"
+		dashboardSlug = "continuous-profiling-container"
 		labelKey = "var-container_id"
 		labelVal = jobResult.ContainerID
 	} else {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "host-memory-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "host-cpu-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-host"
+		dashboardSlug = "continuous-profiling-host"
 		labelKey = "var-hostname"
 		labelVal = jobResult.Hostname
 	}
@@ -297,6 +292,7 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	query.Set("to", to)
 	query.Set("timezone", "browser")
 	query.Set(labelKey, labelVal)
+	query.Set("var-type", profileTypeID)
 
 	return fmt.Sprintf("%s/%s/%s?%s", base, dashboardUID, dashboardSlug, query.Encode())
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -208,6 +208,9 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
 		Language:        privateData.Language,
+		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
+		PID:             privateData.PID,
+		ThreadGroup:     privateData.ThreadGroup,
 	}
 
 	return resp, nil

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -83,6 +83,22 @@ func TestNewHandlerSnapshotsProfilingConfig(t *testing.T) {
 	}
 }
 
+func TestNewHandlerRegistersProfileExports(t *testing.T) {
+	h := NewHandler(nil, nil, Config{})
+	routes := make(map[string]bool, len(h.Handlers))
+	for _, handler := range h.Handlers {
+		routes[handler.Uri] = true
+	}
+	for _, route := range []string{
+		"/flamegraph/export/pprof",
+		"/flamegraph/export/svg",
+	} {
+		if !routes[route] {
+			t.Errorf("profile export route %q is not registered", route)
+		}
+	}
+}
+
 // TestCapabilities verifies that the capabilities handler returns the correct
 // profiling types, languages, memory modes, and default configuration values.
 func TestCapabilities(t *testing.T) {

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -137,6 +137,9 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		Duration:        60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
+		CPUIDs:          []int{1, 3},
+		PID:             4242,
+		ThreadGroup:     true,
 	})
 	if err != nil {
 		t.Fatalf("newProfilingPrivateData() error=%v", err)
@@ -149,8 +152,14 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	if fields["binary_match_path"] != "/usr/bin/example" ||
 		fields["duration"] != float64(60) ||
 		fields["language"] != "go" ||
-		fields["memory_mode"] != "object_alloc" {
+		fields["memory_mode"] != "object_alloc" ||
+		fields["pid"] != float64(4242) ||
+		fields["thread_group"] != true {
 		t.Errorf("newProfilingPrivateData()=%s, want request fields", data)
+	}
+	cpuIDs, ok := fields["cpu_ids"].([]any)
+	if !ok || len(cpuIDs) != 2 || cpuIDs[0] != float64(1) || cpuIDs[1] != float64(3) {
+		t.Errorf("newProfilingPrivateData() cpu_ids=%v, want [1 3]", fields["cpu_ids"])
 	}
 }
 
@@ -162,7 +171,10 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 			"binary_match_path":"/usr/bin/example",
 			"duration":60,
 			"language":"go",
-			"memory_mode":"object_alloc"
+			"memory_mode":"object_alloc",
+			"cpu_ids":[1,3],
+			"pid":4242,
+			"thread_group":true
 		}`),
 	}, "")
 	if err != nil {
@@ -180,6 +192,15 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 	}
 	if resp.Duration != 60 {
 		t.Errorf("Duration=%d, want 60", resp.Duration)
+	}
+	if len(resp.CPUIDs) != 2 || resp.CPUIDs[0] != 1 || resp.CPUIDs[1] != 3 {
+		t.Errorf("CPUIDs=%v, want [1 3]", resp.CPUIDs)
+	}
+	if resp.PID != 4242 {
+		t.Errorf("PID=%d, want 4242", resp.PID)
+	}
+	if !resp.ThreadGroup {
+		t.Error("ThreadGroup=false, want true")
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -25,16 +25,48 @@ import (
 	profileService "huatuo-bamai/internal/profiler/service"
 )
 
-func TestGetFlameGraphURLEscapesLabelValue(t *testing.T) {
-	url := getFlameGraphURL("http://grafana.example/d", &job.Job{
-		Type:        ProfilingCPU,
-		ContainerID: "container+2026&debug",
-		StartTime:   time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC),
-		EndTime:     time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC),
-	})
+func TestGetFlameGraphURLTargetsProvisionedDashboards(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           job.Job
+		wantPath      string
+		wantSelection string
+		wantType      string
+	}{
+		{
+			name: "host CPU",
+			job: job.Job{
+				Type:     ProfilingCPU,
+				Hostname: "node+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-host/continuous-profiling-host?",
+			wantSelection: "var-hostname=node%2B2026%26debug",
+			wantType:      "var-type=process_cpu%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds",
+		},
+		{
+			name: "container memory",
+			job: job.Job{
+				Type:        ProfilingMemory,
+				ContainerID: "container+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-container/continuous-profiling-container?",
+			wantSelection: "var-container_id=container%2B2026%26debug",
+			wantType:      "var-type=memory%3Aalloc_space%3Abytes%3Aspace%3Abytes",
+		},
+	}
 
-	if !strings.Contains(url, "var-container_id=container%2B2026%26debug") {
-		t.Fatalf("url = %q, want escaped container label value", url)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.job.StartTime = time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+			tc.job.EndTime = time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC)
+			url := getFlameGraphURL("http://grafana.example/d", &tc.job)
+
+			for _, want := range []string{tc.wantPath, tc.wantSelection, tc.wantType} {
+				if !strings.Contains(url, want) {
+					t.Fatalf("url = %q, want %q", url, want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -39,16 +39,11 @@ func handleProto[Request, Response any](
 
 	resp, err := invoke(ctx.Request().Context(), req)
 	if err != nil {
-		if errors.Is(err, profileService.ErrInvalidQuery) {
-			ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
-			return nil
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField("operation", operation).Error("profile query failed")
 		}
-		if errors.Is(err, profileService.ErrProfilesAbsent) {
-			ctx.JSON(http.StatusNotFound, map[string]any{"message": "profiles not found"})
-			return nil
-		}
-		log.WithError(err).WithField("operation", operation).Error("profile query failed")
-		ctx.JSON(http.StatusInternalServerError, map[string]any{"message": "internal error"})
+		ctx.JSON(status, map[string]any{"message": message})
 		return nil
 	}
 
@@ -57,12 +52,33 @@ func handleProto[Request, Response any](
 	return nil
 }
 
+func profileQueryHTTPError(err error) (int, string) {
+	switch {
+	case errors.Is(err, profileService.ErrInvalidQuery):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, profileService.ErrProfilesAbsent):
+		return http.StatusNotFound, "profiles not found"
+	case errors.Is(err, profileService.ErrProfileQueryLimitExceeded):
+		return http.StatusUnprocessableEntity, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal error"
+	}
+}
+
 func (h *Handler) displaySelectMergeStacktraces(ctx *server.Context) error {
 	return handleProto(ctx, "select_merge_stacktraces", h.profileService.SelectMergeStacktraces)
 }
 
 func (h *Handler) displayProfileTypes(ctx *server.Context) error {
 	return handleProto(ctx, "profile_types", h.profileService.ProfileTypes)
+}
+
+func (h *Handler) displaySelectSeries(ctx *server.Context) error {
+	return handleProto(ctx, "select_series", h.profileService.SelectSeries)
+}
+
+func (h *Handler) displayDiff(ctx *server.Context) error {
+	return handleProto(ctx, "diff", h.profileService.Diff)
 }
 
 func (h *Handler) displayLabelNames(ctx *server.Context) error {

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -15,15 +15,20 @@
 package profiling
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"huatuo-bamai/internal/log"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 
 	"github.com/gin-gonic/gin/binding"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 )
 
 func handleProto[Request, Response any](
@@ -87,4 +92,96 @@ func (h *Handler) displayLabelNames(ctx *server.Context) error {
 
 func (h *Handler) displayLabelValues(ctx *server.Context) error {
 	return handleProto(ctx, "label_values", h.profileService.LabelValues)
+}
+
+func profileExportRequest(
+	query func(string) string,
+) (*querierv1.SelectMergeStacktracesRequest, error) {
+	profileType := strings.TrimSpace(query("profile_type"))
+	if profileType == "" {
+		return nil, errors.New("profile_type is required")
+	}
+	selector := strings.TrimSpace(query("selector"))
+	if selector == "" {
+		return nil, errors.New("selector is required")
+	}
+	start, err := strconv.ParseInt(query("start"), 10, 64)
+	if err != nil {
+		return nil, errors.New("start must be a Unix timestamp in milliseconds")
+	}
+	end, err := strconv.ParseInt(query("end"), 10, 64)
+	if err != nil {
+		return nil, errors.New("end must be a Unix timestamp in milliseconds")
+	}
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profileType,
+		LabelSelector: selector,
+		Start:         start,
+		End:           end,
+	}, nil
+}
+
+func writeProfileServiceError(ctx *server.Context, operation string, err error) {
+	status, message := profileQueryHTTPError(err)
+	if status == http.StatusInternalServerError {
+		log.WithError(err).WithField("operation", operation).Error("profile query failed")
+	}
+	ctx.JSON(status, map[string]any{"message": message})
+}
+
+func (h *Handler) displayPprofExport(ctx *server.Context) error {
+	req, err := profileExportRequest(ctx.Query)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
+		return nil
+	}
+	payload, err := h.profileService.MarshalPprof(ctx.Request().Context(), req)
+	if err != nil {
+		writeProfileServiceError(ctx, "export_pprof", err)
+		return nil
+	}
+	ctx.Header("Content-Type", "application/octet-stream")
+	ctx.Header(
+		"Content-Disposition",
+		`attachment; filename="huatuo-profile.pb.gz"`,
+	)
+	ctx.Header("X-Content-Type-Options", "nosniff")
+	ctx.Writer().WriteHeader(http.StatusOK)
+	if _, err := ctx.Writer().Write(payload); err != nil {
+		return fmt.Errorf("write pprof export: %w", err)
+	}
+	return nil
+}
+
+func (h *Handler) displaySVGExport(ctx *server.Context) error {
+	req, err := profileExportRequest(ctx.Query)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
+		return nil
+	}
+	var output bytes.Buffer
+	if err := h.profileService.RenderProfileSVG(
+		ctx.Request().Context(),
+		req,
+		&output,
+	); err != nil {
+		writeProfileServiceError(ctx, "export_svg", err)
+		return nil
+	}
+	ctx.Header("Content-Type", "image/svg+xml; charset=utf-8")
+	ctx.Header(
+		"Content-Disposition",
+		`inline; filename="huatuo-flamegraph.svg"`,
+	)
+	ctx.Header(
+		"Content-Security-Policy",
+		"sandbox allow-scripts; default-src 'none'; "+
+			"script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+	)
+	ctx.Header("X-Content-Type-Options", "nosniff")
+	ctx.Writer().WriteHeader(http.StatusOK)
+	if _, err := ctx.Writer().Write(output.Bytes()); err != nil {
+		return fmt.Errorf("write SVG export: %w", err)
+	}
+	return nil
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -31,6 +31,24 @@ import (
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 )
 
+const maxProfileSVGResponseBytes = 8 << 20
+
+type boundedProfileSVGBuffer struct {
+	bytes.Buffer
+}
+
+func (b *boundedProfileSVGBuffer) Write(payload []byte) (int, error) {
+	if b.Len() > maxProfileSVGResponseBytes ||
+		len(payload) > maxProfileSVGResponseBytes-b.Len() {
+		return 0, fmt.Errorf(
+			"%w: rendered SVG exceeds %d bytes; narrow the time range or selector",
+			profileService.ErrProfileQueryLimitExceeded,
+			maxProfileSVGResponseBytes,
+		)
+	}
+	return b.Buffer.Write(payload)
+}
+
 func handleProto[Request, Response any](
 	ctx *server.Context,
 	operation string,
@@ -159,7 +177,7 @@ func (h *Handler) displaySVGExport(ctx *server.Context) error {
 		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
 		return nil
 	}
-	var output bytes.Buffer
+	var output boundedProfileSVGBuffer
 	if err := h.profileService.RenderProfileSVG(
 		ctx.Request().Context(),
 		req,

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	profileService "huatuo-bamai/internal/profiler/service"
+)
+
+func TestProfileQueryHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "invalid query",
+			err:         errors.Join(profileService.ErrInvalidQuery, errors.New("bad selector")),
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "bad selector",
+		},
+		{
+			name:        "not found",
+			err:         profileService.ErrProfilesAbsent,
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "profiles not found",
+		},
+		{
+			name: "selection too large",
+			err: errors.Join(
+				profileService.ErrProfileQueryLimitExceeded,
+				errors.New("10001 documents"),
+			),
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: "10001 documents",
+		},
+		{
+			name:        "internal",
+			err:         errors.New("elasticsearch unavailable"),
+			wantStatus:  http.StatusInternalServerError,
+			wantMessage: "internal error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := profileQueryHTTPError(test.err)
+			if status != test.wantStatus {
+				t.Fatalf("status = %d, want %d", status, test.wantStatus)
+			}
+			if !strings.Contains(message, test.wantMessage) {
+				t.Fatalf("message = %q, want it to contain %q", message, test.wantMessage)
+			}
+		})
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -70,3 +70,78 @@ func TestProfileQueryHTTPError(t *testing.T) {
 		})
 	}
 }
+
+func TestProfileExportRequest(t *testing.T) {
+	values := map[string]string{
+		"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		"selector":     `{hostname="node-a"}`,
+		"start":        "1784944800000",
+		"end":          "1784944860000",
+	}
+	req, err := profileExportRequest(func(name string) string {
+		return values[name]
+	})
+	if err != nil {
+		t.Fatalf("profileExportRequest() error = %v", err)
+	}
+	if req.ProfileTypeID != values["profile_type"] ||
+		req.LabelSelector != values["selector"] ||
+		req.Start != 1784944800000 ||
+		req.End != 1784944860000 {
+		t.Fatalf("profileExportRequest() = %#v, want query values", req)
+	}
+}
+
+func TestProfileExportRequestRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   string
+	}{
+		{
+			name:   "profile type",
+			values: map[string]string{},
+			want:   "profile_type is required",
+		},
+		{
+			name: "selector",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			},
+			want: "selector is required",
+		},
+		{
+			name: "start",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "yesterday",
+			},
+			want: "start must be a Unix timestamp in milliseconds",
+		},
+		{
+			name: "end",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "1784944800000",
+				"end":          "tomorrow",
+			},
+			want: "end must be a Unix timestamp in milliseconds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := profileExportRequest(func(name string) string {
+				return test.values[name]
+			})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf(
+					"profileExportRequest() error = %v, want %q",
+					err,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -145,3 +145,16 @@ func TestProfileExportRequestRejectsInvalidValues(t *testing.T) {
 		})
 	}
 }
+
+func TestBoundedProfileSVGBufferRejectsOversizedOutput(t *testing.T) {
+	var output boundedProfileSVGBuffer
+	if _, err := output.Write(make([]byte, maxProfileSVGResponseBytes)); err != nil {
+		t.Fatalf("write at limit: %v", err)
+	}
+	if _, err := output.Write([]byte("x")); !errors.Is(
+		err,
+		profileService.ErrProfileQueryLimitExceeded,
+	) {
+		t.Fatalf("write above limit error = %v, want query limit", err)
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -49,6 +51,9 @@ type profilingJobPrivateData struct {
 	Duration        int    `json:"duration"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`
+	PID             int    `json:"pid,omitempty"`
+	ThreadGroup     bool   `json:"thread_group,omitempty"`
 }
 
 func parseCreateProfilingJobRequest(ctx *server.Context) (*v1.CreateProfilingJobRequest, error) {
@@ -74,6 +79,9 @@ func buildCreateProfilingJobRequest(
 
 	jobType, err := buildProfilingTracerArgs(&taskReq, req)
 	if err != nil {
+		return nil, err
+	}
+	if err := appendProfilingTargetArgs(&taskReq, req); err != nil {
 		return nil, err
 	}
 	if req.Duration < taskReq.Interval*2 {
@@ -152,12 +160,86 @@ func buildProfilingTracerArgs(
 	}
 }
 
+func appendProfilingTargetArgs(
+	taskReq *job.AgentTaskRequest,
+	req *v1.CreateProfilingJobRequest,
+) error {
+	language, err := profiling.ParseLanguage(req.Language)
+	if err != nil {
+		return err
+	}
+	implementation, ok := profiling.ImplementationFor(language)
+	if !ok {
+		return fmt.Errorf("profiling implementation not found for %q", language)
+	}
+	native := implementation == profiling.ImplementationNative
+	hasNativeSelection := req.PID != 0 || req.ThreadGroup || len(req.CPUIDs) > 0
+	if hasNativeSelection && !native {
+		return errors.New("pid, cpu_ids, and thread_group are supported only by native profiling")
+	}
+
+	if req.ContainerID != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--container-id", req.ContainerID)
+	}
+	if !native {
+		return nil
+	}
+
+	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
+		return fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+	}
+	if req.PID != 0 && req.ContainerID != "" {
+		return errors.New("pid and container_id are mutually exclusive")
+	}
+	if req.ThreadGroup && req.PID == 0 {
+		return errors.New("thread_group requires pid")
+	}
+	if req.ProfilingType == string(profiling.TypeMemory) &&
+		req.PID == 0 && req.ContainerID == "" {
+		return errors.New("native memory profiling requires pid or container_id")
+	}
+
+	if req.PID != 0 {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--pid", strconv.Itoa(req.PID))
+	}
+	if req.ThreadGroup {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--thread-group")
+	}
+	if len(req.CPUIDs) == 0 {
+		return nil
+	}
+	if req.ProfilingType != string(profiling.TypeCPU) {
+		return errors.New("cpu_ids are supported only by CPU profiling")
+	}
+
+	cpuIDs := append([]int(nil), req.CPUIDs...)
+	sort.Ints(cpuIDs)
+	for i, cpuID := range cpuIDs {
+		if cpuID < 0 {
+			return fmt.Errorf("cpu_id must not be negative: %d", cpuID)
+		}
+		if i > 0 && cpuIDs[i-1] == cpuID {
+			return fmt.Errorf("duplicate cpu_id %d", cpuID)
+		}
+	}
+	req.CPUIDs = cpuIDs
+	values := make([]string, len(cpuIDs))
+	for i, cpuID := range cpuIDs {
+		values[i] = strconv.Itoa(cpuID)
+	}
+	taskReq.TracerArgs = append(taskReq.TracerArgs, "--cpuid", strings.Join(values, ","))
+	return nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
 		Duration:        req.Duration,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,
+		CPUIDs:          req.CPUIDs,
+		PID:             req.PID,
+		ThreadGroup:     req.ThreadGroup,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encoding profiling private data: %w", err)

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -15,6 +15,7 @@
 package profiling
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -31,20 +32,23 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 		wantErr        string
 	}{
 		{
-			name: "cpu profiling",
+			name: "native CPU profiling by thread group and CPU IDs",
 			req: v1.CreateProfilingJobRequest{
-				ProfilingType:   "cpu",
-				Language:        "go",
-				BinaryMatchPath: "/usr/bin/example",
-				Duration:        30,
-				ContainerID:     "container-2026",
-				Hostname:        "huatuo-dev",
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				Hostname:      "huatuo-dev",
+				CPUIDs:        []int{3, 1},
+				PID:           4242,
+				ThreadGroup:   true,
 			},
 			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
 				"-t", "cpu",
-				"--binary-match-path", "/usr/bin/example",
 				"-l", "go",
+				"--pid", "4242",
+				"--thread-group",
+				"--cpuid", "1,3",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
@@ -53,24 +57,110 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "memory profiling",
+			name: "native CPU profiling by container",
 			req: v1.CreateProfilingJobRequest{
-				ProfilingType: "memory",
+				ProfilingType: "cpu",
 				Language:      "c",
-				MemoryMode:    "physical_usage",
 				Duration:      30,
+				ContainerID:   "0123456789ab",
+				Hostname:      "huatuo-dev",
 			},
-			wantType: ProfilingMemory,
+			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
-				"-t", "memory",
-				"--memory-mode", "physical_usage",
+				"-t", "cpu",
 				"-l", "c",
+				"--container-id", "0123456789ab",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
 				"--output-format", "remote",
 				"--output-storage", "/var/run/huatuo-toolstream.sock",
 			},
+		},
+		{
+			name: "native memory profiling by exact PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "c",
+				MemoryMode:    "physical_usage",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantType: ProfilingMemory,
+			wantTracerArgs: []string{
+				"-t", "memory",
+				"--memory-mode", "physical_usage",
+				"-l", "c",
+				"--pid", "4242",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "native PID and container are mutually exclusive",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				ContainerID:   "0123456789ab",
+				PID:           4242,
+			},
+			wantErr: "pid and container_id are mutually exclusive",
+		},
+		{
+			name: "thread group requires PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				ThreadGroup:   true,
+			},
+			wantErr: "thread_group requires pid",
+		},
+		{
+			name: "CPU IDs require CPU profiling",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "go",
+				MemoryMode:    "virtual_alloc",
+				Duration:      30,
+				PID:           4242,
+				CPUIDs:        []int{1},
+			},
+			wantErr: "cpu_ids are supported only by CPU profiling",
+		},
+		{
+			name: "CPU IDs reject duplicates",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				CPUIDs:        []int{1, 1},
+			},
+			wantErr: "duplicate cpu_id 1",
+		},
+		{
+			name: "non-native profiling rejects native selection",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantErr: "pid, cpu_ids, and thread_group are supported only by native profiling",
+		},
+		{
+			name: "native memory requires a target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "go",
+				MemoryMode:    "virtual_alloc",
+				Duration:      30,
+			},
+			wantErr: "native memory profiling requires pid or container_id",
 		},
 		{
 			name: "unsupported type",
@@ -119,6 +209,15 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			}
 			if !slices.Equal(got.AgentTask.TracerArgs, tt.wantTracerArgs) {
 				t.Errorf("TracerArgs=%q, want %q", got.AgentTask.TracerArgs, tt.wantTracerArgs)
+			}
+			var privateData profilingJobPrivateData
+			if err := json.Unmarshal(got.PrivateData, &privateData); err != nil {
+				t.Fatalf("json.Unmarshal(PrivateData) error=%v", err)
+			}
+			if !slices.Equal(privateData.CPUIDs, tt.req.CPUIDs) ||
+				privateData.PID != tt.req.PID ||
+				privateData.ThreadGroup != tt.req.ThreadGroup {
+				t.Errorf("PrivateData=%+v, want native target from request", privateData)
 			}
 		})
 	}

--- a/docs/development/profiling_display_evaluation_en.md
+++ b/docs/development/profiling_display_evaluation_en.md
@@ -1,0 +1,133 @@
+---
+title: Continuous Profiling Display Evaluation
+type: docs
+description: Display choices, delivered capabilities, and scaling boundaries
+author: HUATUO Team
+date: 2026-07-25
+weight: 6
+---
+
+## Decision
+
+This document evaluates the display choices requested by
+[Issue #328](https://github.com/ccfos/huatuo/issues/328).
+
+HUATUO delivers two independently usable display paths:
+
+1. **Grafana with the huatuo-apiserver Pyroscope-compatible API** is the
+   integrated online path. It reuses the existing Elasticsearch profile
+   documents and provides time series, Top N, flame graph, and adjacent-window
+   comparison dashboards.
+2. **Standard pprof and standalone interactive SVG export** is the portable
+   path. It uses the same selectors, time range, pagination, and merge logic as
+   Grafana, but does not require Grafana.
+
+The Grafana provisioning also keeps a separate direct-Pyroscope datasource for
+deployments that enable the standalone Pyroscope backend from #327. That
+optional backend is not required by the two paths above.
+
+## Option comparison
+
+| Option | Filtering and aggregation | Views | Scaling model | Operational cost | Result |
+| --- | --- | --- | --- | --- | --- |
+| Grafana and huatuo-apiserver | Exact indexed dimensions, grouped series, and bounded merge/diff queries | Time series, Top 10, flame graph Top table, and comparison | Elasticsearch selection followed by bounded apiserver aggregation | Reuses the existing stack | Delivered |
+| Pyroscope OSS | Native series labels, tag exploration, and group-by | Native flame graph, Top table, comparison, and diff | Profile-native storage with independently scalable components | Adds another store and lifecycle | Optional through #327 |
+| Parca | Profile-native labels and pprof ingestion | Flame graph and label/time comparison | Dedicated profile database and query engine | Requires a new service and ingest path | Evaluated, not deployed |
+| FlameGraph RS | Filtering must occur before rendering | Standalone interactive SVG | Local, on-demand rendering | Low, but not a continuous-profile UI | Experience evaluated; no Rust dependency added |
+
+There is no reproducible benchmark of all four options on the same HUATUO
+dataset and hardware. The table records architecture and verified integration
+boundaries, not an absolute performance ranking.
+
+## Implemented data paths
+
+```text
+profiler -> pprof + managed labels -> Elasticsearch
+                                        |
+Grafana <- Pyroscope-compatible API <- huatuo-apiserver
+                                        |
+                                        +-> pprof download
+                                        +-> interactive SVG
+```
+
+Grafana and the exports use the same profile type, exact label selector, and
+time window. The pprof response remains a gzip-compressed standard protobuf
+accepted by `go tool pprof`. The SVG supports search and zoom in a browser.
+
+When #327 enables direct Pyroscope ingestion, Grafana can also use the
+separately provisioned `huatuo-bamai-pyroscope` datasource. The authenticated
+`huatuo-apiserver-pyroscope` datasource remains available at the same time.
+
+## Multidimensional selection
+
+The collector records managed labels in profile metadata and every pprof
+sample:
+
+| User dimension | Selector |
+| --- | --- |
+| Collection scope | `profiling_scope` |
+| Logical CPU set | `cpu` |
+| Exact process or thread | `pid` |
+| Thread group / process group | `tgid` |
+| Container / cgroup target | `container_id` |
+| Host | `hostname` |
+
+`container_id` is the stable public cgroup selector. HUATUO intentionally does
+not expose host-specific cgroup paths. `tgid` is the common thread-group
+selector and replaces a separate process-group option.
+
+The host and container dashboards expose optional exact
+`profiling_scope`/`cpu`/`pid`/`tgid` variables. Their Top 10 panel can group by
+any managed dimension or tracer. The comparison dashboard forwards the same
+dimensions to both adjacent time windows. An empty dashboard variable omits
+that filter.
+
+The query API accepts equality matchers only. This lets Elasticsearch push down
+every managed dimension and avoids decoding a broad candidate set merely to
+apply a regular expression.
+
+## View coverage
+
+| Capability | Grafana | pprof / SVG |
+| --- | --- | --- |
+| Flame graph | Merged interactive flame graph with Top table | Interactive SVG or any pprof-compatible viewer |
+| Top N | Top 10 grouped series and the flame graph Top table | `go tool pprof -top` |
+| Comparison | Current window versus the immediately preceding equal window | Download two pprof windows for an external diff |
+| Time series | Sum or average profile values in time buckets | A selected-range snapshot |
+
+The document-count panel reports ingestion availability. The profile-value
+timeline reports accumulated profile values; it is not a system CPU-utilization
+metric.
+
+## Scaling boundaries
+
+The online and export paths fail closed instead of silently truncating data:
+
+- A selection may contain at most 10,000 profile documents.
+- Documents are read in stable pages of 1,000.
+- `SelectSeries` returns at most 100 series; dashboards request Top 10.
+- Flame graphs default to 5,000 nodes and reject requests above 10,000 nodes.
+- The comparison JSON adapter and standalone SVG each reject responses above
+  8 MiB.
+- Standalone SVG rendering rejects more than 10,000 distinct stacks.
+- Each high-cardinality dashboard dimension lists at most 500 exact values.
+
+Callers must narrow the time range or selector after a limit error. This keeps
+the UI responsive but does not replace production load testing. Release
+validation should record latency, response size, and apiserver memory against a
+fixed large profile fixture.
+
+## Acceptance verification
+
+The repository tests use labeled pprof fixtures to verify that:
+
+- a `cpu` and `profiling_scope` selector filters stored profiles;
+- `SelectSeries` groups the result by `pid`;
+- the same managed label selects a merged flame graph;
+- adjacent-window comparison forwards every managed dimension;
+- pprof and SVG exports use the bounded common loader; and
+- dashboard contracts contain the dimensions, Top 10, timeline, flame graph,
+  and comparison requests.
+
+Real Grafana rendering still depends on the Grafana, Elasticsearch, and
+huatuo-apiserver services being available in the deployment environment.

--- a/docs/development/profiling_display_evaluation_zh.md
+++ b/docs/development/profiling_display_evaluation_zh.md
@@ -1,0 +1,122 @@
+---
+title: 持续 Profiling 展示方案评估
+type: docs
+description: 展示方案、已交付能力和扩展边界
+author: HUATUO Team
+date: 2026-07-25
+weight: 6
+---
+
+## 结论
+
+本文评估 [Issue #328](https://github.com/ccfos/huatuo/issues/328) 要求的展示
+方案。
+
+HUATUO 提供两个可以独立使用的展示入口：
+
+1. **Grafana + huatuo-apiserver Pyroscope-compatible API** 是集成式在线
+   方案。它复用 Elasticsearch 中现有的 Profile 文档，提供时间序列、Top N、
+   火焰图和相邻时间窗对比。
+2. **标准 pprof 与独立交互式 SVG 导出** 是便携方案。它和 Grafana 共用
+   selector、时间范围、分页和合并逻辑，但不要求部署 Grafana。
+
+Grafana provisioning 同时保留 #327 standalone Pyroscope 后端使用的直连
+datasource。该可选后端不是上述两个入口的依赖。
+
+## 方案对比
+
+| 方案 | 筛选与聚合 | 视图 | 扩展方式 | 运维成本 | 结论 |
+| --- | --- | --- | --- | --- | --- |
+| Grafana + huatuo-apiserver | 精确索引维度、分组时序和有边界的 merge/diff | 时间序列、Top 10、火焰图 Top table、对比 | Elasticsearch 筛选后由 apiserver 有界聚合 | 复用现有组件 | 已交付 |
+| Pyroscope OSS | 原生 series label、标签浏览和 group-by | 原生火焰图、Top table、对比和 diff | Profile 专用存储，可独立扩展组件 | 增加存储和生命周期 | 可通过 #327 启用 |
+| Parca | Profile 原生标签和 pprof 写入 | 火焰图和跨标签/时间比较 | 独立 Profile 数据库和查询引擎 | 需要新增服务和写入路径 | 已评估，未部署 |
+| FlameGraph RS | 必须在渲染前完成筛选 | 独立交互式 SVG | 本地按需渲染 | 较低，但不是持续 Profiling UI | 参考交互体验，不增加 Rust 依赖 |
+
+目前没有在同一 HUATUO 数据集和硬件上对四个方案进行可复现的公开基准测试。
+表格只记录架构和已验证的集成边界，不给出绝对性能排名。
+
+## 已实现数据流
+
+```text
+profiler -> pprof + managed labels -> Elasticsearch
+                                        |
+Grafana <- Pyroscope-compatible API <- huatuo-apiserver
+                                        |
+                                        +-> pprof 下载
+                                        +-> 交互式 SVG
+```
+
+Grafana 和导出接口使用相同的 Profile 类型、精确 label selector 和时间窗。
+pprof 响应是 `go tool pprof` 可读取的 gzip 压缩标准 protobuf；SVG 可直接在
+浏览器中搜索和缩放。
+
+#327 启用直写 Pyroscope 后，Grafana 还可使用独立配置的
+`huatuo-bamai-pyroscope` datasource；带鉴权的
+`huatuo-apiserver-pyroscope` datasource 会同时保留。
+
+## 多维筛选
+
+采集器在 Profile 元数据和每个 pprof sample 中保存以下 managed label：
+
+| 用户维度 | Selector |
+| --- | --- |
+| 采集范围 | `profiling_scope` |
+| 逻辑 CPU 集合 | `cpu` |
+| 精确进程或线程 | `pid` |
+| 线程组 / 进程组 | `tgid` |
+| 容器 / cgroup 目标 | `container_id` |
+| 主机 | `hostname` |
+
+`container_id` 是稳定的公开 cgroup selector，不暴露与宿主机实现绑定的
+cgroup path。`tgid` 复用统一的 thread-group 语义，不再增加单独的
+process-group 参数。
+
+宿主机和容器 dashboard 提供可选的
+`profiling_scope`/`cpu`/`pid`/`tgid` 精确变量，Top 10 面板可按任一 managed
+dimension 或 tracer 分组。对比 dashboard 会把相同维度传给两个相邻时间窗。
+变量为空时不添加该筛选条件。
+
+查询 API 只接受等值 matcher，使 managed dimension 可以全部下推到
+Elasticsearch，避免为正则条件解码大范围候选集。
+
+## 视图覆盖
+
+| 能力 | Grafana | pprof / SVG |
+| --- | --- | --- |
+| 火焰图 | 时间窗合并后的交互式火焰图和 Top table | 交互式 SVG 或任意 pprof 工具 |
+| Top N | Top 10 分组时序和火焰图 Top table | `go tool pprof -top` |
+| 对比 | 当前窗与紧邻的等长前一时间窗 | 下载两个 pprof 时间窗后由外部工具 diff |
+| 时间序列 | 按时间桶求和或平均的 Profile 值 | 单个所选时间窗快照 |
+
+文档计数面板表示写入可用性；Profile 值时间线表示累计 Profile 值，不等同于
+系统 CPU 使用率。
+
+## 海量数据边界
+
+在线查询和导出在超过限制时明确失败，不静默截断：
+
+- 单次最多选择 10,000 份 Profile 文档。
+- 使用每页 1,000 份的稳定分页。
+- `SelectSeries` 最多返回 100 条 series，dashboard 请求 Top 10。
+- 火焰图默认最多 5,000 个节点，拒绝超过 10,000 的请求。
+- 对比 JSON 适配器和独立 SVG 都拒绝超过 8 MiB 的响应。
+- 独立 SVG 拒绝超过 10,000 个不同调用栈。
+- 每个高基数 dashboard 维度最多列出 500 个精确值。
+
+触发限制后需要缩小时间窗或 selector。这些边界用于保持 UI 响应，但不能替代
+生产负载测试。发布验收应使用固定的大型 Profile fixture，记录延迟、响应大小和
+apiserver 内存。
+
+## 验收验证
+
+仓库测试使用带 managed label 的 pprof fixture 验证：
+
+- `cpu` 与 `profiling_scope` selector 能过滤存储数据；
+- `SelectSeries` 可按 `pid` 分组；
+- 同一个 managed label 可选择并生成合并火焰图；
+- 相邻时间窗对比会传递所有 managed dimension；
+- pprof 与 SVG 使用同一个有界加载器；
+- dashboard 合约包含多维筛选、Top 10、时间序列、火焰图和对比请求。
+
+真实 Grafana 渲染仍依赖部署环境中的 Grafana、Elasticsearch 和
+huatuo-apiserver 服务可用。

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -224,7 +224,38 @@ Profiling jobs use these statuses:
 | `failed` | The job failed; inspect `error_message` for the cause |
 | `timeout` | The job exceeded its allowed execution time |
 
-### 6. Get Raw Profiling Data
+### 6. Inspect Profiles in Grafana
+
+Grafana provisioning includes separate host and container continuous profiling
+dashboards. Both dashboards show the number of stored profile snapshots and a
+merged flame graph with a Top table for the selected time range:
+
+- The host dashboard selects an exact `hostname` and excludes container
+  profiles.
+- The container dashboard selects an exact `container_id` and the reporting
+  `hostname`. Container names are not used as identifiers because they are not
+  guaranteed to be unique.
+
+CPU and memory are the only profile types exposed by these dashboards. A
+completed job's `results.url` opens the corresponding dashboard with its
+target, profile type, and collection window preselected.
+
+The Pyroscope datasource sends queries to huatuo-apiserver. If API
+authentication is enabled, configure a dedicated user with
+`POST /v1/profiles/flamegraph/**` permission and pass the same user ID to the
+Grafana container without committing it:
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+The dashboards intentionally use the existing merged-stacktrace API.
+Profile-value timelines, grouped Top-N series, and comparison views require
+Pyroscope-compatible `SelectSeries` and `Diff` endpoints and are not
+provisioned until those endpoints are available.
+
+### 7. Get Raw Profiling Data
 
 `GET /v1/profiles/:id/raw` uses `agent_task_id` to query raw profiling data from storage. The response can be large, so it can be written directly to a file:
 
@@ -239,7 +270,7 @@ The raw records are in `data.data`; `data.limit`, `data.offset`, and
 `data.has_more` describe the page. If the job does not yet have an Agent task
 ID, the endpoint returns `400 Bad Request`.
 
-### 7. Stop a Profiling Job
+### 8. Stop a Profiling Job
 
 Only jobs in `pending` or `running` status can be stopped. The `PATCH` request accepts only `stopped` as the `status` value:
 
@@ -254,7 +285,7 @@ curl -sS \
 
 A successful stop returns `200 OK`. A job that has already ended returns `400 Bad Request`.
 
-### 8. Delete a Profiling Job
+### 9. Delete a Profiling Job
 
 Deletion removes only the job record. Jobs in `pending` or `running` status cannot be deleted directly and must be stopped first:
 

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -229,13 +229,16 @@ Profiling jobs use these statuses:
 Grafana provisioning includes host, container, and comparison continuous
 profiling dashboards. The host and container dashboards show the number of
 stored profile snapshots, total profile value over time, Top 10 series grouped
-by tracer, and a merged flame graph with a Top table:
+by a selected dimension, and a merged flame graph with a Top table:
 
 - The host dashboard selects an exact `hostname` and excludes container
   profiles.
 - The container dashboard queries profiles by exact `container_id` and shows
   the reporting `hostname` for context. Container names are not used as
   identifiers because they are not guaranteed to be unique.
+- Both dashboards can additionally filter exact `profiling_scope`, `cpu`,
+  `pid`, and `tgid` values. The Top 10 panel can group by those dimensions,
+  `container_id`, or tracer.
 
 CPU and memory are the only profile types exposed by these dashboards. A
 completed job's `results.url` opens the corresponding dashboard with its
@@ -255,8 +258,9 @@ The timeline and Top 10 panels use the Pyroscope-compatible `SelectSeries`
 endpoint. The comparison dashboard uses `Diff` through a bounded JSON adapter
 for Grafana's flame graph panel. The selected range is the current window and
 is compared with the immediately preceding window of the same duration. A
-selected `container_id` takes precedence over `hostname`. The adapter defaults
-to 5,000 nodes, rejects values above 10,000, and limits its JSON response to
+selected `container_id` takes precedence over `hostname`. The same optional
+collection dimensions are applied to both windows. The adapter defaults to
+5,000 nodes, rejects values above 10,000, and limits its JSON response to
 8 MiB.
 
 ### 7. Get Raw Profiling Data
@@ -306,7 +310,8 @@ Selectors accept exact `id`, `hostname`, `container_id`,
 least one target or collection-dimension label is required. The service counts
 matching documents before fetching them, reads them in pages, and returns
 `422 Unprocessable Entity` when more than 10,000 documents match. Narrow the
-time range in that case.
+time range in that case. SVG rendering also rejects more than 10,000 distinct
+stacks or an encoded response above 8 MiB.
 
 ### 8. Stop a Profiling Job
 
@@ -344,14 +349,16 @@ returns time buckets using sum or average aggregation. `Diff` compares two
 independent time windows and returns a double flame graph.
 
 Selectors are intentionally exact. They accept `id`, `hostname`,
-`container_id`, `container_hostname`, and `tracer`; the profile type is supplied
-by the protobuf request. Regular expressions, negative matchers, and arbitrary
-labels are rejected with `400 Bad Request`.
+`container_id`, `container_hostname`, `tracer`, `profiling_scope`, `cpu`,
+`pid`, and `tgid`; the profile type is supplied by the protobuf request.
+`SelectSeries` can group by the same managed dimensions. Regular expressions,
+negative matchers, and arbitrary labels are rejected with `400 Bad Request`.
 
 Each selection is counted before profile data is loaded. Up to 10,000 documents
 are read in stable pages of 1,000. A larger selection returns
 `422 Unprocessable Entity` and must be narrowed by time or target. Merge
-requests, and diff requests with neither side populated, return
+and diff flame graphs default to 5,000 nodes and reject values above 10,000.
+Merge requests, and diff requests with neither side populated, return
 `404 Not Found`; storage failures return `500 Internal Server Error`.
 
 ## 📖 profiler CLI Overview

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -226,9 +226,10 @@ Profiling jobs use these statuses:
 
 ### 6. Inspect Profiles in Grafana
 
-Grafana provisioning includes separate host and container continuous profiling
-dashboards. Both dashboards show the number of stored profile snapshots and a
-merged flame graph with a Top table for the selected time range:
+Grafana provisioning includes host, container, and comparison continuous
+profiling dashboards. The host and container dashboards show the number of
+stored profile snapshots, total profile value over time, Top 10 series grouped
+by tracer, and a merged flame graph with a Top table:
 
 - The host dashboard selects an exact `hostname` and excludes container
   profiles.
@@ -250,10 +251,13 @@ export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
 docker compose -f build/docker/docker-compose.yml up -d
 ```
 
-The dashboards intentionally use the existing merged-stacktrace API.
-Profile-value timelines, grouped Top-N series, and comparison views require
-Pyroscope-compatible `SelectSeries` and `Diff` endpoints and are not
-provisioned until those endpoints are available.
+The timeline and Top 10 panels use the Pyroscope-compatible `SelectSeries`
+endpoint. The comparison dashboard uses `Diff` through a bounded JSON adapter
+for Grafana's flame graph panel. The selected range is the current window and
+is compared with the immediately preceding window of the same duration. A
+selected `container_id` takes precedence over `hostname`. The adapter defaults
+to 5,000 nodes, rejects values above 10,000, and limits its JSON response to
+8 MiB.
 
 ### 7. Get Raw Profiling Data
 
@@ -298,7 +302,7 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
-### 9. Pyroscope-compatible Queries
+### 10. Pyroscope-compatible Queries
 
 The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
 methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -401,6 +401,23 @@ sudo _output/bin/profiler \
   --output-format flamegraph --output-path ./profiles/host
 ```
 
+Remote profiles preserve their collection selectors as both profile metadata
+and pprof sample labels. This keeps the dimensions available to
+Pyroscope-compatible label queries and Parca-compatible pprof readers:
+
+| Label | Value |
+| --- | --- |
+| `profiling_scope` | `host`, `container`, `pid`, or `thread_group` |
+| `pid` | Exact PID target, or comma-separated external-profiler targets |
+| `tgid` | Thread-group target used with `--thread-group` |
+| `container_id` | Target supplied through the common container selector |
+| `cpu` | Comma-separated CPU IDs selected with `--cpuid` |
+
+The Pyroscope-compatible API accepts equality matchers for these labels and
+returns their values through the label-values endpoint. A label describes the
+collection filter; it does not replace the per-process frames already present
+in a profile.
+
 Native memory profiling supports these dimensions:
 
 | `--memory-mode` | Measurement | Suitable for |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -232,9 +232,9 @@ merged flame graph with a Top table for the selected time range:
 
 - The host dashboard selects an exact `hostname` and excludes container
   profiles.
-- The container dashboard selects an exact `container_id` and the reporting
-  `hostname`. Container names are not used as identifiers because they are not
-  guaranteed to be unique.
+- The container dashboard queries profiles by exact `container_id` and shows
+  the reporting `hostname` for context. Container names are not used as
+  identifiers because they are not guaranteed to be unique.
 
 CPU and memory are the only profile types exposed by these dashboards. A
 completed job's `results.url` opens the corresponding dashboard with its

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -267,6 +267,24 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
+### 9. Pyroscope-compatible Queries
+
+The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
+methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`
+returns time buckets using sum or average aggregation. `Diff` compares two
+independent time windows and returns a double flame graph.
+
+Selectors are intentionally exact. They accept `id`, `hostname`,
+`container_id`, `container_hostname`, and `tracer`; the profile type is supplied
+by the protobuf request. Regular expressions, negative matchers, and arbitrary
+labels are rejected with `400 Bad Request`.
+
+Each selection is counted before profile data is loaded. Up to 10,000 documents
+are read in stable pages of 1,000. A larger selection returns
+`422 Unprocessable Entity` and must be narrowed by time or target. Merge
+requests, and diff requests with neither side populated, return
+`404 Not Found`; storage failures return `500 Internal Server Error`.
+
 ## 📖 profiler CLI Overview
 
 `profiler` is HUATUO's standalone performance profiling CLI. It samples host processes or processes inside containers without requiring huatuo-apiserver, Elasticsearch, or Grafana. The tool supports C, C++, Go, Java, and Python processes and writes call stacks as folded stacks or SVG flame graphs.

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -88,12 +88,19 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `duration` | Yes | Profiling duration in seconds |
 | `hostname` | Yes | Hostname of the node running the target process; used for job scheduling |
 | `container_id` | No | Target container ID; omit it to profile the host |
+| `pid` | No | Exact target PID for native profiling; mutually exclusive with `container_id` |
+| `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` |
+| `cpu_ids` | No | CPU IDs selected for native CPU profiling |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
 
-Create a Go CPU profiling job on a host:
+Native CPU profiling can omit both `pid` and `container_id` to sample the
+host. Native memory profiling requires exactly one of them. Without
+`thread_group`, `pid` keeps its exact-thread meaning.
+
+Create a Go CPU profiling job for a thread group on selected CPUs:
 
 ```bash
 curl -sS -i \
@@ -104,6 +111,9 @@ curl -sS -i \
     "type": "cpu",
     "language": "go",
     "duration": 60,
+    "pid": 4242,
+    "thread_group": true,
+    "cpu_ids": [1, 3],
     "hostname": "node-01"
   }' \
   "${API_BASE}/v1/profiles"
@@ -193,6 +203,9 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
+| `pid` | Exact native target PID; empty for container or host-wide jobs |
+| `thread_group` | Whether native profiling includes the PID's thread group |
+| `cpu_ids` | CPU IDs selected for native CPU profiling |
 | `status` | Current job status |
 | `start_time`, `end_time` | Job start and end times; empty until available |
 | `tracer_args` | Command-line arguments sent by huatuo-apiserver to profiler |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -274,6 +274,40 @@ The raw records are in `data.data`; `data.limit`, `data.offset`, and
 `data.has_more` describe the page. If the job does not yet have an Agent task
 ID, the endpoint returns `400 Bad Request`.
 
+#### Export merged pprof or SVG
+
+The export endpoints merge the stored snapshots selected by profile type, time
+range, and an exact target label:
+
+```bash
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o profile.pb.gz \
+  "${API_BASE}/v1/profiles/flamegraph/export/pprof"
+
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o flamegraph.svg \
+  "${API_BASE}/v1/profiles/flamegraph/export/svg"
+```
+
+Selectors accept exact `id`, `hostname`, `container_id`,
+`container_hostname`, `profiling_scope`, `cpu`, `pid`, or `tgid` matches. At
+least one target or collection-dimension label is required. The service counts
+matching documents before fetching them, reads them in pages, and returns
+`422 Unprocessable Entity` when more than 10,000 documents match. Narrow the
+time range in that case.
+
 ### 8. Stop a Profiling Job
 
 Only jobs in `pending` or `running` status can be stopped. The `PATCH` request accepts only `stopped` as the `status` value:

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -397,6 +397,20 @@ sudo _output/bin/profiler \
   --output-format flamegraph --output-path ./profiles/host
 ```
 
+远端 profile 会同时在 profile 元数据和每个 pprof sample 中保留采集选择器，
+因此 Pyroscope 兼容的序列查询和 Parca 兼容的 pprof 读取器都可以使用这些维度：
+
+| 标签 | 取值 |
+| --- | --- |
+| `profiling_scope` | `host`、`container`、`pid` 或 `thread_group` |
+| `pid` | 精确 PID；外部 profiler 多目标时为逗号分隔的 PID 列表 |
+| `tgid` | 使用 `--thread-group` 时的线程组目标 |
+| `container_id` | 通过统一容器选择器指定的容器 ID |
+| `cpu` | `--cpuid` 选择的逗号分隔 CPU ID |
+
+Pyroscope 兼容 API 支持这些标签的等值匹配，并通过 label-values 接口返回聚合值。
+标签描述采集过滤条件，不会替代 profile 中已有的进程帧。
+
 原生内存支持以下维度：
 
 | `--memory-mode` | 统计内容 | 适用问题 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -263,6 +263,23 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
+### 9. Pyroscope 兼容查询
+
+Profiling API 在
+`/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的
+`SelectSeries` 和 `Diff` protobuf 方法。`SelectSeries` 按时间桶返回求和或
+平均聚合结果；`Diff` 比较两个独立时间窗口并返回双向火焰图。
+
+选择器只支持精确匹配，可使用 `id`、`hostname`、`container_id`、
+`container_hostname` 和 `tracer`；剖析类型由 protobuf 请求单独提供。
+正则、否定匹配和任意标签会返回 `400 Bad Request`。
+
+服务读取剖析数据前会先统计匹配文档数。单次选择最多读取 10,000 条，
+每页 1,000 条并使用稳定排序。超过上限时返回
+`422 Unprocessable Entity`，调用方需要缩小时间范围或目标范围。合并查询
+没有数据，或差异查询两侧都没有数据时返回 `404 Not Found`；存储故障返回
+`500 Internal Server Error`。
+
 ## 📖 profiler 命令行功能概述
 
 `profiler` 是 HUATUO 提供的独立性能剖析命令行工具。它可以直接对宿主机进程或容器内进程采样，不依赖 huatuo-apiserver、Elasticsearch 或 Grafana。工具支持 C、C++、Go、Java 和 Python 进程，并将调用栈输出为折叠栈或 SVG 火焰图。

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -222,9 +222,9 @@ curl -sS \
 
 ### 6. 在 Grafana 中查看剖析结果
 
-Grafana provisioning 提供独立的宿主机和容器持续剖析 dashboard。两张
-dashboard 都展示选定时间范围内写入的剖析快照数量，以及合并后的火焰图
-和 Top 表：
+Grafana provisioning 提供宿主机、容器和时间窗口对比三张持续剖析
+dashboard。宿主机和容器 dashboard 展示剖析快照数量、剖析值时间线、
+按 tracer 分组的 Top 10 序列，以及合并后的火焰图和 Top 表：
 
 - 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
 - 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
@@ -242,9 +242,11 @@ export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
 docker compose -f build/docker/docker-compose.yml up -d
 ```
 
-当前 dashboard 只依赖已有的合并栈查询接口。剖析值时间线、按维度分组的
-Top-N 序列和对比视图依赖兼容 Pyroscope 的 `SelectSeries`、`Diff` 接口，
-在这些接口可用前不进行 provisioning。
+时间线和 Top 10 面板使用 Pyroscope 兼容的 `SelectSeries` 接口。对比
+dashboard 通过有边界限制的 JSON 适配器调用 `Diff`，并把结果交给 Grafana
+火焰图面板。选定时间范围是当前窗口，对比对象是紧邻其前、长度相同的窗口；
+选择 `container_id` 时优先于 `hostname`。适配器默认最多返回 5,000 个
+节点，拒绝超过 10,000 的配置，并将 JSON 响应限制为 8 MiB。
 
 ### 7. 获取原始剖析数据
 
@@ -289,7 +291,7 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
-### 9. Pyroscope 兼容查询
+### 10. Pyroscope 兼容查询
 
 Profiling API 在
 `/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -224,11 +224,13 @@ curl -sS \
 
 Grafana provisioning 提供宿主机、容器和时间窗口对比三张持续剖析
 dashboard。宿主机和容器 dashboard 展示剖析快照数量、剖析值时间线、
-按 tracer 分组的 Top 10 序列，以及合并后的火焰图和 Top 表：
+按所选维度分组的 Top 10 序列，以及合并后的火焰图和 Top 表：
 
 - 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
 - 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
   `hostname` 作为上下文。容器名不保证唯一，因此不作为容器标识。
+- 两张 dashboard 都可继续按精确的 `profiling_scope`、`cpu`、`pid` 和
+  `tgid` 筛选。Top 10 可按这些维度、`container_id` 或 tracer 分组。
 
 dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
 `results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。
@@ -245,8 +247,9 @@ docker compose -f build/docker/docker-compose.yml up -d
 时间线和 Top 10 面板使用 Pyroscope 兼容的 `SelectSeries` 接口。对比
 dashboard 通过有边界限制的 JSON 适配器调用 `Diff`，并把结果交给 Grafana
 火焰图面板。选定时间范围是当前窗口，对比对象是紧邻其前、长度相同的窗口；
-选择 `container_id` 时优先于 `hostname`。适配器默认最多返回 5,000 个
-节点，拒绝超过 10,000 的配置，并将 JSON 响应限制为 8 MiB。
+选择 `container_id` 时优先于 `hostname`，并把相同的可选采集维度应用到
+两侧时间窗。适配器默认最多返回 5,000 个节点，拒绝超过 10,000 的配置，
+并将 JSON 响应限制为 8 MiB。
 
 ### 7. 获取原始剖析数据
 
@@ -293,7 +296,8 @@ curl -sS --get \
 `container_hostname`、`profiling_scope`、`cpu`、`pid` 或 `tgid`
 匹配，并且至少需要一个目标或采集维度标签。服务会先统计匹配文档数，再分页
 读取。匹配超过 10,000 个文档时返回 `422 Unprocessable Entity`，此时需要
-缩小时间范围。
+缩小时间范围。SVG 渲染还会拒绝超过 10,000 个不同调用栈或编码后超过
+8 MiB 的响应。
 
 ### 8. 停止任务
 
@@ -331,13 +335,16 @@ Profiling API 在
 平均聚合结果；`Diff` 比较两个独立时间窗口并返回双向火焰图。
 
 选择器只支持精确匹配，可使用 `id`、`hostname`、`container_id`、
-`container_hostname` 和 `tracer`；剖析类型由 protobuf 请求单独提供。
-正则、否定匹配和任意标签会返回 `400 Bad Request`。
+`container_hostname`、`tracer`、`profiling_scope`、`cpu`、`pid` 和
+`tgid`；剖析类型由 protobuf 请求单独提供。`SelectSeries` 可按相同的
+managed dimension 分组。正则、否定匹配和任意标签会返回
+`400 Bad Request`。
 
 服务读取剖析数据前会先统计匹配文档数。单次选择最多读取 10,000 条，
 每页 1,000 条并使用稳定排序。超过上限时返回
-`422 Unprocessable Entity`，调用方需要缩小时间范围或目标范围。合并查询
-没有数据，或差异查询两侧都没有数据时返回 `404 Not Found`；存储故障返回
+`422 Unprocessable Entity`，调用方需要缩小时间范围或目标范围。Merge 和
+Diff 火焰图默认 5,000 个节点，并拒绝超过 10,000 的配置。合并查询没有
+数据，或差异查询两侧都没有数据时返回 `404 Not Found`；存储故障返回
 `500 Internal Server Error`。
 
 ## 📖 profiler 命令行功能概述

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -220,7 +220,33 @@ curl -sS \
 | `failed` | 任务执行失败，查看 `error_message` 定位原因 |
 | `timeout` | 任务超过允许的执行时间 |
 
-### 6. 获取原始剖析数据
+### 6. 在 Grafana 中查看剖析结果
+
+Grafana provisioning 提供独立的宿主机和容器持续剖析 dashboard。两张
+dashboard 都展示选定时间范围内写入的剖析快照数量，以及合并后的火焰图
+和 Top 表：
+
+- 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
+- 容器 dashboard 按 `container_id` 和上报节点 `hostname` 精确筛选。容器名
+  不保证唯一，因此不作为容器标识。
+
+dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
+`results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。
+
+Pyroscope datasource 通过 huatuo-apiserver 查询数据。启用 API 鉴权时，
+应创建只拥有 `POST /v1/profiles/flamegraph/**` 权限的专用用户，并通过
+环境变量将同一个用户 ID 传给 Grafana，不要把它提交到仓库：
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+当前 dashboard 只依赖已有的合并栈查询接口。剖析值时间线、按维度分组的
+Top-N 序列和对比视图依赖兼容 Pyroscope 的 `SelectSeries`、`Diff` 接口，
+在这些接口可用前不进行 provisioning。
+
+### 7. 获取原始剖析数据
 
 `GET /v1/profiles/:id/raw` 根据 `agent_task_id` 查询存储中的原始剖析数据。数据量可能较大，可以直接保存到文件：
 
@@ -235,7 +261,7 @@ curl -sS \
 和 `data.has_more` 描述分页。任务尚未分配 Agent 任务 ID 时，接口返回
 `400 Bad Request`。
 
-### 7. 停止任务
+### 8. 停止任务
 
 只有 `pending` 或 `running` 状态的任务可以停止。`PATCH` 请求的 `status` 只接受 `stopped`：
 
@@ -250,7 +276,7 @@ curl -sS \
 
 停止成功返回 `200 OK`。已结束的任务返回 `400 Bad Request`。
 
-### 8. 删除任务
+### 9. 删除任务
 
 删除操作只移除任务记录。`pending` 或 `running` 状态的任务不能直接删除，需要先停止任务：
 

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -86,12 +86,17 @@ curl -sS \
 | `duration` | 是 | 采集时长，单位为秒 |
 | `hostname` | 是 | 运行目标进程的节点主机名，用于任务调度 |
 | `container_id` | 否 | 目标容器 ID；不传表示对宿主机剖析 |
+| `pid` | 否 | 原生剖析的精确目标 PID；不能与 `container_id` 同时使用 |
+| `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须同时指定 `pid` |
+| `cpu_ids` | 否 | 原生 CPU 剖析限定的 CPU ID |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
 
-创建宿主机 Go CPU 剖析任务：
+原生 CPU 剖析可以同时省略 `pid` 和 `container_id`，对整个宿主机采样。原生内存剖析必须指定其中一个。未启用 `thread_group` 时，`pid` 保持精确线程语义。
+
+创建限定 CPU 的 Go 线程组剖析任务：
 
 ```bash
 curl -sS -i \
@@ -102,6 +107,9 @@ curl -sS -i \
     "type": "cpu",
     "language": "go",
     "duration": 60,
+    "pid": 4242,
+    "thread_group": true,
+    "cpu_ids": [1, 3],
     "hostname": "node-01"
   }' \
   "${API_BASE}/v1/profiles"
@@ -191,6 +199,9 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
+| `pid` | 原生剖析的精确目标 PID；容器任务或宿主机级任务为空 |
+| `thread_group` | 是否采集该 PID 所在线程组 |
+| `cpu_ids` | 原生 CPU 剖析限定的 CPU ID |
 | `status` | 当前任务状态 |
 | `start_time`、`end_time` | 任务开始和结束时间；尚未产生时为空 |
 | `tracer_args` | huatuo-apiserver 实际下发给 profiler 的命令行参数 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -263,6 +263,38 @@ curl -sS \
 和 `data.has_more` 描述分页。任务尚未分配 Agent 任务 ID 时，接口返回
 `400 Bad Request`。
 
+#### 导出合并后的 pprof 或 SVG
+
+导出接口根据剖析类型、时间范围和精确目标标签合并存储中的快照：
+
+```bash
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o profile.pb.gz \
+  "${API_BASE}/v1/profiles/flamegraph/export/pprof"
+
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o flamegraph.svg \
+  "${API_BASE}/v1/profiles/flamegraph/export/svg"
+```
+
+选择器接受精确的 `id`、`hostname`、`container_id`、
+`container_hostname`、`profiling_scope`、`cpu`、`pid` 或 `tgid`
+匹配，并且至少需要一个目标或采集维度标签。服务会先统计匹配文档数，再分页
+读取。匹配超过 10,000 个文档时返回 `422 Unprocessable Entity`，此时需要
+缩小时间范围。
+
 ### 8. 停止任务
 
 只有 `pending` 或 `running` 状态的任务可以停止。`PATCH` 请求的 `status` 只接受 `stopped`：

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -227,8 +227,8 @@ dashboard 都展示选定时间范围内写入的剖析快照数量，以及合�
 和 Top 表：
 
 - 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
-- 容器 dashboard 按 `container_id` 和上报节点 `hostname` 精确筛选。容器名
-  不保证唯一，因此不作为容器标识。
+- 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
+  `hostname` 作为上下文。容器名不保证唯一，因此不作为容器标识。
 
 dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
 `results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -33,9 +33,9 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 		return fmt.Errorf("toolstream client not initialized")
 	}
 
-	flameData, ok := data.(*profiler.ProfileData)
-	if !ok {
-		return fmt.Errorf("invalid pprof data for uploading: %T", data)
+	flameData, err := applyCollectionDimensionLabels(p.pctx, data)
+	if err != nil {
+		return err
 	}
 
 	tracerData := &profctx.TracerData{
@@ -60,4 +60,22 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	log.WithField("tracer_id", p.tracerID).Infof("profiling event sent via toolstream")
 
 	return nil
+}
+
+func applyCollectionDimensionLabels(
+	pctx *profctx.ProfilerContext,
+	data any,
+) (*profiler.ProfileData, error) {
+	flameData, ok := data.(*profiler.ProfileData)
+	if !ok {
+		return nil, fmt.Errorf("invalid pprof data for uploading: %T", data)
+	}
+	if err := profiler.ApplyLabels(
+		flameData,
+		pctx.CollectionDimensionLabels(),
+	); err != nil {
+		return nil, fmt.Errorf("apply collection dimension labels: %w", err)
+	}
+
+	return flameData, nil
 }

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+)
+
+func TestApplyCollectionDimensionLabelsUsesProfilerContext(t *testing.T) {
+	data, err := profiler.ParseTree(
+		time.Unix(1, 0),
+		profiler.ProfileTypeCpuSample,
+		[]*profiler.TreeItem{{Stack: [][]byte{[]byte("work")}, Value: 1}},
+		&profiler.ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	got, err := applyCollectionDimensionLabels(&profctx.ProfilerContext{
+		PIDs:        []int{42},
+		ThreadGroup: true,
+	}, data)
+	if err != nil {
+		t.Fatalf("applyCollectionDimensionLabels() error = %v", err)
+	}
+	if got.Labels[profiler.LabelProfilingScope] != "thread_group" {
+		t.Fatalf("profiling_scope = %q, want thread_group", got.Labels[profiler.LabelProfilingScope])
+	}
+	if got.Labels[profiler.LabelTGID] != "42" {
+		t.Fatalf("tgid = %q, want 42", got.Labels[profiler.LabelTGID])
+	}
+	if len(got.Profile.Sample) != 1 ||
+		len(got.Profile.Sample[0].Label) != len(got.Labels) {
+		t.Fatalf("sample labels = %#v, profile labels = %#v", got.Profile.Sample, got.Labels)
+	}
+}

--- a/internal/profiler/context/labels.go
+++ b/internal/profiler/context/labels.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+const (
+	profilingScopeHost        = "host"
+	profilingScopeContainer   = "container"
+	profilingScopePID         = "pid"
+	profilingScopeThreadGroup = "thread_group"
+)
+
+// CollectionDimensionLabels describes the filters that produced a profile.
+func (pctx *ProfilerContext) CollectionDimensionLabels() map[string]string {
+	if pctx == nil {
+		return nil
+	}
+
+	labels := map[string]string{
+		profiler.LabelProfilingScope: profilingScopeHost,
+	}
+	if pctx.ContainerID != "" {
+		labels[profiler.LabelProfilingScope] = profilingScopeContainer
+		labels[profiler.LabelContainerID] = pctx.ContainerID
+	} else if len(pctx.PIDs) > 0 {
+		label := profiler.LabelPID
+		labels[profiler.LabelProfilingScope] = profilingScopePID
+		if pctx.ThreadGroup {
+			label = profiler.LabelTGID
+			labels[profiler.LabelProfilingScope] = profilingScopeThreadGroup
+		}
+		labels[label] = formatDimensionInts(pctx.PIDs)
+	}
+	if len(pctx.CPUIDs) > 0 {
+		labels[profiler.LabelCPU] = formatDimensionInts(pctx.CPUIDs)
+	}
+
+	return labels
+}
+
+func formatDimensionInts(values []int) string {
+	values = append([]int(nil), values...)
+	sort.Ints(values)
+
+	var result strings.Builder
+	for i, value := range values {
+		if i > 0 {
+			result.WriteByte(',')
+		}
+		result.WriteString(strconv.Itoa(value))
+	}
+	return result.String()
+}

--- a/internal/profiler/context/labels_test.go
+++ b/internal/profiler/context/labels_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"reflect"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+func TestCollectionDimensionLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		pctx *ProfilerContext
+		want map[string]string
+	}{
+		{
+			name: "host",
+			pctx: &ProfilerContext{},
+			want: map[string]string{profiler.LabelProfilingScope: profilingScopeHost},
+		},
+		{
+			name: "exact pid and CPUs",
+			pctx: &ProfilerContext{PIDs: []int{42}, CPUIDs: []int{3, 1}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42",
+				profiler.LabelCPU:            "1,3",
+			},
+		},
+		{
+			name: "thread group",
+			pctx: &ProfilerContext{PIDs: []int{42}, ThreadGroup: true},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeThreadGroup,
+				profiler.LabelTGID:           "42",
+			},
+		},
+		{
+			name: "container",
+			pctx: &ProfilerContext{ContainerID: "containerd://abc"},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeContainer,
+				profiler.LabelContainerID:    "containerd://abc",
+			},
+		},
+		{
+			name: "multiple external profiler targets",
+			pctx: &ProfilerContext{PIDs: []int{42, 99}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42,99",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.pctx.CollectionDimensionLabels(); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("CollectionDimensionLabels() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var (
+	collectionDimensionLabels = [...]string{
+		LabelProfilingScope,
+		LabelCPU,
+		LabelPID,
+		LabelTGID,
+		LabelContainerID,
+	}
+	labelNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+// CollectionDimensionLabelNames returns labels managed by collection filters.
+func CollectionDimensionLabelNames() []string {
+	labels := make([]string, len(collectionDimensionLabels))
+	copy(labels, collectionDimensionLabels[:])
+	return labels
+}
+
+// IsCollectionDimensionLabel reports whether name is managed by the profiler.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}
+
+// ApplyLabels injects profile-wide string labels into every pprof sample.
+func ApplyLabels(data *ProfileData, labels map[string]string) error {
+	if data == nil || len(labels) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		if value == "" {
+			continue
+		}
+		if !labelNamePattern.MatchString(key) {
+			return fmt.Errorf("invalid profiling label name %q", key)
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	sort.Strings(keys)
+
+	if len(data.Profile.StringTable) == 0 {
+		data.Profile.StringTable = append(data.Profile.StringTable, "")
+	} else if data.Profile.StringTable[0] != "" {
+		return fmt.Errorf("invalid pprof string table: first entry must be empty")
+	}
+
+	if data.Labels == nil {
+		data.Labels = make(map[string]string, len(keys))
+	}
+	for _, key := range keys {
+		data.Labels[key] = labels[key]
+	}
+
+	stringIndexes := make(map[string]int64, len(data.Profile.StringTable)+len(keys)*2)
+	for i, value := range data.Profile.StringTable {
+		stringIndexes[value] = int64(i)
+	}
+	stringIndex := func(value string) int64 {
+		if index, ok := stringIndexes[value]; ok {
+			return index
+		}
+		index := int64(len(data.Profile.StringTable))
+		data.Profile.StringTable = append(data.Profile.StringTable, value)
+		stringIndexes[value] = index
+		return index
+	}
+
+	keyNames := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keyNames[key] = struct{}{}
+		stringIndex(key)
+	}
+	keyIndexes := make(map[int64]struct{}, len(keys))
+	for index, value := range data.Profile.StringTable {
+		if _, replaced := keyNames[value]; replaced {
+			keyIndexes[int64(index)] = struct{}{}
+		}
+	}
+
+	for _, sample := range data.Profile.Sample {
+		if sample == nil {
+			continue
+		}
+
+		kept := sample.Label[:0]
+		for _, label := range sample.Label {
+			if label == nil {
+				continue
+			}
+			if _, replaced := keyIndexes[label.Key]; !replaced {
+				kept = append(kept, label)
+			}
+		}
+		sample.Label = kept
+		for _, key := range keys {
+			sample.Label = append(sample.Label, &ptree.Label{
+				Key: stringIndex(key),
+				Str: stringIndex(labels[key]),
+			})
+		}
+		sort.Slice(sample.Label, func(i, j int) bool {
+			if sample.Label[i].Key != sample.Label[j].Key {
+				return sample.Label[i].Key < sample.Label[j].Key
+			}
+			return sample.Label[i].Str < sample.Label[j].Str
+		})
+	}
+
+	return nil
+}

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestApplyLabelsInjectsAndReplacesPprofLabels(t *testing.T) {
+	data, err := ParseTree(time.Unix(1, 0), ProfileTypeCpuSample, []*TreeItem{
+		{
+			Stack: [][]byte{[]byte("process"), []byte("work")},
+			Value: 1,
+		},
+		{
+			Stack: [][]byte{[]byte("process"), []byte("wait")},
+			Value: 2,
+		},
+	}, &ParseOption{SampleRate: 99})
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	if err := ApplyLabels(data, map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "4242",
+	}); err != nil {
+		t.Fatalf("ApplyLabels() error = %v", err)
+	}
+	if err := ApplyLabels(data, map[string]string{LabelTGID: "5252"}); err != nil {
+		t.Fatalf("ApplyLabels() replacement error = %v", err)
+	}
+
+	if got, want := data.Labels, map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "5252",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("profile labels = %#v, want %#v", got, want)
+	}
+	if len(data.Profile.Sample) != 2 {
+		t.Fatalf("samples = %d, want 2", len(data.Profile.Sample))
+	}
+
+	for _, sample := range data.Profile.Sample {
+		resolved := make(map[string]string)
+		for _, label := range sample.Label {
+			resolved[data.Profile.StringTable[label.Key]] = data.Profile.StringTable[label.Str]
+		}
+		if !reflect.DeepEqual(resolved, data.Labels) {
+			t.Fatalf("pprof labels = %#v, want %#v", resolved, data.Labels)
+		}
+		if got := len(sample.Label); got != len(resolved) {
+			t.Fatalf("pprof label entries = %d, unique labels = %d", got, len(resolved))
+		}
+	}
+}
+
+func TestApplyLabelsValidatesBeforeMutation(t *testing.T) {
+	data := &ProfileData{}
+	err := ApplyLabels(data, map[string]string{
+		LabelPID:   "42",
+		"bad-name": "value",
+	})
+	if err == nil {
+		t.Fatal("ApplyLabels() error = nil, want invalid label error")
+	}
+	if data.Labels != nil || len(data.Profile.StringTable) != 0 {
+		t.Fatalf("profile mutated after validation error: %#v", data)
+	}
+}
+
+func TestApplyLabelsRejectsMalformedStringTable(t *testing.T) {
+	data := &ProfileData{}
+	data.Profile.StringTable = []string{"not-empty"}
+
+	err := ApplyLabels(data, map[string]string{LabelPID: "42"})
+	if err == nil {
+		t.Fatal("ApplyLabels() error = nil, want malformed string table error")
+	}
+	if data.Labels != nil || len(data.Profile.StringTable) != 1 {
+		t.Fatalf("profile mutated after string table error: %#v", data)
+	}
+}
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	labels := CollectionDimensionLabelNames()
+	labels[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}

--- a/internal/profiler/output/flamegraph/render.go
+++ b/internal/profiler/output/flamegraph/render.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"strings"
 )
 
 type frame struct {
@@ -157,9 +156,12 @@ func (r *renderer) drawFrame(f frame, ew *errWriter) {
 	x := r.style.XMargin + (f.LeftPercent / 100 * usableWidth)
 	y := r.style.FramesYOffset + (r.maxFrameDepth-f.Depth-1)*r.style.FrameHeight
 
-	jsTitle := strings.ReplaceAll(html.EscapeString(title), "'", "&#39;")
+	// Keep symbol data out of JavaScript source. XML entities are decoded
+	// before event handlers run, so escaping a quote inside s('...') would not
+	// prevent a crafted symbol from terminating that string.
+	attributeTitle := html.EscapeString(title)
 
-	ew.printf(`<g class="func_g" onmouseover="s('%s')" onmouseout="c()" onclick="zoom(this)">`+"\n", jsTitle)
+	ew.printf(`<g class="func_g" data-title="%s" onmouseover="s(this.getAttribute('data-title'))" onmouseout="c()" onclick="zoom(this)">`+"\n", attributeTitle)
 	ew.printf("  <title>%s</title>\n", html.EscapeString(title))
 	ew.printf(`  <rect x="%.1f" y="%d" width="%.1f" height="%d" fill="%s" rx="2" ry="2"/>`+"\n",
 		x, y, w, h, color)

--- a/internal/profiler/output/flamegraph/render_test.go
+++ b/internal/profiler/output/flamegraph/render_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderStyleKeepsSymbolsOutOfJavaScript(t *testing.T) {
+	symbol := `');alert(1);//<script>alert(2)</script>`
+	var output bytes.Buffer
+	if err := RenderStyle([]Stack{{
+		Names:   []string{"root", symbol},
+		Samples: 1,
+	}}, &output, DefaultStyle); err != nil {
+		t.Fatalf("RenderStyle() error = %v", err)
+	}
+
+	content := output.String()
+	if strings.Contains(content, `onmouseover="s('`) ||
+		strings.Contains(content, "<script>alert(2)</script>") {
+		t.Fatalf("SVG embeds an untrusted symbol as executable markup: %s", content)
+	}
+	if !strings.Contains(content, `data-title="`) ||
+		!strings.Contains(content, "&lt;script&gt;alert(2)&lt;/script&gt;") {
+		t.Fatalf("SVG does not preserve the escaped symbol as data: %s", content)
+	}
+}

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 
+	"huatuo-bamai/internal/profiler"
+
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
@@ -33,6 +35,8 @@ const (
 	profileQueryLimit    = 10000
 	profileQueryPageSize = 1000
 	profileSeriesLimit   = 100
+	defaultProfileNodes  = 5000
+	profileNodeLimit     = 10000
 )
 
 type profileSelection struct {
@@ -78,7 +82,8 @@ func buildProfileSelection(profileType, selector string, start, end int64) (*pro
 	}
 	if !hasExactProfileTarget(filter) {
 		return nil, invalidProfileQueryf(
-			"id, hostname, container_id, container_hostname, or tracer must be specified",
+			"id, hostname, container_id, container_hostname, tracer, or a " +
+				"collection dimension must be specified",
 		)
 	}
 	return &profileSelection{filter: filter, sampleType: profileTypeParts[1]}, nil
@@ -89,12 +94,22 @@ func invalidProfileQueryf(format string, args ...any) error {
 }
 
 func hasExactProfileTarget(filter *SearchFilter) bool {
-	return filter != nil &&
-		(filter.ID != "" ||
-			filter.Hostname != "" ||
-			filter.ContainerID != "" ||
-			filter.ContainerHostname != "" ||
-			filter.TracerID != "")
+	if filter == nil {
+		return false
+	}
+	if filter.ID != "" ||
+		filter.Hostname != "" ||
+		filter.ContainerID != "" ||
+		filter.ContainerHostname != "" ||
+		filter.TracerID != "" {
+		return true
+	}
+	for _, value := range filter.Labels {
+		if value != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Service) searchProfileDocuments(
@@ -289,6 +304,10 @@ func (s *Service) Diff(
 	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
 		return nil, invalidProfileQueryf("left and right profile types must match")
 	}
+	maxNodes, err := diffMaxNodes(req)
+	if err != nil {
+		return nil, err
+	}
 	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
 	if err != nil {
 		return nil, fmt.Errorf("select left profiles: %w", err)
@@ -300,24 +319,41 @@ func (s *Service) Diff(
 	if !leftFound && !rightFound {
 		return nil, ErrProfilesAbsent
 	}
-	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, diffMaxNodes(req))
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, maxNodes)
 	if err != nil {
 		return nil, fmt.Errorf("build flamegraph diff: %w", err)
 	}
 	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
 }
 
-func diffMaxNodes(req *querierv1.DiffRequest) int64 {
-	left := req.Left.GetMaxNodes()
-	right := req.Right.GetMaxNodes()
-	switch {
-	case left > 0 && right > 0 && right < left:
-		return right
-	case left > 0:
-		return left
-	default:
-		return right
+func diffMaxNodes(req *querierv1.DiffRequest) (int64, error) {
+	left, err := normalizeProfileMaxNodes(req.Left.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("left selection: %w", err)
 	}
+	right, err := normalizeProfileMaxNodes(req.Right.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("right selection: %w", err)
+	}
+	switch {
+	case right < left:
+		return right, nil
+	default:
+		return left, nil
+	}
+}
+
+func normalizeProfileMaxNodes(maxNodes int64) (int64, error) {
+	if maxNodes == 0 {
+		return defaultProfileNodes, nil
+	}
+	if maxNodes < 0 || maxNodes > profileNodeLimit {
+		return 0, invalidProfileQueryf(
+			"max nodes must be between 0 and %d",
+			profileNodeLimit,
+		)
+	}
+	return maxNodes, nil
 }
 
 // SelectSeries returns sample totals bucketed by time and exact profile labels.
@@ -460,7 +496,9 @@ func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
 		switch name {
 		case "id", "hostname", "container_id", "container_hostname", "tracer":
 		default:
-			return nil, invalidProfileQueryf("invalid group-by label %q", name)
+			if !profiler.IsCollectionDimensionLabel(name) {
+				return nil, invalidProfileQueryf("invalid group-by label %q", name)
+			}
 		}
 		if _, ok := seen[name]; ok {
 			continue
@@ -518,6 +556,9 @@ func profileDocumentLabelValue(document *ProfileDocument, name string) string {
 	case "container_hostname":
 		return document.ContainerHostname
 	default:
+		if profiler.IsCollectionDimensionLabel(name) {
+			return document.TracerData.Flamedata.Labels[name]
+		}
 		return ""
 	}
 }

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -108,6 +108,9 @@ func (s *Service) searchProfileDocuments(
 	if err != nil {
 		return nil, fmt.Errorf("count profiles: %w", err)
 	}
+	if count < 0 {
+		return nil, fmt.Errorf("count profiles: storage returned negative count %d", count)
+	}
 	if count > profileQueryLimit {
 		return nil, fmt.Errorf(
 			"%w: matched %d documents; narrow the time range or selector to at most %d",
@@ -126,10 +129,31 @@ func (s *Service) searchProfileDocuments(
 		if err != nil {
 			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
 		}
-		documents = append(documents, page...)
-		if len(page) < pageFilter.Limit {
-			break
+		if len(page) != pageFilter.Limit {
+			return nil, fmt.Errorf(
+				"search profiles at offset %d: storage returned %d documents, expected %d",
+				offset,
+				len(page),
+				pageFilter.Limit,
+			)
 		}
+		for index, document := range page {
+			if document == nil {
+				return nil, fmt.Errorf(
+					"search profiles at offset %d: storage returned nil document at page index %d",
+					offset,
+					index,
+				)
+			}
+		}
+		documents = append(documents, page...)
+	}
+	if int64(len(documents)) != count {
+		return nil, fmt.Errorf(
+			"search profiles: storage returned %d documents after count reported %d",
+			len(documents),
+			count,
+		)
 	}
 	return documents, nil
 }
@@ -161,26 +185,27 @@ func (s *Service) selectProfileTree(
 	}
 
 	tree := new(phlaremodel.Tree)
+	hasSamples := false
 	for _, document := range documents {
-		if document == nil {
-			continue
-		}
-		if err := addProfileDocumentToTree(tree, document, selection.sampleType); err != nil {
-			return nil, false, err
+		if addProfileDocumentToTree(tree, document, selection.sampleType) {
+			hasSamples = true
 		}
 	}
-	return tree, len(documents) > 0, nil
+	if !hasSamples && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+	return tree, hasSamples, nil
 }
 
 func addProfileDocumentToTree(
 	tree *phlaremodel.Tree,
 	document *ProfileDocument,
 	sampleType string,
-) error {
+) bool {
 	profile := &document.TracerData.Flamedata.Profile
-	sampleTypeIndex, err := profileSampleTypeIndex(profile, sampleType)
-	if err != nil {
-		return err
+	sampleTypeIndex, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return false
 	}
 
 	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
@@ -195,6 +220,7 @@ func addProfileDocumentToTree(
 			functions[function.Id] = function
 		}
 	}
+	inserted := false
 	for _, sample := range profile.Sample {
 		if sample == nil || sampleTypeIndex >= len(sample.Value) {
 			continue
@@ -202,21 +228,22 @@ func addProfileDocumentToTree(
 		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
 		if len(stack) > 0 {
 			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+			inserted = true
 		}
 	}
-	return nil
+	return inserted
 }
 
-func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, error) {
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, bool) {
 	for i, valueType := range profile.SampleType {
 		if valueType == nil {
 			continue
 		}
 		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
-			return i, nil
+			return i, true
 		}
 	}
-	return -1, invalidProfileQueryf("sample type %q not found", sampleType)
+	return -1, false
 }
 
 func profileSampleStack(
@@ -347,10 +374,7 @@ func (s *Service) SelectSeries(
 		if document == nil {
 			continue
 		}
-		value, found, err := profileDocumentSampleTotal(document, selection.sampleType)
-		if err != nil {
-			return nil, err
-		}
+		value, found := profileDocumentSampleTotal(document, selection.sampleType)
 		if !found {
 			continue
 		}
@@ -451,11 +475,11 @@ func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
 func profileDocumentSampleTotal(
 	document *ProfileDocument,
 	sampleType string,
-) (float64, bool, error) {
+) (float64, bool) {
 	profile := &document.TracerData.Flamedata.Profile
-	index, err := profileSampleTypeIndex(profile, sampleType)
-	if err != nil {
-		return 0, false, err
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return 0, false
 	}
 	var total float64
 	var found bool
@@ -466,7 +490,7 @@ func profileDocumentSampleTotal(
 		total += float64(sample.Value[index])
 		found = true
 	}
-	return total, found, nil
+	return total, found
 }
 
 func profileSeriesLabels(

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -1,0 +1,514 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	profileQueryLimit    = 10000
+	profileQueryPageSize = 1000
+	profileSeriesLimit   = 100
+)
+
+type profileSelection struct {
+	filter     *SearchFilter
+	sampleType string
+}
+
+func buildProfileSelection(profileType, selector string, start, end int64) (*profileSelection, error) {
+	profileTypeParts := strings.Split(profileType, ":")
+	if len(profileTypeParts) != 5 {
+		return nil, invalidProfileQueryf("invalid profile type %q", profileType)
+	}
+	if end < start {
+		return nil, invalidProfileQueryf("end time precedes start time")
+	}
+
+	matchers, err := parser.ParseMetricSelector(selector)
+	if err != nil {
+		return nil, invalidProfileQueryf("parse matchers: %v", err)
+	}
+	filter := &SearchFilter{
+		StartTime:   time.UnixMilli(start),
+		EndTime:     time.UnixMilli(end),
+		ProfileType: profileType,
+	}
+	for _, matcher := range matchers {
+		if matcher == nil {
+			continue
+		}
+		if matcher.Name == "__profile_type__" && matcher.Value != profileType {
+			return nil, invalidProfileQueryf(
+				"profile type matcher %q does not match request %q",
+				matcher.Value,
+				profileType,
+			)
+		}
+		if err := applyProfileMatcher(filter, matcher); err != nil {
+			return nil, err
+		}
+	}
+	if filter.ID != "" && filter.TracerID != "" && filter.ID != filter.TracerID {
+		return nil, invalidProfileQueryf("id and tracer select different profiles")
+	}
+	if !hasExactProfileTarget(filter) {
+		return nil, invalidProfileQueryf(
+			"id, hostname, container_id, container_hostname, or tracer must be specified",
+		)
+	}
+	return &profileSelection{filter: filter, sampleType: profileTypeParts[1]}, nil
+}
+
+func invalidProfileQueryf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidQuery, fmt.Sprintf(format, args...))
+}
+
+func hasExactProfileTarget(filter *SearchFilter) bool {
+	return filter != nil &&
+		(filter.ID != "" ||
+			filter.Hostname != "" ||
+			filter.ContainerID != "" ||
+			filter.ContainerHostname != "" ||
+			filter.TracerID != "")
+}
+
+func (s *Service) searchProfileDocuments(
+	ctx context.Context,
+	selection *profileSelection,
+) ([]*ProfileDocument, error) {
+	if s == nil || s.profileStorage == nil {
+		return nil, errorsProfileStorageNotInitialized()
+	}
+	count, err := s.profileStorage.CountProfilesContext(ctx, selection.filter)
+	if err != nil {
+		return nil, fmt.Errorf("count profiles: %w", err)
+	}
+	if count > profileQueryLimit {
+		return nil, fmt.Errorf(
+			"%w: matched %d documents; narrow the time range or selector to at most %d",
+			ErrProfileQueryLimitExceeded,
+			count,
+			profileQueryLimit,
+		)
+	}
+
+	documents := make([]*ProfileDocument, 0, int(count))
+	for offset := 0; offset < int(count); offset += profileQueryPageSize {
+		pageFilter := *selection.filter
+		pageFilter.Limit = min(profileQueryPageSize, int(count)-offset)
+		pageFilter.Offset = offset
+		page, err := s.profileStorage.SearchProfilesContext(ctx, &pageFilter)
+		if err != nil {
+			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
+		}
+		documents = append(documents, page...)
+		if len(page) < pageFilter.Limit {
+			break
+		}
+	}
+	return documents, nil
+}
+
+func errorsProfileStorageNotInitialized() error {
+	return fmt.Errorf("profile storage is not initialized")
+}
+
+func (s *Service) selectProfileTree(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	allowEmpty bool,
+) (*phlaremodel.Tree, bool, error) {
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(documents) == 0 && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+
+	tree := new(phlaremodel.Tree)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		if err := addProfileDocumentToTree(tree, document, selection.sampleType); err != nil {
+			return nil, false, err
+		}
+	}
+	return tree, len(documents) > 0, nil
+}
+
+func addProfileDocumentToTree(
+	tree *phlaremodel.Tree,
+	document *ProfileDocument,
+	sampleType string,
+) error {
+	profile := &document.TracerData.Flamedata.Profile
+	sampleTypeIndex, err := profileSampleTypeIndex(profile, sampleType)
+	if err != nil {
+		return err
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+	for _, sample := range profile.Sample {
+		if sample == nil || sampleTypeIndex >= len(sample.Value) {
+			continue
+		}
+		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
+		if len(stack) > 0 {
+			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+		}
+	}
+	return nil
+}
+
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, error) {
+	for i, valueType := range profile.SampleType {
+		if valueType == nil {
+			continue
+		}
+		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
+			return i, nil
+		}
+	}
+	return -1, invalidProfileQueryf("sample type %q not found", sampleType)
+}
+
+func profileSampleStack(
+	profile *profilev1.Profile,
+	locations map[uint64]*profilev1.Location,
+	functions map[uint64]*profilev1.Function,
+	locationIDs []uint64,
+) []string {
+	stack := make([]string, 0, len(locationIDs))
+	for _, locationID := range locationIDs {
+		location := locations[locationID]
+		if location == nil {
+			continue
+		}
+		for _, line := range location.Line {
+			if line == nil {
+				continue
+			}
+			function := functions[line.FunctionId]
+			if function == nil {
+				continue
+			}
+			name, ok := profileString(profile.StringTable, function.Name)
+			if ok {
+				stack = append(stack, name)
+			}
+		}
+	}
+	for left, right := 0, len(stack)-1; left < right; left, right = left+1, right-1 {
+		stack[left], stack[right] = stack[right], stack[left]
+	}
+	return stack
+}
+
+// Diff compares two independently selected profile windows.
+func (s *Service) Diff(
+	ctx context.Context,
+	req *querierv1.DiffRequest,
+) (*querierv1.DiffResponse, error) {
+	if req == nil || req.Left == nil || req.Right == nil {
+		return nil, invalidProfileQueryf("left and right profile selections are required")
+	}
+	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
+		return nil, invalidProfileQueryf("left and right profile types must match")
+	}
+	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
+	if err != nil {
+		return nil, fmt.Errorf("select left profiles: %w", err)
+	}
+	right, rightFound, err := s.selectProfileTree(ctx, req.Right, true)
+	if err != nil {
+		return nil, fmt.Errorf("select right profiles: %w", err)
+	}
+	if !leftFound && !rightFound {
+		return nil, ErrProfilesAbsent
+	}
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, diffMaxNodes(req))
+	if err != nil {
+		return nil, fmt.Errorf("build flamegraph diff: %w", err)
+	}
+	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
+}
+
+func diffMaxNodes(req *querierv1.DiffRequest) int64 {
+	left := req.Left.GetMaxNodes()
+	right := req.Right.GetMaxNodes()
+	switch {
+	case left > 0 && right > 0 && right < left:
+		return right
+	case left > 0:
+		return left
+	default:
+		return right
+	}
+}
+
+// SelectSeries returns sample totals bucketed by time and exact profile labels.
+func (s *Service) SelectSeries(
+	ctx context.Context,
+	req *querierv1.SelectSeriesRequest,
+) (*querierv1.SelectSeriesResponse, error) {
+	if req == nil {
+		return nil, invalidProfileQueryf("request is required")
+	}
+	stepMillis, err := seriesStepMillis(req.Step)
+	if err != nil {
+		return nil, err
+	}
+	aggregation := typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM
+	if req.Aggregation != nil {
+		aggregation = *req.Aggregation
+	}
+	if aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM &&
+		aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+		return nil, invalidProfileQueryf(
+			"unsupported time series aggregation %q",
+			aggregation.String(),
+		)
+	}
+	groupBy, err := normalizeProfileGroupBy(req.GroupBy)
+	if err != nil {
+		return nil, err
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	type bucketValue struct {
+		sum   float64
+		count int64
+	}
+	type groupedSeries struct {
+		labels  []*typesv1.LabelPair
+		buckets map[int64]*bucketValue
+	}
+	groups := make(map[string]*groupedSeries)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		value, found, err := profileDocumentSampleTotal(document, selection.sampleType)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		seriesLabels, key := profileSeriesLabels(document, groupBy)
+		group := groups[key]
+		if group == nil {
+			group = &groupedSeries{
+				labels:  seriesLabels,
+				buckets: make(map[int64]*bucketValue),
+			}
+			groups[key] = group
+		}
+		timestamp := profileDocumentTimestamp(document).UnixMilli()
+		bucketTimestamp := req.Start + ((timestamp-req.Start)/stepMillis)*stepMillis
+		bucket := group.buckets[bucketTimestamp]
+		if bucket == nil {
+			bucket = &bucketValue{}
+			group.buckets[bucketTimestamp] = bucket
+		}
+		bucket.sum += value
+		bucket.count++
+	}
+
+	series := make([]*typesv1.Series, 0, len(groups))
+	for _, group := range groups {
+		points := make([]*typesv1.Point, 0, len(group.buckets))
+		for timestamp, value := range group.buckets {
+			pointValue := value.sum
+			if aggregation ==
+				typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+				pointValue /= float64(value.count)
+			}
+			points = append(points, &typesv1.Point{
+				Value:     pointValue,
+				Timestamp: timestamp,
+			})
+		}
+		sort.Slice(points, func(i, j int) bool {
+			return points[i].Timestamp < points[j].Timestamp
+		})
+		series = append(series, &typesv1.Series{
+			Labels: group.labels,
+			Points: points,
+		})
+	}
+	sort.Slice(series, func(i, j int) bool {
+		left, right := profileSeriesValue(series[i]), profileSeriesValue(series[j])
+		if left != right {
+			return left > right
+		}
+		return phlaremodel.CompareLabelPairs(series[i].Labels, series[j].Labels) < 0
+	})
+	if len(series) > profileSeriesLimit {
+		series = series[:profileSeriesLimit]
+	}
+	return &querierv1.SelectSeriesResponse{Series: series}, nil
+}
+
+func seriesStepMillis(step float64) (int64, error) {
+	if math.IsNaN(step) ||
+		math.IsInf(step, 0) ||
+		step <= 0 ||
+		step > float64(math.MaxInt64)/1000 {
+		return 0, invalidProfileQueryf(
+			"step must be a finite positive number of seconds",
+		)
+	}
+	milliseconds := int64(math.Round(step * 1000))
+	if milliseconds < 1 {
+		return 1, nil
+	}
+	return milliseconds, nil
+}
+
+func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(groupBy))
+	result := make([]string, 0, len(groupBy))
+	for _, name := range groupBy {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		switch name {
+		case "id", "hostname", "container_id", "container_hostname", "tracer":
+		default:
+			return nil, invalidProfileQueryf("invalid group-by label %q", name)
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func profileDocumentSampleTotal(
+	document *ProfileDocument,
+	sampleType string,
+) (float64, bool, error) {
+	profile := &document.TracerData.Flamedata.Profile
+	index, err := profileSampleTypeIndex(profile, sampleType)
+	if err != nil {
+		return 0, false, err
+	}
+	var total float64
+	var found bool
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) {
+			continue
+		}
+		total += float64(sample.Value[index])
+		found = true
+	}
+	return total, found, nil
+}
+
+func profileSeriesLabels(
+	document *ProfileDocument,
+	groupBy []string,
+) ([]*typesv1.LabelPair, string) {
+	pairs := make([]*typesv1.LabelPair, 0, len(groupBy))
+	var key strings.Builder
+	for _, name := range groupBy {
+		value := profileDocumentLabelValue(document, name)
+		pairs = append(pairs, &typesv1.LabelPair{Name: name, Value: value})
+		_, _ = fmt.Fprintf(&key, "%d:%s=%d:%s;", len(name), name, len(value), value)
+	}
+	return pairs, key.String()
+}
+
+func profileDocumentLabelValue(document *ProfileDocument, name string) string {
+	switch name {
+	case "id", "tracer":
+		return document.TracerID
+	case "hostname":
+		return document.Hostname
+	case "container_id":
+		return document.ContainerID
+	case "container_hostname":
+		return document.ContainerHostname
+	default:
+		return ""
+	}
+}
+
+func profileDocumentTimestamp(document *ProfileDocument) time.Time {
+	if !document.UploadedTime.IsZero() {
+		return document.UploadedTime
+	}
+	return parseProfileDocumentTime(document.TracerTime, time.Unix(0, 0))
+}
+
+func profileSeriesValue(series *typesv1.Series) float64 {
+	var total float64
+	for _, point := range series.GetPoints() {
+		total += point.GetValue()
+	}
+	return total
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -27,6 +27,7 @@ import (
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
 type fakeProfileQueryStorage struct {
@@ -83,6 +84,7 @@ func (*fakeProfileQueryStorage) AggregationsByFieldContext(
 
 func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*ProfileDocument {
 	documents := make([]*ProfileDocument, 0, len(s.documents))
+documentLoop:
 	for _, document := range s.documents {
 		if document == nil {
 			continue
@@ -115,6 +117,12 @@ func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*Pro
 		if filter.ContainerHostname != "" &&
 			filter.ContainerHostname != document.ContainerHostname {
 			continue
+		}
+		for name, value := range filter.Labels {
+			if value != "" &&
+				document.TracerData.Flamedata.Labels[name] != value {
+				continue documentLoop
+			}
 		}
 		documents = append(documents, document)
 	}
@@ -298,6 +306,7 @@ func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
 		`{region="ap-guangzhou"}`,
 		`{arbitrary_label="value"}`,
 		`{id="trace-a",tracer="trace-b"}`,
+		`{pid=""}`,
 	} {
 		t.Run(selector, func(t *testing.T) {
 			_, err := buildProfileSelection(
@@ -345,6 +354,148 @@ func TestSelectSeriesBucketsAndGroups(t *testing.T) {
 	}}
 	if got := response.Series[0].Points; !reflect.DeepEqual(got, wantPoints) {
 		t.Fatalf("trace-a points = %#v, want %#v", got, wantPoints)
+	}
+}
+
+func TestCollectionDimensionsFilterAndGroupFixtureProfiles(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 30, 0, 0, time.UTC)
+	matching := testProfileDocument(
+		start.Add(time.Second),
+		"trace-pid-4242",
+		25,
+		"root",
+		"hot",
+	)
+	matching.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "pid",
+		profiler.LabelCPU:            "2,4,5,6,7",
+		profiler.LabelPID:            "4242",
+	}
+	matching.TracerData.Flamedata.Profile.StringTable = append(
+		matching.TracerData.Flamedata.Profile.StringTable,
+		profiler.LabelProfilingScope,
+		"pid",
+		"2,4,5,6,7",
+		"4242",
+	)
+	matching.TracerData.Flamedata.Profile.Sample[0].Label = []*profilev1.Label{
+		{Key: 5, Str: 6},
+		{Key: 1, Str: 7},
+		{Key: 6, Str: 8},
+	}
+	other := testProfileDocument(
+		start.Add(2*time.Second),
+		"trace-pid-9000",
+		100,
+		"root",
+		"cold",
+	)
+	other.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "pid",
+		profiler.LabelCPU:            "3",
+		profiler.LabelPID:            "9000",
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{matching, other},
+	})
+
+	response, err := service.SelectSeries(
+		t.Context(),
+		&querierv1.SelectSeriesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{profiling_scope="pid",cpu="2,4,5,6,7"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+			GroupBy:       []string{profiler.LabelPID},
+			Step:          10,
+		},
+	)
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 1 ||
+		len(response.Series[0].Labels) != 1 ||
+		response.Series[0].Labels[0].Name != profiler.LabelPID ||
+		response.Series[0].Labels[0].Value != "4242" ||
+		len(response.Series[0].Points) != 1 ||
+		response.Series[0].Points[0].Value != 25 {
+		t.Fatalf("dimensioned series = %#v", response.Series)
+	}
+
+	flamegraph, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{pid="4242"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("SelectMergeStacktraces() error = %v", err)
+	}
+	if flamegraph.GetFlamegraph().GetTotal() != 25 {
+		t.Fatalf(
+			"dimensioned flame graph total = %d, want 25",
+			flamegraph.GetFlamegraph().GetTotal(),
+		)
+	}
+
+	payload, err := service.MarshalPprof(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{pid="4242"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	exported, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("decode exported pprof: %v", err)
+	}
+	if len(exported.Sample) != 1 || len(exported.Sample[0].Label) != 3 {
+		t.Fatalf("exported managed sample labels = %#v", exported.Sample)
+	}
+	exportedLabels := make(map[string]string, len(exported.Sample[0].Label))
+	for _, label := range exported.Sample[0].Label {
+		name, nameOK := profileString(exported.StringTable, label.Key)
+		value, valueOK := profileString(exported.StringTable, label.Str)
+		if nameOK && valueOK {
+			exportedLabels[name] = value
+		}
+	}
+	if !reflect.DeepEqual(
+		exportedLabels,
+		matching.TracerData.Flamedata.Labels,
+	) {
+		t.Fatalf(
+			"exported labels = %#v, want %#v",
+			exportedLabels,
+			matching.TracerData.Flamedata.Labels,
+		)
+	}
+}
+
+func TestProfileNodeLimits(t *testing.T) {
+	if got, err := normalizeProfileMaxNodes(0); err != nil ||
+		got != defaultProfileNodes {
+		t.Fatalf("normalizeProfileMaxNodes(0) = (%d, %v)", got, err)
+	}
+	for _, value := range []int64{-1, profileNodeLimit + 1} {
+		if _, err := normalizeProfileMaxNodes(value); !errors.Is(
+			err,
+			ErrInvalidQuery,
+		) {
+			t.Fatalf(
+				"normalizeProfileMaxNodes(%d) error = %v, want invalid query",
+				value,
+				err,
+			)
+		}
 	}
 }
 

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -35,6 +35,7 @@ type fakeProfileQueryStorage struct {
 	countErr    error
 	searchErr   error
 	searchCalls []SearchFilter
+	pages       map[int][]*ProfileDocument
 }
 
 func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
@@ -48,6 +49,9 @@ func (s *fakeProfileQueryStorage) SearchProfilesContext(
 		return nil, s.searchErr
 	}
 	s.searchCalls = append(s.searchCalls, *filter)
+	if s.pages != nil {
+		return s.pages[filter.Offset], nil
+	}
 	documents := s.matchingDocuments(filter)
 	if filter.Offset >= len(documents) {
 		return nil, nil
@@ -223,6 +227,71 @@ func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
 	}
 }
 
+func TestSearchProfileDocumentsRejectsInvalidStorageResults(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	tests := []struct {
+		name    string
+		storage *fakeProfileQueryStorage
+	}{
+		{
+			name:    "negative count",
+			storage: &fakeProfileQueryStorage{count: -1},
+		},
+		{
+			name: "empty page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {}},
+			},
+		},
+		{
+			name: "short page",
+			storage: &fakeProfileQueryStorage{
+				count: 2,
+				pages: map[int][]*ProfileDocument{0: {document}},
+			},
+		},
+		{
+			name: "oversized page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {document, document}},
+			},
+		},
+		{
+			name: "nil document",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {nil}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTestProfileService(test.storage)
+			selection, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				`{id="trace-a"}`,
+				0,
+				time.Now().Add(time.Hour).UnixMilli(),
+			)
+			if err != nil {
+				t.Fatalf("buildProfileSelection() error = %v", err)
+			}
+
+			_, err = service.searchProfileDocuments(t.Context(), selection)
+			if err == nil {
+				t.Fatal("searchProfileDocuments() error = nil, want storage contract error")
+			}
+			if errors.Is(err, ErrInvalidQuery) ||
+				errors.Is(err, ErrProfilesAbsent) ||
+				errors.Is(err, ErrProfileQueryLimitExceeded) {
+				t.Fatalf("storage contract error = %v, want internal error", err)
+			}
+		})
+	}
+}
+
 func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
 	for _, selector := range []string{
 		`{hostname=~"node-.*"}`,
@@ -306,6 +375,85 @@ func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
 	}
 	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
 		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestEmptyStoredProfileHasNoUsableSamples(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	_, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="empty-profile"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="empty-profile"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+}
+
+func TestSamplesWithoutValuesAreSkipped(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 13, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "no-values", 1, "root", "leaf")
+	document.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{
+		nil,
+		{LocationId: []uint64{2, 1}},
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="no-values"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+
+	_, err = service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="no-values"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
 	}
 }
 

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+type fakeProfileQueryStorage struct {
+	documents   []*ProfileDocument
+	count       int64
+	countErr    error
+	searchErr   error
+	searchCalls []SearchFilter
+}
+
+func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
+func (*fakeProfileQueryStorage) Ready(context.Context) error { return nil }
+
+func (s *fakeProfileQueryStorage) SearchProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) ([]*ProfileDocument, error) {
+	if s.searchErr != nil {
+		return nil, s.searchErr
+	}
+	s.searchCalls = append(s.searchCalls, *filter)
+	documents := s.matchingDocuments(filter)
+	if filter.Offset >= len(documents) {
+		return nil, nil
+	}
+	end := min(filter.Offset+filter.Limit, len(documents))
+	return documents[filter.Offset:end], nil
+}
+
+func (s *fakeProfileQueryStorage) CountProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) (int64, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	if s.count != 0 {
+		return s.count, nil
+	}
+	return int64(len(s.matchingDocuments(filter))), nil
+}
+
+func (*fakeProfileQueryStorage) AggregationsByFieldContext(
+	context.Context,
+	*SearchFilter,
+	string,
+) ([]string, error) {
+	return nil, nil
+}
+
+func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*ProfileDocument {
+	documents := make([]*ProfileDocument, 0, len(s.documents))
+	for _, document := range s.documents {
+		if document == nil {
+			continue
+		}
+		timestamp := profileDocumentTimestamp(document)
+		if !filter.StartTime.IsZero() && timestamp.Before(filter.StartTime) {
+			continue
+		}
+		if !filter.EndTime.IsZero() && timestamp.After(filter.EndTime) {
+			continue
+		}
+		if filter.ProfileType != "" &&
+			filter.ProfileType != document.TracerData.Flamedata.ProfileType {
+			continue
+		}
+		tracerID := filter.TracerID
+		if tracerID == "" {
+			tracerID = filter.ID
+		}
+		if tracerID != "" && tracerID != document.TracerID {
+			continue
+		}
+		if filter.Hostname != "" &&
+			(filter.Hostname != document.Hostname || document.ContainerHostname != "") {
+			continue
+		}
+		if filter.ContainerID != "" && filter.ContainerID != document.ContainerID {
+			continue
+		}
+		if filter.ContainerHostname != "" &&
+			filter.ContainerHostname != document.ContainerHostname {
+			continue
+		}
+		documents = append(documents, document)
+	}
+	return documents
+}
+
+func newTestProfileService(storage *fakeProfileQueryStorage) *Service {
+	return &Service{profileStorage: storage}
+}
+
+func testProfileDocument(
+	timestamp time.Time,
+	tracerID string,
+	value int64,
+	stack ...string,
+) *ProfileDocument {
+	stringTable := []string{"", "cpu", "nanoseconds"}
+	functions := make([]*profilev1.Function, len(stack))
+	locations := make([]*profilev1.Location, len(stack))
+	locationIDs := make([]uint64, len(stack))
+	for i, name := range stack {
+		stringTable = append(stringTable, name)
+		id := uint64(i + 1)
+		functions[i] = &profilev1.Function{
+			Id:   id,
+			Name: int64(len(stringTable) - 1),
+		}
+		locations[i] = &profilev1.Location{
+			Id:   id,
+			Line: []*profilev1.Line{{FunctionId: id}},
+		}
+		locationIDs[len(stack)-1-i] = id
+	}
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: timestamp,
+		TracerID:     tracerID,
+		TracerTime:   timestamp.Format(profileTimeLayout),
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	document.TracerData.Flamedata.Profile = profilev1.Profile{
+		StringTable: stringTable,
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+			Unit: 2,
+		}},
+		Function: functions,
+		Location: locations,
+		Sample: []*profilev1.Sample{{
+			LocationId: locationIDs,
+			Value:      []int64{value},
+		}},
+	}
+	return document
+}
+
+func TestSearchProfileDocumentsPaginatesWithoutTruncation(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	documents := make([]*ProfileDocument, 1001)
+	for i := range documents {
+		documents[i] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{hostname="node-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	got, err := service.searchProfileDocuments(t.Context(), selection)
+	if err != nil {
+		t.Fatalf("searchProfileDocuments() error = %v", err)
+	}
+	if len(got) != len(documents) {
+		t.Fatalf("documents = %d, want %d", len(got), len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	if storage.searchCalls[0].Limit != 1000 ||
+		storage.searchCalls[0].Offset != 0 ||
+		storage.searchCalls[1].Limit != 1 ||
+		storage.searchCalls[1].Offset != 1000 {
+		t.Fatalf("search pages = %#v, want 1000@0 and 1@1000", storage.searchCalls)
+	}
+}
+
+func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		count: profileQueryLimit + 1,
+	})
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	_, err = service.searchProfileDocuments(t.Context(), selection)
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf("searchProfileDocuments() error = %v, want query limit error", err)
+	}
+}
+
+func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
+	for _, selector := range []string{
+		`{hostname=~"node-.*"}`,
+		`{region="ap-guangzhou"}`,
+		`{arbitrary_label="value"}`,
+		`{id="trace-a",tracer="trace-b"}`,
+	} {
+		t.Run(selector, func(t *testing.T) {
+			_, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				selector,
+				0,
+				1,
+			)
+			if !errors.Is(err, ErrInvalidQuery) {
+				t.Fatalf("buildProfileSelection() error = %v, want invalid query", err)
+			}
+		})
+	}
+}
+
+func TestSelectSeriesBucketsAndGroups(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(100*time.Millisecond), "trace-a", 10, "root", "hot"),
+		testProfileDocument(start.Add(1500*time.Millisecond), "trace-a", 20, "root", "hot"),
+		testProfileDocument(start.Add(500*time.Millisecond), "trace-b", 7, "root", "worker"),
+	}}
+	service := newTestProfileService(storage)
+
+	response, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(4 * time.Second).UnixMilli(),
+		GroupBy:       []string{"tracer"},
+		Step:          2,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 2 {
+		t.Fatalf("series = %#v, want two tracer groups", response.Series)
+	}
+	if got := response.Series[0].Labels[0].Value; got != "trace-a" {
+		t.Fatalf("first series tracer = %q, want trace-a", got)
+	}
+	wantPoints := []*typesv1.Point{{
+		Value:     30,
+		Timestamp: start.UnixMilli(),
+	}}
+	if got := response.Series[0].Points; !reflect.DeepEqual(got, wantPoints) {
+		t.Fatalf("trace-a points = %#v, want %#v", got, wantPoints)
+	}
+}
+
+func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(time.Second), "left", 10, "root", "hot"),
+	}})
+	maxNodes := int64(100)
+	response, err := service.Diff(t.Context(), &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="left"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(5 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="right"}`,
+			Start:         start.Add(10 * time.Second).UnixMilli(),
+			End:           start.Add(15 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
+		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestProfileQueryStorageErrorsRemainInternal(t *testing.T) {
+	sentinel := fmt.Errorf("backend unavailable")
+	service := newTestProfileService(&fakeProfileQueryStorage{countErr: sentinel})
+	_, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="trace-a"}`,
+		Start:         0,
+		End:           1,
+		Step:          1,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("SelectSeries() error = %v, want wrapped backend error", err)
+	}
+}

--- a/internal/profiler/service/errors.go
+++ b/internal/profiler/service/errors.go
@@ -17,6 +17,7 @@ package service
 import "errors"
 
 var (
-	ErrInvalidQuery   = errors.New("invalid profile query")
-	ErrProfilesAbsent = errors.New("profiles not found")
+	ErrInvalidQuery              = errors.New("invalid profile query")
+	ErrProfilesAbsent            = errors.New("profiles not found")
+	ErrProfileQueryLimitExceeded = errors.New("profile query limit exceeded")
 )

--- a/internal/profiler/service/export.go
+++ b/internal/profiler/service/export.go
@@ -1,0 +1,202 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"huatuo-bamai/internal/profiler/output/flamegraph"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+// SelectMergePprof returns the standard pprof profile for an exact target
+// selection. Broad and unsupported label queries are rejected before storage
+// access.
+func (s *Service) SelectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, error) {
+	profile, _, err := s.selectMergePprof(ctx, req)
+	return profile, err
+}
+
+func (s *Service) selectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, string, error) {
+	if req == nil {
+		return nil, "", invalidProfileQueryf("request is required")
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(documents) == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+
+	var merged pprof.ProfileMerge
+	mergedProfiles := 0
+	for _, document := range documents {
+		if _, found := profileDocumentSampleTotal(
+			document,
+			selection.sampleType,
+		); !found {
+			continue
+		}
+		profile := document.TracerData.Flamedata.Profile.CloneVT()
+		if profile == nil {
+			continue
+		}
+		// Pyroscope's merge helper requires a value even though pprof makes it
+		// optional.
+		if profile.PeriodType == nil {
+			profile.PeriodType = &profilev1.ValueType{}
+		}
+		if err := merged.Merge(profile); err != nil {
+			return nil, "", fmt.Errorf("merge profile: %w", err)
+		}
+		mergedProfiles++
+	}
+	if mergedProfiles == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+	profile := merged.Profile()
+	if profile == nil {
+		return nil, "", ErrProfilesAbsent
+	}
+	return profile, selection.sampleType, nil
+}
+
+// MarshalPprof serializes a selected profile as gzip-compressed pprof data.
+func (s *Service) MarshalPprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) ([]byte, error) {
+	profile, err := s.SelectMergePprof(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := pprof.Marshal(profile, true)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pprof: %w", err)
+	}
+	return payload, nil
+}
+
+// RenderProfileSVG writes a standalone interactive SVG for selected pprof
+// data.
+func (s *Service) RenderProfileSVG(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	writer io.Writer,
+) error {
+	if writer == nil {
+		return errors.New("render profile SVG: writer is nil")
+	}
+	profile, sampleType, err := s.selectMergePprof(ctx, req)
+	if err != nil {
+		return err
+	}
+	stacks, err := profileFlamegraphStacks(profile, sampleType)
+	if err != nil {
+		return err
+	}
+	if len(stacks) == 0 {
+		return fmt.Errorf("%w: selected profile has no positive stack samples", ErrProfilesAbsent)
+	}
+	if err := flamegraph.RenderStyle(stacks, writer, flamegraph.DefaultStyle); err != nil {
+		return fmt.Errorf("render profile SVG: %w", err)
+	}
+	return nil
+}
+
+func profileFlamegraphStacks(
+	profile *profilev1.Profile,
+	sampleType string,
+) ([]flamegraph.Stack, error) {
+	if profile == nil {
+		return nil, errors.New("build profile stacks: profile is nil")
+	}
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return nil, invalidProfileQueryf("sample type %q not found", sampleType)
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+
+	const stackSeparator = "\x00"
+	counts := make(map[string]int64)
+	stackNames := make(map[string][]string)
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) || sample.Value[index] <= 0 {
+			continue
+		}
+		names := profileSampleStack(
+			profile,
+			locations,
+			functions,
+			sample.LocationId,
+		)
+		if len(names) == 0 {
+			continue
+		}
+		key := strings.Join(names, stackSeparator)
+		counts[key] += sample.Value[index]
+		stackNames[key] = names
+	}
+
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	stacks := make([]flamegraph.Stack, 0, len(keys))
+	for _, key := range keys {
+		stacks = append(stacks, flamegraph.Stack{
+			Names:   stackNames[key],
+			Samples: counts[key],
+		})
+	}
+	return stacks, nil
+}

--- a/internal/profiler/service/export.go
+++ b/internal/profiler/service/export.go
@@ -29,6 +29,8 @@ import (
 	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
+const profileSVGStackLimit = 10000
+
 // SelectMergePprof returns the standard pprof profile for an exact target
 // selection. Broad and unsupported label queries are rejected before storage
 // access.
@@ -182,6 +184,15 @@ func profileFlamegraphStacks(
 			continue
 		}
 		key := strings.Join(names, stackSeparator)
+		if _, exists := counts[key]; !exists &&
+			len(counts) >= profileSVGStackLimit {
+			return nil, fmt.Errorf(
+				"%w: rendered SVG exceeds %d distinct stacks; narrow the "+
+					"time range or selector",
+				ErrProfileQueryLimitExceeded,
+				profileSVGStackLimit,
+			)
+		}
 		counts[key] += sample.Value[index]
 		stackNames[key] = names
 	}

--- a/internal/profiler/service/export_test.go
+++ b/internal/profiler/service/export_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+func exportTestRequest(start time.Time) *querierv1.SelectMergeStacktracesRequest {
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(time.Minute).UnixMilli(),
+	}
+}
+
+func TestSelectMergePprofUsesBoundedProfileLoader(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "trace-a", 1, "root", "worker")
+	documents := make([]*ProfileDocument, profileQueryPageSize+1)
+	for index := range documents {
+		documents[index] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+
+	profile, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if err != nil {
+		t.Fatalf("SelectMergePprof() error = %v", err)
+	}
+	var total int64
+	for _, sample := range profile.Sample {
+		if sample != nil && len(sample.Value) > 0 {
+			total += sample.Value[0]
+		}
+	}
+	if total != int64(len(documents)) {
+		t.Fatalf("merged sample total = %d, want %d", total, len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	first, second := storage.searchCalls[0], storage.searchCalls[1]
+	if first.Offset != 0 ||
+		first.Limit != profileQueryPageSize ||
+		second.Offset != profileQueryPageSize ||
+		second.Limit != 1 {
+		t.Fatalf(
+			"search pages = (%d,%d),(%d,%d), want (0,1000),(1000,1)",
+			first.Offset,
+			first.Limit,
+			second.Offset,
+			second.Limit,
+		)
+	}
+}
+
+func TestSelectMergePprofRejectsOversizedSelectionBeforeFetch(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{count: profileQueryLimit + 1}
+	service := newTestProfileService(storage)
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfileQueryLimitExceeded",
+			err,
+		)
+	}
+	if len(storage.searchCalls) != 0 {
+		t.Fatalf("search calls = %d, want 0", len(storage.searchCalls))
+	}
+}
+
+func TestSelectMergePprofRejectsEmptyStoredProfilesWithoutPanicking(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 30, 0, 0, time.UTC)
+	empty := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	empty.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	empty.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{nil}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{empty},
+	})
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfilesAbsent",
+			err,
+		)
+	}
+}
+
+func TestMarshalPprofAndRenderProfileSVG(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 14, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{
+			testProfileDocument(start, "trace-a", 10, "root", "hot"),
+		},
+	})
+	req := exportTestRequest(start)
+
+	payload, err := service.MarshalPprof(t.Context(), req)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	decoded, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("RawFromBytes() error = %v", err)
+	}
+	if len(decoded.Sample) != 1 || decoded.Sample[0].Value[0] != 10 {
+		t.Fatalf("pprof samples = %#v, want value 10", decoded.Sample)
+	}
+
+	var output bytes.Buffer
+	if err := service.RenderProfileSVG(
+		t.Context(),
+		req,
+		&output,
+	); err != nil {
+		t.Fatalf("RenderProfileSVG() error = %v", err)
+	}
+	for _, expected := range []string{
+		"<svg",
+		"Flame Graph",
+		"root",
+		"hot",
+		"Search",
+	} {
+		if !strings.Contains(output.String(), expected) {
+			t.Fatalf("SVG does not contain %q", expected)
+		}
+	}
+}
+
+func TestRenderProfileSVGRejectsNilWriter(t *testing.T) {
+	service := &Service{}
+	err := service.RenderProfileSVG(
+		t.Context(),
+		exportTestRequest(time.Now()),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "writer is nil") {
+		t.Fatalf("RenderProfileSVG() error = %v, want nil writer error", err)
+	}
+}

--- a/internal/profiler/service/export_test.go
+++ b/internal/profiler/service/export_test.go
@@ -17,6 +17,7 @@ package service
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -168,5 +169,46 @@ func TestRenderProfileSVGRejectsNilWriter(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "writer is nil") {
 		t.Fatalf("RenderProfileSVG() error = %v, want nil writer error", err)
+	}
+}
+
+func TestProfileFlamegraphStacksRejectsExcessiveCardinality(t *testing.T) {
+	profile := &profilev1.Profile{
+		StringTable: []string{"", "cpu"},
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+		}},
+		Function: make([]*profilev1.Function, 0, profileSVGStackLimit+1),
+		Location: make([]*profilev1.Location, 0, profileSVGStackLimit+1),
+		Sample:   make([]*profilev1.Sample, 0, profileSVGStackLimit+1),
+	}
+	for index := range profileSVGStackLimit + 1 {
+		id := uint64(index + 1)
+		profile.StringTable = append(
+			profile.StringTable,
+			fmt.Sprintf("function-%d", index),
+		)
+		profile.Function = append(profile.Function, &profilev1.Function{
+			Id:   id,
+			Name: int64(len(profile.StringTable) - 1),
+		})
+		profile.Location = append(profile.Location, &profilev1.Location{
+			Id: id,
+			Line: []*profilev1.Line{{
+				FunctionId: id,
+			}},
+		})
+		profile.Sample = append(profile.Sample, &profilev1.Sample{
+			LocationId: []uint64{id},
+			Value:      []int64{1},
+		})
+	}
+
+	_, err := profileFlamegraphStacks(profile, "cpu")
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf(
+			"profileFlamegraphStacks() error = %v, want query limit",
+			err,
+		)
 	}
 }

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -89,12 +89,16 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
+	maxNodes, err := normalizeProfileMaxNodes(req.GetMaxNodes())
+	if err != nil {
+		return nil, err
+	}
 	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
 		return nil, err
 	}
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(tree, req.GetMaxNodes()),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, maxNodes),
 	}, nil
 }
 

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -24,11 +24,9 @@ import (
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/profiler"
 
-	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
-	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -37,9 +35,21 @@ type ElasticSearchConfig struct {
 	Address, Username, Password, Index string
 }
 
+type profileQueryStorage interface {
+	Close(ctx context.Context) error
+	Ready(ctx context.Context) error
+	SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error)
+	CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error)
+	AggregationsByFieldContext(
+		ctx context.Context,
+		filter *SearchFilter,
+		field string,
+	) ([]string, error)
+}
+
 // Service provides profile query operations.
 type Service struct {
-	profileStorage *ProfileStorage
+	profileStorage profileQueryStorage
 }
 
 // NewService initializes a profile query service.
@@ -78,159 +88,13 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
-	if req.End < req.Start {
-		return nil, fmt.Errorf("%w: end time precedes start time", ErrInvalidQuery)
-	}
-	filter := &SearchFilter{
-		StartTime:   time.UnixMilli(req.Start),
-		EndTime:     time.UnixMilli(req.End),
-		ProfileType: req.ProfileTypeID,
-		Limit:       100,
-	}
-
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
-
-	profileTypes := strings.Split(filter.ProfileType, ":")
-	if len(profileTypes) != 5 {
-		return nil, fmt.Errorf("%w: invalid profile type %q", ErrInvalidQuery, filter.ProfileType)
-	}
-
-	// labels
-	labels, err := parser.ParseMetricSelector(req.LabelSelector)
+	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
-		return nil, errors.Join(ErrInvalidQuery, fmt.Errorf("parse matchers: %w", err))
+		return nil, err
 	}
-
-	for _, label := range labels {
-		// skip empty or "All"
-		if label.Value == "" || label.Value == "all" || label.Value == "All" || label.Value == "*" {
-			continue
-		}
-
-		if err := applyProfileMatcher(filter, label); err != nil {
-			return nil, err
-		}
-	}
-
-	if filter.ID == "" &&
-		filter.Hostname == "" &&
-		filter.ContainerID == "" &&
-		filter.ContainerHostname == "" &&
-		len(filter.Labels) == 0 {
-		return nil, fmt.Errorf(
-			"%w: id, hostname, container, or collection dimension must be specified",
-			ErrInvalidQuery,
-		)
-	}
-
-	// search
-	profileDocs, err := s.profileStorage.SearchProfilesContext(ctx, filter)
-	if err != nil {
-		return nil, fmt.Errorf("search profiles: %w", err)
-	}
-	if len(profileDocs) == 0 {
-		return nil, ErrProfilesAbsent
-	}
-
-	// merge profileDocs
-	var profilesMerge pprof.ProfileMerge
-	for _, profileDoc := range profileDocs {
-		profile := &profileDoc.TracerData.Flamedata.Profile
-		if err := profilesMerge.Merge(profile); err != nil {
-			return nil, fmt.Errorf("merge profile: %w", err)
-		}
-	}
-	profile := profilesMerge.Profile()
-	if profile == nil {
-		return nil, ErrProfilesAbsent
-	}
-	sampleType := profileTypes[1]
-
-	// convert profilev1.Profile to phlaremodel.Tree
-	phlaremodelTree := new(phlaremodel.Tree)
-
-	// Find the index of the sample type we're interested in
-	sampleTypeIndex := -1
-	for i, st := range profile.SampleType {
-		if st == nil {
-			continue
-		}
-		if value, ok := profileString(profile.StringTable, st.Type); ok && value == sampleType {
-			sampleTypeIndex = i
-			break
-		}
-	}
-	if sampleTypeIndex == -1 {
-		return nil, fmt.Errorf("%w: sample type %q not found", ErrInvalidQuery, sampleType)
-	}
-
-	// Create a map for quick location lookup
-	locationMap := make(map[uint64]*googlev1.Location, len(profile.Location))
-	for _, loc := range profile.Location {
-		if loc == nil {
-			continue
-		}
-		locationMap[loc.Id] = loc
-	}
-
-	// Create a map for quick function lookup
-	functionMap := make(map[uint64]*googlev1.Function, len(profile.Function))
-	for _, fn := range profile.Function {
-		if fn == nil {
-			continue
-		}
-		functionMap[fn.Id] = fn
-	}
-
-	// Process each sample
-	for _, sample := range profile.Sample {
-		if sample == nil {
-			continue
-		}
-		// Get the value for our sample type
-		if len(sample.Value) <= sampleTypeIndex {
-			continue
-		}
-		value := sample.Value[sampleTypeIndex]
-
-		// Build stack trace string from location ids
-		stack := make([]string, 0, len(sample.LocationId))
-		for _, locId := range sample.LocationId {
-			loc, exists := locationMap[locId]
-			if !exists || len(loc.Line) == 0 {
-				continue
-			}
-
-			// Get the first line entry (primary function)
-			line := loc.Line[0]
-			if line == nil {
-				continue
-			}
-			fn, exists := functionMap[line.FunctionId]
-			if !exists {
-				continue
-			}
-
-			// Get function name from string table
-			funcName, ok := profileString(profile.StringTable, fn.Name)
-			if !ok {
-				continue
-			}
-			stack = append(stack, funcName)
-		}
-
-		// Insert stack into tree (leaf is at stack[0], so we need to reverse for phlaremodel.Tree)
-		if len(stack) > 0 {
-			for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
-				stack[i], stack[j] = stack[j], stack[i]
-			}
-			phlaremodelTree.InsertStack(value, stack...)
-		}
-	}
-
-	// convert phlaremodel.Tree to FlameGraph
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(phlaremodelTree, -1),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, req.GetMaxNodes()),
 	}, nil
 }
 
@@ -247,6 +111,8 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 		filter.ContainerID = matcher.Value
 	case "container_hostname":
 		filter.ContainerHostname = matcher.Value
+	case "tracer":
+		filter.TracerID = matcher.Value
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 
 	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -111,8 +112,15 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 		}
 	}
 
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
+	if filter.ID == "" &&
+		filter.Hostname == "" &&
+		filter.ContainerID == "" &&
+		filter.ContainerHostname == "" &&
+		len(filter.Labels) == 0 {
+		return nil, fmt.Errorf(
+			"%w: id, hostname, container, or collection dimension must be specified",
+			ErrInvalidQuery,
+		)
 	}
 
 	// search
@@ -242,7 +250,13 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:
-		return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		if !profiler.IsCollectionDimensionLabel(matcher.Name) {
+			return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		}
+		if filter.Labels == nil {
+			filter.Labels = make(map[string]string)
+		}
+		filter.Labels[matcher.Name] = matcher.Value
 	}
 	return nil
 }
@@ -300,8 +314,25 @@ func (s *Service) ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesR
 //	request: typesv1.LabelNamesRequest
 //	response: typesv1.LabelNamesResponse
 func (s *Service) LabelNames(context.Context, *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error) {
+	names := []string{
+		"region",
+		"hostname",
+		"container_id",
+		"container_hostname",
+		"container_host_namespace",
+	}
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		seen[name] = struct{}{}
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
 	response := &typesv1.LabelNamesResponse{
-		Names: []string{"region", "hostname", "container_id", "container_hostname", "container_host_namespace"},
+		Names: names,
 	}
 	return response, nil
 }

--- a/internal/profiler/service/flamegraph_test.go
+++ b/internal/profiler/service/flamegraph_test.go
@@ -17,6 +17,10 @@ package service
 import (
 	"strings"
 	"testing"
+
+	"huatuo-bamai/internal/profiler"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 func TestServiceReadyRejectsUninitializedStorage(t *testing.T) {
@@ -42,5 +46,33 @@ func TestBuildProfileSearchQueryIncludesPage(t *testing.T) {
 	query := buildProfileSearchQuery(&SearchFilter{TracerID: "task-2026", Limit: 25, Offset: 50})
 	if query.Limit != 25 || query.Offset != 50 {
 		t.Fatalf("query page=(%d,%d), want (25,50)", query.Limit, query.Offset)
+	}
+}
+
+func TestApplyProfileMatcherAcceptsCollectionDimensions(t *testing.T) {
+	filter := &SearchFilter{}
+	matcher := labels.MustNewMatcher(labels.MatchEqual, profiler.LabelTGID, "4242")
+
+	if err := applyProfileMatcher(filter, matcher); err != nil {
+		t.Fatalf("applyProfileMatcher() error = %v", err)
+	}
+	if got := filter.Labels[profiler.LabelTGID]; got != "4242" {
+		t.Fatalf("tgid matcher = %q, want 4242", got)
+	}
+}
+
+func TestLabelNamesIncludesCollectionDimensions(t *testing.T) {
+	response, err := (&Service{}).LabelNames(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("LabelNames() error = %v", err)
+	}
+	names := make(map[string]struct{}, len(response.Names))
+	for _, name := range response.Names {
+		names[name] = struct{}{}
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if _, ok := names[name]; !ok {
+			t.Errorf("LabelNames() missing %q", name)
+		}
 	}
 }

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/timeutil"
 	"huatuo-bamai/internal/storage"
 	"huatuo-bamai/internal/storage/driver"
@@ -74,6 +75,7 @@ type ProfileDocument struct {
 	TracerData struct {
 		Flamedata struct {
 			ProfileType string            `json:"profile_type,omitempty"`
+			Labels      map[string]string `json:"labels,omitempty"`
 			Profile     profilev1.Profile `json:"profile,omitempty"`
 		} `json:"flamedata,omitempty"`
 		// others
@@ -90,6 +92,7 @@ type SearchFilter struct {
 	StartTime         time.Time
 	EndTime           time.Time
 	ProfileType       string
+	Labels            map[string]string
 	Limit             int
 	Offset            int
 }
@@ -214,7 +217,7 @@ func (profileDocumentMapper) Decode(data []byte) (*ProfileDocument, error) {
 }
 
 func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, error) {
-	return map[string]any{
+	fields := map[string]any{
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
@@ -229,11 +232,20 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldTracerTime:        parseProfileDocumentTime(document.TracerTime, document.UploadedTime),
 		profileFieldTracerType:        document.TracerRunType,
 		profileFieldProfileType:       document.TracerData.Flamedata.ProfileType,
-	}, nil
+	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label == profiler.LabelContainerID {
+			continue
+		}
+		if value := document.TracerData.Flamedata.Labels[label]; value != "" {
+			fields[profileLabelField(label)] = value
+		}
+	}
+	return fields, nil
 }
 
 func (profileDocumentMapper) Indexes() []driver.Index {
-	return []driver.Index{
+	indexes := []driver.Index{
 		{Field: profileFieldTracerID},
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
@@ -249,6 +261,12 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldTracerType},
 		{Field: profileFieldProfileType},
 	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label != profiler.LabelContainerID {
+			indexes = append(indexes, driver.Index{Field: profileLabelField(label)})
+		}
+	}
+	return indexes
 }
 
 func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
@@ -335,11 +353,29 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Value: filter.ProfileType,
 		})
 	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name == profiler.LabelContainerID {
+			continue
+		}
+		if value := filter.Labels[name]; value != "" {
+			query.Filters = append(query.Filters, driver.Filter{
+				Field: profileLabelKeywordField(name),
+				Op:    driver.OpEq,
+				Value: value,
+			})
+		}
+	}
 
 	return query
 }
 
 func normalizeProfileAggregationField(field string) (string, error) {
+	if profiler.IsCollectionDimensionLabel(field) {
+		if field == profiler.LabelContainerID {
+			return profileFieldContainerID + ".keyword", nil
+		}
+		return profileLabelKeywordField(field), nil
+	}
 	switch field {
 	case "id":
 		return profileFieldTracerID, nil
@@ -358,6 +394,14 @@ func normalizeProfileAggregationField(field string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}
+}
+
+func profileLabelField(name string) string {
+	return "tracer_data.flamedata.labels." + name
+}
+
+func profileLabelKeywordField(name string) string {
+	return profileLabelField(name) + ".keyword"
 }
 
 func normalizeProfileSearchLimit(filter *SearchFilter) int {

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -170,6 +170,14 @@ func (s *ProfileStorage) SearchProfilesContext(ctx context.Context, filter *Sear
 	return documents, nil
 }
 
+// CountProfilesContext counts profiles matching a filter.
+func (s *ProfileStorage) CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error) {
+	if s == nil || s.store == nil {
+		return 0, errors.New("profile storage is not initialized")
+	}
+	return s.store.Count(ctx, buildProfileAggregationQuery(filter))
+}
+
 // AggregationsByField gets aggregations by field.
 func (s *ProfileStorage) AggregationsByField(filter *SearchFilter, field string) ([]string, error) {
 	return s.AggregationsByFieldContext(context.Background(), filter, field)
@@ -277,6 +285,7 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	}
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
 	}
 	return query
 }

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -132,3 +132,15 @@ func TestNormalizeProfileAggregationFieldSupportsDimensions(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildProfileSearchQueryUsesStablePaginationOrder(t *testing.T) {
+	query := buildProfileSearchQuery(&SearchFilter{Limit: 1000, Offset: 1000})
+	want := []driver.Sort{
+		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
+	}
+
+	if !reflect.DeepEqual(query.Sorts, want) {
+		t.Fatalf("query sorts = %#v, want %#v", query.Sorts, want)
+	}
+}

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/storage/driver"
 )
 
@@ -56,5 +57,78 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 
 	if !reflect.DeepEqual(query.Filters, want) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestProfileDocumentMapperIndexesCollectionDimensions(t *testing.T) {
+	document := &ProfileDocument{}
+	document.ContainerID = "containerd://abc"
+	document.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelTGID:           "4242",
+		profiler.LabelContainerID:    document.ContainerID,
+	}
+
+	fields, err := (profileDocumentMapper{}).Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
+	if got := fields[profileLabelField(profiler.LabelProfilingScope)]; got != "thread_group" {
+		t.Fatalf("profiling_scope field = %v, want thread_group", got)
+	}
+	if got := fields[profileLabelField(profiler.LabelTGID)]; got != "4242" {
+		t.Fatalf("tgid field = %v, want 4242", got)
+	}
+	if _, duplicated := fields[profileLabelField(profiler.LabelContainerID)]; duplicated {
+		t.Fatal("container_id duplicated under profile labels")
+	}
+}
+
+func TestBuildProfileAggregationQueryAddsDimensionMatchers(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		ContainerID: "containerd://abc",
+		Labels: map[string]string{
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelTGID:           "4242",
+			"unmanaged":                  "ignored",
+		},
+	})
+	want := []driver.Filter{
+		{
+			Field: profileFieldContainerID + ".keyword",
+			Op:    driver.OpEq,
+			Value: "containerd://abc",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelProfilingScope),
+			Op:    driver.OpEq,
+			Value: "thread_group",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelTGID),
+			Op:    driver.OpEq,
+			Value: "4242",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldSupportsDimensions(t *testing.T) {
+	tests := map[string]string{
+		profiler.LabelPID:         profileLabelKeywordField(profiler.LabelPID),
+		profiler.LabelTGID:        profileLabelKeywordField(profiler.LabelTGID),
+		profiler.LabelContainerID: profileFieldContainerID + ".keyword",
+	}
+	for input, want := range tests {
+		got, err := normalizeProfileAggregationField(input)
+		if err != nil {
+			t.Fatalf("normalizeProfileAggregationField(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("normalizeProfileAggregationField(%q) = %q, want %q", input, got, want)
+		}
 	}
 }

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -36,6 +36,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels are mirrored into pprof samples and indexed for label queries.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends


### PR DESCRIPTION
## Summary

- provide Grafana host, container, comparison, and advanced profiling dashboards
- add profiling_scope, CPU, PID, TGID, container, hostname, type, and tracer selectors plus matching Series groupBy support
- implement Pyroscope-compatible Series and Diff queries with paged-result validation and a 10,000-document guard
- add profile-value timelines, Top 10 views, current-vs-previous comparison, standard pprof download, and safe interactive SVG export
- retain direct Pyroscope and authenticated huatuo-apiserver datasources
- document the evaluated Grafana, Pyroscope, Parca, and FlameGraph RS trade-offs in English and Chinese

## Split review chain

This is the closing integration PR for #328. The independently reviewable prerequisite patches are #423, #424, and #425. The remaining commits preserve focused query, dashboard, export, and documentation boundaries.

## Validation

- Linux profiling service, context, handler, and export tests passed
- targeted race tests passed
- Linux cross-build and 26 repository linters passed
- dashboard JSON, datasource, selector, response-size, and export security contracts passed

Closes #328