### PR TITLE
[5/5] feat(profiling): add advanced and comparison profile views

### DIFF
--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     network_mode: host
     environment:
       GF_INSTALL_PLUGINS: "yesoreyeram-infinity-datasource ${INFINITY_DATA_SOURCE:-3.4.1}"
+      HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}
     volumes:
       - ./grafana/datasources/elasticsearch.yaml:/etc/grafana/provisioning/datasources/elasticsearch.yaml:ro
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro
       - ./grafana/datasources/infinity.yaml:/etc/grafana/provisioning/datasources/infinity.yaml:ro
       - ./grafana/datasources/pyroscope.yaml:/etc/grafana/provisioning/datasources/pyroscope.yaml:ro
+      - ./grafana/datasources/profiling-json.yaml:/etc/grafana/provisioning/datasources/profiling-json.yaml:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
     depends_on:
       - prometheus

--- a/build/docker/grafana/dashboards/continuous-profiling-compare.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-compare.json
@@ -1,0 +1,230 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "The selected Grafana time range is the current (right) window. It is compared with the immediately preceding window of the same duration. Select a container ID for container profiles; otherwise the exact hostname is used.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.3",
+      "title": "Comparison window",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "huatuo-apiserver-profile-json"
+      },
+      "description": "Compares the selected window with the immediately preceding window of the same duration.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {},
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "level",
+              "text": "level",
+              "type": "number"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "self",
+              "text": "self",
+              "type": "number"
+            },
+            {
+              "selector": "valueRight",
+              "text": "valueRight",
+              "type": "number"
+            },
+            {
+              "selector": "selfRight",
+              "text": "selfRight",
+              "type": "number"
+            },
+            {
+              "selector": "label",
+              "text": "label",
+              "type": "string"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "huatuo-apiserver-profile-json"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/profiles/flamegraph/diff-rows",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{\n  \"profile_type_id\": ${type:json},\n  \"hostname\": ${hostname:json},\n  \"container_id\": ${container_id:json},\n  \"start\": ${__from},\n  \"end\": ${__to},\n  \"max_nodes\": 5000\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Current versus previous window",
+      "type": "flamegraph"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [
+    "profiling",
+    "continuous profiling"
+  ],
+  "templating": {
+    "list": [
+      {
+        "description": "profiling type",
+        "label": "type",
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+            "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+          },
+          {
+            "selected": false,
+            "text": "memory:alloc_space:bytes:space:bytes",
+            "value": "memory:alloc_space:bytes:space:bytes"
+          }
+        ],
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "description": "Used when no container ID is selected.",
+        "label": "hostname",
+        "name": "hostname",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Overrides hostname when a stable container ID is selected.",
+        "includeAll": true,
+        "label": "container ID",
+        "multi": false,
+        "name": "container_id",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Continuous profiling comparison",
+  "uid": "continuous-profiling-compare",
+  "version": 1,
+  "weekStart": ""
+}

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -24,7 +24,20 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -135,12 +148,13 @@
               "type": "count"
             }
           ],
-          "query": "hostname.keyword:$hostname\nAND container_hostname.keyword:$container_hostname\nAND tracer_data.flamedata.profile_type.keyword:$type",
+          "query": "hostname.keyword:$hostname\nAND container_id.keyword:$container_id\nAND tracer_data.flamedata.profile_type.keyword:$type",
           "refId": "A",
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
       "type": "timeseries"
     },
     {
@@ -171,14 +185,15 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{container_hostname=\"$container_hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",container_id=\"$container_id\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "title": "$container_hostname",
+      "description": "Merged profile for the selected container, host, type, and time range.",
+      "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -192,12 +207,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
-        "description": "Selects container-level profiles.",
-        "label": "container hostname",
-        "name": "container_hostname",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Selects one container by its stable ID.",
+        "label": "container ID",
+        "name": "container_id",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -208,12 +223,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
-        "description": "Read-only. Displays the host where the selected container resides. Not used as a query filter; filtering is by container_hostname only.",
-        "label": "hostname(Read-only)",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
+        "description": "Selects the host that reported the container profile.",
+        "label": "hostname",
         "name": "hostname",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -232,29 +247,19 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(container)",
+  "title": "Continuous Profiling (Container)",
   "uid": "continuous-profiling-container"
 }

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -185,14 +185,14 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{hostname=\"$hostname\",container_id=\"$container_id\"}",
+          "labelSelector": "{container_id=\"$container_id\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "description": "Merged profile for the selected container, host, type, and time range.",
+      "description": "Merged profile for the selected container ID, type, and time range.",
       "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -36,6 +36,18 @@
       "tooltip": "Open the host profiling dashboard.",
       "type": "link",
       "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Compare windows",
+      "tooltip": "Compare the selected window with its preceding window.",
+      "type": "link",
+      "url": "/d/continuous-profiling-compare/continuous-profiling-compare"
     }
   ],
   "panels": [
@@ -162,6 +174,112 @@
         "type": "grafana-pyroscope-datasource",
         "uid": "huatuo-apiserver-pyroscope"
       },
+      "description": "Total profile value in each time bucket for the selected container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{container_id=\"$container_id\"}",
+          "limit": 1,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Profile value over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Ten highest-value profiling jobs in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [
+            "tracer"
+          ],
+          "labelSelector": "{container_id=\"$container_id\"}",
+          "limit": 10,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 by tracer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -170,7 +288,7 @@
         "h": 20,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 12
       },
       "id": 1,
       "maxPerRow": 2,

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -24,7 +24,20 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -140,7 +153,8 @@
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
       "type": "timeseries"
     },
     {
@@ -178,7 +192,8 @@
           "spanSelector": []
         }
       ],
-      "title": "$hostname",
+      "description": "Merged profile for the selected host, type, and time range.",
+      "title": "$hostname flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -217,29 +232,19 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(host)",
+  "title": "Continuous Profiling (Host)",
   "uid": "continuous-profiling-host"
 }

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -36,6 +36,18 @@
       "tooltip": "Open the container profiling dashboard.",
       "type": "link",
       "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Compare windows",
+      "tooltip": "Compare the selected window with its preceding window.",
+      "type": "link",
+      "url": "/d/continuous-profiling-compare/continuous-profiling-compare"
     }
   ],
   "panels": [
@@ -162,6 +174,112 @@
         "type": "grafana-pyroscope-datasource",
         "uid": "huatuo-apiserver-pyroscope"
       },
+      "description": "Total profile value in each time bucket for the selected host.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{hostname=\"$hostname\"}",
+          "limit": 1,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Profile value over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Ten highest-value profiling jobs in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [
+            "tracer"
+          ],
+          "labelSelector": "{hostname=\"$hostname\"}",
+          "limit": 10,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 by tracer",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -170,7 +288,7 @@
         "h": 20,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 12
       },
       "id": 1,
       "maxPerRow": 2,

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	cpuProfileType    = "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+	memoryProfileType = "memory:alloc_space:bytes:space:bytes"
+)
+
+type dashboardVariable struct {
+	Name       string `json:"name"`
+	Definition string `json:"definition"`
+	Query      string `json:"query"`
+	Options    []struct {
+		Value string `json:"value"`
+	} `json:"options"`
+}
+
+type dashboardContract struct {
+	UID        string `json:"uid"`
+	Templating struct {
+		List []dashboardVariable `json:"list"`
+	} `json:"templating"`
+}
+
+func loadDashboard(t *testing.T, filename string) (dashboardContract, any, string) {
+	t.Helper()
+
+	payload, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+
+	var contract dashboardContract
+	if err := json.Unmarshal(payload, &contract); err != nil {
+		t.Fatalf("decode %s: %v", filename, err)
+	}
+
+	var raw any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatalf("decode raw %s: %v", filename, err)
+	}
+
+	return contract, raw, string(payload)
+}
+
+func dashboardStrings(value any, field string, values *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				if text, ok := item.(string); ok {
+					*values = append(*values, text)
+				}
+			}
+			dashboardStrings(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardStrings(item, field, values)
+		}
+	}
+}
+
+func findDashboardVariable(t *testing.T, dashboard dashboardContract, name string) dashboardVariable {
+	t.Helper()
+
+	for _, variable := range dashboard.Templating.List {
+		if variable.Name == name {
+			return variable
+		}
+	}
+	t.Fatalf("dashboard %q has no %q variable", dashboard.UID, name)
+	return dashboardVariable{}
+}
+
+func requireSupportedProfileTypes(t *testing.T, dashboard dashboardContract) {
+	t.Helper()
+
+	variable := findDashboardVariable(t, dashboard, "type")
+	values := make([]string, 0, len(variable.Options))
+	for _, option := range variable.Options {
+		values = append(values, option.Value)
+	}
+	if !slices.Equal(values, []string{cpuProfileType, memoryProfileType}) {
+		t.Fatalf("profile types = %v, want only CPU and memory", values)
+	}
+}
+
+func TestContinuousProfilingHostDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-host.json")
+	if dashboard.UID != "continuous-profiling-host" {
+		t.Fatalf("UID = %q, want continuous-profiling-host", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "NOT _exists_:container_hostname") {
+		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
+	}
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	if !slices.Equal(selectors, []string{`{hostname="$hostname"}`}) {
+		t.Fatalf("profile selectors = %v, want exact hostname selector", selectors)
+	}
+	if strings.Contains(payload, "process_lock") {
+		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	}
+}
+
+func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-container.json")
+	if dashboard.UID != "continuous-profiling-container" {
+		t.Fatalf("UID = %q, want continuous-profiling-container", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "container_id.keyword:$container_id") {
+		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
+	}
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	wantSelector := `{hostname="$hostname",container_id="$container_id"}`
+	if !slices.Equal(selectors, []string{wantSelector}) {
+		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
+	}
+	if strings.Contains(payload, "container_hostname") {
+		t.Fatal("dashboard uses non-unique container hostname")
+	}
+	if strings.Contains(payload, "process_lock") {
+		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	}
+}
+
+func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
+	datasource, err := os.ReadFile("../datasources/pyroscope.yaml")
+	if err != nil {
+		t.Fatalf("read Pyroscope datasource: %v", err)
+	}
+	datasourceText := string(datasource)
+	if !strings.Contains(
+		datasourceText,
+		"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
+	) {
+		t.Fatal("Pyroscope datasource does not use the runtime bearer token")
+	}
+	if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
+		t.Fatal("Pyroscope datasource contains a placeholder credential")
+	}
+
+	compose, err := os.ReadFile("../../docker-compose.yml")
+	if err != nil {
+		t.Fatalf("read Docker Compose config: %v", err)
+	}
+	if !strings.Contains(
+		string(compose),
+		"HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}",
+	) {
+		t.Fatal("Grafana container does not receive the profile query token")
+	}
+}

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -82,6 +82,22 @@ func dashboardStrings(value any, field string, values *[]string) {
 	}
 }
 
+func dashboardValues(value any, field string, values *[]any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				*values = append(*values, item)
+			}
+			dashboardValues(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardValues(item, field, values)
+		}
+	}
+}
+
 func findDashboardVariable(t *testing.T, dashboard dashboardContract, name string) dashboardVariable {
 	t.Helper()
 
@@ -107,6 +123,67 @@ func requireSupportedProfileTypes(t *testing.T, dashboard dashboardContract) {
 	}
 }
 
+func requireExactProfileQueries(
+	t *testing.T,
+	raw any,
+	selector string,
+) {
+	t.Helper()
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	if !slices.Equal(selectors, []string{selector, selector, selector}) {
+		t.Fatalf("profile selectors = %v, want exact %s selectors", selectors, selector)
+	}
+
+	var queryTypes []string
+	dashboardStrings(raw, "queryType", &queryTypes)
+	if !slices.Equal(queryTypes, []string{"metrics", "metrics", "profile"}) {
+		t.Fatalf("query types = %v, want two series and one profile query", queryTypes)
+	}
+
+	var groupBys []any
+	dashboardValues(raw, "groupBy", &groupBys)
+	if len(groupBys) != 3 {
+		t.Fatalf("profile groupBy values = %v, want three", groupBys)
+	}
+	if grouped, ok := groupBys[1].([]any); !ok ||
+		len(grouped) != 1 ||
+		grouped[0] != "tracer" {
+		t.Fatalf("Top series groupBy = %v, want tracer", groupBys[1])
+	}
+
+	var limits []any
+	dashboardValues(raw, "limit", &limits)
+	profileLimits := make([]float64, 0, len(limits))
+	for _, limit := range limits {
+		if number, ok := limit.(float64); ok {
+			profileLimits = append(profileLimits, number)
+		}
+	}
+	if !slices.Contains(profileLimits, float64(10)) {
+		t.Fatalf("dashboard limits = %v, want Top 10 bound", profileLimits)
+	}
+}
+
+func requireNoUnsupportedSelectors(t *testing.T, payload string) {
+	t.Helper()
+
+	for _, unsupported := range []string{
+		"profiling_scope",
+		"cgroup",
+		"process_group",
+		"process_lock",
+		"lock_type",
+		`=~`,
+		`!~`,
+	} {
+		if strings.Contains(payload, unsupported) {
+			t.Fatalf("dashboard contains unsupported selector %q", unsupported)
+		}
+	}
+}
+
 func TestContinuousProfilingHostDashboardContract(t *testing.T) {
 	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-host.json")
 	if dashboard.UID != "continuous-profiling-host" {
@@ -119,14 +196,8 @@ func TestContinuousProfilingHostDashboardContract(t *testing.T) {
 		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
 	}
 
-	var selectors []string
-	dashboardStrings(raw, "labelSelector", &selectors)
-	if !slices.Equal(selectors, []string{`{hostname="$hostname"}`}) {
-		t.Fatalf("profile selectors = %v, want exact hostname selector", selectors)
-	}
-	if strings.Contains(payload, "process_lock") {
-		t.Fatal("dashboard exposes lock profiling before the backend supports it")
-	}
+	requireExactProfileQueries(t, raw, `{hostname="$hostname"}`)
+	requireNoUnsupportedSelectors(t, payload)
 }
 
 func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
@@ -145,34 +216,76 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
 	}
 
-	var selectors []string
-	dashboardStrings(raw, "labelSelector", &selectors)
-	wantSelector := `{container_id="$container_id"}`
-	if !slices.Equal(selectors, []string{wantSelector}) {
-		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
-	}
+	requireExactProfileQueries(t, raw, `{container_id="$container_id"}`)
 	if strings.Contains(payload, "container_hostname") {
 		t.Fatal("dashboard uses non-unique container hostname")
 	}
-	if strings.Contains(payload, "process_lock") {
-		t.Fatal("dashboard exposes lock profiling before the backend supports it")
+	requireNoUnsupportedSelectors(t, payload)
+}
+
+func TestContinuousProfilingComparisonDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(
+		t,
+		"continuous-profiling-compare.json",
+	)
+	if dashboard.UID != "continuous-profiling-compare" {
+		t.Fatalf("UID = %q, want continuous-profiling-compare", dashboard.UID)
 	}
+	requireSupportedProfileTypes(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+
+	var urls []string
+	dashboardStrings(raw, "url", &urls)
+	if !slices.Contains(urls, "/v1/profiles/flamegraph/diff-rows") {
+		t.Fatalf("comparison URLs = %v, want bounded diff adapter", urls)
+	}
+	var roots []string
+	dashboardStrings(raw, "root_selector", &roots)
+	if !slices.Equal(roots, []string{"data"}) {
+		t.Fatalf("root selectors = %v, want data", roots)
+	}
+	var columns []string
+	dashboardStrings(raw, "selector", &columns)
+	if !slices.Equal(
+		columns,
+		[]string{"level", "value", "self", "valueRight", "selfRight", "label"},
+	) {
+		t.Fatalf("comparison columns = %v", columns)
+	}
+	var bodies []string
+	dashboardStrings(raw, "data", &bodies)
+	if len(bodies) != 1 ||
+		!strings.Contains(bodies[0], `"max_nodes": 5000`) ||
+		!strings.Contains(bodies[0], `${hostname:json}`) ||
+		!strings.Contains(bodies[0], `${container_id:json}`) {
+		t.Fatalf("comparison request is not bounded or JSON-escaped: %v", bodies)
+	}
+	requireNoUnsupportedSelectors(t, payload)
 }
 
 func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
-	datasource, err := os.ReadFile("../datasources/pyroscope.yaml")
-	if err != nil {
-		t.Fatalf("read Pyroscope datasource: %v", err)
-	}
-	datasourceText := string(datasource)
-	if !strings.Contains(
-		datasourceText,
-		"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
-	) {
-		t.Fatal("Pyroscope datasource does not use the runtime bearer token")
-	}
-	if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
-		t.Fatal("Pyroscope datasource contains a placeholder credential")
+	for _, filename := range []string{
+		"../datasources/pyroscope.yaml",
+		"../datasources/profiling-json.yaml",
+	} {
+		datasource, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("read %s: %v", filename, err)
+		}
+		datasourceText := string(datasource)
+		if !strings.Contains(
+			datasourceText,
+			"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
+		) {
+			t.Fatalf("%s does not use the runtime bearer token", filename)
+		}
+		if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
+			t.Fatalf("%s contains a placeholder credential", filename)
+		}
 	}
 
 	compose, err := os.ReadFile("../../docker-compose.yml")
@@ -184,5 +297,11 @@ func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
 		"HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}",
 	) {
 		t.Fatal("Grafana container does not receive the profile query token")
+	}
+	if !strings.Contains(
+		string(compose),
+		"./grafana/datasources/profiling-json.yaml:",
+	) {
+		t.Fatal("Grafana does not provision the profile JSON datasource")
 	}
 }

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -147,7 +147,7 @@ func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
 
 	var selectors []string
 	dashboardStrings(raw, "labelSelector", &selectors)
-	wantSelector := `{hostname="$hostname",container_id="$container_id"}`
+	wantSelector := `{container_id="$container_id"}`
 	if !slices.Equal(selectors, []string{wantSelector}) {
 		t.Fatalf("profile selectors = %v, want %s", selectors, wantSelector)
 	}

--- a/build/docker/grafana/datasources/profiling-json.yaml
+++ b/build/docker/grafana/datasources/profiling-json.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+datasources:
+  - name: huatuo-apiserver-profile-json
+    type: yesoreyeram-infinity-datasource
+    uid: huatuo-apiserver-profile-json
+    access: proxy
+    orgId: 1
+    url: http://127.0.0.1:12740
+    jsonData:
+      allowedHosts:
+        - http://127.0.0.1:12740
+      httpHeaderName1: 'Authorization'
+    secureJsonData:
+      httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'
+    editable: false

--- a/build/docker/grafana/datasources/pyroscope.yaml
+++ b/build/docker/grafana/datasources/pyroscope.yaml
@@ -11,5 +11,5 @@ datasources:
       minStep: '15s'
       httpHeaderName1: 'Authorization'
     secureJsonData:
-      httpHeaderValue1: REPLACE_WITH_RANDOM_HEX
+      httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'
     editable: false

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
@@ -1,0 +1,380 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/server/response"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	diffFlamegraphNodeWidth     = 7
+	defaultProfileDiffMaxNodes  = 5000
+	maxProfileDiffMaxNodes      = 10000
+	maxProfileDiffTargetLength  = 512
+	maxProfileDiffTypeLength    = 256
+	maxProfileDiffResponseBytes = 8 << 20
+)
+
+type profileDiffRowsRequest struct {
+	ProfileTypeID string `json:"profile_type_id"`
+	Hostname      string `json:"hostname"`
+	ContainerID   string `json:"container_id"`
+	Start         int64  `json:"start"`
+	End           int64  `json:"end"`
+	MaxNodes      int64  `json:"max_nodes"`
+}
+
+type profileDiffRow struct {
+	Level      int    `json:"level"`
+	Value      int64  `json:"value"`
+	Self       int64  `json:"self"`
+	ValueRight int64  `json:"valueRight"`
+	SelfRight  int64  `json:"selfRight"`
+	Label      string `json:"label"`
+}
+
+type profileDiffNode struct {
+	row        profileDiffRow
+	leftStart  int64
+	rightStart int64
+	children   []*profileDiffNode
+}
+
+func (h *Handler) displayDiffRows(ctx *server.Context) error {
+	var request profileDiffRowsRequest
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		return response.ErrInvalidRequest.WithMessage(
+			"invalid profile diff request",
+		)
+	}
+
+	diffRequest, err := buildAdjacentProfileDiffRequest(request)
+	if err != nil {
+		return response.ErrInvalidRequest.WithMessage(err.Error())
+	}
+	diffResponse, err := h.profileService.Diff(
+		ctx.Request().Context(),
+		diffRequest,
+	)
+	if err != nil {
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField(
+				"operation",
+				"display_diff_rows",
+			).Error("profile query failed")
+		}
+		ctx.JSON(status, map[string]any{"message": message})
+		return nil
+	}
+
+	rows, err := profileDiffRows(diffResponse.GetFlamegraph())
+	if err != nil {
+		log.WithError(err).Error("invalid profile diff response")
+		ctx.JSON(
+			http.StatusInternalServerError,
+			map[string]any{"message": "internal error"},
+		)
+		return nil
+	}
+	tooLarge, err := profileDiffResponseExceedsLimit(rows)
+	if err != nil {
+		log.WithError(err).Error("encode profile diff response")
+		ctx.JSON(
+			http.StatusInternalServerError,
+			map[string]any{"message": "internal error"},
+		)
+		return nil
+	}
+	if tooLarge {
+		ctx.JSON(http.StatusUnprocessableEntity, map[string]any{
+			"message": fmt.Sprintf(
+				"profile diff response exceeds %d bytes",
+				maxProfileDiffResponseBytes,
+			),
+		})
+		return nil
+	}
+	response.Success(ctx, rows)
+	return nil
+}
+
+func profileDiffResponseExceedsLimit(rows []profileDiffRow) (bool, error) {
+	payload, err := json.Marshal(response.Response{
+		Code:    0,
+		Message: "success",
+		Data:    rows,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(payload) > maxProfileDiffResponseBytes, nil
+}
+
+func buildAdjacentProfileDiffRequest(
+	request profileDiffRowsRequest,
+) (*querierv1.DiffRequest, error) {
+	if request.ProfileTypeID == "" {
+		return nil, fmt.Errorf("profile_type_id is required")
+	}
+	if len(request.ProfileTypeID) > maxProfileDiffTypeLength {
+		return nil, fmt.Errorf(
+			"profile_type_id must not exceed %d bytes",
+			maxProfileDiffTypeLength,
+		)
+	}
+	if request.Start < 0 || request.End <= request.Start {
+		return nil, fmt.Errorf("end must be later than a non-negative start")
+	}
+	window := request.End - request.Start
+	if window > request.Start {
+		return nil, fmt.Errorf("selected range has no preceding window")
+	}
+	if request.MaxNodes < 0 ||
+		request.MaxNodes > maxProfileDiffMaxNodes {
+		return nil, fmt.Errorf(
+			"max_nodes must be between 0 and %d",
+			maxProfileDiffMaxNodes,
+		)
+	}
+
+	targetName := "hostname"
+	targetValue := request.Hostname
+	if request.ContainerID != "" {
+		targetName = "container_id"
+		targetValue = request.ContainerID
+	}
+	if strings.TrimSpace(targetValue) == "" {
+		return nil, fmt.Errorf("hostname or container_id is required")
+	}
+	if len(targetValue) > maxProfileDiffTargetLength {
+		return nil, fmt.Errorf(
+			"%s must not exceed %d bytes",
+			targetName,
+			maxProfileDiffTargetLength,
+		)
+	}
+	matcher, err := labels.NewMatcher(labels.MatchEqual, targetName, targetValue)
+	if err != nil {
+		return nil, fmt.Errorf("build target selector: %w", err)
+	}
+	selector := "{" + matcher.String() + "}"
+
+	maxNodesValue := request.MaxNodes
+	if maxNodesValue == 0 {
+		maxNodesValue = defaultProfileDiffMaxNodes
+	}
+	maxNodes := &maxNodesValue
+	return &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: request.ProfileTypeID,
+			LabelSelector: selector,
+			Start:         request.Start - window,
+			End:           request.Start - 1,
+			MaxNodes:      maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: request.ProfileTypeID,
+			LabelSelector: selector,
+			Start:         request.Start,
+			End:           request.End,
+			MaxNodes:      maxNodes,
+		},
+	}, nil
+}
+
+func profileDiffRows(graph *querierv1.FlameGraphDiff) ([]profileDiffRow, error) {
+	if graph == nil || len(graph.Levels) == 0 {
+		return []profileDiffRow{}, nil
+	}
+
+	levels := make([][]*profileDiffNode, len(graph.Levels))
+	nodeCount := 0
+	for levelIndex, level := range graph.Levels {
+		if level == nil ||
+			len(level.Values)%diffFlamegraphNodeWidth != 0 {
+			return nil, fmt.Errorf(
+				"invalid diff flame graph level %d",
+				levelIndex,
+			)
+		}
+		nodeCount += len(level.Values) / diffFlamegraphNodeWidth
+		if nodeCount > maxProfileDiffMaxNodes {
+			return nil, fmt.Errorf(
+				"diff flame graph exceeds %d nodes",
+				maxProfileDiffMaxNodes,
+			)
+		}
+		nodes := make(
+			[]*profileDiffNode,
+			0,
+			len(level.Values)/diffFlamegraphNodeWidth,
+		)
+		var leftOffset int64
+		var rightOffset int64
+		for index := 0; index < len(level.Values); index += diffFlamegraphNodeWidth {
+			leftStart, ok := addProfileDiffValue(
+				leftOffset,
+				level.Values[index],
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"invalid left offset in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			rightStart, ok := addProfileDiffValue(
+				rightOffset,
+				level.Values[index+3],
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"invalid right offset in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			nameIndex := level.Values[index+6]
+			if nameIndex < 0 || nameIndex >= int64(len(graph.Names)) {
+				return nil, fmt.Errorf(
+					"invalid diff flame graph name index %d",
+					nameIndex,
+				)
+			}
+			node := &profileDiffNode{
+				row: profileDiffRow{
+					Level:      levelIndex,
+					Value:      level.Values[index+1],
+					Self:       level.Values[index+2],
+					ValueRight: level.Values[index+4],
+					SelfRight:  level.Values[index+5],
+					Label:      graph.Names[nameIndex],
+				},
+				leftStart:  leftStart,
+				rightStart: rightStart,
+			}
+			if node.row.Value < 0 ||
+				node.row.Self < 0 ||
+				node.row.ValueRight < 0 ||
+				node.row.SelfRight < 0 ||
+				node.row.Self > node.row.Value ||
+				node.row.SelfRight > node.row.ValueRight {
+				return nil, fmt.Errorf(
+					"invalid values in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			nodes = append(nodes, node)
+			leftOffset, ok = addProfileDiffValue(leftStart, node.row.Value)
+			if !ok {
+				return nil, fmt.Errorf(
+					"left range overflows in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			rightOffset, ok = addProfileDiffValue(
+				rightStart,
+				node.row.ValueRight,
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"right range overflows in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+		}
+		levels[levelIndex] = nodes
+	}
+	if len(levels[0]) != 1 {
+		return nil, fmt.Errorf("diff flame graph must have one root")
+	}
+
+	for levelIndex := 1; levelIndex < len(levels); levelIndex++ {
+		for _, node := range levels[levelIndex] {
+			parent := profileDiffParent(levels[levelIndex-1], node)
+			if parent == nil {
+				return nil, fmt.Errorf(
+					"diff flame graph level %d node %q has no parent",
+					levelIndex,
+					node.row.Label,
+				)
+			}
+			parent.children = append(parent.children, node)
+		}
+	}
+
+	rows := make([]profileDiffRow, 0, nodeCount)
+	var appendNode func(*profileDiffNode)
+	appendNode = func(node *profileDiffNode) {
+		rows = append(rows, node.row)
+		for _, child := range node.children {
+			appendNode(child)
+		}
+	}
+	appendNode(levels[0][0])
+	return rows, nil
+}
+
+func profileDiffParent(
+	parents []*profileDiffNode,
+	child *profileDiffNode,
+) *profileDiffNode {
+	for _, parent := range parents {
+		if profileDiffRangeContains(
+			parent.leftStart,
+			parent.row.Value,
+			child.leftStart,
+			child.row.Value,
+		) || profileDiffRangeContains(
+			parent.rightStart,
+			parent.row.ValueRight,
+			child.rightStart,
+			child.row.ValueRight,
+		) {
+			return parent
+		}
+	}
+	return nil
+}
+
+func profileDiffRangeContains(
+	parentStart, parentValue, childStart, childValue int64,
+) bool {
+	parentEnd, parentOK := addProfileDiffValue(parentStart, parentValue)
+	childEnd, childOK := addProfileDiffValue(childStart, childValue)
+	return childValue > 0 &&
+		parentValue >= childValue &&
+		parentOK &&
+		childOK &&
+		childStart >= parentStart &&
+		childEnd <= parentEnd
+}
+
+func addProfileDiffValue(left, right int64) (int64, bool) {
+	if left < 0 || right < 0 || left > math.MaxInt64-right {
+		return 0, false
+	}
+	return left + right, true
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+)
+
+func TestBuildAdjacentProfileDiffRequest(t *testing.T) {
+	request, err := buildAdjacentProfileDiffRequest(profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node-a",
+		ContainerID:   `container\"a`,
+		Start:         2000,
+		End:           3000,
+		MaxNodes:      500,
+	})
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+
+	if request.Left.Start != 1000 || request.Left.End != 1999 {
+		t.Fatalf(
+			"left range = %d..%d, want 1000..1999",
+			request.Left.Start,
+			request.Left.End,
+		)
+	}
+	if request.Right.Start != 2000 || request.Right.End != 3000 {
+		t.Fatalf(
+			"right range = %d..%d, want 2000..3000",
+			request.Right.Start,
+			request.Right.End,
+		)
+	}
+	wantSelector := `{container_id="container\\\"a"}`
+	if request.Left.LabelSelector != wantSelector ||
+		request.Right.LabelSelector != wantSelector {
+		t.Fatalf(
+			"selectors = %q and %q, want %q",
+			request.Left.LabelSelector,
+			request.Right.LabelSelector,
+			wantSelector,
+		)
+	}
+	if request.Left.GetMaxNodes() != 500 || request.Right.GetMaxNodes() != 500 {
+		t.Fatal("max_nodes was not forwarded to both selections")
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestRequiresTargetAndPreviousWindow(t *testing.T) {
+	tests := []profileDiffRowsRequest{
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         500,
+			End:           1500,
+		},
+	}
+	for _, request := range tests {
+		if _, err := buildAdjacentProfileDiffRequest(request); err == nil {
+			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
+		}
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestDefaultsAndBounds(t *testing.T) {
+	valid := profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node-a",
+		Start:         2000,
+		End:           3000,
+	}
+	request, err := buildAdjacentProfileDiffRequest(valid)
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+	if request.Left.GetMaxNodes() != defaultProfileDiffMaxNodes ||
+		request.Right.GetMaxNodes() != defaultProfileDiffMaxNodes {
+		t.Fatal("default max_nodes was not applied to both selections")
+	}
+
+	tests := []profileDiffRowsRequest{
+		{ProfileTypeID: "", Hostname: "node-a", Start: 2000, End: 3000},
+		{
+			ProfileTypeID: strings.Repeat("p", maxProfileDiffTypeLength+1),
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      strings.Repeat("h", maxProfileDiffTargetLength+1),
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         -1,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           2000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+			MaxNodes:      -1,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+			MaxNodes:      maxProfileDiffMaxNodes + 1,
+		},
+	}
+	for _, request := range tests {
+		if _, err := buildAdjacentProfileDiffRequest(request); err == nil {
+			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
+		}
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestEscapesSelectorInput(t *testing.T) {
+	request, err := buildAdjacentProfileDiffRequest(profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node\n\"a\\b",
+		Start:         2000,
+		End:           3000,
+	})
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+	if request.Left.LabelSelector != `{hostname="node\n\"a\\b"}` {
+		t.Fatalf("selector = %q", request.Left.LabelSelector)
+	}
+}
+
+func TestProfileDiffRowsBuildsNestedSetOrder(t *testing.T) {
+	graph := &querierv1.FlameGraphDiff{
+		Names: []string{"total", "a", "b", "a-child"},
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 30, 0, 0, 40, 0, 0}},
+			{Values: []int64{
+				0, 10, 5, 0, 30, 10, 1,
+				0, 20, 20, 0, 10, 10, 2,
+			}},
+			{Values: []int64{5, 5, 5, 10, 20, 20, 3}},
+		},
+	}
+
+	rows, err := profileDiffRows(graph)
+	if err != nil {
+		t.Fatalf("profileDiffRows() error = %v", err)
+	}
+	want := []profileDiffRow{
+		{Level: 0, Value: 30, ValueRight: 40, Label: "total"},
+		{
+			Level: 1, Value: 10, Self: 5,
+			ValueRight: 30, SelfRight: 10, Label: "a",
+		},
+		{
+			Level: 2, Value: 5, Self: 5,
+			ValueRight: 20, SelfRight: 20, Label: "a-child",
+		},
+		{
+			Level: 1, Value: 20, Self: 20,
+			ValueRight: 10, SelfRight: 10, Label: "b",
+		},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %#v, want %#v", rows, want)
+	}
+}
+
+func TestProfileDiffRowsRejectsMalformedLevel(t *testing.T) {
+	_, err := profileDiffRows(&querierv1.FlameGraphDiff{
+		Names:  []string{"total"},
+		Levels: []*querierv1.Level{{Values: []int64{0, 1}}},
+	})
+	if err == nil {
+		t.Fatal("profileDiffRows() succeeded for a malformed level")
+	}
+}
+
+func TestProfileDiffRowsRejectsMaliciousValues(t *testing.T) {
+	tests := []*querierv1.FlameGraphDiff{
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, -1, 0, 0, 1, 0, 0}}},
+		},
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, 1, 2, 0, 1, 0, 0}}},
+		},
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, 1, 0, 0, 1, 0, 1}}},
+		},
+		{
+			Names: []string{"total", "orphan"},
+			Levels: []*querierv1.Level{
+				{Values: []int64{0, 1, 0, 0, 1, 0, 0}},
+				{Values: []int64{2, 1, 0, 2, 1, 0, 1}},
+			},
+		},
+		{
+			Names: []string{"total", "overflow"},
+			Levels: []*querierv1.Level{
+				{Values: []int64{0, math.MaxInt64, 0, 0, 1, 0, 0}},
+				{Values: []int64{math.MaxInt64, 1, 0, 0, 1, 0, 1}},
+			},
+		},
+	}
+	for index, graph := range tests {
+		if _, err := profileDiffRows(graph); err == nil {
+			t.Fatalf("profileDiffRows(test %d) succeeded", index)
+		}
+	}
+}
+
+func TestProfileDiffRowsLimitsTotalNodes(t *testing.T) {
+	level := &querierv1.Level{
+		Values: make([]int64, 0, maxProfileDiffMaxNodes*diffFlamegraphNodeWidth),
+	}
+	for range maxProfileDiffMaxNodes {
+		level.Values = append(level.Values, 0, 0, 0, 0, 0, 0, 0)
+	}
+
+	_, err := profileDiffRows(&querierv1.FlameGraphDiff{
+		Names: []string{"total"},
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 1, 0, 0, 1, 0, 0}},
+			level,
+		},
+	})
+	if err == nil {
+		t.Fatal("profileDiffRows() accepted more than the node limit")
+	}
+}
+
+func TestProfileDiffResponseSizeLimit(t *testing.T) {
+	tooLarge, err := profileDiffResponseExceedsLimit([]profileDiffRow{{
+		Label: strings.Repeat("x", maxProfileDiffResponseBytes),
+	}})
+	if err != nil {
+		t.Fatalf("profileDiffResponseExceedsLimit() error = %v", err)
+	}
+	if !tooLarge {
+		t.Fatal("profile diff response exceeded the byte limit")
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -44,6 +44,8 @@ type Config struct {
 // ProfileQueryService defines profile query operations consumed by the handler.
 type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
+	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
+	Diff(ctx context.Context, req *querierv1.DiffRequest) (*querierv1.DiffResponse, error)
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -81,6 +83,8 @@ func NewHandler(
 		{Typ: server.HttpDelete, Uri: "/:id", Handle: h.delete},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces", Handle: h.displaySelectMergeStacktraces},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
+		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},
+		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/Diff", Handle: h.displayDiff},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelNames", Handle: h.displayLabelNames},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelValues", Handle: h.displayLabelValues},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -85,6 +85,7 @@ func NewHandler(
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/Diff", Handle: h.displayDiff},
+		{Typ: server.HttpPost, Uri: "/flamegraph/diff-rows", Handle: h.displayDiffRows},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelNames", Handle: h.displayLabelNames},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/LabelValues", Handle: h.displayLabelValues},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -16,6 +16,7 @@ package profiling
 
 import (
 	"context"
+	"io"
 
 	"huatuo-bamai/internal/job"
 	profileService "huatuo-bamai/internal/profiler/service"
@@ -46,6 +47,8 @@ type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
 	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
 	Diff(ctx context.Context, req *querierv1.DiffRequest) (*querierv1.DiffResponse, error)
+	MarshalPprof(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) ([]byte, error)
+	RenderProfileSVG(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest, writer io.Writer) error
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -81,6 +84,8 @@ func NewHandler(
 		{Typ: server.HttpGet, Uri: "/:id/raw", Handle: h.getRawData},
 		{Typ: server.HttpPatch, Uri: "/:id", Handle: h.patchOne},
 		{Typ: server.HttpDelete, Uri: "/:id", Handle: h.delete},
+		{Typ: server.HttpGet, Uri: "/flamegraph/export/pprof", Handle: h.displayPprofExport},
+		{Typ: server.HttpGet, Uri: "/flamegraph/export/svg", Handle: h.displaySVGExport},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces", Handle: h.displaySelectMergeStacktraces},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/ProfileTypes", Handle: h.displayProfileTypes},
 		{Typ: server.HttpPost, Uri: "/flamegraph/querier.v1.QuerierService/SelectSeries", Handle: h.displaySelectSeries},

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -24,6 +24,7 @@ import (
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/server/response"
@@ -256,34 +257,28 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	var dashboardSlug string
 	var labelKey string
 	var labelVal string
+	var profileTypeID string
 
 	from := jobResult.StartTime.UTC().Format("2006-01-02T15:04:05.000Z")
 	to := jobResult.EndTime.UTC().Format("2006-01-02T15:04:05.000Z")
 
+	switch jobResult.Type {
+	case ProfilingMemory:
+		profileTypeID = profiler.ProfileTypeMemSample
+	case ProfilingCPU:
+		profileTypeID = profiler.ProfileTypeCpuSample
+	default:
+		return ""
+	}
+
 	if jobResult.ContainerID != "" {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "container-memory-profiling"
-			dashboardSlug = "e5aeb9-e599a8-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "container-cpu-profiling"
-			dashboardSlug = "e5aeb9-e599a8-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-container"
+		dashboardSlug = "continuous-profiling-container"
 		labelKey = "var-container_id"
 		labelVal = jobResult.ContainerID
 	} else {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "host-memory-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "host-cpu-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-host"
+		dashboardSlug = "continuous-profiling-host"
 		labelKey = "var-hostname"
 		labelVal = jobResult.Hostname
 	}
@@ -294,6 +289,7 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	query.Set("to", to)
 	query.Set("timezone", "browser")
 	query.Set(labelKey, labelVal)
+	query.Set("var-type", profileTypeID)
 
 	return fmt.Sprintf("%s/%s/%s?%s", base, dashboardUID, dashboardSlug, query.Encode())
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -51,6 +51,22 @@ func TestNewHandlerSnapshotsProfilingConfig(t *testing.T) {
 	}
 }
 
+func TestNewHandlerRegistersProfileExports(t *testing.T) {
+	h := NewHandler(nil, nil, Config{})
+	routes := make(map[string]bool, len(h.Handlers))
+	for _, handler := range h.Handlers {
+		routes[handler.Uri] = true
+	}
+	for _, route := range []string{
+		"/flamegraph/export/pprof",
+		"/flamegraph/export/svg",
+	} {
+		if !routes[route] {
+			t.Errorf("profile export route %q is not registered", route)
+		}
+	}
+}
+
 // TestCapabilities verifies that the capabilities handler returns the correct
 // profiling types, languages, memory modes, and default configuration values.
 func TestCapabilities(t *testing.T) {

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -25,16 +25,48 @@ import (
 	profileService "huatuo-bamai/internal/profiler/service"
 )
 
-func TestGetFlameGraphURLEscapesLabelValue(t *testing.T) {
-	url := getFlameGraphURL("http://grafana.example/d", &job.Job{
-		Type:        ProfilingCPU,
-		ContainerID: "container+2026&debug",
-		StartTime:   time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC),
-		EndTime:     time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC),
-	})
+func TestGetFlameGraphURLTargetsProvisionedDashboards(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           job.Job
+		wantPath      string
+		wantSelection string
+		wantType      string
+	}{
+		{
+			name: "host CPU",
+			job: job.Job{
+				Type:     ProfilingCPU,
+				Hostname: "node+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-host/continuous-profiling-host?",
+			wantSelection: "var-hostname=node%2B2026%26debug",
+			wantType:      "var-type=process_cpu%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds",
+		},
+		{
+			name: "container memory",
+			job: job.Job{
+				Type:        ProfilingMemory,
+				ContainerID: "container+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-container/continuous-profiling-container?",
+			wantSelection: "var-container_id=container%2B2026%26debug",
+			wantType:      "var-type=memory%3Aalloc_space%3Abytes%3Aspace%3Abytes",
+		},
+	}
 
-	if !strings.Contains(url, "var-container_id=container%2B2026%26debug") {
-		t.Fatalf("url = %q, want escaped container label value", url)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.job.StartTime = time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+			tc.job.EndTime = time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC)
+			url := getFlameGraphURL("http://grafana.example/d", &tc.job)
+
+			for _, want := range []string{tc.wantPath, tc.wantSelection, tc.wantType} {
+				if !strings.Contains(url, want) {
+					t.Fatalf("url = %q, want %q", url, want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -39,16 +39,11 @@ func handleProto[Request, Response any](
 
 	resp, err := invoke(ctx.Request().Context(), req)
 	if err != nil {
-		if errors.Is(err, profileService.ErrInvalidQuery) {
-			ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
-			return nil
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField("operation", operation).Error("profile query failed")
 		}
-		if errors.Is(err, profileService.ErrProfilesAbsent) {
-			ctx.JSON(http.StatusNotFound, map[string]any{"message": "profiles not found"})
-			return nil
-		}
-		log.WithError(err).WithField("operation", operation).Error("profile query failed")
-		ctx.JSON(http.StatusInternalServerError, map[string]any{"message": "internal error"})
+		ctx.JSON(status, map[string]any{"message": message})
 		return nil
 	}
 
@@ -57,12 +52,33 @@ func handleProto[Request, Response any](
 	return nil
 }
 
+func profileQueryHTTPError(err error) (int, string) {
+	switch {
+	case errors.Is(err, profileService.ErrInvalidQuery):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, profileService.ErrProfilesAbsent):
+		return http.StatusNotFound, "profiles not found"
+	case errors.Is(err, profileService.ErrProfileQueryLimitExceeded):
+		return http.StatusUnprocessableEntity, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal error"
+	}
+}
+
 func (h *Handler) displaySelectMergeStacktraces(ctx *server.Context) error {
 	return handleProto(ctx, "select_merge_stacktraces", h.profileService.SelectMergeStacktraces)
 }
 
 func (h *Handler) displayProfileTypes(ctx *server.Context) error {
 	return handleProto(ctx, "profile_types", h.profileService.ProfileTypes)
+}
+
+func (h *Handler) displaySelectSeries(ctx *server.Context) error {
+	return handleProto(ctx, "select_series", h.profileService.SelectSeries)
+}
+
+func (h *Handler) displayDiff(ctx *server.Context) error {
+	return handleProto(ctx, "diff", h.profileService.Diff)
 }
 
 func (h *Handler) displayLabelNames(ctx *server.Context) error {

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -15,15 +15,20 @@
 package profiling
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"huatuo-bamai/internal/log"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 
 	"github.com/gin-gonic/gin/binding"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 )
 
 func handleProto[Request, Response any](
@@ -87,4 +92,96 @@ func (h *Handler) displayLabelNames(ctx *server.Context) error {
 
 func (h *Handler) displayLabelValues(ctx *server.Context) error {
 	return handleProto(ctx, "label_values", h.profileService.LabelValues)
+}
+
+func profileExportRequest(
+	query func(string) string,
+) (*querierv1.SelectMergeStacktracesRequest, error) {
+	profileType := strings.TrimSpace(query("profile_type"))
+	if profileType == "" {
+		return nil, errors.New("profile_type is required")
+	}
+	selector := strings.TrimSpace(query("selector"))
+	if selector == "" {
+		return nil, errors.New("selector is required")
+	}
+	start, err := strconv.ParseInt(query("start"), 10, 64)
+	if err != nil {
+		return nil, errors.New("start must be a Unix timestamp in milliseconds")
+	}
+	end, err := strconv.ParseInt(query("end"), 10, 64)
+	if err != nil {
+		return nil, errors.New("end must be a Unix timestamp in milliseconds")
+	}
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profileType,
+		LabelSelector: selector,
+		Start:         start,
+		End:           end,
+	}, nil
+}
+
+func writeProfileServiceError(ctx *server.Context, operation string, err error) {
+	status, message := profileQueryHTTPError(err)
+	if status == http.StatusInternalServerError {
+		log.WithError(err).WithField("operation", operation).Error("profile query failed")
+	}
+	ctx.JSON(status, map[string]any{"message": message})
+}
+
+func (h *Handler) displayPprofExport(ctx *server.Context) error {
+	req, err := profileExportRequest(ctx.Query)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
+		return nil
+	}
+	payload, err := h.profileService.MarshalPprof(ctx.Request().Context(), req)
+	if err != nil {
+		writeProfileServiceError(ctx, "export_pprof", err)
+		return nil
+	}
+	ctx.Header("Content-Type", "application/octet-stream")
+	ctx.Header(
+		"Content-Disposition",
+		`attachment; filename="huatuo-profile.pb.gz"`,
+	)
+	ctx.Header("X-Content-Type-Options", "nosniff")
+	ctx.Writer().WriteHeader(http.StatusOK)
+	if _, err := ctx.Writer().Write(payload); err != nil {
+		return fmt.Errorf("write pprof export: %w", err)
+	}
+	return nil
+}
+
+func (h *Handler) displaySVGExport(ctx *server.Context) error {
+	req, err := profileExportRequest(ctx.Query)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
+		return nil
+	}
+	var output bytes.Buffer
+	if err := h.profileService.RenderProfileSVG(
+		ctx.Request().Context(),
+		req,
+		&output,
+	); err != nil {
+		writeProfileServiceError(ctx, "export_svg", err)
+		return nil
+	}
+	ctx.Header("Content-Type", "image/svg+xml; charset=utf-8")
+	ctx.Header(
+		"Content-Disposition",
+		`inline; filename="huatuo-flamegraph.svg"`,
+	)
+	ctx.Header(
+		"Content-Security-Policy",
+		"sandbox allow-scripts; default-src 'none'; "+
+			"script-src 'unsafe-inline'; style-src 'unsafe-inline'",
+	)
+	ctx.Header("X-Content-Type-Options", "nosniff")
+	ctx.Writer().WriteHeader(http.StatusOK)
+	if _, err := ctx.Writer().Write(output.Bytes()); err != nil {
+		return fmt.Errorf("write SVG export: %w", err)
+	}
+	return nil
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -31,6 +31,24 @@ import (
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 )
 
+const maxProfileSVGResponseBytes = 8 << 20
+
+type boundedProfileSVGBuffer struct {
+	bytes.Buffer
+}
+
+func (b *boundedProfileSVGBuffer) Write(payload []byte) (int, error) {
+	if b.Len() > maxProfileSVGResponseBytes ||
+		len(payload) > maxProfileSVGResponseBytes-b.Len() {
+		return 0, fmt.Errorf(
+			"%w: rendered SVG exceeds %d bytes; narrow the time range or selector",
+			profileService.ErrProfileQueryLimitExceeded,
+			maxProfileSVGResponseBytes,
+		)
+	}
+	return b.Buffer.Write(payload)
+}
+
 func handleProto[Request, Response any](
 	ctx *server.Context,
 	operation string,
@@ -159,7 +177,7 @@ func (h *Handler) displaySVGExport(ctx *server.Context) error {
 		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
 		return nil
 	}
-	var output bytes.Buffer
+	var output boundedProfileSVGBuffer
 	if err := h.profileService.RenderProfileSVG(
 		ctx.Request().Context(),
 		req,

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	profileService "huatuo-bamai/internal/profiler/service"
+)
+
+func TestProfileQueryHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "invalid query",
+			err:         errors.Join(profileService.ErrInvalidQuery, errors.New("bad selector")),
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "bad selector",
+		},
+		{
+			name:        "not found",
+			err:         profileService.ErrProfilesAbsent,
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "profiles not found",
+		},
+		{
+			name: "selection too large",
+			err: errors.Join(
+				profileService.ErrProfileQueryLimitExceeded,
+				errors.New("10001 documents"),
+			),
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: "10001 documents",
+		},
+		{
+			name:        "internal",
+			err:         errors.New("elasticsearch unavailable"),
+			wantStatus:  http.StatusInternalServerError,
+			wantMessage: "internal error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := profileQueryHTTPError(test.err)
+			if status != test.wantStatus {
+				t.Fatalf("status = %d, want %d", status, test.wantStatus)
+			}
+			if !strings.Contains(message, test.wantMessage) {
+				t.Fatalf("message = %q, want it to contain %q", message, test.wantMessage)
+			}
+		})
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -70,3 +70,78 @@ func TestProfileQueryHTTPError(t *testing.T) {
 		})
 	}
 }
+
+func TestProfileExportRequest(t *testing.T) {
+	values := map[string]string{
+		"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		"selector":     `{hostname="node-a"}`,
+		"start":        "1784944800000",
+		"end":          "1784944860000",
+	}
+	req, err := profileExportRequest(func(name string) string {
+		return values[name]
+	})
+	if err != nil {
+		t.Fatalf("profileExportRequest() error = %v", err)
+	}
+	if req.ProfileTypeID != values["profile_type"] ||
+		req.LabelSelector != values["selector"] ||
+		req.Start != 1784944800000 ||
+		req.End != 1784944860000 {
+		t.Fatalf("profileExportRequest() = %#v, want query values", req)
+	}
+}
+
+func TestProfileExportRequestRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   string
+	}{
+		{
+			name:   "profile type",
+			values: map[string]string{},
+			want:   "profile_type is required",
+		},
+		{
+			name: "selector",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			},
+			want: "selector is required",
+		},
+		{
+			name: "start",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "yesterday",
+			},
+			want: "start must be a Unix timestamp in milliseconds",
+		},
+		{
+			name: "end",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "1784944800000",
+				"end":          "tomorrow",
+			},
+			want: "end must be a Unix timestamp in milliseconds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := profileExportRequest(func(name string) string {
+				return test.values[name]
+			})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf(
+					"profileExportRequest() error = %v, want %q",
+					err,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -145,3 +145,16 @@ func TestProfileExportRequestRejectsInvalidValues(t *testing.T) {
 		})
 	}
 }
+
+func TestBoundedProfileSVGBufferRejectsOversizedOutput(t *testing.T) {
+	var output boundedProfileSVGBuffer
+	if _, err := output.Write(make([]byte, maxProfileSVGResponseBytes)); err != nil {
+		t.Fatalf("write at limit: %v", err)
+	}
+	if _, err := output.Write([]byte("x")); !errors.Is(
+		err,
+		profileService.ErrProfileQueryLimitExceeded,
+	) {
+		t.Fatalf("write above limit error = %v, want query limit", err)
+	}
+}

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -213,9 +213,10 @@ Profiling jobs use these statuses:
 
 ### 6. Inspect Profiles in Grafana
 
-Grafana provisioning includes separate host and container continuous profiling
-dashboards. Both dashboards show the number of stored profile snapshots and a
-merged flame graph with a Top table for the selected time range:
+Grafana provisioning includes host, container, and comparison continuous
+profiling dashboards. The host and container dashboards show the number of
+stored profile snapshots, total profile value over time, Top 10 series grouped
+by tracer, and a merged flame graph with a Top table:
 
 - The host dashboard selects an exact `hostname` and excludes container
   profiles.
@@ -237,10 +238,13 @@ export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
 docker compose -f build/docker/docker-compose.yml up -d
 ```
 
-The dashboards intentionally use the existing merged-stacktrace API.
-Profile-value timelines, grouped Top-N series, and comparison views require
-Pyroscope-compatible `SelectSeries` and `Diff` endpoints and are not
-provisioned until those endpoints are available.
+The timeline and Top 10 panels use the Pyroscope-compatible `SelectSeries`
+endpoint. The comparison dashboard uses `Diff` through a bounded JSON adapter
+for Grafana's flame graph panel. The selected range is the current window and
+is compared with the immediately preceding window of the same duration. A
+selected `container_id` takes precedence over `hostname`. The adapter defaults
+to 5,000 nodes, rejects values above 10,000, and limits its JSON response to
+8 MiB.
 
 ### 7. Get Raw Profiling Data
 
@@ -285,7 +289,7 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
-### 9. Pyroscope-compatible Queries
+### 10. Pyroscope-compatible Queries
 
 The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
 methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -211,7 +211,38 @@ Profiling jobs use these statuses:
 | `failed` | The job failed; inspect `error_message` for the cause |
 | `timeout` | The job exceeded its allowed execution time |
 
-### 6. Get Raw Profiling Data
+### 6. Inspect Profiles in Grafana
+
+Grafana provisioning includes separate host and container continuous profiling
+dashboards. Both dashboards show the number of stored profile snapshots and a
+merged flame graph with a Top table for the selected time range:
+
+- The host dashboard selects an exact `hostname` and excludes container
+  profiles.
+- The container dashboard selects an exact `container_id` and the reporting
+  `hostname`. Container names are not used as identifiers because they are not
+  guaranteed to be unique.
+
+CPU and memory are the only profile types exposed by these dashboards. A
+completed job's `results.url` opens the corresponding dashboard with its
+target, profile type, and collection window preselected.
+
+The Pyroscope datasource sends queries to huatuo-apiserver. If API
+authentication is enabled, configure a dedicated user with
+`POST /v1/profiles/flamegraph/**` permission and pass the same user ID to the
+Grafana container without committing it:
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+The dashboards intentionally use the existing merged-stacktrace API.
+Profile-value timelines, grouped Top-N series, and comparison views require
+Pyroscope-compatible `SelectSeries` and `Diff` endpoints and are not
+provisioned until those endpoints are available.
+
+### 7. Get Raw Profiling Data
 
 `GET /v1/profiles/:id/raw` uses `agent_task_id` to query raw profiling data from storage. The response can be large, so it can be written directly to a file:
 
@@ -226,7 +257,7 @@ The raw records are in `data.data`; `data.limit`, `data.offset`, and
 `data.has_more` describe the page. If the job does not yet have an Agent task
 ID, the endpoint returns `400 Bad Request`.
 
-### 7. Stop a Profiling Job
+### 8. Stop a Profiling Job
 
 Only jobs in `pending` or `running` status can be stopped. The `PATCH` request accepts only `stopped` as the `status` value:
 
@@ -241,7 +272,7 @@ curl -sS \
 
 A successful stop returns `200 OK`. A job that has already ended returns `400 Bad Request`.
 
-### 8. Delete a Profiling Job
+### 9. Delete a Profiling Job
 
 Deletion removes only the job record. Jobs in `pending` or `running` status cannot be deleted directly and must be stopped first:
 

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -254,6 +254,24 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
+### 9. Pyroscope-compatible Queries
+
+The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
+methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`
+returns time buckets using sum or average aggregation. `Diff` compares two
+independent time windows and returns a double flame graph.
+
+Selectors are intentionally exact. They accept `id`, `hostname`,
+`container_id`, `container_hostname`, and `tracer`; the profile type is supplied
+by the protobuf request. Regular expressions, negative matchers, and arbitrary
+labels are rejected with `400 Bad Request`.
+
+Each selection is counted before profile data is loaded. Up to 10,000 documents
+are read in stable pages of 1,000. A larger selection returns
+`422 Unprocessable Entity` and must be narrowed by time or target. Merge
+requests, and diff requests with neither side populated, return
+`404 Not Found`; storage failures return `500 Internal Server Error`.
+
 ## 📖 profiler CLI Overview
 
 `profiler` is HUATUO's standalone performance profiling CLI. It samples host processes or processes inside containers without requiring huatuo-apiserver, Elasticsearch, or Grafana. The tool supports C, C++, Go, Java, and Python processes and writes call stacks as folded stacks or SVG flame graphs.

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -219,9 +219,9 @@ merged flame graph with a Top table for the selected time range:
 
 - The host dashboard selects an exact `hostname` and excludes container
   profiles.
-- The container dashboard selects an exact `container_id` and the reporting
-  `hostname`. Container names are not used as identifiers because they are not
-  guaranteed to be unique.
+- The container dashboard queries profiles by exact `container_id` and shows
+  the reporting `hostname` for context. Container names are not used as
+  identifiers because they are not guaranteed to be unique.
 
 CPU and memory are the only profile types exposed by these dashboards. A
 completed job's `results.url` opens the corresponding dashboard with its

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -226,7 +226,40 @@ The raw records are in `data.data`; `data.limit`, `data.offset`, and
 `data.has_more` describe the page. If the job does not yet have an Agent task
 ID, the endpoint returns `400 Bad Request`.
 
-### 7. Stop a Profiling Job
+### 7. Export Merged pprof or SVG
+
+The export endpoints merge the stored snapshots selected by profile type, time
+range, and an exact target label:
+
+```bash
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o profile.pb.gz \
+  "${API_BASE}/v1/profiles/flamegraph/export/pprof"
+
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o flamegraph.svg \
+  "${API_BASE}/v1/profiles/flamegraph/export/svg"
+```
+
+Selectors accept exact `id`, `hostname`, `container_id`,
+`container_hostname`, or `tracer` matches. At least one target is required.
+The service counts matching documents before fetching them, reads them in
+pages, and returns `422 Unprocessable Entity` when more than 10,000 documents
+match. Narrow the time range in that case.
+
+### 8. Stop a Profiling Job
 
 Only jobs in `pending` or `running` status can be stopped. The `PATCH` request accepts only `stopped` as the `status` value:
 
@@ -241,7 +274,7 @@ curl -sS \
 
 A successful stop returns `200 OK`. A job that has already ended returns `400 Bad Request`.
 
-### 8. Delete a Profiling Job
+### 9. Delete a Profiling Job
 
 Deletion removes only the job record. Jobs in `pending` or `running` status cannot be deleted directly and must be stopped first:
 
@@ -254,7 +287,7 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
-### 9. Pyroscope-compatible Queries
+### 10. Pyroscope-compatible Queries
 
 The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
 methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -209,7 +209,33 @@ curl -sS \
 | `failed` | 任务执行失败，查看 `error_message` 定位原因 |
 | `timeout` | 任务超过允许的执行时间 |
 
-### 6. 获取原始剖析数据
+### 6. 在 Grafana 中查看剖析结果
+
+Grafana provisioning 提供独立的宿主机和容器持续剖析 dashboard。两张
+dashboard 都展示选定时间范围内写入的剖析快照数量，以及合并后的火焰图
+和 Top 表：
+
+- 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
+- 容器 dashboard 按 `container_id` 和上报节点 `hostname` 精确筛选。容器名
+  不保证唯一，因此不作为容器标识。
+
+dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
+`results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。
+
+Pyroscope datasource 通过 huatuo-apiserver 查询数据。启用 API 鉴权时，
+应创建只拥有 `POST /v1/profiles/flamegraph/**` 权限的专用用户，并通过
+环境变量将同一个用户 ID 传给 Grafana，不要把它提交到仓库：
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+当前 dashboard 只依赖已有的合并栈查询接口。剖析值时间线、按维度分组的
+Top-N 序列和对比视图依赖兼容 Pyroscope 的 `SelectSeries`、`Diff` 接口，
+在这些接口可用前不进行 provisioning。
+
+### 7. 获取原始剖析数据
 
 `GET /v1/profiles/:id/raw` 根据 `agent_task_id` 查询存储中的原始剖析数据。数据量可能较大，可以直接保存到文件：
 
@@ -224,7 +250,7 @@ curl -sS \
 和 `data.has_more` 描述分页。任务尚未分配 Agent 任务 ID 时，接口返回
 `400 Bad Request`。
 
-### 7. 停止任务
+### 8. 停止任务
 
 只有 `pending` 或 `running` 状态的任务可以停止。`PATCH` 请求的 `status` 只接受 `stopped`：
 
@@ -239,7 +265,7 @@ curl -sS \
 
 停止成功返回 `200 OK`。已结束的任务返回 `400 Bad Request`。
 
-### 8. 删除任务
+### 9. 删除任务
 
 删除操作只移除任务记录。`pending` 或 `running` 状态的任务不能直接删除，需要先停止任务：
 

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -211,9 +211,9 @@ curl -sS \
 
 ### 6. 在 Grafana 中查看剖析结果
 
-Grafana provisioning 提供独立的宿主机和容器持续剖析 dashboard。两张
-dashboard 都展示选定时间范围内写入的剖析快照数量，以及合并后的火焰图
-和 Top 表：
+Grafana provisioning 提供宿主机、容器和时间窗口对比三张持续剖析
+dashboard。宿主机和容器 dashboard 展示剖析快照数量、剖析值时间线、
+按 tracer 分组的 Top 10 序列，以及合并后的火焰图和 Top 表：
 
 - 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
 - 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
@@ -231,9 +231,11 @@ export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
 docker compose -f build/docker/docker-compose.yml up -d
 ```
 
-当前 dashboard 只依赖已有的合并栈查询接口。剖析值时间线、按维度分组的
-Top-N 序列和对比视图依赖兼容 Pyroscope 的 `SelectSeries`、`Diff` 接口，
-在这些接口可用前不进行 provisioning。
+时间线和 Top 10 面板使用 Pyroscope 兼容的 `SelectSeries` 接口。对比
+dashboard 通过有边界限制的 JSON 适配器调用 `Diff`，并把结果交给 Grafana
+火焰图面板。选定时间范围是当前窗口，对比对象是紧邻其前、长度相同的窗口；
+选择 `container_id` 时优先于 `hostname`。适配器默认最多返回 5,000 个
+节点，拒绝超过 10,000 的配置，并将 JSON 响应限制为 8 MiB。
 
 ### 7. 获取原始剖析数据
 
@@ -278,7 +280,7 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
-### 9. Pyroscope 兼容查询
+### 10. Pyroscope 兼容查询
 
 Profiling API 在
 `/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -224,7 +224,38 @@ curl -sS \
 和 `data.has_more` 描述分页。任务尚未分配 Agent 任务 ID 时，接口返回
 `400 Bad Request`。
 
-### 7. 停止任务
+### 7. 导出合并后的 pprof 或 SVG
+
+导出接口根据剖析类型、时间范围和精确目标标签合并存储中的快照：
+
+```bash
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o profile.pb.gz \
+  "${API_BASE}/v1/profiles/flamegraph/export/pprof"
+
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o flamegraph.svg \
+  "${API_BASE}/v1/profiles/flamegraph/export/svg"
+```
+
+选择器接受精确的 `id`、`hostname`、`container_id`、
+`container_hostname` 或 `tracer` 匹配，并且至少需要一个目标。服务会先
+统计匹配文档数，再分页读取。匹配超过 10,000 个文档时返回
+`422 Unprocessable Entity`，此时需要缩小时间范围。
+
+### 8. 停止任务
 
 只有 `pending` 或 `running` 状态的任务可以停止。`PATCH` 请求的 `status` 只接受 `stopped`：
 
@@ -239,7 +270,7 @@ curl -sS \
 
 停止成功返回 `200 OK`。已结束的任务返回 `400 Bad Request`。
 
-### 8. 删除任务
+### 9. 删除任务
 
 删除操作只移除任务记录。`pending` 或 `running` 状态的任务不能直接删除，需要先停止任务：
 
@@ -252,7 +283,7 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
-### 9. Pyroscope 兼容查询
+### 10. Pyroscope 兼容查询
 
 Profiling API 在
 `/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -216,8 +216,8 @@ dashboard 都展示选定时间范围内写入的剖析快照数量，以及合�
 和 Top 表：
 
 - 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
-- 容器 dashboard 按 `container_id` 和上报节点 `hostname` 精确筛选。容器名
-  不保证唯一，因此不作为容器标识。
+- 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
+  `hostname` 作为上下文。容器名不保证唯一，因此不作为容器标识。
 
 dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
 `results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -252,6 +252,23 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
+### 9. Pyroscope 兼容查询
+
+Profiling API 在
+`/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的
+`SelectSeries` 和 `Diff` protobuf 方法。`SelectSeries` 按时间桶返回求和或
+平均聚合结果；`Diff` 比较两个独立时间窗口并返回双向火焰图。
+
+选择器只支持精确匹配，可使用 `id`、`hostname`、`container_id`、
+`container_hostname` 和 `tracer`；剖析类型由 protobuf 请求单独提供。
+正则、否定匹配和任意标签会返回 `400 Bad Request`。
+
+服务读取剖析数据前会先统计匹配文档数。单次选择最多读取 10,000 条，
+每页 1,000 条并使用稳定排序。超过上限时返回
+`422 Unprocessable Entity`，调用方需要缩小时间范围或目标范围。合并查询
+没有数据，或差异查询两侧都没有数据时返回 `404 Not Found`；存储故障返回
+`500 Internal Server Error`。
+
 ## 📖 profiler 命令行功能概述
 
 `profiler` 是 HUATUO 提供的独立性能剖析命令行工具。它可以直接对宿主机进程或容器内进程采样，不依赖 huatuo-apiserver、Elasticsearch 或 Grafana。工具支持 C、C++、Go、Java 和 Python 进程，并将调用栈输出为折叠栈或 SVG 火焰图。

--- a/internal/profiler/output/flamegraph/render.go
+++ b/internal/profiler/output/flamegraph/render.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"strings"
 )
 
 type frame struct {
@@ -157,9 +156,12 @@ func (r *renderer) drawFrame(f frame, ew *errWriter) {
 	x := r.style.XMargin + (f.LeftPercent / 100 * usableWidth)
 	y := r.style.FramesYOffset + (r.maxFrameDepth-f.Depth-1)*r.style.FrameHeight
 
-	jsTitle := strings.ReplaceAll(html.EscapeString(title), "'", "&#39;")
+	// Keep symbol data out of JavaScript source. XML entities are decoded
+	// before event handlers run, so escaping a quote inside s('...') would not
+	// prevent a crafted symbol from terminating that string.
+	attributeTitle := html.EscapeString(title)
 
-	ew.printf(`<g class="func_g" onmouseover="s('%s')" onmouseout="c()" onclick="zoom(this)">`+"\n", jsTitle)
+	ew.printf(`<g class="func_g" data-title="%s" onmouseover="s(this.getAttribute('data-title'))" onmouseout="c()" onclick="zoom(this)">`+"\n", attributeTitle)
 	ew.printf("  <title>%s</title>\n", html.EscapeString(title))
 	ew.printf(`  <rect x="%.1f" y="%d" width="%.1f" height="%d" fill="%s" rx="2" ry="2"/>`+"\n",
 		x, y, w, h, color)

--- a/internal/profiler/output/flamegraph/render_test.go
+++ b/internal/profiler/output/flamegraph/render_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderStyleKeepsSymbolsOutOfJavaScript(t *testing.T) {
+	symbol := `');alert(1);//<script>alert(2)</script>`
+	var output bytes.Buffer
+	if err := RenderStyle([]Stack{{
+		Names:   []string{"root", symbol},
+		Samples: 1,
+	}}, &output, DefaultStyle); err != nil {
+		t.Fatalf("RenderStyle() error = %v", err)
+	}
+
+	content := output.String()
+	if strings.Contains(content, `onmouseover="s('`) ||
+		strings.Contains(content, "<script>alert(2)</script>") {
+		t.Fatalf("SVG embeds an untrusted symbol as executable markup: %s", content)
+	}
+	if !strings.Contains(content, `data-title="`) ||
+		!strings.Contains(content, "&lt;script&gt;alert(2)&lt;/script&gt;") {
+		t.Fatalf("SVG does not preserve the escaped symbol as data: %s", content)
+	}
+}

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -33,6 +33,8 @@ const (
 	profileQueryLimit    = 10000
 	profileQueryPageSize = 1000
 	profileSeriesLimit   = 100
+	defaultProfileNodes  = 5000
+	profileNodeLimit     = 10000
 )
 
 type profileSelection struct {
@@ -289,6 +291,10 @@ func (s *Service) Diff(
 	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
 		return nil, invalidProfileQueryf("left and right profile types must match")
 	}
+	maxNodes, err := diffMaxNodes(req)
+	if err != nil {
+		return nil, err
+	}
 	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
 	if err != nil {
 		return nil, fmt.Errorf("select left profiles: %w", err)
@@ -300,24 +306,41 @@ func (s *Service) Diff(
 	if !leftFound && !rightFound {
 		return nil, ErrProfilesAbsent
 	}
-	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, diffMaxNodes(req))
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, maxNodes)
 	if err != nil {
 		return nil, fmt.Errorf("build flamegraph diff: %w", err)
 	}
 	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
 }
 
-func diffMaxNodes(req *querierv1.DiffRequest) int64 {
-	left := req.Left.GetMaxNodes()
-	right := req.Right.GetMaxNodes()
-	switch {
-	case left > 0 && right > 0 && right < left:
-		return right
-	case left > 0:
-		return left
-	default:
-		return right
+func diffMaxNodes(req *querierv1.DiffRequest) (int64, error) {
+	left, err := normalizeProfileMaxNodes(req.Left.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("left selection: %w", err)
 	}
+	right, err := normalizeProfileMaxNodes(req.Right.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("right selection: %w", err)
+	}
+	switch {
+	case right < left:
+		return right, nil
+	default:
+		return left, nil
+	}
+}
+
+func normalizeProfileMaxNodes(maxNodes int64) (int64, error) {
+	if maxNodes == 0 {
+		return defaultProfileNodes, nil
+	}
+	if maxNodes < 0 || maxNodes > profileNodeLimit {
+		return 0, invalidProfileQueryf(
+			"max nodes must be between 0 and %d",
+			profileNodeLimit,
+		)
+	}
+	return maxNodes, nil
 }
 
 // SelectSeries returns sample totals bucketed by time and exact profile labels.

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -108,6 +108,9 @@ func (s *Service) searchProfileDocuments(
 	if err != nil {
 		return nil, fmt.Errorf("count profiles: %w", err)
 	}
+	if count < 0 {
+		return nil, fmt.Errorf("count profiles: storage returned negative count %d", count)
+	}
 	if count > profileQueryLimit {
 		return nil, fmt.Errorf(
 			"%w: matched %d documents; narrow the time range or selector to at most %d",
@@ -126,10 +129,31 @@ func (s *Service) searchProfileDocuments(
 		if err != nil {
 			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
 		}
-		documents = append(documents, page...)
-		if len(page) < pageFilter.Limit {
-			break
+		if len(page) != pageFilter.Limit {
+			return nil, fmt.Errorf(
+				"search profiles at offset %d: storage returned %d documents, expected %d",
+				offset,
+				len(page),
+				pageFilter.Limit,
+			)
 		}
+		for index, document := range page {
+			if document == nil {
+				return nil, fmt.Errorf(
+					"search profiles at offset %d: storage returned nil document at page index %d",
+					offset,
+					index,
+				)
+			}
+		}
+		documents = append(documents, page...)
+	}
+	if int64(len(documents)) != count {
+		return nil, fmt.Errorf(
+			"search profiles: storage returned %d documents after count reported %d",
+			len(documents),
+			count,
+		)
 	}
 	return documents, nil
 }
@@ -161,26 +185,27 @@ func (s *Service) selectProfileTree(
 	}
 
 	tree := new(phlaremodel.Tree)
+	hasSamples := false
 	for _, document := range documents {
-		if document == nil {
-			continue
-		}
-		if err := addProfileDocumentToTree(tree, document, selection.sampleType); err != nil {
-			return nil, false, err
+		if addProfileDocumentToTree(tree, document, selection.sampleType) {
+			hasSamples = true
 		}
 	}
-	return tree, len(documents) > 0, nil
+	if !hasSamples && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+	return tree, hasSamples, nil
 }
 
 func addProfileDocumentToTree(
 	tree *phlaremodel.Tree,
 	document *ProfileDocument,
 	sampleType string,
-) error {
+) bool {
 	profile := &document.TracerData.Flamedata.Profile
-	sampleTypeIndex, err := profileSampleTypeIndex(profile, sampleType)
-	if err != nil {
-		return err
+	sampleTypeIndex, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return false
 	}
 
 	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
@@ -195,6 +220,7 @@ func addProfileDocumentToTree(
 			functions[function.Id] = function
 		}
 	}
+	inserted := false
 	for _, sample := range profile.Sample {
 		if sample == nil || sampleTypeIndex >= len(sample.Value) {
 			continue
@@ -202,21 +228,22 @@ func addProfileDocumentToTree(
 		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
 		if len(stack) > 0 {
 			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+			inserted = true
 		}
 	}
-	return nil
+	return inserted
 }
 
-func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, error) {
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, bool) {
 	for i, valueType := range profile.SampleType {
 		if valueType == nil {
 			continue
 		}
 		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
-			return i, nil
+			return i, true
 		}
 	}
-	return -1, invalidProfileQueryf("sample type %q not found", sampleType)
+	return -1, false
 }
 
 func profileSampleStack(
@@ -347,10 +374,7 @@ func (s *Service) SelectSeries(
 		if document == nil {
 			continue
 		}
-		value, found, err := profileDocumentSampleTotal(document, selection.sampleType)
-		if err != nil {
-			return nil, err
-		}
+		value, found := profileDocumentSampleTotal(document, selection.sampleType)
 		if !found {
 			continue
 		}
@@ -451,11 +475,11 @@ func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
 func profileDocumentSampleTotal(
 	document *ProfileDocument,
 	sampleType string,
-) (float64, bool, error) {
+) (float64, bool) {
 	profile := &document.TracerData.Flamedata.Profile
-	index, err := profileSampleTypeIndex(profile, sampleType)
-	if err != nil {
-		return 0, false, err
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return 0, false
 	}
 	var total float64
 	var found bool
@@ -466,7 +490,7 @@ func profileDocumentSampleTotal(
 		total += float64(sample.Value[index])
 		found = true
 	}
-	return total, found, nil
+	return total, found
 }
 
 func profileSeriesLabels(

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -1,0 +1,514 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	profileQueryLimit    = 10000
+	profileQueryPageSize = 1000
+	profileSeriesLimit   = 100
+)
+
+type profileSelection struct {
+	filter     *SearchFilter
+	sampleType string
+}
+
+func buildProfileSelection(profileType, selector string, start, end int64) (*profileSelection, error) {
+	profileTypeParts := strings.Split(profileType, ":")
+	if len(profileTypeParts) != 5 {
+		return nil, invalidProfileQueryf("invalid profile type %q", profileType)
+	}
+	if end < start {
+		return nil, invalidProfileQueryf("end time precedes start time")
+	}
+
+	matchers, err := parser.ParseMetricSelector(selector)
+	if err != nil {
+		return nil, invalidProfileQueryf("parse matchers: %v", err)
+	}
+	filter := &SearchFilter{
+		StartTime:   time.UnixMilli(start),
+		EndTime:     time.UnixMilli(end),
+		ProfileType: profileType,
+	}
+	for _, matcher := range matchers {
+		if matcher == nil {
+			continue
+		}
+		if matcher.Name == "__profile_type__" && matcher.Value != profileType {
+			return nil, invalidProfileQueryf(
+				"profile type matcher %q does not match request %q",
+				matcher.Value,
+				profileType,
+			)
+		}
+		if err := applyProfileMatcher(filter, matcher); err != nil {
+			return nil, err
+		}
+	}
+	if filter.ID != "" && filter.TracerID != "" && filter.ID != filter.TracerID {
+		return nil, invalidProfileQueryf("id and tracer select different profiles")
+	}
+	if !hasExactProfileTarget(filter) {
+		return nil, invalidProfileQueryf(
+			"id, hostname, container_id, container_hostname, or tracer must be specified",
+		)
+	}
+	return &profileSelection{filter: filter, sampleType: profileTypeParts[1]}, nil
+}
+
+func invalidProfileQueryf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidQuery, fmt.Sprintf(format, args...))
+}
+
+func hasExactProfileTarget(filter *SearchFilter) bool {
+	return filter != nil &&
+		(filter.ID != "" ||
+			filter.Hostname != "" ||
+			filter.ContainerID != "" ||
+			filter.ContainerHostname != "" ||
+			filter.TracerID != "")
+}
+
+func (s *Service) searchProfileDocuments(
+	ctx context.Context,
+	selection *profileSelection,
+) ([]*ProfileDocument, error) {
+	if s == nil || s.profileStorage == nil {
+		return nil, errorsProfileStorageNotInitialized()
+	}
+	count, err := s.profileStorage.CountProfilesContext(ctx, selection.filter)
+	if err != nil {
+		return nil, fmt.Errorf("count profiles: %w", err)
+	}
+	if count > profileQueryLimit {
+		return nil, fmt.Errorf(
+			"%w: matched %d documents; narrow the time range or selector to at most %d",
+			ErrProfileQueryLimitExceeded,
+			count,
+			profileQueryLimit,
+		)
+	}
+
+	documents := make([]*ProfileDocument, 0, int(count))
+	for offset := 0; offset < int(count); offset += profileQueryPageSize {
+		pageFilter := *selection.filter
+		pageFilter.Limit = min(profileQueryPageSize, int(count)-offset)
+		pageFilter.Offset = offset
+		page, err := s.profileStorage.SearchProfilesContext(ctx, &pageFilter)
+		if err != nil {
+			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
+		}
+		documents = append(documents, page...)
+		if len(page) < pageFilter.Limit {
+			break
+		}
+	}
+	return documents, nil
+}
+
+func errorsProfileStorageNotInitialized() error {
+	return fmt.Errorf("profile storage is not initialized")
+}
+
+func (s *Service) selectProfileTree(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	allowEmpty bool,
+) (*phlaremodel.Tree, bool, error) {
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(documents) == 0 && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+
+	tree := new(phlaremodel.Tree)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		if err := addProfileDocumentToTree(tree, document, selection.sampleType); err != nil {
+			return nil, false, err
+		}
+	}
+	return tree, len(documents) > 0, nil
+}
+
+func addProfileDocumentToTree(
+	tree *phlaremodel.Tree,
+	document *ProfileDocument,
+	sampleType string,
+) error {
+	profile := &document.TracerData.Flamedata.Profile
+	sampleTypeIndex, err := profileSampleTypeIndex(profile, sampleType)
+	if err != nil {
+		return err
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+	for _, sample := range profile.Sample {
+		if sample == nil || sampleTypeIndex >= len(sample.Value) {
+			continue
+		}
+		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
+		if len(stack) > 0 {
+			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+		}
+	}
+	return nil
+}
+
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, error) {
+	for i, valueType := range profile.SampleType {
+		if valueType == nil {
+			continue
+		}
+		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
+			return i, nil
+		}
+	}
+	return -1, invalidProfileQueryf("sample type %q not found", sampleType)
+}
+
+func profileSampleStack(
+	profile *profilev1.Profile,
+	locations map[uint64]*profilev1.Location,
+	functions map[uint64]*profilev1.Function,
+	locationIDs []uint64,
+) []string {
+	stack := make([]string, 0, len(locationIDs))
+	for _, locationID := range locationIDs {
+		location := locations[locationID]
+		if location == nil {
+			continue
+		}
+		for _, line := range location.Line {
+			if line == nil {
+				continue
+			}
+			function := functions[line.FunctionId]
+			if function == nil {
+				continue
+			}
+			name, ok := profileString(profile.StringTable, function.Name)
+			if ok {
+				stack = append(stack, name)
+			}
+		}
+	}
+	for left, right := 0, len(stack)-1; left < right; left, right = left+1, right-1 {
+		stack[left], stack[right] = stack[right], stack[left]
+	}
+	return stack
+}
+
+// Diff compares two independently selected profile windows.
+func (s *Service) Diff(
+	ctx context.Context,
+	req *querierv1.DiffRequest,
+) (*querierv1.DiffResponse, error) {
+	if req == nil || req.Left == nil || req.Right == nil {
+		return nil, invalidProfileQueryf("left and right profile selections are required")
+	}
+	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
+		return nil, invalidProfileQueryf("left and right profile types must match")
+	}
+	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
+	if err != nil {
+		return nil, fmt.Errorf("select left profiles: %w", err)
+	}
+	right, rightFound, err := s.selectProfileTree(ctx, req.Right, true)
+	if err != nil {
+		return nil, fmt.Errorf("select right profiles: %w", err)
+	}
+	if !leftFound && !rightFound {
+		return nil, ErrProfilesAbsent
+	}
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, diffMaxNodes(req))
+	if err != nil {
+		return nil, fmt.Errorf("build flamegraph diff: %w", err)
+	}
+	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
+}
+
+func diffMaxNodes(req *querierv1.DiffRequest) int64 {
+	left := req.Left.GetMaxNodes()
+	right := req.Right.GetMaxNodes()
+	switch {
+	case left > 0 && right > 0 && right < left:
+		return right
+	case left > 0:
+		return left
+	default:
+		return right
+	}
+}
+
+// SelectSeries returns sample totals bucketed by time and exact profile labels.
+func (s *Service) SelectSeries(
+	ctx context.Context,
+	req *querierv1.SelectSeriesRequest,
+) (*querierv1.SelectSeriesResponse, error) {
+	if req == nil {
+		return nil, invalidProfileQueryf("request is required")
+	}
+	stepMillis, err := seriesStepMillis(req.Step)
+	if err != nil {
+		return nil, err
+	}
+	aggregation := typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM
+	if req.Aggregation != nil {
+		aggregation = *req.Aggregation
+	}
+	if aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM &&
+		aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+		return nil, invalidProfileQueryf(
+			"unsupported time series aggregation %q",
+			aggregation.String(),
+		)
+	}
+	groupBy, err := normalizeProfileGroupBy(req.GroupBy)
+	if err != nil {
+		return nil, err
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	type bucketValue struct {
+		sum   float64
+		count int64
+	}
+	type groupedSeries struct {
+		labels  []*typesv1.LabelPair
+		buckets map[int64]*bucketValue
+	}
+	groups := make(map[string]*groupedSeries)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		value, found, err := profileDocumentSampleTotal(document, selection.sampleType)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			continue
+		}
+		seriesLabels, key := profileSeriesLabels(document, groupBy)
+		group := groups[key]
+		if group == nil {
+			group = &groupedSeries{
+				labels:  seriesLabels,
+				buckets: make(map[int64]*bucketValue),
+			}
+			groups[key] = group
+		}
+		timestamp := profileDocumentTimestamp(document).UnixMilli()
+		bucketTimestamp := req.Start + ((timestamp-req.Start)/stepMillis)*stepMillis
+		bucket := group.buckets[bucketTimestamp]
+		if bucket == nil {
+			bucket = &bucketValue{}
+			group.buckets[bucketTimestamp] = bucket
+		}
+		bucket.sum += value
+		bucket.count++
+	}
+
+	series := make([]*typesv1.Series, 0, len(groups))
+	for _, group := range groups {
+		points := make([]*typesv1.Point, 0, len(group.buckets))
+		for timestamp, value := range group.buckets {
+			pointValue := value.sum
+			if aggregation ==
+				typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+				pointValue /= float64(value.count)
+			}
+			points = append(points, &typesv1.Point{
+				Value:     pointValue,
+				Timestamp: timestamp,
+			})
+		}
+		sort.Slice(points, func(i, j int) bool {
+			return points[i].Timestamp < points[j].Timestamp
+		})
+		series = append(series, &typesv1.Series{
+			Labels: group.labels,
+			Points: points,
+		})
+	}
+	sort.Slice(series, func(i, j int) bool {
+		left, right := profileSeriesValue(series[i]), profileSeriesValue(series[j])
+		if left != right {
+			return left > right
+		}
+		return phlaremodel.CompareLabelPairs(series[i].Labels, series[j].Labels) < 0
+	})
+	if len(series) > profileSeriesLimit {
+		series = series[:profileSeriesLimit]
+	}
+	return &querierv1.SelectSeriesResponse{Series: series}, nil
+}
+
+func seriesStepMillis(step float64) (int64, error) {
+	if math.IsNaN(step) ||
+		math.IsInf(step, 0) ||
+		step <= 0 ||
+		step > float64(math.MaxInt64)/1000 {
+		return 0, invalidProfileQueryf(
+			"step must be a finite positive number of seconds",
+		)
+	}
+	milliseconds := int64(math.Round(step * 1000))
+	if milliseconds < 1 {
+		return 1, nil
+	}
+	return milliseconds, nil
+}
+
+func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(groupBy))
+	result := make([]string, 0, len(groupBy))
+	for _, name := range groupBy {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		switch name {
+		case "id", "hostname", "container_id", "container_hostname", "tracer":
+		default:
+			return nil, invalidProfileQueryf("invalid group-by label %q", name)
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func profileDocumentSampleTotal(
+	document *ProfileDocument,
+	sampleType string,
+) (float64, bool, error) {
+	profile := &document.TracerData.Flamedata.Profile
+	index, err := profileSampleTypeIndex(profile, sampleType)
+	if err != nil {
+		return 0, false, err
+	}
+	var total float64
+	var found bool
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) {
+			continue
+		}
+		total += float64(sample.Value[index])
+		found = true
+	}
+	return total, found, nil
+}
+
+func profileSeriesLabels(
+	document *ProfileDocument,
+	groupBy []string,
+) ([]*typesv1.LabelPair, string) {
+	pairs := make([]*typesv1.LabelPair, 0, len(groupBy))
+	var key strings.Builder
+	for _, name := range groupBy {
+		value := profileDocumentLabelValue(document, name)
+		pairs = append(pairs, &typesv1.LabelPair{Name: name, Value: value})
+		_, _ = fmt.Fprintf(&key, "%d:%s=%d:%s;", len(name), name, len(value), value)
+	}
+	return pairs, key.String()
+}
+
+func profileDocumentLabelValue(document *ProfileDocument, name string) string {
+	switch name {
+	case "id", "tracer":
+		return document.TracerID
+	case "hostname":
+		return document.Hostname
+	case "container_id":
+		return document.ContainerID
+	case "container_hostname":
+		return document.ContainerHostname
+	default:
+		return ""
+	}
+}
+
+func profileDocumentTimestamp(document *ProfileDocument) time.Time {
+	if !document.UploadedTime.IsZero() {
+		return document.UploadedTime
+	}
+	return parseProfileDocumentTime(document.TracerTime, time.Unix(0, 0))
+}
+
+func profileSeriesValue(series *typesv1.Series) float64 {
+	var total float64
+	for _, point := range series.GetPoints() {
+		total += point.GetValue()
+	}
+	return total
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -35,6 +35,7 @@ type fakeProfileQueryStorage struct {
 	countErr    error
 	searchErr   error
 	searchCalls []SearchFilter
+	pages       map[int][]*ProfileDocument
 }
 
 func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
@@ -48,6 +49,9 @@ func (s *fakeProfileQueryStorage) SearchProfilesContext(
 		return nil, s.searchErr
 	}
 	s.searchCalls = append(s.searchCalls, *filter)
+	if s.pages != nil {
+		return s.pages[filter.Offset], nil
+	}
 	documents := s.matchingDocuments(filter)
 	if filter.Offset >= len(documents) {
 		return nil, nil
@@ -223,6 +227,71 @@ func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
 	}
 }
 
+func TestSearchProfileDocumentsRejectsInvalidStorageResults(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	tests := []struct {
+		name    string
+		storage *fakeProfileQueryStorage
+	}{
+		{
+			name:    "negative count",
+			storage: &fakeProfileQueryStorage{count: -1},
+		},
+		{
+			name: "empty page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {}},
+			},
+		},
+		{
+			name: "short page",
+			storage: &fakeProfileQueryStorage{
+				count: 2,
+				pages: map[int][]*ProfileDocument{0: {document}},
+			},
+		},
+		{
+			name: "oversized page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {document, document}},
+			},
+		},
+		{
+			name: "nil document",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {nil}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTestProfileService(test.storage)
+			selection, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				`{id="trace-a"}`,
+				0,
+				time.Now().Add(time.Hour).UnixMilli(),
+			)
+			if err != nil {
+				t.Fatalf("buildProfileSelection() error = %v", err)
+			}
+
+			_, err = service.searchProfileDocuments(t.Context(), selection)
+			if err == nil {
+				t.Fatal("searchProfileDocuments() error = nil, want storage contract error")
+			}
+			if errors.Is(err, ErrInvalidQuery) ||
+				errors.Is(err, ErrProfilesAbsent) ||
+				errors.Is(err, ErrProfileQueryLimitExceeded) {
+				t.Fatalf("storage contract error = %v, want internal error", err)
+			}
+		})
+	}
+}
+
 func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
 	for _, selector := range []string{
 		`{hostname=~"node-.*"}`,
@@ -306,6 +375,85 @@ func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
 	}
 	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
 		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestEmptyStoredProfileHasNoUsableSamples(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	_, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="empty-profile"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="empty-profile"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+}
+
+func TestSamplesWithoutValuesAreSkipped(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 13, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "no-values", 1, "root", "leaf")
+	document.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{
+		nil,
+		{LocationId: []uint64{2, 1}},
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="no-values"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+
+	_, err = service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="no-values"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
 	}
 }
 

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+type fakeProfileQueryStorage struct {
+	documents   []*ProfileDocument
+	count       int64
+	countErr    error
+	searchErr   error
+	searchCalls []SearchFilter
+}
+
+func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
+func (*fakeProfileQueryStorage) Ready(context.Context) error { return nil }
+
+func (s *fakeProfileQueryStorage) SearchProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) ([]*ProfileDocument, error) {
+	if s.searchErr != nil {
+		return nil, s.searchErr
+	}
+	s.searchCalls = append(s.searchCalls, *filter)
+	documents := s.matchingDocuments(filter)
+	if filter.Offset >= len(documents) {
+		return nil, nil
+	}
+	end := min(filter.Offset+filter.Limit, len(documents))
+	return documents[filter.Offset:end], nil
+}
+
+func (s *fakeProfileQueryStorage) CountProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) (int64, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	if s.count != 0 {
+		return s.count, nil
+	}
+	return int64(len(s.matchingDocuments(filter))), nil
+}
+
+func (*fakeProfileQueryStorage) AggregationsByFieldContext(
+	context.Context,
+	*SearchFilter,
+	string,
+) ([]string, error) {
+	return nil, nil
+}
+
+func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*ProfileDocument {
+	documents := make([]*ProfileDocument, 0, len(s.documents))
+	for _, document := range s.documents {
+		if document == nil {
+			continue
+		}
+		timestamp := profileDocumentTimestamp(document)
+		if !filter.StartTime.IsZero() && timestamp.Before(filter.StartTime) {
+			continue
+		}
+		if !filter.EndTime.IsZero() && timestamp.After(filter.EndTime) {
+			continue
+		}
+		if filter.ProfileType != "" &&
+			filter.ProfileType != document.TracerData.Flamedata.ProfileType {
+			continue
+		}
+		tracerID := filter.TracerID
+		if tracerID == "" {
+			tracerID = filter.ID
+		}
+		if tracerID != "" && tracerID != document.TracerID {
+			continue
+		}
+		if filter.Hostname != "" &&
+			(filter.Hostname != document.Hostname || document.ContainerHostname != "") {
+			continue
+		}
+		if filter.ContainerID != "" && filter.ContainerID != document.ContainerID {
+			continue
+		}
+		if filter.ContainerHostname != "" &&
+			filter.ContainerHostname != document.ContainerHostname {
+			continue
+		}
+		documents = append(documents, document)
+	}
+	return documents
+}
+
+func newTestProfileService(storage *fakeProfileQueryStorage) *Service {
+	return &Service{profileStorage: storage}
+}
+
+func testProfileDocument(
+	timestamp time.Time,
+	tracerID string,
+	value int64,
+	stack ...string,
+) *ProfileDocument {
+	stringTable := []string{"", "cpu", "nanoseconds"}
+	functions := make([]*profilev1.Function, len(stack))
+	locations := make([]*profilev1.Location, len(stack))
+	locationIDs := make([]uint64, len(stack))
+	for i, name := range stack {
+		stringTable = append(stringTable, name)
+		id := uint64(i + 1)
+		functions[i] = &profilev1.Function{
+			Id:   id,
+			Name: int64(len(stringTable) - 1),
+		}
+		locations[i] = &profilev1.Location{
+			Id:   id,
+			Line: []*profilev1.Line{{FunctionId: id}},
+		}
+		locationIDs[len(stack)-1-i] = id
+	}
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: timestamp,
+		TracerID:     tracerID,
+		TracerTime:   timestamp.Format(profileTimeLayout),
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	document.TracerData.Flamedata.Profile = profilev1.Profile{
+		StringTable: stringTable,
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+			Unit: 2,
+		}},
+		Function: functions,
+		Location: locations,
+		Sample: []*profilev1.Sample{{
+			LocationId: locationIDs,
+			Value:      []int64{value},
+		}},
+	}
+	return document
+}
+
+func TestSearchProfileDocumentsPaginatesWithoutTruncation(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	documents := make([]*ProfileDocument, 1001)
+	for i := range documents {
+		documents[i] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{hostname="node-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	got, err := service.searchProfileDocuments(t.Context(), selection)
+	if err != nil {
+		t.Fatalf("searchProfileDocuments() error = %v", err)
+	}
+	if len(got) != len(documents) {
+		t.Fatalf("documents = %d, want %d", len(got), len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	if storage.searchCalls[0].Limit != 1000 ||
+		storage.searchCalls[0].Offset != 0 ||
+		storage.searchCalls[1].Limit != 1 ||
+		storage.searchCalls[1].Offset != 1000 {
+		t.Fatalf("search pages = %#v, want 1000@0 and 1@1000", storage.searchCalls)
+	}
+}
+
+func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		count: profileQueryLimit + 1,
+	})
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	_, err = service.searchProfileDocuments(t.Context(), selection)
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf("searchProfileDocuments() error = %v, want query limit error", err)
+	}
+}
+
+func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
+	for _, selector := range []string{
+		`{hostname=~"node-.*"}`,
+		`{region="ap-guangzhou"}`,
+		`{arbitrary_label="value"}`,
+		`{id="trace-a",tracer="trace-b"}`,
+	} {
+		t.Run(selector, func(t *testing.T) {
+			_, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				selector,
+				0,
+				1,
+			)
+			if !errors.Is(err, ErrInvalidQuery) {
+				t.Fatalf("buildProfileSelection() error = %v, want invalid query", err)
+			}
+		})
+	}
+}
+
+func TestSelectSeriesBucketsAndGroups(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(100*time.Millisecond), "trace-a", 10, "root", "hot"),
+		testProfileDocument(start.Add(1500*time.Millisecond), "trace-a", 20, "root", "hot"),
+		testProfileDocument(start.Add(500*time.Millisecond), "trace-b", 7, "root", "worker"),
+	}}
+	service := newTestProfileService(storage)
+
+	response, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(4 * time.Second).UnixMilli(),
+		GroupBy:       []string{"tracer"},
+		Step:          2,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 2 {
+		t.Fatalf("series = %#v, want two tracer groups", response.Series)
+	}
+	if got := response.Series[0].Labels[0].Value; got != "trace-a" {
+		t.Fatalf("first series tracer = %q, want trace-a", got)
+	}
+	wantPoints := []*typesv1.Point{{
+		Value:     30,
+		Timestamp: start.UnixMilli(),
+	}}
+	if got := response.Series[0].Points; !reflect.DeepEqual(got, wantPoints) {
+		t.Fatalf("trace-a points = %#v, want %#v", got, wantPoints)
+	}
+}
+
+func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(time.Second), "left", 10, "root", "hot"),
+	}})
+	maxNodes := int64(100)
+	response, err := service.Diff(t.Context(), &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="left"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(5 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="right"}`,
+			Start:         start.Add(10 * time.Second).UnixMilli(),
+			End:           start.Add(15 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
+		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestProfileQueryStorageErrorsRemainInternal(t *testing.T) {
+	sentinel := fmt.Errorf("backend unavailable")
+	service := newTestProfileService(&fakeProfileQueryStorage{countErr: sentinel})
+	_, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="trace-a"}`,
+		Start:         0,
+		End:           1,
+		Step:          1,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("SelectSeries() error = %v, want wrapped backend error", err)
+	}
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -348,6 +348,25 @@ func TestSelectSeriesBucketsAndGroups(t *testing.T) {
 	}
 }
 
+func TestProfileNodeLimits(t *testing.T) {
+	if got, err := normalizeProfileMaxNodes(0); err != nil ||
+		got != defaultProfileNodes {
+		t.Fatalf("normalizeProfileMaxNodes(0) = (%d, %v)", got, err)
+	}
+	for _, value := range []int64{-1, profileNodeLimit + 1} {
+		if _, err := normalizeProfileMaxNodes(value); !errors.Is(
+			err,
+			ErrInvalidQuery,
+		) {
+			t.Fatalf(
+				"normalizeProfileMaxNodes(%d) error = %v, want invalid query",
+				value,
+				err,
+			)
+		}
+	}
+}
+
 func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
 	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
 	service := newTestProfileService(&fakeProfileQueryStorage{documents: []*ProfileDocument{

--- a/internal/profiler/service/errors.go
+++ b/internal/profiler/service/errors.go
@@ -17,6 +17,7 @@ package service
 import "errors"
 
 var (
-	ErrInvalidQuery   = errors.New("invalid profile query")
-	ErrProfilesAbsent = errors.New("profiles not found")
+	ErrInvalidQuery              = errors.New("invalid profile query")
+	ErrProfilesAbsent            = errors.New("profiles not found")
+	ErrProfileQueryLimitExceeded = errors.New("profile query limit exceeded")
 )

--- a/internal/profiler/service/export.go
+++ b/internal/profiler/service/export.go
@@ -1,0 +1,202 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"huatuo-bamai/internal/profiler/output/flamegraph"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+// SelectMergePprof returns the standard pprof profile for an exact target
+// selection. Broad and unsupported label queries are rejected before storage
+// access.
+func (s *Service) SelectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, error) {
+	profile, _, err := s.selectMergePprof(ctx, req)
+	return profile, err
+}
+
+func (s *Service) selectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, string, error) {
+	if req == nil {
+		return nil, "", invalidProfileQueryf("request is required")
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(documents) == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+
+	var merged pprof.ProfileMerge
+	mergedProfiles := 0
+	for _, document := range documents {
+		if _, found := profileDocumentSampleTotal(
+			document,
+			selection.sampleType,
+		); !found {
+			continue
+		}
+		profile := document.TracerData.Flamedata.Profile.CloneVT()
+		if profile == nil {
+			continue
+		}
+		// Pyroscope's merge helper requires a value even though pprof makes it
+		// optional.
+		if profile.PeriodType == nil {
+			profile.PeriodType = &profilev1.ValueType{}
+		}
+		if err := merged.Merge(profile); err != nil {
+			return nil, "", fmt.Errorf("merge profile: %w", err)
+		}
+		mergedProfiles++
+	}
+	if mergedProfiles == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+	profile := merged.Profile()
+	if profile == nil {
+		return nil, "", ErrProfilesAbsent
+	}
+	return profile, selection.sampleType, nil
+}
+
+// MarshalPprof serializes a selected profile as gzip-compressed pprof data.
+func (s *Service) MarshalPprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) ([]byte, error) {
+	profile, err := s.SelectMergePprof(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := pprof.Marshal(profile, true)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pprof: %w", err)
+	}
+	return payload, nil
+}
+
+// RenderProfileSVG writes a standalone interactive SVG for selected pprof
+// data.
+func (s *Service) RenderProfileSVG(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	writer io.Writer,
+) error {
+	if writer == nil {
+		return errors.New("render profile SVG: writer is nil")
+	}
+	profile, sampleType, err := s.selectMergePprof(ctx, req)
+	if err != nil {
+		return err
+	}
+	stacks, err := profileFlamegraphStacks(profile, sampleType)
+	if err != nil {
+		return err
+	}
+	if len(stacks) == 0 {
+		return fmt.Errorf("%w: selected profile has no positive stack samples", ErrProfilesAbsent)
+	}
+	if err := flamegraph.RenderStyle(stacks, writer, flamegraph.DefaultStyle); err != nil {
+		return fmt.Errorf("render profile SVG: %w", err)
+	}
+	return nil
+}
+
+func profileFlamegraphStacks(
+	profile *profilev1.Profile,
+	sampleType string,
+) ([]flamegraph.Stack, error) {
+	if profile == nil {
+		return nil, errors.New("build profile stacks: profile is nil")
+	}
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return nil, invalidProfileQueryf("sample type %q not found", sampleType)
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+
+	const stackSeparator = "\x00"
+	counts := make(map[string]int64)
+	stackNames := make(map[string][]string)
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) || sample.Value[index] <= 0 {
+			continue
+		}
+		names := profileSampleStack(
+			profile,
+			locations,
+			functions,
+			sample.LocationId,
+		)
+		if len(names) == 0 {
+			continue
+		}
+		key := strings.Join(names, stackSeparator)
+		counts[key] += sample.Value[index]
+		stackNames[key] = names
+	}
+
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	stacks := make([]flamegraph.Stack, 0, len(keys))
+	for _, key := range keys {
+		stacks = append(stacks, flamegraph.Stack{
+			Names:   stackNames[key],
+			Samples: counts[key],
+		})
+	}
+	return stacks, nil
+}

--- a/internal/profiler/service/export.go
+++ b/internal/profiler/service/export.go
@@ -29,6 +29,8 @@ import (
 	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
+const profileSVGStackLimit = 10000
+
 // SelectMergePprof returns the standard pprof profile for an exact target
 // selection. Broad and unsupported label queries are rejected before storage
 // access.
@@ -182,6 +184,15 @@ func profileFlamegraphStacks(
 			continue
 		}
 		key := strings.Join(names, stackSeparator)
+		if _, exists := counts[key]; !exists &&
+			len(counts) >= profileSVGStackLimit {
+			return nil, fmt.Errorf(
+				"%w: rendered SVG exceeds %d distinct stacks; narrow the "+
+					"time range or selector",
+				ErrProfileQueryLimitExceeded,
+				profileSVGStackLimit,
+			)
+		}
 		counts[key] += sample.Value[index]
 		stackNames[key] = names
 	}

--- a/internal/profiler/service/export_test.go
+++ b/internal/profiler/service/export_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+func exportTestRequest(start time.Time) *querierv1.SelectMergeStacktracesRequest {
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(time.Minute).UnixMilli(),
+	}
+}
+
+func TestSelectMergePprofUsesBoundedProfileLoader(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "trace-a", 1, "root", "worker")
+	documents := make([]*ProfileDocument, profileQueryPageSize+1)
+	for index := range documents {
+		documents[index] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+
+	profile, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if err != nil {
+		t.Fatalf("SelectMergePprof() error = %v", err)
+	}
+	var total int64
+	for _, sample := range profile.Sample {
+		if sample != nil && len(sample.Value) > 0 {
+			total += sample.Value[0]
+		}
+	}
+	if total != int64(len(documents)) {
+		t.Fatalf("merged sample total = %d, want %d", total, len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	first, second := storage.searchCalls[0], storage.searchCalls[1]
+	if first.Offset != 0 ||
+		first.Limit != profileQueryPageSize ||
+		second.Offset != profileQueryPageSize ||
+		second.Limit != 1 {
+		t.Fatalf(
+			"search pages = (%d,%d),(%d,%d), want (0,1000),(1000,1)",
+			first.Offset,
+			first.Limit,
+			second.Offset,
+			second.Limit,
+		)
+	}
+}
+
+func TestSelectMergePprofRejectsOversizedSelectionBeforeFetch(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{count: profileQueryLimit + 1}
+	service := newTestProfileService(storage)
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfileQueryLimitExceeded",
+			err,
+		)
+	}
+	if len(storage.searchCalls) != 0 {
+		t.Fatalf("search calls = %d, want 0", len(storage.searchCalls))
+	}
+}
+
+func TestSelectMergePprofRejectsEmptyStoredProfilesWithoutPanicking(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 30, 0, 0, time.UTC)
+	empty := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	empty.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	empty.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{nil}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{empty},
+	})
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfilesAbsent",
+			err,
+		)
+	}
+}
+
+func TestMarshalPprofAndRenderProfileSVG(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 14, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{
+			testProfileDocument(start, "trace-a", 10, "root", "hot"),
+		},
+	})
+	req := exportTestRequest(start)
+
+	payload, err := service.MarshalPprof(t.Context(), req)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	decoded, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("RawFromBytes() error = %v", err)
+	}
+	if len(decoded.Sample) != 1 || decoded.Sample[0].Value[0] != 10 {
+		t.Fatalf("pprof samples = %#v, want value 10", decoded.Sample)
+	}
+
+	var output bytes.Buffer
+	if err := service.RenderProfileSVG(
+		t.Context(),
+		req,
+		&output,
+	); err != nil {
+		t.Fatalf("RenderProfileSVG() error = %v", err)
+	}
+	for _, expected := range []string{
+		"<svg",
+		"Flame Graph",
+		"root",
+		"hot",
+		"Search",
+	} {
+		if !strings.Contains(output.String(), expected) {
+			t.Fatalf("SVG does not contain %q", expected)
+		}
+	}
+}
+
+func TestRenderProfileSVGRejectsNilWriter(t *testing.T) {
+	service := &Service{}
+	err := service.RenderProfileSVG(
+		t.Context(),
+		exportTestRequest(time.Now()),
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "writer is nil") {
+		t.Fatalf("RenderProfileSVG() error = %v, want nil writer error", err)
+	}
+}

--- a/internal/profiler/service/export_test.go
+++ b/internal/profiler/service/export_test.go
@@ -17,6 +17,7 @@ package service
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -168,5 +169,46 @@ func TestRenderProfileSVGRejectsNilWriter(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "writer is nil") {
 		t.Fatalf("RenderProfileSVG() error = %v, want nil writer error", err)
+	}
+}
+
+func TestProfileFlamegraphStacksRejectsExcessiveCardinality(t *testing.T) {
+	profile := &profilev1.Profile{
+		StringTable: []string{"", "cpu"},
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+		}},
+		Function: make([]*profilev1.Function, 0, profileSVGStackLimit+1),
+		Location: make([]*profilev1.Location, 0, profileSVGStackLimit+1),
+		Sample:   make([]*profilev1.Sample, 0, profileSVGStackLimit+1),
+	}
+	for index := range profileSVGStackLimit + 1 {
+		id := uint64(index + 1)
+		profile.StringTable = append(
+			profile.StringTable,
+			fmt.Sprintf("function-%d", index),
+		)
+		profile.Function = append(profile.Function, &profilev1.Function{
+			Id:   id,
+			Name: int64(len(profile.StringTable) - 1),
+		})
+		profile.Location = append(profile.Location, &profilev1.Location{
+			Id: id,
+			Line: []*profilev1.Line{{
+				FunctionId: id,
+			}},
+		})
+		profile.Sample = append(profile.Sample, &profilev1.Sample{
+			LocationId: []uint64{id},
+			Value:      []int64{1},
+		})
+	}
+
+	_, err := profileFlamegraphStacks(profile, "cpu")
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf(
+			"profileFlamegraphStacks() error = %v, want query limit",
+			err,
+		)
 	}
 }

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -23,11 +23,9 @@ import (
 
 	"huatuo-bamai/internal/log"
 
-	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
-	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -36,9 +34,21 @@ type ElasticSearchConfig struct {
 	Address, Username, Password, Index string
 }
 
+type profileQueryStorage interface {
+	Close(ctx context.Context) error
+	Ready(ctx context.Context) error
+	SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error)
+	CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error)
+	AggregationsByFieldContext(
+		ctx context.Context,
+		filter *SearchFilter,
+		field string,
+	) ([]string, error)
+}
+
 // Service provides profile query operations.
 type Service struct {
-	profileStorage *ProfileStorage
+	profileStorage profileQueryStorage
 }
 
 // NewService initializes a profile query service.
@@ -77,152 +87,13 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
-	if req.End < req.Start {
-		return nil, fmt.Errorf("%w: end time precedes start time", ErrInvalidQuery)
-	}
-	filter := &SearchFilter{
-		StartTime:   time.UnixMilli(req.Start),
-		EndTime:     time.UnixMilli(req.End),
-		ProfileType: req.ProfileTypeID,
-		Limit:       100,
-	}
-
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
-
-	profileTypes := strings.Split(filter.ProfileType, ":")
-	if len(profileTypes) != 5 {
-		return nil, fmt.Errorf("%w: invalid profile type %q", ErrInvalidQuery, filter.ProfileType)
-	}
-
-	// labels
-	labels, err := parser.ParseMetricSelector(req.LabelSelector)
+	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
-		return nil, errors.Join(ErrInvalidQuery, fmt.Errorf("parse matchers: %w", err))
+		return nil, err
 	}
-
-	for _, label := range labels {
-		// skip empty or "All"
-		if label.Value == "" || label.Value == "all" || label.Value == "All" || label.Value == "*" {
-			continue
-		}
-
-		if err := applyProfileMatcher(filter, label); err != nil {
-			return nil, err
-		}
-	}
-
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
-	}
-
-	// search
-	profileDocs, err := s.profileStorage.SearchProfilesContext(ctx, filter)
-	if err != nil {
-		return nil, fmt.Errorf("search profiles: %w", err)
-	}
-	if len(profileDocs) == 0 {
-		return nil, ErrProfilesAbsent
-	}
-
-	// merge profileDocs
-	var profilesMerge pprof.ProfileMerge
-	for _, profileDoc := range profileDocs {
-		profile := &profileDoc.TracerData.Flamedata.Profile
-		if err := profilesMerge.Merge(profile); err != nil {
-			return nil, fmt.Errorf("merge profile: %w", err)
-		}
-	}
-	profile := profilesMerge.Profile()
-	if profile == nil {
-		return nil, ErrProfilesAbsent
-	}
-	sampleType := profileTypes[1]
-
-	// convert profilev1.Profile to phlaremodel.Tree
-	phlaremodelTree := new(phlaremodel.Tree)
-
-	// Find the index of the sample type we're interested in
-	sampleTypeIndex := -1
-	for i, st := range profile.SampleType {
-		if st == nil {
-			continue
-		}
-		if value, ok := profileString(profile.StringTable, st.Type); ok && value == sampleType {
-			sampleTypeIndex = i
-			break
-		}
-	}
-	if sampleTypeIndex == -1 {
-		return nil, fmt.Errorf("%w: sample type %q not found", ErrInvalidQuery, sampleType)
-	}
-
-	// Create a map for quick location lookup
-	locationMap := make(map[uint64]*googlev1.Location, len(profile.Location))
-	for _, loc := range profile.Location {
-		if loc == nil {
-			continue
-		}
-		locationMap[loc.Id] = loc
-	}
-
-	// Create a map for quick function lookup
-	functionMap := make(map[uint64]*googlev1.Function, len(profile.Function))
-	for _, fn := range profile.Function {
-		if fn == nil {
-			continue
-		}
-		functionMap[fn.Id] = fn
-	}
-
-	// Process each sample
-	for _, sample := range profile.Sample {
-		if sample == nil {
-			continue
-		}
-		// Get the value for our sample type
-		if len(sample.Value) <= sampleTypeIndex {
-			continue
-		}
-		value := sample.Value[sampleTypeIndex]
-
-		// Build stack trace string from location ids
-		stack := make([]string, 0, len(sample.LocationId))
-		for _, locId := range sample.LocationId {
-			loc, exists := locationMap[locId]
-			if !exists || len(loc.Line) == 0 {
-				continue
-			}
-
-			// Get the first line entry (primary function)
-			line := loc.Line[0]
-			if line == nil {
-				continue
-			}
-			fn, exists := functionMap[line.FunctionId]
-			if !exists {
-				continue
-			}
-
-			// Get function name from string table
-			funcName, ok := profileString(profile.StringTable, fn.Name)
-			if !ok {
-				continue
-			}
-			stack = append(stack, funcName)
-		}
-
-		// Insert stack into tree (leaf is at stack[0], so we need to reverse for phlaremodel.Tree)
-		if len(stack) > 0 {
-			for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
-				stack[i], stack[j] = stack[j], stack[i]
-			}
-			phlaremodelTree.InsertStack(value, stack...)
-		}
-	}
-
-	// convert phlaremodel.Tree to FlameGraph
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(phlaremodelTree, -1),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, req.GetMaxNodes()),
 	}, nil
 }
 
@@ -239,6 +110,8 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 		filter.ContainerID = matcher.Value
 	case "container_hostname":
 		filter.ContainerHostname = matcher.Value
+	case "tracer":
+		filter.TracerID = matcher.Value
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -88,12 +88,16 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
+	maxNodes, err := normalizeProfileMaxNodes(req.GetMaxNodes())
+	if err != nil {
+		return nil, err
+	}
 	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
 		return nil, err
 	}
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(tree, req.GetMaxNodes()),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, maxNodes),
 	}, nil
 }
 

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -167,6 +167,14 @@ func (s *ProfileStorage) SearchProfilesContext(ctx context.Context, filter *Sear
 	return documents, nil
 }
 
+// CountProfilesContext counts profiles matching a filter.
+func (s *ProfileStorage) CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error) {
+	if s == nil || s.store == nil {
+		return 0, errors.New("profile storage is not initialized")
+	}
+	return s.store.Count(ctx, buildProfileAggregationQuery(filter))
+}
+
 // AggregationsByField gets aggregations by field.
 func (s *ProfileStorage) AggregationsByField(filter *SearchFilter, field string) ([]string, error) {
 	return s.AggregationsByFieldContext(context.Background(), filter, field)
@@ -259,6 +267,7 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	}
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
 	}
 	return query
 }

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -58,3 +58,15 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
 	}
 }
+
+func TestBuildProfileSearchQueryUsesStablePaginationOrder(t *testing.T) {
+	query := buildProfileSearchQuery(&SearchFilter{Limit: 1000, Offset: 1000})
+	want := []driver.Sort{
+		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
+	}
+
+	if !reflect.DeepEqual(query.Sorts, want) {
+		t.Fatalf("query sorts = %#v, want %#v", query.Sorts, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add profile value timelines
- add Top 10 grouping by tracer
- add flame graph Top tables
- add adjacent-window comparison views
- expose a bounded JSON adapter for comparison rows

## Dependencies

This final integration PR combines #445 and #446.

Multidimensional dashboard variables remain dependent on #329 and are not
duplicated here. Rebase after the preceding PRs merge.

## Testing

- make check
- go test ./internal/profiler/output/flamegraph
- go test ./internal/profiler/service
- go test ./build/docker/grafana/dashboards
- go test ./cmd/huatuo-apiserver/handlers/profiling

Closes #328.