### PR TITLE
[1/5] fix(profiler): harden native profiling foundations

### DIFF
--- a/cmd/profiler/provider/native_bpf_context.go
+++ b/cmd/profiler/provider/native_bpf_context.go
@@ -49,6 +49,16 @@ type ProfilerEventBase struct {
 	Value     int64 // CPU: always 1 (sample count), Memory: page/byte delta
 }
 
+func (e *ProfilerEventBase) hasStack() bool {
+	return e != nil && (e.Kernstack >= 0 || e.Userstack >= 0)
+}
+
+type userStackCacheKey uint64
+
+func newUserStackCacheKey(stackID int32, pid uint32) userStackCacheKey {
+	return userStackCacheKey(uint64(pid)<<32 | uint64(uint32(stackID)))
+}
+
 // ringBufferContext holds the shared ring buffer state for A/B buffer management.
 // It encapsulates all the common infrastructure needed for dual-buffer profiling
 // (readers, state map, stack maps) so profilers don't need to pass these around.
@@ -203,7 +213,7 @@ func (r *ringBufferContext) drainActiveRingBuffer(
 			base := (*ProfilerEventBase)(unsafe.Pointer(ptrValue.Pointer()))
 
 			// Skip events without valid stacks
-			if base.Kernstack <= 0 && base.Userstack <= 0 {
+			if !base.hasStack() {
 				continue
 			}
 
@@ -287,7 +297,7 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 	convertValue func(int64) int64,
 ) {
 	kstackCache := make(map[int32]string)
-	ustackCache := make(map[int32]string)
+	ustackCache := make(map[userStackCacheKey]string)
 
 	var records int
 	for pidName, stacks := range stackCountsByProc {
@@ -301,20 +311,23 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 				continue
 			}
 
-			if stackID.KernelID > 0 {
+			if stackID.KernelID >= 0 {
 				if _, ok := kstackCache[stackID.KernelID]; !ok {
 					kstackCache[stackID.KernelID] = r.resolveKstackWithFallback(ring, stackID.KernelID)
 				}
 			}
-			if stackID.UserID > 0 {
-				if _, ok := ustackCache[stackID.UserID]; !ok {
-					ustackCache[stackID.UserID] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
+			userStack := ""
+			if stackID.UserID >= 0 {
+				key := newUserStackCacheKey(stackID.UserID, pidName.Pid)
+				if _, ok := ustackCache[key]; !ok {
+					ustackCache[key] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
 				}
+				userStack = ustackCache[key]
 			}
 
 			record := &stackEntry{
 				Proc:    &processIDName{Pid: pidName.Pid, Name: pidName.Name},
-				User:    ustackCache[stackID.UserID],
+				User:    userStack,
 				Kernel:  kstackCache[stackID.KernelID],
 				Samples: value,
 			}

--- a/cmd/profiler/provider/native_bpf_context_test.go
+++ b/cmd/profiler/provider/native_bpf_context_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import "testing"
+
+func TestProfilerEventBaseHasStackAcceptsStackIDZero(t *testing.T) {
+	tests := []struct {
+		name string
+		base *ProfilerEventBase
+		want bool
+	}{
+		{name: "nil", base: nil, want: false},
+		{name: "no stack", base: &ProfilerEventBase{Kernstack: -1, Userstack: -1}, want: false},
+		{name: "kernel stack zero", base: &ProfilerEventBase{Kernstack: 0, Userstack: -1}, want: true},
+		{name: "user stack zero", base: &ProfilerEventBase{Kernstack: -1, Userstack: 0}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.hasStack(); got != tt.want {
+				t.Fatalf("hasStack() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserStackCacheKeyIncludesPID(t *testing.T) {
+	cache := map[userStackCacheKey]string{
+		newUserStackCacheKey(7, 100): "first process",
+		newUserStackCacheKey(7, 200): "second process",
+	}
+	if len(cache) != 2 {
+		t.Fatalf("cache entries = %d, want stack ID reused independently by two processes", len(cache))
+	}
+}

--- a/internal/bpf/bpf_kprobe.go
+++ b/internal/bpf/bpf_kprobe.go
@@ -16,6 +16,7 @@ package bpf
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -25,21 +26,17 @@ var (
 	kprobeOnce   sync.Mutex
 	kprobeCache  map[string]struct{}
 	kprobeCached bool
+
+	// Tracefs has its own mount point on current kernels, while older systems
+	// commonly expose the same file through debugfs. Check both layouts.
+	kprobeFunctionFiles = []string{
+		"/sys/kernel/tracing/available_filter_functions",
+		"/sys/kernel/debug/tracing/available_filter_functions",
+	}
 )
 
-// loadKprobeFunctions reads /sys/kernel/debug/tracing/available_filter_functions
-// and populates kprobeCache. On success kprobeCached is set so subsequent
-// calls skip the file read; on failure the cache remains unset and the next
-// call retries.
-func loadKprobeFunctions() {
-	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	cache := make(map[string]struct{})
-	scanner := bufio.NewScanner(file)
+func scanKprobeFunctions(r io.Reader, cache map[string]struct{}) error {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -47,23 +44,41 @@ func loadKprobeFunctions() {
 		}
 		cache[strings.Fields(line)[0]] = struct{}{}
 	}
+	return scanner.Err()
+}
 
-	if err := scanner.Err(); err != nil {
-		return
+// loadKprobeFunctions reads the available function list and populates
+// kprobeCache. On success kprobeCached is set so subsequent calls skip the
+// file read; if neither tracefs nor debugfs is readable, the next call retries.
+func loadKprobeFunctions() {
+	cache := make(map[string]struct{})
+	readOK := false
+	for _, path := range kprobeFunctionFiles {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		err = scanKprobeFunctions(file, cache)
+		_ = file.Close()
+		if err == nil {
+			readOK = true
+		}
 	}
 
-	kprobeCache = cache
-	kprobeCached = true
+	if readOK {
+		kprobeCache = cache
+		kprobeCached = true
+	}
 }
 
 // HasKprobeFunction returns whether the given symbol is reported as
 // attachable in the kernel's available_filter_functions list.
 func HasKprobeFunction(name string) bool {
 	kprobeOnce.Lock()
+	defer kprobeOnce.Unlock()
 	if !kprobeCached {
 		loadKprobeFunctions()
 	}
-	kprobeOnce.Unlock()
 
 	_, ok := kprobeCache[name]
 	return ok

--- a/internal/bpf/bpf_kprobe_test.go
+++ b/internal/bpf/bpf_kprobe_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanKprobeFunctions(t *testing.T) {
+	cache := make(map[string]struct{})
+	input := "  mutex_lock\n_raw_spin_lock   [kernel]\n\n_raw_read_lock\t[kernel]\n"
+	if err := scanKprobeFunctions(strings.NewReader(input), cache); err != nil {
+		t.Fatalf("scanKprobeFunctions() error = %v", err)
+	}
+	for _, symbol := range []string{"mutex_lock", "_raw_spin_lock", "_raw_read_lock"} {
+		if _, ok := cache[symbol]; !ok {
+			t.Errorf("symbol %q missing from cache", symbol)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- discover kprobe symbols from tracefs instead of kernel-private paths
- resolve valid zero stack IDs instead of treating them as missing
- use a collision-free uint64 process-and-stack cache key
- add focused regression coverage for symbol and stack resolution

## Testing

- make bpf-build
- make build
- targeted kprobe and native profiler unit tests
- make check

Part of #329.