### PR TITLE
[2/5] feat(profiling): add bounded Series and Diff query APIs

### DIFF
--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -44,6 +44,8 @@ type Config struct {
 // ProfileQueryService defines profile query operations consumed by the handler.
 type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
+	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
+	Diff(ctx context.Context, req *querierv1.DiffRequest) (*querierv1.DiffResponse, error)
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -81,6 +83,8 @@ func NewHandler(
 		{Typ: server.HttpDelete, Uri: "/:id", Handle: h.delete},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces", Handle: h.displaySelectMergeStacktraces},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
+		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},
+		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/Diff", Handle: h.displayDiff},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelNames", Handle: h.displayLabelNames},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelValues", Handle: h.displayLabelValues},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -39,16 +39,11 @@ func handleProto[Request, Response any](
 
 	resp, err := invoke(ctx.Request().Context(), req)
 	if err != nil {
-		if errors.Is(err, profileService.ErrInvalidQuery) {
-			ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
-			return nil
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField("operation", operation).Error("profile query failed")
 		}
-		if errors.Is(err, profileService.ErrProfilesAbsent) {
-			ctx.JSON(http.StatusNotFound, map[string]any{"message": "profiles not found"})
-			return nil
-		}
-		log.WithError(err).WithField("operation", operation).Error("profile query failed")
-		ctx.JSON(http.StatusInternalServerError, map[string]any{"message": "internal error"})
+		ctx.JSON(status, map[string]any{"message": message})
 		return nil
 	}
 
@@ -57,12 +52,33 @@ func handleProto[Request, Response any](
 	return nil
 }
 
+func profileQueryHTTPError(err error) (int, string) {
+	switch {
+	case errors.Is(err, profileService.ErrInvalidQuery):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, profileService.ErrProfilesAbsent):
+		return http.StatusNotFound, "profiles not found"
+	case errors.Is(err, profileService.ErrProfileQueryLimitExceeded):
+		return http.StatusUnprocessableEntity, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal error"
+	}
+}
+
 func (h *Handler) displaySelectMergeStacktraces(ctx *server.Context) error {
 	return handleProto(ctx, "select_merge_stacktraces", h.profileService.SelectMergeStacktraces)
 }
 
 func (h *Handler) displayProfileTypes(ctx *server.Context) error {
 	return handleProto(ctx, "profile_types", h.profileService.ProfileTypes)
+}
+
+func (h *Handler) displaySelectSeries(ctx *server.Context) error {
+	return handleProto(ctx, "select_series", h.profileService.SelectSeries)
+}
+
+func (h *Handler) displayDiff(ctx *server.Context) error {
+	return handleProto(ctx, "diff", h.profileService.Diff)
 }
 
 func (h *Handler) displayLabelNames(ctx *server.Context) error {

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	profileService "huatuo-bamai/internal/profiler/service"
+)
+
+func TestProfileQueryHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "invalid query",
+			err:         errors.Join(profileService.ErrInvalidQuery, errors.New("bad selector")),
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "bad selector",
+		},
+		{
+			name:        "not found",
+			err:         profileService.ErrProfilesAbsent,
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "profiles not found",
+		},
+		{
+			name: "selection too large",
+			err: errors.Join(
+				profileService.ErrProfileQueryLimitExceeded,
+				errors.New("10001 documents"),
+			),
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: "10001 documents",
+		},
+		{
+			name:        "internal",
+			err:         errors.New("elasticsearch unavailable"),
+			wantStatus:  http.StatusInternalServerError,
+			wantMessage: "internal error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := profileQueryHTTPError(test.err)
+			if status != test.wantStatus {
+				t.Fatalf("status = %d, want %d", status, test.wantStatus)
+			}
+			if !strings.Contains(message, test.wantMessage) {
+				t.Fatalf("message = %q, want it to contain %q", message, test.wantMessage)
+			}
+		})
+	}
+}

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -254,6 +254,24 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
+### 9. Pyroscope-compatible Queries
+
+The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
+methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`
+returns time buckets using sum or average aggregation. `Diff` compares two
+independent time windows and returns a double flame graph.
+
+Selectors are intentionally exact. They accept `id`, `hostname`,
+`container_id`, `container_hostname`, and `tracer`; the profile type is supplied
+by the protobuf request. Regular expressions, negative matchers, and arbitrary
+labels are rejected with `400 Bad Request`.
+
+Each selection is counted before profile data is loaded. Up to 10,000 documents
+are read in stable pages of 1,000. A larger selection returns
+`422 Unprocessable Entity` and must be narrowed by time or target. Merge
+requests, and diff requests with neither side populated, return
+`404 Not Found`; storage failures return `500 Internal Server Error`.
+
 ## 📖 profiler CLI Overview
 
 `profiler` is HUATUO's standalone performance profiling CLI. It samples host processes or processes inside containers without requiring huatuo-apiserver, Elasticsearch, or Grafana. The tool supports C, C++, Go, Java, and Python processes and writes call stacks as folded stacks or SVG flame graphs.

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -252,6 +252,23 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
+### 9. Pyroscope 兼容查询
+
+Profiling API 在
+`/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的
+`SelectSeries` 和 `Diff` protobuf 方法。`SelectSeries` 按时间桶返回求和或
+平均聚合结果；`Diff` 比较两个独立时间窗口并返回双向火焰图。
+
+选择器只支持精确匹配，可使用 `id`、`hostname`、`container_id`、
+`container_hostname` 和 `tracer`；剖析类型由 protobuf 请求单独提供。
+正则、否定匹配和任意标签会返回 `400 Bad Request`。
+
+服务读取剖析数据前会先统计匹配文档数。单次选择最多读取 10,000 条，
+每页 1,000 条并使用稳定排序。超过上限时返回
+`422 Unprocessable Entity`，调用方需要缩小时间范围或目标范围。合并查询
+没有数据，或差异查询两侧都没有数据时返回 `404 Not Found`；存储故障返回
+`500 Internal Server Error`。
+
 ## 📖 profiler 命令行功能概述
 
 `profiler` 是 HUATUO 提供的独立性能剖析命令行工具。它可以直接对宿主机进程或容器内进程采样，不依赖 huatuo-apiserver、Elasticsearch 或 Grafana。工具支持 C、C++、Go、Java 和 Python 进程，并将调用栈输出为折叠栈或 SVG 火焰图。

--- a/internal/profiler/output/flamegraph/render.go
+++ b/internal/profiler/output/flamegraph/render.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"strings"
 )
 
 type frame struct {
@@ -157,9 +156,12 @@ func (r *renderer) drawFrame(f frame, ew *errWriter) {
 	x := r.style.XMargin + (f.LeftPercent / 100 * usableWidth)
 	y := r.style.FramesYOffset + (r.maxFrameDepth-f.Depth-1)*r.style.FrameHeight
 
-	jsTitle := strings.ReplaceAll(html.EscapeString(title), "'", "&#39;")
+	// Keep symbol data out of JavaScript source. XML entities are decoded
+	// before event handlers run, so escaping a quote inside s('...') would not
+	// prevent a crafted symbol from terminating that string.
+	attributeTitle := html.EscapeString(title)
 
-	ew.printf(`<g class="func_g" onmouseover="s('%s')" onmouseout="c()" onclick="zoom(this)">`+"\n", jsTitle)
+	ew.printf(`<g class="func_g" data-title="%s" onmouseover="s(this.getAttribute('data-title'))" onmouseout="c()" onclick="zoom(this)">`+"\n", attributeTitle)
 	ew.printf("  <title>%s</title>\n", html.EscapeString(title))
 	ew.printf(`  <rect x="%.1f" y="%d" width="%.1f" height="%d" fill="%s" rx="2" ry="2"/>`+"\n",
 		x, y, w, h, color)

--- a/internal/profiler/output/flamegraph/render_test.go
+++ b/internal/profiler/output/flamegraph/render_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderStyleKeepsSymbolsOutOfJavaScript(t *testing.T) {
+	symbol := `');alert(1);//<script>alert(2)</script>`
+	var output bytes.Buffer
+	if err := RenderStyle([]Stack{{
+		Names:   []string{"root", symbol},
+		Samples: 1,
+	}}, &output, DefaultStyle); err != nil {
+		t.Fatalf("RenderStyle() error = %v", err)
+	}
+
+	content := output.String()
+	if strings.Contains(content, `onmouseover="s('`) ||
+		strings.Contains(content, "<script>alert(2)</script>") {
+		t.Fatalf("SVG embeds an untrusted symbol as executable markup: %s", content)
+	}
+	if !strings.Contains(content, `data-title="`) ||
+		!strings.Contains(content, "&lt;script&gt;alert(2)&lt;/script&gt;") {
+		t.Fatalf("SVG does not preserve the escaped symbol as data: %s", content)
+	}
+}

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -33,6 +33,8 @@ const (
 	profileQueryLimit    = 10000
 	profileQueryPageSize = 1000
 	profileSeriesLimit   = 100
+	defaultProfileNodes  = 5000
+	profileNodeLimit     = 10000
 )
 
 type profileSelection struct {
@@ -289,6 +291,10 @@ func (s *Service) Diff(
 	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
 		return nil, invalidProfileQueryf("left and right profile types must match")
 	}
+	maxNodes, err := diffMaxNodes(req)
+	if err != nil {
+		return nil, err
+	}
 	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
 	if err != nil {
 		return nil, fmt.Errorf("select left profiles: %w", err)
@@ -300,24 +306,41 @@ func (s *Service) Diff(
 	if !leftFound && !rightFound {
 		return nil, ErrProfilesAbsent
 	}
-	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, diffMaxNodes(req))
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, maxNodes)
 	if err != nil {
 		return nil, fmt.Errorf("build flamegraph diff: %w", err)
 	}
 	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
 }
 
-func diffMaxNodes(req *querierv1.DiffRequest) int64 {
-	left := req.Left.GetMaxNodes()
-	right := req.Right.GetMaxNodes()
-	switch {
-	case left > 0 && right > 0 && right < left:
-		return right
-	case left > 0:
-		return left
-	default:
-		return right
+func diffMaxNodes(req *querierv1.DiffRequest) (int64, error) {
+	left, err := normalizeProfileMaxNodes(req.Left.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("left selection: %w", err)
 	}
+	right, err := normalizeProfileMaxNodes(req.Right.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("right selection: %w", err)
+	}
+	switch {
+	case right < left:
+		return right, nil
+	default:
+		return left, nil
+	}
+}
+
+func normalizeProfileMaxNodes(maxNodes int64) (int64, error) {
+	if maxNodes == 0 {
+		return defaultProfileNodes, nil
+	}
+	if maxNodes < 0 || maxNodes > profileNodeLimit {
+		return 0, invalidProfileQueryf(
+			"max nodes must be between 0 and %d",
+			profileNodeLimit,
+		)
+	}
+	return maxNodes, nil
 }
 
 // SelectSeries returns sample totals bucketed by time and exact profile labels.

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -108,6 +108,9 @@ func (s *Service) searchProfileDocuments(
 	if err != nil {
 		return nil, fmt.Errorf("count profiles: %w", err)
 	}
+	if count < 0 {
+		return nil, fmt.Errorf("count profiles: storage returned negative count %d", count)
+	}
 	if count > profileQueryLimit {
 		return nil, fmt.Errorf(
 			"%w: matched %d documents; narrow the time range or selector to at most %d",
@@ -126,10 +129,31 @@ func (s *Service) searchProfileDocuments(
 		if err != nil {
 			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
 		}
-		documents = append(documents, page...)
-		if len(page) < pageFilter.Limit {
-			break
+		if len(page) != pageFilter.Limit {
+			return nil, fmt.Errorf(
+				"search profiles at offset %d: storage returned %d documents, expected %d",
+				offset,
+				len(page),
+				pageFilter.Limit,
+			)
 		}
+		for index, document := range page {
+			if document == nil {
+				return nil, fmt.Errorf(
+					"search profiles at offset %d: storage returned nil document at page index %d",
+					offset,
+					index,
+				)
+			}
+		}
+		documents = append(documents, page...)
+	}
+	if int64(len(documents)) != count {
+		return nil, fmt.Errorf(
+			"search profiles: storage returned %d documents after count reported %d",
+			len(documents),
+			count,
+		)
 	}
 	return documents, nil
 }
@@ -161,26 +185,27 @@ func (s *Service) selectProfileTree(
 	}
 
 	tree := new(phlaremodel.Tree)
+	hasSamples := false
 	for _, document := range documents {
-		if document == nil {
-			continue
-		}
-		if err := addProfileDocumentToTree(tree, document, selection.sampleType); err != nil {
-			return nil, false, err
+		if addProfileDocumentToTree(tree, document, selection.sampleType) {
+			hasSamples = true
 		}
 	}
-	return tree, len(documents) > 0, nil
+	if !hasSamples && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+	return tree, hasSamples, nil
 }
 
 func addProfileDocumentToTree(
 	tree *phlaremodel.Tree,
 	document *ProfileDocument,
 	sampleType string,
-) error {
+) bool {
 	profile := &document.TracerData.Flamedata.Profile
-	sampleTypeIndex, err := profileSampleTypeIndex(profile, sampleType)
-	if err != nil {
-		return err
+	sampleTypeIndex, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return false
 	}
 
 	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
@@ -195,6 +220,7 @@ func addProfileDocumentToTree(
 			functions[function.Id] = function
 		}
 	}
+	inserted := false
 	for _, sample := range profile.Sample {
 		if sample == nil || sampleTypeIndex >= len(sample.Value) {
 			continue
@@ -202,21 +228,22 @@ func addProfileDocumentToTree(
 		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
 		if len(stack) > 0 {
 			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+			inserted = true
 		}
 	}
-	return nil
+	return inserted
 }
 
-func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, error) {
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, bool) {
 	for i, valueType := range profile.SampleType {
 		if valueType == nil {
 			continue
 		}
 		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
-			return i, nil
+			return i, true
 		}
 	}
-	return -1, invalidProfileQueryf("sample type %q not found", sampleType)
+	return -1, false
 }
 
 func profileSampleStack(
@@ -347,10 +374,7 @@ func (s *Service) SelectSeries(
 		if document == nil {
 			continue
 		}
-		value, found, err := profileDocumentSampleTotal(document, selection.sampleType)
-		if err != nil {
-			return nil, err
-		}
+		value, found := profileDocumentSampleTotal(document, selection.sampleType)
 		if !found {
 			continue
 		}
@@ -451,11 +475,11 @@ func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
 func profileDocumentSampleTotal(
 	document *ProfileDocument,
 	sampleType string,
-) (float64, bool, error) {
+) (float64, bool) {
 	profile := &document.TracerData.Flamedata.Profile
-	index, err := profileSampleTypeIndex(profile, sampleType)
-	if err != nil {
-		return 0, false, err
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return 0, false
 	}
 	var total float64
 	var found bool
@@ -466,7 +490,7 @@ func profileDocumentSampleTotal(
 		total += float64(sample.Value[index])
 		found = true
 	}
-	return total, found, nil
+	return total, found
 }
 
 func profileSeriesLabels(

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -1,0 +1,514 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	profileQueryLimit    = 10000
+	profileQueryPageSize = 1000
+	profileSeriesLimit   = 100
+)
+
+type profileSelection struct {
+	filter     *SearchFilter
+	sampleType string
+}
+
+func buildProfileSelection(profileType, selector string, start, end int64) (*profileSelection, error) {
+	profileTypeParts := strings.Split(profileType, ":")
+	if len(profileTypeParts) != 5 {
+		return nil, invalidProfileQueryf("invalid profile type %q", profileType)
+	}
+	if end < start {
+		return nil, invalidProfileQueryf("end time precedes start time")
+	}
+
+	matchers, err := parser.ParseMetricSelector(selector)
+	if err != nil {
+		return nil, invalidProfileQueryf("parse matchers: %v", err)
+	}
+	filter := &SearchFilter{
+		StartTime:   time.UnixMilli(start),
+		EndTime:     time.UnixMilli(end),
+		ProfileType: profileType,
+	}
+	for _, matcher := range matchers {
+		if matcher == nil {
+			continue
+		}
+		if matcher.Name == "__profile_type__" && matcher.Value != profileType {
+			return nil, invalidProfileQueryf(
+				"profile type matcher %q does not match request %q",
+				matcher.Value,
+				profileType,
+			)
+		}
+		if err := applyProfileMatcher(filter, matcher); err != nil {
+			return nil, err
+		}
+	}
+	if filter.ID != "" && filter.TracerID != "" && filter.ID != filter.TracerID {
+		return nil, invalidProfileQueryf("id and tracer select different profiles")
+	}
+	if !hasExactProfileTarget(filter) {
+		return nil, invalidProfileQueryf(
+			"id, hostname, container_id, container_hostname, or tracer must be specified",
+		)
+	}
+	return &profileSelection{filter: filter, sampleType: profileTypeParts[1]}, nil
+}
+
+func invalidProfileQueryf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidQuery, fmt.Sprintf(format, args...))
+}
+
+func hasExactProfileTarget(filter *SearchFilter) bool {
+	return filter != nil &&
+		(filter.ID != "" ||
+			filter.Hostname != "" ||
+			filter.ContainerID != "" ||
+			filter.ContainerHostname != "" ||
+			filter.TracerID != "")
+}
+
+func (s *Service) searchProfileDocuments(
+	ctx context.Context,
+	selection *profileSelection,
+) ([]*ProfileDocument, error) {
+	if s == nil || s.profileStorage == nil {
+		return nil, errorsProfileStorageNotInitialized()
+	}
+	count, err := s.profileStorage.CountProfilesContext(ctx, selection.filter)
+	if err != nil {
+		return nil, fmt.Errorf("count profiles: %w", err)
+	}
+	if count > profileQueryLimit {
+		return nil, fmt.Errorf(
+			"%w: matched %d documents; narrow the time range or selector to at most %d",
+			ErrProfileQueryLimitExceeded,
+			count,
+			profileQueryLimit,
+		)
+	}
+
+	documents := make([]*ProfileDocument, 0, int(count))
+	for offset := 0; offset < int(count); offset += profileQueryPageSize {
+		pageFilter := *selection.filter
+		pageFilter.Limit = min(profileQueryPageSize, int(count)-offset)
+		pageFilter.Offset = offset
+		page, err := s.profileStorage.SearchProfilesContext(ctx, &pageFilter)
+		if err != nil {
+			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
+		}
+		documents = append(documents, page...)
+		if len(page) < pageFilter.Limit {
+			break
+		}
+	}
+	return documents, nil
+}
+
+func errorsProfileStorageNotInitialized() error {
+	return fmt.Errorf("profile storage is not initialized")
+}
+
+func (s *Service) selectProfileTree(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	allowEmpty bool,
+) (*phlaremodel.Tree, bool, error) {
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(documents) == 0 && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+
+	tree := new(phlaremodel.Tree)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		if err := addProfileDocumentToTree(tree, document, selection.sampleType); err != nil {
+			return nil, false, err
+		}
+	}
+	return tree, len(documents) > 0, nil
+}
+
+func addProfileDocumentToTree(
+	tree *phlaremodel.Tree,
+	document *ProfileDocument,
+	sampleType string,
+) error {
+	profile := &document.TracerData.Flamedata.Profile
+	sampleTypeIndex, err := profileSampleTypeIndex(profile, sampleType)
+	if err != nil {
+		return err
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+	for _, sample := range profile.Sample {
+		if sample == nil || sampleTypeIndex >= len(sample.Value) {
+			continue
+		}
+		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
+		if len(stack) > 0 {
+			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+		}
+	}
+	return nil
+}
+
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, error) {
+	for i, valueType := range profile.SampleType {
+		if valueType == nil {
+			continue
+		}
+		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
+			return i, nil
+		}
+	}
+	return -1, invalidProfileQueryf("sample type %q not found", sampleType)
+}
+
+func profileSampleStack(
+	profile *profilev1.Profile,
+	locations map[uint64]*profilev1.Location,
+	functions map[uint64]*profilev1.Function,
+	locationIDs []uint64,
+) []string {
+	stack := make([]string, 0, len(locationIDs))
+	for _, locationID := range locationIDs {
+		location := locations[locationID]
+		if location == nil {
+			continue
+		}
+		for _, line := range location.Line {
+			if line == nil {
+				continue
+			}
+			function := functions[line.FunctionId]
+			if function == nil {
+				continue
+			}
+			name, ok := profileString(profile.StringTable, function.Name)
+			if ok {
+				stack = append(stack, name)
+			}
+		}
+	}
+	for left, right := 0, len(stack)-1; left < right; left, right = left+1, right-1 {
+		stack[left], stack[right] = stack[right], stack[left]
+	}
+	return stack
+}
+
+// Diff compares two independently selected profile windows.
+func (s *Service) Diff(
+	ctx context.Context,
+	req *querierv1.DiffRequest,
+) (*querierv1.DiffResponse, error) {
+	if req == nil || req.Left == nil || req.Right == nil {
+		return nil, invalidProfileQueryf("left and right profile selections are required")
+	}
+	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
+		return nil, invalidProfileQueryf("left and right profile types must match")
+	}
+	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
+	if err != nil {
+		return nil, fmt.Errorf("select left profiles: %w", err)
+	}
+	right, rightFound, err := s.selectProfileTree(ctx, req.Right, true)
+	if err != nil {
+		return nil, fmt.Errorf("select right profiles: %w", err)
+	}
+	if !leftFound && !rightFound {
+		return nil, ErrProfilesAbsent
+	}
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, diffMaxNodes(req))
+	if err != nil {
+		return nil, fmt.Errorf("build flamegraph diff: %w", err)
+	}
+	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
+}
+
+func diffMaxNodes(req *querierv1.DiffRequest) int64 {
+	left := req.Left.GetMaxNodes()
+	right := req.Right.GetMaxNodes()
+	switch {
+	case left > 0 && right > 0 && right < left:
+		return right
+	case left > 0:
+		return left
+	default:
+		return right
+	}
+}
+
+// SelectSeries returns sample totals bucketed by time and exact profile labels.
+func (s *Service) SelectSeries(
+	ctx context.Context,
+	req *querierv1.SelectSeriesRequest,
+) (*querierv1.SelectSeriesResponse, error) {
+	if req == nil {
+		return nil, invalidProfileQueryf("request is required")
+	}
+	stepMillis, err := seriesStepMillis(req.Step)
+	if err != nil {
+		return nil, err
+	}
+	aggregation := typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM
+	if req.Aggregation != nil {
+		aggregation = *req.Aggregation
+	}
+	if aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM &&
+		aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+		return nil, invalidProfileQueryf(
+			"unsupported time series aggregation %q",
+			aggregation.String(),
+		)
+	}
+	groupBy, err := normalizeProfileGroupBy(req.GroupBy)
+	if err != nil {
+		return nil, err
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	type bucketValue struct {
+		sum   float64
+		count int64
+	}
+	type groupedSeries struct {
+		labels  []*typesv1.LabelPair
+		buckets map[int64]*bucketValue
+	}
+	groups := make(map[string]*groupedSeries)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		value, found, err := profileDocumentSampleTotal(document, selection.sampleType)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		seriesLabels, key := profileSeriesLabels(document, groupBy)
+		group := groups[key]
+		if group == nil {
+			group = &groupedSeries{
+				labels:  seriesLabels,
+				buckets: make(map[int64]*bucketValue),
+			}
+			groups[key] = group
+		}
+		timestamp := profileDocumentTimestamp(document).UnixMilli()
+		bucketTimestamp := req.Start + ((timestamp-req.Start)/stepMillis)*stepMillis
+		bucket := group.buckets[bucketTimestamp]
+		if bucket == nil {
+			bucket = &bucketValue{}
+			group.buckets[bucketTimestamp] = bucket
+		}
+		bucket.sum += value
+		bucket.count++
+	}
+
+	series := make([]*typesv1.Series, 0, len(groups))
+	for _, group := range groups {
+		points := make([]*typesv1.Point, 0, len(group.buckets))
+		for timestamp, value := range group.buckets {
+			pointValue := value.sum
+			if aggregation ==
+				typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+				pointValue /= float64(value.count)
+			}
+			points = append(points, &typesv1.Point{
+				Value:     pointValue,
+				Timestamp: timestamp,
+			})
+		}
+		sort.Slice(points, func(i, j int) bool {
+			return points[i].Timestamp < points[j].Timestamp
+		})
+		series = append(series, &typesv1.Series{
+			Labels: group.labels,
+			Points: points,
+		})
+	}
+	sort.Slice(series, func(i, j int) bool {
+		left, right := profileSeriesValue(series[i]), profileSeriesValue(series[j])
+		if left != right {
+			return left > right
+		}
+		return phlaremodel.CompareLabelPairs(series[i].Labels, series[j].Labels) < 0
+	})
+	if len(series) > profileSeriesLimit {
+		series = series[:profileSeriesLimit]
+	}
+	return &querierv1.SelectSeriesResponse{Series: series}, nil
+}
+
+func seriesStepMillis(step float64) (int64, error) {
+	if math.IsNaN(step) ||
+		math.IsInf(step, 0) ||
+		step <= 0 ||
+		step > float64(math.MaxInt64)/1000 {
+		return 0, invalidProfileQueryf(
+			"step must be a finite positive number of seconds",
+		)
+	}
+	milliseconds := int64(math.Round(step * 1000))
+	if milliseconds < 1 {
+		return 1, nil
+	}
+	return milliseconds, nil
+}
+
+func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(groupBy))
+	result := make([]string, 0, len(groupBy))
+	for _, name := range groupBy {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		switch name {
+		case "id", "hostname", "container_id", "container_hostname", "tracer":
+		default:
+			return nil, invalidProfileQueryf("invalid group-by label %q", name)
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func profileDocumentSampleTotal(
+	document *ProfileDocument,
+	sampleType string,
+) (float64, bool, error) {
+	profile := &document.TracerData.Flamedata.Profile
+	index, err := profileSampleTypeIndex(profile, sampleType)
+	if err != nil {
+		return 0, false, err
+	}
+	var total float64
+	var found bool
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) {
+			continue
+		}
+		total += float64(sample.Value[index])
+		found = true
+	}
+	return total, found, nil
+}
+
+func profileSeriesLabels(
+	document *ProfileDocument,
+	groupBy []string,
+) ([]*typesv1.LabelPair, string) {
+	pairs := make([]*typesv1.LabelPair, 0, len(groupBy))
+	var key strings.Builder
+	for _, name := range groupBy {
+		value := profileDocumentLabelValue(document, name)
+		pairs = append(pairs, &typesv1.LabelPair{Name: name, Value: value})
+		_, _ = fmt.Fprintf(&key, "%d:%s=%d:%s;", len(name), name, len(value), value)
+	}
+	return pairs, key.String()
+}
+
+func profileDocumentLabelValue(document *ProfileDocument, name string) string {
+	switch name {
+	case "id", "tracer":
+		return document.TracerID
+	case "hostname":
+		return document.Hostname
+	case "container_id":
+		return document.ContainerID
+	case "container_hostname":
+		return document.ContainerHostname
+	default:
+		return ""
+	}
+}
+
+func profileDocumentTimestamp(document *ProfileDocument) time.Time {
+	if !document.UploadedTime.IsZero() {
+		return document.UploadedTime
+	}
+	return parseProfileDocumentTime(document.TracerTime, time.Unix(0, 0))
+}
+
+func profileSeriesValue(series *typesv1.Series) float64 {
+	var total float64
+	for _, point := range series.GetPoints() {
+		total += point.GetValue()
+	}
+	return total
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -35,6 +35,7 @@ type fakeProfileQueryStorage struct {
 	countErr    error
 	searchErr   error
 	searchCalls []SearchFilter
+	pages       map[int][]*ProfileDocument
 }
 
 func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
@@ -48,6 +49,9 @@ func (s *fakeProfileQueryStorage) SearchProfilesContext(
 		return nil, s.searchErr
 	}
 	s.searchCalls = append(s.searchCalls, *filter)
+	if s.pages != nil {
+		return s.pages[filter.Offset], nil
+	}
 	documents := s.matchingDocuments(filter)
 	if filter.Offset >= len(documents) {
 		return nil, nil
@@ -223,6 +227,71 @@ func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
 	}
 }
 
+func TestSearchProfileDocumentsRejectsInvalidStorageResults(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	tests := []struct {
+		name    string
+		storage *fakeProfileQueryStorage
+	}{
+		{
+			name:    "negative count",
+			storage: &fakeProfileQueryStorage{count: -1},
+		},
+		{
+			name: "empty page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {}},
+			},
+		},
+		{
+			name: "short page",
+			storage: &fakeProfileQueryStorage{
+				count: 2,
+				pages: map[int][]*ProfileDocument{0: {document}},
+			},
+		},
+		{
+			name: "oversized page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {document, document}},
+			},
+		},
+		{
+			name: "nil document",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {nil}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTestProfileService(test.storage)
+			selection, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				`{id="trace-a"}`,
+				0,
+				time.Now().Add(time.Hour).UnixMilli(),
+			)
+			if err != nil {
+				t.Fatalf("buildProfileSelection() error = %v", err)
+			}
+
+			_, err = service.searchProfileDocuments(t.Context(), selection)
+			if err == nil {
+				t.Fatal("searchProfileDocuments() error = nil, want storage contract error")
+			}
+			if errors.Is(err, ErrInvalidQuery) ||
+				errors.Is(err, ErrProfilesAbsent) ||
+				errors.Is(err, ErrProfileQueryLimitExceeded) {
+				t.Fatalf("storage contract error = %v, want internal error", err)
+			}
+		})
+	}
+}
+
 func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
 	for _, selector := range []string{
 		`{hostname=~"node-.*"}`,
@@ -306,6 +375,85 @@ func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
 	}
 	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
 		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestEmptyStoredProfileHasNoUsableSamples(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	_, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="empty-profile"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="empty-profile"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+}
+
+func TestSamplesWithoutValuesAreSkipped(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 13, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "no-values", 1, "root", "leaf")
+	document.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{
+		nil,
+		{LocationId: []uint64{2, 1}},
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="no-values"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+
+	_, err = service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="no-values"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
 	}
 }
 

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+type fakeProfileQueryStorage struct {
+	documents   []*ProfileDocument
+	count       int64
+	countErr    error
+	searchErr   error
+	searchCalls []SearchFilter
+}
+
+func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
+func (*fakeProfileQueryStorage) Ready(context.Context) error { return nil }
+
+func (s *fakeProfileQueryStorage) SearchProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) ([]*ProfileDocument, error) {
+	if s.searchErr != nil {
+		return nil, s.searchErr
+	}
+	s.searchCalls = append(s.searchCalls, *filter)
+	documents := s.matchingDocuments(filter)
+	if filter.Offset >= len(documents) {
+		return nil, nil
+	}
+	end := min(filter.Offset+filter.Limit, len(documents))
+	return documents[filter.Offset:end], nil
+}
+
+func (s *fakeProfileQueryStorage) CountProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) (int64, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	if s.count != 0 {
+		return s.count, nil
+	}
+	return int64(len(s.matchingDocuments(filter))), nil
+}
+
+func (*fakeProfileQueryStorage) AggregationsByFieldContext(
+	context.Context,
+	*SearchFilter,
+	string,
+) ([]string, error) {
+	return nil, nil
+}
+
+func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*ProfileDocument {
+	documents := make([]*ProfileDocument, 0, len(s.documents))
+	for _, document := range s.documents {
+		if document == nil {
+			continue
+		}
+		timestamp := profileDocumentTimestamp(document)
+		if !filter.StartTime.IsZero() && timestamp.Before(filter.StartTime) {
+			continue
+		}
+		if !filter.EndTime.IsZero() && timestamp.After(filter.EndTime) {
+			continue
+		}
+		if filter.ProfileType != "" &&
+			filter.ProfileType != document.TracerData.Flamedata.ProfileType {
+			continue
+		}
+		tracerID := filter.TracerID
+		if tracerID == "" {
+			tracerID = filter.ID
+		}
+		if tracerID != "" && tracerID != document.TracerID {
+			continue
+		}
+		if filter.Hostname != "" &&
+			(filter.Hostname != document.Hostname || document.ContainerHostname != "") {
+			continue
+		}
+		if filter.ContainerID != "" && filter.ContainerID != document.ContainerID {
+			continue
+		}
+		if filter.ContainerHostname != "" &&
+			filter.ContainerHostname != document.ContainerHostname {
+			continue
+		}
+		documents = append(documents, document)
+	}
+	return documents
+}
+
+func newTestProfileService(storage *fakeProfileQueryStorage) *Service {
+	return &Service{profileStorage: storage}
+}
+
+func testProfileDocument(
+	timestamp time.Time,
+	tracerID string,
+	value int64,
+	stack ...string,
+) *ProfileDocument {
+	stringTable := []string{"", "cpu", "nanoseconds"}
+	functions := make([]*profilev1.Function, len(stack))
+	locations := make([]*profilev1.Location, len(stack))
+	locationIDs := make([]uint64, len(stack))
+	for i, name := range stack {
+		stringTable = append(stringTable, name)
+		id := uint64(i + 1)
+		functions[i] = &profilev1.Function{
+			Id:   id,
+			Name: int64(len(stringTable) - 1),
+		}
+		locations[i] = &profilev1.Location{
+			Id:   id,
+			Line: []*profilev1.Line{{FunctionId: id}},
+		}
+		locationIDs[len(stack)-1-i] = id
+	}
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: timestamp,
+		TracerID:     tracerID,
+		TracerTime:   timestamp.Format(profileTimeLayout),
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	document.TracerData.Flamedata.Profile = profilev1.Profile{
+		StringTable: stringTable,
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+			Unit: 2,
+		}},
+		Function: functions,
+		Location: locations,
+		Sample: []*profilev1.Sample{{
+			LocationId: locationIDs,
+			Value:      []int64{value},
+		}},
+	}
+	return document
+}
+
+func TestSearchProfileDocumentsPaginatesWithoutTruncation(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	documents := make([]*ProfileDocument, 1001)
+	for i := range documents {
+		documents[i] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{hostname="node-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	got, err := service.searchProfileDocuments(t.Context(), selection)
+	if err != nil {
+		t.Fatalf("searchProfileDocuments() error = %v", err)
+	}
+	if len(got) != len(documents) {
+		t.Fatalf("documents = %d, want %d", len(got), len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	if storage.searchCalls[0].Limit != 1000 ||
+		storage.searchCalls[0].Offset != 0 ||
+		storage.searchCalls[1].Limit != 1 ||
+		storage.searchCalls[1].Offset != 1000 {
+		t.Fatalf("search pages = %#v, want 1000@0 and 1@1000", storage.searchCalls)
+	}
+}
+
+func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		count: profileQueryLimit + 1,
+	})
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	_, err = service.searchProfileDocuments(t.Context(), selection)
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf("searchProfileDocuments() error = %v, want query limit error", err)
+	}
+}
+
+func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
+	for _, selector := range []string{
+		`{hostname=~"node-.*"}`,
+		`{region="ap-guangzhou"}`,
+		`{arbitrary_label="value"}`,
+		`{id="trace-a",tracer="trace-b"}`,
+	} {
+		t.Run(selector, func(t *testing.T) {
+			_, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				selector,
+				0,
+				1,
+			)
+			if !errors.Is(err, ErrInvalidQuery) {
+				t.Fatalf("buildProfileSelection() error = %v, want invalid query", err)
+			}
+		})
+	}
+}
+
+func TestSelectSeriesBucketsAndGroups(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(100*time.Millisecond), "trace-a", 10, "root", "hot"),
+		testProfileDocument(start.Add(1500*time.Millisecond), "trace-a", 20, "root", "hot"),
+		testProfileDocument(start.Add(500*time.Millisecond), "trace-b", 7, "root", "worker"),
+	}}
+	service := newTestProfileService(storage)
+
+	response, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(4 * time.Second).UnixMilli(),
+		GroupBy:       []string{"tracer"},
+		Step:          2,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 2 {
+		t.Fatalf("series = %#v, want two tracer groups", response.Series)
+	}
+	if got := response.Series[0].Labels[0].Value; got != "trace-a" {
+		t.Fatalf("first series tracer = %q, want trace-a", got)
+	}
+	wantPoints := []*typesv1.Point{{
+		Value:     30,
+		Timestamp: start.UnixMilli(),
+	}}
+	if got := response.Series[0].Points; !reflect.DeepEqual(got, wantPoints) {
+		t.Fatalf("trace-a points = %#v, want %#v", got, wantPoints)
+	}
+}
+
+func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(time.Second), "left", 10, "root", "hot"),
+	}})
+	maxNodes := int64(100)
+	response, err := service.Diff(t.Context(), &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="left"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(5 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="right"}`,
+			Start:         start.Add(10 * time.Second).UnixMilli(),
+			End:           start.Add(15 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
+		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestProfileQueryStorageErrorsRemainInternal(t *testing.T) {
+	sentinel := fmt.Errorf("backend unavailable")
+	service := newTestProfileService(&fakeProfileQueryStorage{countErr: sentinel})
+	_, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="trace-a"}`,
+		Start:         0,
+		End:           1,
+		Step:          1,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("SelectSeries() error = %v, want wrapped backend error", err)
+	}
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -348,6 +348,25 @@ func TestSelectSeriesBucketsAndGroups(t *testing.T) {
 	}
 }
 
+func TestProfileNodeLimits(t *testing.T) {
+	if got, err := normalizeProfileMaxNodes(0); err != nil ||
+		got != defaultProfileNodes {
+		t.Fatalf("normalizeProfileMaxNodes(0) = (%d, %v)", got, err)
+	}
+	for _, value := range []int64{-1, profileNodeLimit + 1} {
+		if _, err := normalizeProfileMaxNodes(value); !errors.Is(
+			err,
+			ErrInvalidQuery,
+		) {
+			t.Fatalf(
+				"normalizeProfileMaxNodes(%d) error = %v, want invalid query",
+				value,
+				err,
+			)
+		}
+	}
+}
+
 func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
 	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
 	service := newTestProfileService(&fakeProfileQueryStorage{documents: []*ProfileDocument{

--- a/internal/profiler/service/errors.go
+++ b/internal/profiler/service/errors.go
@@ -17,6 +17,7 @@ package service
 import "errors"
 
 var (
-	ErrInvalidQuery   = errors.New("invalid profile query")
-	ErrProfilesAbsent = errors.New("profiles not found")
+	ErrInvalidQuery              = errors.New("invalid profile query")
+	ErrProfilesAbsent            = errors.New("profiles not found")
+	ErrProfileQueryLimitExceeded = errors.New("profile query limit exceeded")
 )

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -23,11 +23,9 @@ import (
 
 	"huatuo-bamai/internal/log"
 
-	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
-	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -36,9 +34,21 @@ type ElasticSearchConfig struct {
 	Address, Username, Password, Index string
 }
 
+type profileQueryStorage interface {
+	Close(ctx context.Context) error
+	Ready(ctx context.Context) error
+	SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error)
+	CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error)
+	AggregationsByFieldContext(
+		ctx context.Context,
+		filter *SearchFilter,
+		field string,
+	) ([]string, error)
+}
+
 // Service provides profile query operations.
 type Service struct {
-	profileStorage *ProfileStorage
+	profileStorage profileQueryStorage
 }
 
 // NewService initializes a profile query service.
@@ -77,152 +87,13 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
-	if req.End < req.Start {
-		return nil, fmt.Errorf("%w: end time precedes start time", ErrInvalidQuery)
-	}
-	filter := &SearchFilter{
-		StartTime:   time.UnixMilli(req.Start),
-		EndTime:     time.UnixMilli(req.End),
-		ProfileType: req.ProfileTypeID,
-		Limit:       100,
-	}
-
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
-
-	profileTypes := strings.Split(filter.ProfileType, ":")
-	if len(profileTypes) != 5 {
-		return nil, fmt.Errorf("%w: invalid profile type %q", ErrInvalidQuery, filter.ProfileType)
-	}
-
-	// labels
-	labels, err := parser.ParseMetricSelector(req.LabelSelector)
+	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
-		return nil, errors.Join(ErrInvalidQuery, fmt.Errorf("parse matchers: %w", err))
+		return nil, err
 	}
-
-	for _, label := range labels {
-		// skip empty or "All"
-		if label.Value == "" || label.Value == "all" || label.Value == "All" || label.Value == "*" {
-			continue
-		}
-
-		if err := applyProfileMatcher(filter, label); err != nil {
-			return nil, err
-		}
-	}
-
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
-	}
-
-	// search
-	profileDocs, err := s.profileStorage.SearchProfilesContext(ctx, filter)
-	if err != nil {
-		return nil, fmt.Errorf("search profiles: %w", err)
-	}
-	if len(profileDocs) == 0 {
-		return nil, ErrProfilesAbsent
-	}
-
-	// merge profileDocs
-	var profilesMerge pprof.ProfileMerge
-	for _, profileDoc := range profileDocs {
-		profile := &profileDoc.TracerData.Flamedata.Profile
-		if err := profilesMerge.Merge(profile); err != nil {
-			return nil, fmt.Errorf("merge profile: %w", err)
-		}
-	}
-	profile := profilesMerge.Profile()
-	if profile == nil {
-		return nil, ErrProfilesAbsent
-	}
-	sampleType := profileTypes[1]
-
-	// convert profilev1.Profile to phlaremodel.Tree
-	phlaremodelTree := new(phlaremodel.Tree)
-
-	// Find the index of the sample type we're interested in
-	sampleTypeIndex := -1
-	for i, st := range profile.SampleType {
-		if st == nil {
-			continue
-		}
-		if value, ok := profileString(profile.StringTable, st.Type); ok && value == sampleType {
-			sampleTypeIndex = i
-			break
-		}
-	}
-	if sampleTypeIndex == -1 {
-		return nil, fmt.Errorf("%w: sample type %q not found", ErrInvalidQuery, sampleType)
-	}
-
-	// Create a map for quick location lookup
-	locationMap := make(map[uint64]*googlev1.Location, len(profile.Location))
-	for _, loc := range profile.Location {
-		if loc == nil {
-			continue
-		}
-		locationMap[loc.Id] = loc
-	}
-
-	// Create a map for quick function lookup
-	functionMap := make(map[uint64]*googlev1.Function, len(profile.Function))
-	for _, fn := range profile.Function {
-		if fn == nil {
-			continue
-		}
-		functionMap[fn.Id] = fn
-	}
-
-	// Process each sample
-	for _, sample := range profile.Sample {
-		if sample == nil {
-			continue
-		}
-		// Get the value for our sample type
-		if len(sample.Value) <= sampleTypeIndex {
-			continue
-		}
-		value := sample.Value[sampleTypeIndex]
-
-		// Build stack trace string from location ids
-		stack := make([]string, 0, len(sample.LocationId))
-		for _, locId := range sample.LocationId {
-			loc, exists := locationMap[locId]
-			if !exists || len(loc.Line) == 0 {
-				continue
-			}
-
-			// Get the first line entry (primary function)
-			line := loc.Line[0]
-			if line == nil {
-				continue
-			}
-			fn, exists := functionMap[line.FunctionId]
-			if !exists {
-				continue
-			}
-
-			// Get function name from string table
-			funcName, ok := profileString(profile.StringTable, fn.Name)
-			if !ok {
-				continue
-			}
-			stack = append(stack, funcName)
-		}
-
-		// Insert stack into tree (leaf is at stack[0], so we need to reverse for phlaremodel.Tree)
-		if len(stack) > 0 {
-			for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
-				stack[i], stack[j] = stack[j], stack[i]
-			}
-			phlaremodelTree.InsertStack(value, stack...)
-		}
-	}
-
-	// convert phlaremodel.Tree to FlameGraph
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(phlaremodelTree, -1),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, req.GetMaxNodes()),
 	}, nil
 }
 
@@ -239,6 +110,8 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 		filter.ContainerID = matcher.Value
 	case "container_hostname":
 		filter.ContainerHostname = matcher.Value
+	case "tracer":
+		filter.TracerID = matcher.Value
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -88,12 +88,16 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
+	maxNodes, err := normalizeProfileMaxNodes(req.GetMaxNodes())
+	if err != nil {
+		return nil, err
+	}
 	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
 		return nil, err
 	}
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(tree, req.GetMaxNodes()),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, maxNodes),
 	}, nil
 }
 

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -167,6 +167,14 @@ func (s *ProfileStorage) SearchProfilesContext(ctx context.Context, filter *Sear
 	return documents, nil
 }
 
+// CountProfilesContext counts profiles matching a filter.
+func (s *ProfileStorage) CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error) {
+	if s == nil || s.store == nil {
+		return 0, errors.New("profile storage is not initialized")
+	}
+	return s.store.Count(ctx, buildProfileAggregationQuery(filter))
+}
+
 // AggregationsByField gets aggregations by field.
 func (s *ProfileStorage) AggregationsByField(filter *SearchFilter, field string) ([]string, error) {
 	return s.AggregationsByFieldContext(context.Background(), filter, field)
@@ -259,6 +267,7 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	}
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
 	}
 	return query
 }

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -58,3 +58,15 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
 	}
 }
+
+func TestBuildProfileSearchQueryUsesStablePaginationOrder(t *testing.T) {
+	query := buildProfileSearchQuery(&SearchFilter{Limit: 1000, Offset: 1000})
+	want := []driver.Sort{
+		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
+	}
+
+	if !reflect.DeepEqual(query.Sorts, want) {
+		t.Fatalf("query sorts = %#v, want %#v", query.Sorts, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add Pyroscope-compatible SelectSeries and Diff queries
- load selected profiles with stable pagination and consistency checks
- reject selections above 10,000 documents
- apply bounded flame graph node limits

## Dependencies

This PR is stacked on #443.

Multidimensional collection labels are intentionally excluded and remain
dependent on #329.

## Testing

- make check
- go test ./internal/profiler/service
- go test ./cmd/huatuo-apiserver/handlers/profiling

Part of #328.