### PR TITLE
[2/5] feat(profiling): add native target dimensions and labels

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -24,6 +24,7 @@ import (
 type CreateProfilingJobRequest struct {
 	ProfilingType   string `json:"type"`                   // cpu or memory
 	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
+	ToolPath        string `json:"tool_path"`              // external profiler installation directory
 	Language        string `json:"language"`               // programming language of the target process
 	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
 	Duration        int    `json:"duration"`               // profiling duration in seconds
@@ -49,6 +50,7 @@ type ProfilingJobResponse struct {
 	MemoryMode      string           `json:"memory_mode"`            // memory profiling mode
 	Language        string           `json:"language"`               // programming language of the target process
 	BinaryMatchPath string           `json:"binary_match_path"`      // executable path used to match target processes
+	ToolPath        string           `json:"tool_path"`              // external profiler installation directory
 	Status          string           `json:"status"`                 // job status
 	StartTime       string           `json:"start_time"`             // start time
 	EndTime         string           `json:"end_time"`               // end time

--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -22,13 +22,16 @@ import (
 
 // CreateProfilingJobRequest represents a request to create a profiling job.
 type CreateProfilingJobRequest struct {
-	ProfilingType   string `json:"type"`              // cpu or memory
-	BinaryMatchPath string `json:"binary_match_path"` // executable path used to match target processes
-	Language        string `json:"language"`          // programming language of the target process
-	MemoryMode      string `json:"memory_mode"`       // memory profiling mode
-	Duration        int    `json:"duration"`          // profiling duration in seconds
-	ContainerID     string `json:"container_id"`      // container ID
-	Hostname        string `json:"hostname"`          // host name
+	ProfilingType   string `json:"type"`                   // cpu or memory
+	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
+	Language        string `json:"language"`               // programming language of the target process
+	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
+	Duration        int    `json:"duration"`               // profiling duration in seconds
+	ContainerID     string `json:"container_id"`           // container ID
+	Hostname        string `json:"hostname"`               // host name
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	PID             int    `json:"pid,omitempty"`          // exact PID selected for native profiling
+	ThreadGroup     bool   `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // CreateProfilingJobResponse represents a response to create a profiling job.
@@ -38,21 +41,24 @@ type CreateProfilingJobResponse struct {
 
 // ProfilingJobResponse represents a profiling job response.
 type ProfilingJobResponse struct {
-	ID              string           `json:"id"`                // profiling job ID
-	AgentTaskID     string           `json:"agent_task_id"`     // agent task ID
-	ContainerID     string           `json:"container_id"`      // container ID
-	Hostname        string           `json:"hostname"`          // host name
-	Type            string           `json:"type"`              // cpu or memory
-	MemoryMode      string           `json:"memory_mode"`       // memory profiling mode
-	Language        string           `json:"language"`          // programming language of the target process
-	BinaryMatchPath string           `json:"binary_match_path"` // executable path used to match target processes
-	Status          string           `json:"status"`            // job status
-	StartTime       string           `json:"start_time"`        // start time
-	EndTime         string           `json:"end_time"`          // end time
-	TracerArgs      []string         `json:"tracer_args"`       // tracer arguments
-	Duration        int              `json:"duration"`          // profiling duration
-	Results         ProfilingResults `json:"results"`           // profiling results
-	ErrorMessage    string           `json:"error_message"`     // error message if any
+	ID              string           `json:"id"`                     // profiling job ID
+	AgentTaskID     string           `json:"agent_task_id"`          // agent task ID
+	ContainerID     string           `json:"container_id"`           // container ID
+	Hostname        string           `json:"hostname"`               // host name
+	Type            string           `json:"type"`                   // cpu or memory
+	MemoryMode      string           `json:"memory_mode"`            // memory profiling mode
+	Language        string           `json:"language"`               // programming language of the target process
+	BinaryMatchPath string           `json:"binary_match_path"`      // executable path used to match target processes
+	Status          string           `json:"status"`                 // job status
+	StartTime       string           `json:"start_time"`             // start time
+	EndTime         string           `json:"end_time"`               // end time
+	TracerArgs      []string         `json:"tracer_args"`            // tracer arguments
+	Duration        int              `json:"duration"`               // profiling duration
+	Results         ProfilingResults `json:"results"`                // profiling results
+	ErrorMessage    string           `json:"error_message"`          // error message if any
+	CPUIDs          []int            `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	PID             int              `json:"pid,omitempty"`          // exact PID selected for native profiling
+	ThreadGroup     bool             `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // ProfilingResults represents profiling results

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -32,6 +32,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				BinaryMatchPath: "/usr/bin/example",
 				Language:        "go",
 				ContainerID:     "container-id",
+				CPUIDs:          []int{1},
+				PID:             4242,
+				ThreadGroup:     true,
 			},
 			fields: []string{
 				"type",
@@ -41,6 +44,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				"duration",
 				"container_id",
 				"hostname",
+				"cpu_ids",
+				"pid",
+				"thread_group",
 			},
 		},
 		{
@@ -110,12 +116,19 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 		fields []string
 	}{
 		{
-			name:  "profiling response",
-			value: ProfilingJobResponse{},
+			name: "profiling response",
+			value: ProfilingJobResponse{
+				CPUIDs:      []int{1},
+				PID:         4242,
+				ThreadGroup: true,
+			},
 			fields: []string{
 				"container_id",
 				"binary_match_path",
 				"language",
+				"cpu_ids",
+				"pid",
+				"thread_group",
 			},
 		},
 		{

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -39,6 +39,7 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 			fields: []string{
 				"type",
 				"binary_match_path",
+				"tool_path",
 				"language",
 				"memory_mode",
 				"duration",
@@ -125,6 +126,7 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 			fields: []string{
 				"container_id",
 				"binary_match_path",
+				"tool_path",
 				"language",
 				"cpu_ids",
 				"pid",

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -207,6 +207,7 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		ErrorMessage:    jobResult.ErrorMessage,
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
+		ToolPath:        privateData.ToolPath,
 		Language:        privateData.Language,
 		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
 		PID:             privateData.PID,

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -208,6 +208,9 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
 		Language:        privateData.Language,
+		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
+		PID:             privateData.PID,
+		ThreadGroup:     privateData.ThreadGroup,
 	}
 
 	return resp, nil

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -134,6 +134,7 @@ func TestCapabilitiesReturnsIndependentMemoryModeMap(t *testing.T) {
 func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	data, err := newProfilingPrivateData(&v1.CreateProfilingJobRequest{
 		BinaryMatchPath: "/usr/bin/example",
+		ToolPath:        "/opt/profiler",
 		Duration:        60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
@@ -150,6 +151,7 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error=%v", err)
 	}
 	if fields["binary_match_path"] != "/usr/bin/example" ||
+		fields["tool_path"] != "/opt/profiler" ||
 		fields["duration"] != float64(60) ||
 		fields["language"] != "go" ||
 		fields["memory_mode"] != "object_alloc" ||
@@ -169,6 +171,7 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 		Status: job.JobStatusRunning,
 		PrivateData: json.RawMessage(`{
 			"binary_match_path":"/usr/bin/example",
+			"tool_path":"/opt/profiler",
 			"duration":60,
 			"language":"go",
 			"memory_mode":"object_alloc",
@@ -183,6 +186,9 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 
 	if resp.BinaryMatchPath != "/usr/bin/example" {
 		t.Errorf("BinaryMatchPath=%q, want %q", resp.BinaryMatchPath, "/usr/bin/example")
+	}
+	if resp.ToolPath != "/opt/profiler" {
+		t.Errorf("ToolPath=%q, want %q", resp.ToolPath, "/opt/profiler")
 	}
 	if resp.Language != "go" {
 		t.Errorf("Language=%q, want %q", resp.Language, "go")

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -137,6 +137,9 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		Duration:        60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
+		CPUIDs:          []int{1, 3},
+		PID:             4242,
+		ThreadGroup:     true,
 	})
 	if err != nil {
 		t.Fatalf("newProfilingPrivateData() error=%v", err)
@@ -149,8 +152,14 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	if fields["binary_match_path"] != "/usr/bin/example" ||
 		fields["duration"] != float64(60) ||
 		fields["language"] != "go" ||
-		fields["memory_mode"] != "object_alloc" {
+		fields["memory_mode"] != "object_alloc" ||
+		fields["pid"] != float64(4242) ||
+		fields["thread_group"] != true {
 		t.Errorf("newProfilingPrivateData()=%s, want request fields", data)
+	}
+	cpuIDs, ok := fields["cpu_ids"].([]any)
+	if !ok || len(cpuIDs) != 2 || cpuIDs[0] != float64(1) || cpuIDs[1] != float64(3) {
+		t.Errorf("newProfilingPrivateData() cpu_ids=%v, want [1 3]", fields["cpu_ids"])
 	}
 }
 
@@ -162,7 +171,10 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 			"binary_match_path":"/usr/bin/example",
 			"duration":60,
 			"language":"go",
-			"memory_mode":"object_alloc"
+			"memory_mode":"object_alloc",
+			"cpu_ids":[1,3],
+			"pid":4242,
+			"thread_group":true
 		}`),
 	}, "")
 	if err != nil {
@@ -180,6 +192,15 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 	}
 	if resp.Duration != 60 {
 		t.Errorf("Duration=%d, want 60", resp.Duration)
+	}
+	if len(resp.CPUIDs) != 2 || resp.CPUIDs[0] != 1 || resp.CPUIDs[1] != 3 {
+		t.Errorf("CPUIDs=%v, want [1 3]", resp.CPUIDs)
+	}
+	if resp.PID != 4242 {
+		t.Errorf("PID=%d, want 4242", resp.PID)
+	}
+	if !resp.ThreadGroup {
+		t.Error("ThreadGroup=false, want true")
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -78,13 +78,15 @@ func buildCreateProfilingJobRequest(
 		TraceTimeout: cfg.ExecutionTimeout,
 	}
 
+	targetArgs, err := profilingTargetArgs(req)
+	if err != nil {
+		return nil, err
+	}
 	jobType, err := buildProfilingTracerArgs(&taskReq, req)
 	if err != nil {
 		return nil, err
 	}
-	if err := appendProfilingTargetArgs(&taskReq, req); err != nil {
-		return nil, err
-	}
+	taskReq.TracerArgs = append(taskReq.TracerArgs, targetArgs...)
 	if req.Duration < taskReq.Interval*2 {
 		return nil, errors.New("duration must cover at least two profiling intervals")
 	}
@@ -183,66 +185,73 @@ func appendProfilingToolPath(
 	return nil
 }
 
-func appendProfilingTargetArgs(
-	taskReq *job.AgentTaskRequest,
-	req *v1.CreateProfilingJobRequest,
-) error {
+func profilingTargetArgs(req *v1.CreateProfilingJobRequest) ([]string, error) {
+	switch req.ProfilingType {
+	case string(profiling.TypeCPU), string(profiling.TypeMemory):
+	default:
+		return nil, nil
+	}
 	language, err := profiling.ParseLanguage(req.Language)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	implementation, ok := profiling.ImplementationFor(language)
 	if !ok {
-		return fmt.Errorf("profiling implementation not found for %q", language)
+		return nil, fmt.Errorf("profiling implementation not found for %q", language)
 	}
 	native := implementation == profiling.ImplementationNative
 	hasNativeSelection := req.PID != 0 || req.ThreadGroup || len(req.CPUIDs) > 0
 	if hasNativeSelection && !native {
-		return errors.New("pid, cpu_ids, and thread_group are supported only by native profiling")
+		return nil, errors.New(
+			"pid, cpu_ids, and thread_group are supported only by native profiling",
+		)
 	}
 
+	targetArgs := make([]string, 0, 6)
 	if req.ContainerID != "" {
-		taskReq.TracerArgs = append(taskReq.TracerArgs, "--container-id", req.ContainerID)
+		targetArgs = append(targetArgs, "--container-id", req.ContainerID)
 	}
 	if !native {
-		return nil
+		return targetArgs, nil
 	}
 
 	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
-		return fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+		return nil, fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
 	}
 	if req.PID != 0 && req.ContainerID != "" {
-		return errors.New("pid and container_id are mutually exclusive")
+		return nil, errors.New("pid and container_id are mutually exclusive")
 	}
 	if req.ThreadGroup && req.PID == 0 {
-		return errors.New("thread_group requires pid")
+		return nil, errors.New("thread_group requires pid")
 	}
 	if req.ProfilingType == string(profiling.TypeMemory) &&
 		req.PID == 0 && req.ContainerID == "" {
-		return errors.New("native memory profiling requires pid or container_id")
+		return nil, errors.New(
+			"native memory profiling requires pid or container_id",
+		)
 	}
 
 	if req.PID != 0 {
-		taskReq.TracerArgs = append(taskReq.TracerArgs, "--pid", strconv.Itoa(req.PID))
+		targetArgs = append(targetArgs, "--pid", strconv.Itoa(req.PID))
 	}
 	if req.ThreadGroup {
-		taskReq.TracerArgs = append(taskReq.TracerArgs, "--thread-group")
+		targetArgs = append(targetArgs, "--thread-group")
 	}
 	if len(req.CPUIDs) == 0 {
-		return nil
+		return targetArgs, nil
 	}
 	if req.ProfilingType != string(profiling.TypeCPU) {
-		return errors.New("cpu_ids are supported only by CPU profiling")
+		return nil, errors.New("cpu_ids are supported only by CPU profiling")
 	}
 
 	cpuIDs := append([]int(nil), req.CPUIDs...)
 	sort.Ints(cpuIDs)
 	for i, cpuID := range cpuIDs {
 		if cpuID < 0 {
-			return fmt.Errorf("cpu_id must not be negative: %d", cpuID)
+			return nil, fmt.Errorf("cpu_id must not be negative: %d", cpuID)
 		}
 		if i > 0 && cpuIDs[i-1] == cpuID {
-			return fmt.Errorf("duplicate cpu_id %d", cpuID)
+			return nil, fmt.Errorf("duplicate cpu_id %d", cpuID)
 		}
 	}
 	req.CPUIDs = cpuIDs
@@ -250,8 +259,8 @@ func appendProfilingTargetArgs(
 	for i, cpuID := range cpuIDs {
 		values[i] = strconv.Itoa(cpuID)
 	}
-	taskReq.TracerArgs = append(taskReq.TracerArgs, "--cpuid", strings.Join(values, ","))
-	return nil
+	targetArgs = append(targetArgs, "--cpuid", strings.Join(values, ","))
+	return targetArgs, nil
 }
 
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -49,6 +51,9 @@ type profilingJobPrivateData struct {
 	Duration        int    `json:"duration"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`
+	PID             int    `json:"pid,omitempty"`
+	ThreadGroup     bool   `json:"thread_group,omitempty"`
 }
 
 func parseCreateProfilingJobRequest(ctx *server.Context) (*v1.CreateProfilingJobRequest, error) {
@@ -74,6 +79,9 @@ func buildCreateProfilingJobRequest(
 
 	jobType, err := buildProfilingTracerArgs(&taskReq, req)
 	if err != nil {
+		return nil, err
+	}
+	if err := appendProfilingTargetArgs(&taskReq, req); err != nil {
 		return nil, err
 	}
 	if req.Duration < taskReq.Interval*2 {
@@ -152,12 +160,86 @@ func buildProfilingTracerArgs(
 	}
 }
 
+func appendProfilingTargetArgs(
+	taskReq *job.AgentTaskRequest,
+	req *v1.CreateProfilingJobRequest,
+) error {
+	language, err := profiling.ParseLanguage(req.Language)
+	if err != nil {
+		return err
+	}
+	implementation, ok := profiling.ImplementationFor(language)
+	if !ok {
+		return fmt.Errorf("profiling implementation not found for %q", language)
+	}
+	native := implementation == profiling.ImplementationNative
+	hasNativeSelection := req.PID != 0 || req.ThreadGroup || len(req.CPUIDs) > 0
+	if hasNativeSelection && !native {
+		return errors.New("pid, cpu_ids, and thread_group are supported only by native profiling")
+	}
+
+	if req.ContainerID != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--container-id", req.ContainerID)
+	}
+	if !native {
+		return nil
+	}
+
+	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
+		return fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+	}
+	if req.PID != 0 && req.ContainerID != "" {
+		return errors.New("pid and container_id are mutually exclusive")
+	}
+	if req.ThreadGroup && req.PID == 0 {
+		return errors.New("thread_group requires pid")
+	}
+	if req.ProfilingType == string(profiling.TypeMemory) &&
+		req.PID == 0 && req.ContainerID == "" {
+		return errors.New("native memory profiling requires pid or container_id")
+	}
+
+	if req.PID != 0 {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--pid", strconv.Itoa(req.PID))
+	}
+	if req.ThreadGroup {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--thread-group")
+	}
+	if len(req.CPUIDs) == 0 {
+		return nil
+	}
+	if req.ProfilingType != string(profiling.TypeCPU) {
+		return errors.New("cpu_ids are supported only by CPU profiling")
+	}
+
+	cpuIDs := append([]int(nil), req.CPUIDs...)
+	sort.Ints(cpuIDs)
+	for i, cpuID := range cpuIDs {
+		if cpuID < 0 {
+			return fmt.Errorf("cpu_id must not be negative: %d", cpuID)
+		}
+		if i > 0 && cpuIDs[i-1] == cpuID {
+			return fmt.Errorf("duplicate cpu_id %d", cpuID)
+		}
+	}
+	req.CPUIDs = cpuIDs
+	values := make([]string, len(cpuIDs))
+	for i, cpuID := range cpuIDs {
+		values[i] = strconv.Itoa(cpuID)
+	}
+	taskReq.TracerArgs = append(taskReq.TracerArgs, "--cpuid", strings.Join(values, ","))
+	return nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
 		Duration:        req.Duration,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,
+		CPUIDs:          req.CPUIDs,
+		PID:             req.PID,
+		ThreadGroup:     req.ThreadGroup,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encoding profiling private data: %w", err)

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -48,6 +48,7 @@ type patchProfilingJobRequest struct {
 
 type profilingJobPrivateData struct {
 	BinaryMatchPath string `json:"binary_match_path"`
+	ToolPath        string `json:"tool_path"`
 	Duration        int    `json:"duration"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
@@ -139,6 +140,9 @@ func buildProfilingTracerArgs(
 			)
 		}
 		taskReq.TracerArgs = append(taskReq.TracerArgs, "-l", string(language))
+		if err := appendProfilingToolPath(taskReq, req.ToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingCPU, nil
 	case string(profiling.TypeMemory):
 		language, err := profiling.ParseLanguage(req.Language)
@@ -154,10 +158,29 @@ func buildProfilingTracerArgs(
 			"--memory-mode", string(mode),
 			"-l", string(language),
 		}
+		if err := appendProfilingToolPath(taskReq, req.ToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingMemory, nil
 	default:
 		return "", fmt.Errorf("unsupported profiling type %q", req.ProfilingType)
 	}
+}
+
+func appendProfilingToolPath(
+	taskReq *job.AgentTaskRequest,
+	toolPath string,
+	language profiling.Language,
+) error {
+	toolPath = strings.TrimSpace(toolPath)
+	implementation, _ := profiling.ImplementationFor(language)
+	if implementation != profiling.ImplementationNative && toolPath == "" {
+		return fmt.Errorf("language %q requires tool_path", language)
+	}
+	if toolPath != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--tool-path", toolPath)
+	}
+	return nil
 }
 
 func appendProfilingTargetArgs(
@@ -234,6 +257,7 @@ func appendProfilingTargetArgs(
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
+		ToolPath:        strings.TrimSpace(req.ToolPath),
 		Duration:        req.Duration,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -15,6 +15,7 @@
 package profiling
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -31,20 +32,23 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 		wantErr        string
 	}{
 		{
-			name: "cpu profiling",
+			name: "native CPU profiling by thread group and CPU IDs",
 			req: v1.CreateProfilingJobRequest{
-				ProfilingType:   "cpu",
-				Language:        "go",
-				BinaryMatchPath: "/usr/bin/example",
-				Duration:        30,
-				ContainerID:     "container-2026",
-				Hostname:        "huatuo-dev",
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				Hostname:      "huatuo-dev",
+				CPUIDs:        []int{3, 1},
+				PID:           4242,
+				ThreadGroup:   true,
 			},
 			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
 				"-t", "cpu",
-				"--binary-match-path", "/usr/bin/example",
 				"-l", "go",
+				"--pid", "4242",
+				"--thread-group",
+				"--cpuid", "1,3",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
@@ -53,24 +57,110 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "memory profiling",
+			name: "native CPU profiling by container",
 			req: v1.CreateProfilingJobRequest{
-				ProfilingType: "memory",
+				ProfilingType: "cpu",
 				Language:      "c",
-				MemoryMode:    "physical_usage",
 				Duration:      30,
+				ContainerID:   "0123456789ab",
+				Hostname:      "huatuo-dev",
 			},
-			wantType: ProfilingMemory,
+			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
-				"-t", "memory",
-				"--memory-mode", "physical_usage",
+				"-t", "cpu",
 				"-l", "c",
+				"--container-id", "0123456789ab",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
 				"--output-format", "remote",
 				"--output-storage", "/var/run/huatuo-toolstream.sock",
 			},
+		},
+		{
+			name: "native memory profiling by exact PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "c",
+				MemoryMode:    "physical_usage",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantType: ProfilingMemory,
+			wantTracerArgs: []string{
+				"-t", "memory",
+				"--memory-mode", "physical_usage",
+				"-l", "c",
+				"--pid", "4242",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "native PID and container are mutually exclusive",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				ContainerID:   "0123456789ab",
+				PID:           4242,
+			},
+			wantErr: "pid and container_id are mutually exclusive",
+		},
+		{
+			name: "thread group requires PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				ThreadGroup:   true,
+			},
+			wantErr: "thread_group requires pid",
+		},
+		{
+			name: "CPU IDs require CPU profiling",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "go",
+				MemoryMode:    "virtual_alloc",
+				Duration:      30,
+				PID:           4242,
+				CPUIDs:        []int{1},
+			},
+			wantErr: "cpu_ids are supported only by CPU profiling",
+		},
+		{
+			name: "CPU IDs reject duplicates",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				CPUIDs:        []int{1, 1},
+			},
+			wantErr: "duplicate cpu_id 1",
+		},
+		{
+			name: "non-native profiling rejects native selection",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantErr: "pid, cpu_ids, and thread_group are supported only by native profiling",
+		},
+		{
+			name: "native memory requires a target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "go",
+				MemoryMode:    "virtual_alloc",
+				Duration:      30,
+			},
+			wantErr: "native memory profiling requires pid or container_id",
 		},
 		{
 			name: "unsupported type",
@@ -119,6 +209,15 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			}
 			if !slices.Equal(got.AgentTask.TracerArgs, tt.wantTracerArgs) {
 				t.Errorf("TracerArgs=%q, want %q", got.AgentTask.TracerArgs, tt.wantTracerArgs)
+			}
+			var privateData profilingJobPrivateData
+			if err := json.Unmarshal(got.PrivateData, &privateData); err != nil {
+				t.Fatalf("json.Unmarshal(PrivateData) error=%v", err)
+			}
+			if !slices.Equal(privateData.CPUIDs, tt.req.CPUIDs) ||
+				privateData.PID != tt.req.PID ||
+				privateData.ThreadGroup != tt.req.ThreadGroup {
+				t.Errorf("PrivateData=%+v, want native target from request", privateData)
 			}
 		})
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -78,6 +78,26 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "java profiling with external tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				ToolPath:      "/opt/async-profiler",
+				Duration:      30,
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"-l", "java",
+				"--tool-path", "/opt/async-profiler",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
 			name: "native memory profiling by exact PID",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType: "memory",
@@ -98,6 +118,16 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				"--output-format", "remote",
 				"--output-storage", "/var/run/huatuo-toolstream.sock",
 			},
+		},
+		{
+			name: "java profiling requires external tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				ToolPath:      "   ",
+				Duration:      30,
+			},
+			wantErr: `language "java" requires tool_path`,
 		},
 		{
 			name: "native PID and container are mutually exclusive",

--- a/cmd/profiler/provider/native_bpf_context.go
+++ b/cmd/profiler/provider/native_bpf_context.go
@@ -49,6 +49,16 @@ type ProfilerEventBase struct {
 	Value     int64 // CPU: always 1 (sample count), Memory: page/byte delta
 }
 
+func (e *ProfilerEventBase) hasStack() bool {
+	return e != nil && (e.Kernstack >= 0 || e.Userstack >= 0)
+}
+
+type userStackCacheKey uint64
+
+func newUserStackCacheKey(stackID int32, pid uint32) userStackCacheKey {
+	return userStackCacheKey(uint64(pid)<<32 | uint64(uint32(stackID)))
+}
+
 // ringBufferContext holds the shared ring buffer state for A/B buffer management.
 // It encapsulates all the common infrastructure needed for dual-buffer profiling
 // (readers, state map, stack maps) so profilers don't need to pass these around.
@@ -203,7 +213,7 @@ func (r *ringBufferContext) drainActiveRingBuffer(
 			base := (*ProfilerEventBase)(unsafe.Pointer(ptrValue.Pointer()))
 
 			// Skip events without valid stacks
-			if base.Kernstack <= 0 && base.Userstack <= 0 {
+			if !base.hasStack() {
 				continue
 			}
 
@@ -287,7 +297,7 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 	convertValue func(int64) int64,
 ) {
 	kstackCache := make(map[int32]string)
-	ustackCache := make(map[int32]string)
+	ustackCache := make(map[userStackCacheKey]string)
 
 	var records int
 	for pidName, stacks := range stackCountsByProc {
@@ -301,20 +311,23 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 				continue
 			}
 
-			if stackID.KernelID > 0 {
+			if stackID.KernelID >= 0 {
 				if _, ok := kstackCache[stackID.KernelID]; !ok {
 					kstackCache[stackID.KernelID] = r.resolveKstackWithFallback(ring, stackID.KernelID)
 				}
 			}
-			if stackID.UserID > 0 {
-				if _, ok := ustackCache[stackID.UserID]; !ok {
-					ustackCache[stackID.UserID] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
+			userStack := ""
+			if stackID.UserID >= 0 {
+				key := newUserStackCacheKey(stackID.UserID, pidName.Pid)
+				if _, ok := ustackCache[key]; !ok {
+					ustackCache[key] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
 				}
+				userStack = ustackCache[key]
 			}
 
 			record := &stackEntry{
 				Proc:    &processIDName{Pid: pidName.Pid, Name: pidName.Name},
-				User:    ustackCache[stackID.UserID],
+				User:    userStack,
 				Kernel:  kstackCache[stackID.KernelID],
 				Samples: value,
 			}

--- a/cmd/profiler/provider/native_bpf_context_test.go
+++ b/cmd/profiler/provider/native_bpf_context_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import "testing"
+
+func TestProfilerEventBaseHasStackAcceptsStackIDZero(t *testing.T) {
+	tests := []struct {
+		name string
+		base *ProfilerEventBase
+		want bool
+	}{
+		{name: "nil", base: nil, want: false},
+		{name: "no stack", base: &ProfilerEventBase{Kernstack: -1, Userstack: -1}, want: false},
+		{name: "kernel stack zero", base: &ProfilerEventBase{Kernstack: 0, Userstack: -1}, want: true},
+		{name: "user stack zero", base: &ProfilerEventBase{Kernstack: -1, Userstack: 0}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.hasStack(); got != tt.want {
+				t.Fatalf("hasStack() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserStackCacheKeyIncludesPID(t *testing.T) {
+	cache := map[userStackCacheKey]string{
+		newUserStackCacheKey(7, 100): "first process",
+		newUserStackCacheKey(7, 200): "second process",
+	}
+	if len(cache) != 2 {
+		t.Fatalf("cache entries = %d, want stack ID reused independently by two processes", len(cache))
+	}
+}

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -92,6 +92,7 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` |
 | `cpu_ids` | No | CPU IDs selected for native CPU profiling |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
+| `tool_path` | For Java/Python profiling | Tool installation directory on the Agent host: async-profiler for Java or py-spy for Python |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
@@ -130,6 +131,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "tool_path": "/opt/async-profiler",
     "duration": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -203,6 +205,7 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
+| `tool_path` | External profiler installation directory specified when the job was created |
 | `pid` | Exact native target PID; empty for container or host-wide jobs |
 | `thread_group` | Whether native profiling includes the PID's thread group |
 | `cpu_ids` | CPU IDs selected for native CPU profiling |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -404,6 +404,23 @@ sudo _output/bin/profiler \
   --output-format flamegraph --output-path ./profiles/host
 ```
 
+Remote profiles preserve their collection selectors as both profile metadata
+and pprof sample labels. This keeps the dimensions available to
+Pyroscope-compatible label queries and Parca-compatible pprof readers:
+
+| Label | Value |
+| --- | --- |
+| `profiling_scope` | `host`, `container`, `pid`, or `thread_group` |
+| `pid` | Exact PID target, or comma-separated external-profiler targets |
+| `tgid` | Thread-group target used with `--thread-group` |
+| `container_id` | Target supplied through the common container selector |
+| `cpu` | Comma-separated CPU IDs selected with `--cpuid` |
+
+The Pyroscope-compatible API accepts equality matchers for these labels and
+returns their values through the label-values endpoint. A label describes the
+collection filter; it does not replace the per-process frames already present
+in a profile.
+
 Native memory profiling supports these dimensions:
 
 | `--memory-mode` | Measurement | Suitable for |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -88,12 +88,19 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `duration` | Yes | Profiling duration in seconds |
 | `hostname` | Yes | Hostname of the node running the target process; used for job scheduling |
 | `container_id` | No | Target container ID; omit it to profile the host |
+| `pid` | No | Exact target PID for native profiling; mutually exclusive with `container_id` |
+| `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` |
+| `cpu_ids` | No | CPU IDs selected for native CPU profiling |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
 
-Create a Go CPU profiling job on a host:
+Native CPU profiling can omit both `pid` and `container_id` to sample the
+host. Native memory profiling requires exactly one of them. Without
+`thread_group`, `pid` keeps its exact-thread meaning.
+
+Create a Go CPU profiling job for a thread group on selected CPUs:
 
 ```bash
 curl -sS -i \
@@ -104,6 +111,9 @@ curl -sS -i \
     "type": "cpu",
     "language": "go",
     "duration": 60,
+    "pid": 4242,
+    "thread_group": true,
+    "cpu_ids": [1, 3],
     "hostname": "node-01"
   }' \
   "${API_BASE}/v1/profiles"
@@ -193,6 +203,9 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
+| `pid` | Exact native target PID; empty for container or host-wide jobs |
+| `thread_group` | Whether native profiling includes the PID's thread group |
+| `cpu_ids` | CPU IDs selected for native CPU profiling |
 | `status` | Current job status |
 | `start_time`, `end_time` | Job start and end times; empty until available |
 | `tracer_args` | Command-line arguments sent by huatuo-apiserver to profiler |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -90,6 +90,7 @@ curl -sS \
 | `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须同时指定 `pid` |
 | `cpu_ids` | 否 | 原生 CPU 剖析限定的 CPU ID |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
+| `tool_path` | Java/Python 剖析必需 | Agent 主机上的工具安装目录：Java 使用 async-profiler，Python 使用 py-spy |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
@@ -126,6 +127,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "tool_path": "/opt/async-profiler",
     "duration": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -199,6 +201,7 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
+| `tool_path` | 创建任务时指定的外部 profiler 安装目录 |
 | `pid` | 原生剖析的精确目标 PID；容器任务或宿主机级任务为空 |
 | `thread_group` | 是否采集该 PID 所在线程组 |
 | `cpu_ids` | 原生 CPU 剖析限定的 CPU ID |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -400,6 +400,20 @@ sudo _output/bin/profiler \
   --output-format flamegraph --output-path ./profiles/host
 ```
 
+远端 profile 会同时在 profile 元数据和每个 pprof sample 中保留采集选择器，
+因此 Pyroscope 兼容的序列查询和 Parca 兼容的 pprof 读取器都可以使用这些维度：
+
+| 标签 | 取值 |
+| --- | --- |
+| `profiling_scope` | `host`、`container`、`pid` 或 `thread_group` |
+| `pid` | 精确 PID；外部 profiler 多目标时为逗号分隔的 PID 列表 |
+| `tgid` | 使用 `--thread-group` 时的线程组目标 |
+| `container_id` | 通过统一容器选择器指定的容器 ID |
+| `cpu` | `--cpuid` 选择的逗号分隔 CPU ID |
+
+Pyroscope 兼容 API 支持这些标签的等值匹配，并通过 label-values 接口返回聚合值。
+标签描述采集过滤条件，不会替代 profile 中已有的进程帧。
+
 原生内存支持以下维度：
 
 | `--memory-mode` | 统计内容 | 适用问题 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -86,12 +86,17 @@ curl -sS \
 | `duration` | 是 | 采集时长，单位为秒 |
 | `hostname` | 是 | 运行目标进程的节点主机名，用于任务调度 |
 | `container_id` | 否 | 目标容器 ID；不传表示对宿主机剖析 |
+| `pid` | 否 | 原生剖析的精确目标 PID；不能与 `container_id` 同时使用 |
+| `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须同时指定 `pid` |
+| `cpu_ids` | 否 | 原生 CPU 剖析限定的 CPU ID |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
 
-创建宿主机 Go CPU 剖析任务：
+原生 CPU 剖析可以同时省略 `pid` 和 `container_id`，对整个宿主机采样。原生内存剖析必须指定其中一个。未启用 `thread_group` 时，`pid` 保持精确线程语义。
+
+创建限定 CPU 的 Go 线程组剖析任务：
 
 ```bash
 curl -sS -i \
@@ -102,6 +107,9 @@ curl -sS -i \
     "type": "cpu",
     "language": "go",
     "duration": 60,
+    "pid": 4242,
+    "thread_group": true,
+    "cpu_ids": [1, 3],
     "hostname": "node-01"
   }' \
   "${API_BASE}/v1/profiles"
@@ -191,6 +199,9 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
+| `pid` | 原生剖析的精确目标 PID；容器任务或宿主机级任务为空 |
+| `thread_group` | 是否采集该 PID 所在线程组 |
+| `cpu_ids` | 原生 CPU 剖析限定的 CPU ID |
 | `status` | 当前任务状态 |
 | `start_time`、`end_time` | 任务开始和结束时间；尚未产生时为空 |
 | `tracer_args` | huatuo-apiserver 实际下发给 profiler 的命令行参数 |

--- a/internal/bpf/bpf_kprobe.go
+++ b/internal/bpf/bpf_kprobe.go
@@ -16,6 +16,7 @@ package bpf
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -25,21 +26,17 @@ var (
 	kprobeOnce   sync.Mutex
 	kprobeCache  map[string]struct{}
 	kprobeCached bool
+
+	// Tracefs has its own mount point on current kernels, while older systems
+	// commonly expose the same file through debugfs. Check both layouts.
+	kprobeFunctionFiles = []string{
+		"/sys/kernel/tracing/available_filter_functions",
+		"/sys/kernel/debug/tracing/available_filter_functions",
+	}
 )
 
-// loadKprobeFunctions reads /sys/kernel/debug/tracing/available_filter_functions
-// and populates kprobeCache. On success kprobeCached is set so subsequent
-// calls skip the file read; on failure the cache remains unset and the next
-// call retries.
-func loadKprobeFunctions() {
-	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	cache := make(map[string]struct{})
-	scanner := bufio.NewScanner(file)
+func scanKprobeFunctions(r io.Reader, cache map[string]struct{}) error {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -47,23 +44,41 @@ func loadKprobeFunctions() {
 		}
 		cache[strings.Fields(line)[0]] = struct{}{}
 	}
+	return scanner.Err()
+}
 
-	if err := scanner.Err(); err != nil {
-		return
+// loadKprobeFunctions reads the available function list and populates
+// kprobeCache. On success kprobeCached is set so subsequent calls skip the
+// file read; if neither tracefs nor debugfs is readable, the next call retries.
+func loadKprobeFunctions() {
+	cache := make(map[string]struct{})
+	readOK := false
+	for _, path := range kprobeFunctionFiles {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		err = scanKprobeFunctions(file, cache)
+		_ = file.Close()
+		if err == nil {
+			readOK = true
+		}
 	}
 
-	kprobeCache = cache
-	kprobeCached = true
+	if readOK {
+		kprobeCache = cache
+		kprobeCached = true
+	}
 }
 
 // HasKprobeFunction returns whether the given symbol is reported as
 // attachable in the kernel's available_filter_functions list.
 func HasKprobeFunction(name string) bool {
 	kprobeOnce.Lock()
+	defer kprobeOnce.Unlock()
 	if !kprobeCached {
 		loadKprobeFunctions()
 	}
-	kprobeOnce.Unlock()
 
 	_, ok := kprobeCache[name]
 	return ok

--- a/internal/bpf/bpf_kprobe_test.go
+++ b/internal/bpf/bpf_kprobe_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanKprobeFunctions(t *testing.T) {
+	cache := make(map[string]struct{})
+	input := "  mutex_lock\n_raw_spin_lock   [kernel]\n\n_raw_read_lock\t[kernel]\n"
+	if err := scanKprobeFunctions(strings.NewReader(input), cache); err != nil {
+		t.Fatalf("scanKprobeFunctions() error = %v", err)
+	}
+	for _, symbol := range []string{"mutex_lock", "_raw_spin_lock", "_raw_read_lock"} {
+		if _, ok := cache[symbol]; !ok {
+			t.Errorf("symbol %q missing from cache", symbol)
+		}
+	}
+}

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -33,9 +33,9 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 		return fmt.Errorf("toolstream client not initialized")
 	}
 
-	flameData, ok := data.(*profiler.ProfileData)
-	if !ok {
-		return fmt.Errorf("invalid pprof data for uploading: %T", data)
+	flameData, err := applyCollectionDimensionLabels(p.pctx, data)
+	if err != nil {
+		return err
 	}
 
 	tracerData := &profctx.TracerData{
@@ -60,4 +60,22 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	log.WithField("tracer_id", p.tracerID).Infof("profiling event sent via toolstream")
 
 	return nil
+}
+
+func applyCollectionDimensionLabels(
+	pctx *profctx.ProfilerContext,
+	data any,
+) (*profiler.ProfileData, error) {
+	flameData, ok := data.(*profiler.ProfileData)
+	if !ok {
+		return nil, fmt.Errorf("invalid pprof data for uploading: %T", data)
+	}
+	if err := profiler.ApplyLabels(
+		flameData,
+		pctx.CollectionDimensionLabels(),
+	); err != nil {
+		return nil, fmt.Errorf("apply collection dimension labels: %w", err)
+	}
+
+	return flameData, nil
 }

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+)
+
+func TestApplyCollectionDimensionLabelsUsesProfilerContext(t *testing.T) {
+	data, err := profiler.ParseTree(
+		time.Unix(1, 0),
+		profiler.ProfileTypeCpuSample,
+		[]*profiler.TreeItem{{Stack: [][]byte{[]byte("work")}, Value: 1}},
+		&profiler.ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	got, err := applyCollectionDimensionLabels(&profctx.ProfilerContext{
+		PIDs:        []int{42},
+		ThreadGroup: true,
+	}, data)
+	if err != nil {
+		t.Fatalf("applyCollectionDimensionLabels() error = %v", err)
+	}
+	if got.Labels[profiler.LabelProfilingScope] != "thread_group" {
+		t.Fatalf("profiling_scope = %q, want thread_group", got.Labels[profiler.LabelProfilingScope])
+	}
+	if got.Labels[profiler.LabelTGID] != "42" {
+		t.Fatalf("tgid = %q, want 42", got.Labels[profiler.LabelTGID])
+	}
+	if len(got.Profile.Sample) != 1 ||
+		len(got.Profile.Sample[0].Label) != len(got.Labels) {
+		t.Fatalf("sample labels = %#v, profile labels = %#v", got.Profile.Sample, got.Labels)
+	}
+}

--- a/internal/profiler/context/labels.go
+++ b/internal/profiler/context/labels.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+const (
+	profilingScopeHost        = "host"
+	profilingScopeContainer   = "container"
+	profilingScopePID         = "pid"
+	profilingScopeThreadGroup = "thread_group"
+)
+
+// CollectionDimensionLabels describes the filters that produced a profile.
+func (pctx *ProfilerContext) CollectionDimensionLabels() map[string]string {
+	if pctx == nil {
+		return nil
+	}
+
+	labels := map[string]string{
+		profiler.LabelProfilingScope: profilingScopeHost,
+	}
+	if pctx.ContainerID != "" {
+		labels[profiler.LabelProfilingScope] = profilingScopeContainer
+		labels[profiler.LabelContainerID] = pctx.ContainerID
+	} else if len(pctx.PIDs) > 0 {
+		label := profiler.LabelPID
+		labels[profiler.LabelProfilingScope] = profilingScopePID
+		if pctx.ThreadGroup {
+			label = profiler.LabelTGID
+			labels[profiler.LabelProfilingScope] = profilingScopeThreadGroup
+		}
+		labels[label] = formatDimensionInts(pctx.PIDs)
+	}
+	if len(pctx.CPUIDs) > 0 {
+		labels[profiler.LabelCPU] = formatDimensionInts(pctx.CPUIDs)
+	}
+
+	return labels
+}
+
+func formatDimensionInts(values []int) string {
+	values = append([]int(nil), values...)
+	sort.Ints(values)
+
+	var result strings.Builder
+	for i, value := range values {
+		if i > 0 {
+			result.WriteByte(',')
+		}
+		result.WriteString(strconv.Itoa(value))
+	}
+	return result.String()
+}

--- a/internal/profiler/context/labels_test.go
+++ b/internal/profiler/context/labels_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"reflect"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+func TestCollectionDimensionLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		pctx *ProfilerContext
+		want map[string]string
+	}{
+		{
+			name: "host",
+			pctx: &ProfilerContext{},
+			want: map[string]string{profiler.LabelProfilingScope: profilingScopeHost},
+		},
+		{
+			name: "exact pid and CPUs",
+			pctx: &ProfilerContext{PIDs: []int{42}, CPUIDs: []int{3, 1}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42",
+				profiler.LabelCPU:            "1,3",
+			},
+		},
+		{
+			name: "thread group",
+			pctx: &ProfilerContext{PIDs: []int{42}, ThreadGroup: true},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeThreadGroup,
+				profiler.LabelTGID:           "42",
+			},
+		},
+		{
+			name: "container",
+			pctx: &ProfilerContext{ContainerID: "containerd://abc"},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeContainer,
+				profiler.LabelContainerID:    "containerd://abc",
+			},
+		},
+		{
+			name: "multiple external profiler targets",
+			pctx: &ProfilerContext{PIDs: []int{42, 99}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42,99",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.pctx.CollectionDimensionLabels(); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("CollectionDimensionLabels() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var (
+	collectionDimensionLabels = [...]string{
+		LabelProfilingScope,
+		LabelCPU,
+		LabelPID,
+		LabelTGID,
+		LabelContainerID,
+	}
+	labelNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+// CollectionDimensionLabelNames returns labels managed by collection filters.
+func CollectionDimensionLabelNames() []string {
+	labels := make([]string, len(collectionDimensionLabels))
+	copy(labels, collectionDimensionLabels[:])
+	return labels
+}
+
+// IsCollectionDimensionLabel reports whether name is managed by the profiler.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}
+
+// ApplyLabels injects profile-wide string labels into every pprof sample.
+func ApplyLabels(data *ProfileData, labels map[string]string) error {
+	if data == nil || len(labels) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		if value == "" {
+			continue
+		}
+		if !labelNamePattern.MatchString(key) {
+			return fmt.Errorf("invalid profiling label name %q", key)
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	sort.Strings(keys)
+
+	if len(data.Profile.StringTable) == 0 {
+		data.Profile.StringTable = append(data.Profile.StringTable, "")
+	} else if data.Profile.StringTable[0] != "" {
+		return fmt.Errorf("invalid pprof string table: first entry must be empty")
+	}
+
+	if data.Labels == nil {
+		data.Labels = make(map[string]string, len(keys))
+	}
+	for _, key := range keys {
+		data.Labels[key] = labels[key]
+	}
+
+	stringIndexes := make(map[string]int64, len(data.Profile.StringTable)+len(keys)*2)
+	for i, value := range data.Profile.StringTable {
+		stringIndexes[value] = int64(i)
+	}
+	stringIndex := func(value string) int64 {
+		if index, ok := stringIndexes[value]; ok {
+			return index
+		}
+		index := int64(len(data.Profile.StringTable))
+		data.Profile.StringTable = append(data.Profile.StringTable, value)
+		stringIndexes[value] = index
+		return index
+	}
+
+	keyNames := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keyNames[key] = struct{}{}
+		stringIndex(key)
+	}
+	keyIndexes := make(map[int64]struct{}, len(keys))
+	for index, value := range data.Profile.StringTable {
+		if _, replaced := keyNames[value]; replaced {
+			keyIndexes[int64(index)] = struct{}{}
+		}
+	}
+
+	for _, sample := range data.Profile.Sample {
+		if sample == nil {
+			continue
+		}
+
+		kept := sample.Label[:0]
+		for _, label := range sample.Label {
+			if label == nil {
+				continue
+			}
+			if _, replaced := keyIndexes[label.Key]; !replaced {
+				kept = append(kept, label)
+			}
+		}
+		sample.Label = kept
+		for _, key := range keys {
+			sample.Label = append(sample.Label, &ptree.Label{
+				Key: stringIndex(key),
+				Str: stringIndex(labels[key]),
+			})
+		}
+		sort.Slice(sample.Label, func(i, j int) bool {
+			if sample.Label[i].Key != sample.Label[j].Key {
+				return sample.Label[i].Key < sample.Label[j].Key
+			}
+			return sample.Label[i].Str < sample.Label[j].Str
+		})
+	}
+
+	return nil
+}

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestApplyLabelsInjectsAndReplacesPprofLabels(t *testing.T) {
+	data, err := ParseTree(time.Unix(1, 0), ProfileTypeCpuSample, []*TreeItem{
+		{
+			Stack: [][]byte{[]byte("process"), []byte("work")},
+			Value: 1,
+		},
+		{
+			Stack: [][]byte{[]byte("process"), []byte("wait")},
+			Value: 2,
+		},
+	}, &ParseOption{SampleRate: 99})
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	if err := ApplyLabels(data, map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "4242",
+	}); err != nil {
+		t.Fatalf("ApplyLabels() error = %v", err)
+	}
+	if err := ApplyLabels(data, map[string]string{LabelTGID: "5252"}); err != nil {
+		t.Fatalf("ApplyLabels() replacement error = %v", err)
+	}
+
+	if got, want := data.Labels, map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "5252",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("profile labels = %#v, want %#v", got, want)
+	}
+	if len(data.Profile.Sample) != 2 {
+		t.Fatalf("samples = %d, want 2", len(data.Profile.Sample))
+	}
+
+	for _, sample := range data.Profile.Sample {
+		resolved := make(map[string]string)
+		for _, label := range sample.Label {
+			resolved[data.Profile.StringTable[label.Key]] = data.Profile.StringTable[label.Str]
+		}
+		if !reflect.DeepEqual(resolved, data.Labels) {
+			t.Fatalf("pprof labels = %#v, want %#v", resolved, data.Labels)
+		}
+		if got := len(sample.Label); got != len(resolved) {
+			t.Fatalf("pprof label entries = %d, unique labels = %d", got, len(resolved))
+		}
+	}
+}
+
+func TestApplyLabelsValidatesBeforeMutation(t *testing.T) {
+	data := &ProfileData{}
+	err := ApplyLabels(data, map[string]string{
+		LabelPID:   "42",
+		"bad-name": "value",
+	})
+	if err == nil {
+		t.Fatal("ApplyLabels() error = nil, want invalid label error")
+	}
+	if data.Labels != nil || len(data.Profile.StringTable) != 0 {
+		t.Fatalf("profile mutated after validation error: %#v", data)
+	}
+}
+
+func TestApplyLabelsRejectsMalformedStringTable(t *testing.T) {
+	data := &ProfileData{}
+	data.Profile.StringTable = []string{"not-empty"}
+
+	err := ApplyLabels(data, map[string]string{LabelPID: "42"})
+	if err == nil {
+		t.Fatal("ApplyLabels() error = nil, want malformed string table error")
+	}
+	if data.Labels != nil || len(data.Profile.StringTable) != 1 {
+		t.Fatalf("profile mutated after string table error: %#v", data)
+	}
+}
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	labels := CollectionDimensionLabelNames()
+	labels[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 
 	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -111,8 +112,15 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 		}
 	}
 
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
+	if filter.ID == "" &&
+		filter.Hostname == "" &&
+		filter.ContainerID == "" &&
+		filter.ContainerHostname == "" &&
+		len(filter.Labels) == 0 {
+		return nil, fmt.Errorf(
+			"%w: id, hostname, container, or collection dimension must be specified",
+			ErrInvalidQuery,
+		)
 	}
 
 	// search
@@ -242,7 +250,13 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:
-		return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		if !profiler.IsCollectionDimensionLabel(matcher.Name) {
+			return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		}
+		if filter.Labels == nil {
+			filter.Labels = make(map[string]string)
+		}
+		filter.Labels[matcher.Name] = matcher.Value
 	}
 	return nil
 }
@@ -300,8 +314,25 @@ func (s *Service) ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesR
 //	request: typesv1.LabelNamesRequest
 //	response: typesv1.LabelNamesResponse
 func (s *Service) LabelNames(context.Context, *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error) {
+	names := []string{
+		"region",
+		"hostname",
+		"container_id",
+		"container_hostname",
+		"container_host_namespace",
+	}
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		seen[name] = struct{}{}
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
 	response := &typesv1.LabelNamesResponse{
-		Names: []string{"region", "hostname", "container_id", "container_hostname", "container_host_namespace"},
+		Names: names,
 	}
 	return response, nil
 }

--- a/internal/profiler/service/flamegraph_test.go
+++ b/internal/profiler/service/flamegraph_test.go
@@ -17,6 +17,10 @@ package service
 import (
 	"strings"
 	"testing"
+
+	"huatuo-bamai/internal/profiler"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 func TestServiceReadyRejectsUninitializedStorage(t *testing.T) {
@@ -42,5 +46,33 @@ func TestBuildProfileSearchQueryIncludesPage(t *testing.T) {
 	query := buildProfileSearchQuery(&SearchFilter{TracerID: "task-2026", Limit: 25, Offset: 50})
 	if query.Limit != 25 || query.Offset != 50 {
 		t.Fatalf("query page=(%d,%d), want (25,50)", query.Limit, query.Offset)
+	}
+}
+
+func TestApplyProfileMatcherAcceptsCollectionDimensions(t *testing.T) {
+	filter := &SearchFilter{}
+	matcher := labels.MustNewMatcher(labels.MatchEqual, profiler.LabelTGID, "4242")
+
+	if err := applyProfileMatcher(filter, matcher); err != nil {
+		t.Fatalf("applyProfileMatcher() error = %v", err)
+	}
+	if got := filter.Labels[profiler.LabelTGID]; got != "4242" {
+		t.Fatalf("tgid matcher = %q, want 4242", got)
+	}
+}
+
+func TestLabelNamesIncludesCollectionDimensions(t *testing.T) {
+	response, err := (&Service{}).LabelNames(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("LabelNames() error = %v", err)
+	}
+	names := make(map[string]struct{}, len(response.Names))
+	for _, name := range response.Names {
+		names[name] = struct{}{}
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if _, ok := names[name]; !ok {
+			t.Errorf("LabelNames() missing %q", name)
+		}
 	}
 }

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/timeutil"
 	"huatuo-bamai/internal/storage"
 	"huatuo-bamai/internal/storage/driver"
@@ -74,6 +75,7 @@ type ProfileDocument struct {
 	TracerData struct {
 		Flamedata struct {
 			ProfileType string            `json:"profile_type,omitempty"`
+			Labels      map[string]string `json:"labels,omitempty"`
 			Profile     profilev1.Profile `json:"profile,omitempty"`
 		} `json:"flamedata,omitempty"`
 		// others
@@ -90,6 +92,7 @@ type SearchFilter struct {
 	StartTime         time.Time
 	EndTime           time.Time
 	ProfileType       string
+	Labels            map[string]string
 	Limit             int
 	Offset            int
 }
@@ -214,7 +217,7 @@ func (profileDocumentMapper) Decode(data []byte) (*ProfileDocument, error) {
 }
 
 func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, error) {
-	return map[string]any{
+	fields := map[string]any{
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
@@ -229,11 +232,20 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldTracerTime:        parseProfileDocumentTime(document.TracerTime, document.UploadedTime),
 		profileFieldTracerType:        document.TracerRunType,
 		profileFieldProfileType:       document.TracerData.Flamedata.ProfileType,
-	}, nil
+	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label == profiler.LabelContainerID {
+			continue
+		}
+		if value := document.TracerData.Flamedata.Labels[label]; value != "" {
+			fields[profileLabelField(label)] = value
+		}
+	}
+	return fields, nil
 }
 
 func (profileDocumentMapper) Indexes() []driver.Index {
-	return []driver.Index{
+	indexes := []driver.Index{
 		{Field: profileFieldTracerID},
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
@@ -249,6 +261,12 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldTracerType},
 		{Field: profileFieldProfileType},
 	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label != profiler.LabelContainerID {
+			indexes = append(indexes, driver.Index{Field: profileLabelField(label)})
+		}
+	}
+	return indexes
 }
 
 func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
@@ -335,11 +353,29 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Value: filter.ProfileType,
 		})
 	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name == profiler.LabelContainerID {
+			continue
+		}
+		if value := filter.Labels[name]; value != "" {
+			query.Filters = append(query.Filters, driver.Filter{
+				Field: profileLabelKeywordField(name),
+				Op:    driver.OpEq,
+				Value: value,
+			})
+		}
+	}
 
 	return query
 }
 
 func normalizeProfileAggregationField(field string) (string, error) {
+	if profiler.IsCollectionDimensionLabel(field) {
+		if field == profiler.LabelContainerID {
+			return profileFieldContainerID + ".keyword", nil
+		}
+		return profileLabelKeywordField(field), nil
+	}
 	switch field {
 	case "id":
 		return profileFieldTracerID, nil
@@ -358,6 +394,14 @@ func normalizeProfileAggregationField(field string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}
+}
+
+func profileLabelField(name string) string {
+	return "tracer_data.flamedata.labels." + name
+}
+
+func profileLabelKeywordField(name string) string {
+	return profileLabelField(name) + ".keyword"
 }
 
 func normalizeProfileSearchLimit(filter *SearchFilter) int {

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/storage/driver"
 )
 
@@ -56,5 +57,78 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 
 	if !reflect.DeepEqual(query.Filters, want) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestProfileDocumentMapperIndexesCollectionDimensions(t *testing.T) {
+	document := &ProfileDocument{}
+	document.ContainerID = "containerd://abc"
+	document.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelTGID:           "4242",
+		profiler.LabelContainerID:    document.ContainerID,
+	}
+
+	fields, err := (profileDocumentMapper{}).Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
+	if got := fields[profileLabelField(profiler.LabelProfilingScope)]; got != "thread_group" {
+		t.Fatalf("profiling_scope field = %v, want thread_group", got)
+	}
+	if got := fields[profileLabelField(profiler.LabelTGID)]; got != "4242" {
+		t.Fatalf("tgid field = %v, want 4242", got)
+	}
+	if _, duplicated := fields[profileLabelField(profiler.LabelContainerID)]; duplicated {
+		t.Fatal("container_id duplicated under profile labels")
+	}
+}
+
+func TestBuildProfileAggregationQueryAddsDimensionMatchers(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		ContainerID: "containerd://abc",
+		Labels: map[string]string{
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelTGID:           "4242",
+			"unmanaged":                  "ignored",
+		},
+	})
+	want := []driver.Filter{
+		{
+			Field: profileFieldContainerID + ".keyword",
+			Op:    driver.OpEq,
+			Value: "containerd://abc",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelProfilingScope),
+			Op:    driver.OpEq,
+			Value: "thread_group",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelTGID),
+			Op:    driver.OpEq,
+			Value: "4242",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldSupportsDimensions(t *testing.T) {
+	tests := map[string]string{
+		profiler.LabelPID:         profileLabelKeywordField(profiler.LabelPID),
+		profiler.LabelTGID:        profileLabelKeywordField(profiler.LabelTGID),
+		profiler.LabelContainerID: profileFieldContainerID + ".keyword",
+	}
+	for input, want := range tests {
+		got, err := normalizeProfileAggregationField(input)
+		if err != nil {
+			t.Fatalf("normalizeProfileAggregationField(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("normalizeProfileAggregationField(%q) = %q, want %q", input, got, want)
+		}
 	}
 }

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -36,6 +36,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels are mirrored into pprof samples and indexed for label queries.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends


### PR DESCRIPTION
## Summary

- add PID, TGID, CPU and container target selectors
- forward one common external profiler tool path
- inject canonical collection dimensions into stored pprof profiles
- validate native selectors before external-tool requirements

## Dependencies

This PR is stacked on #448 and owns the canonical dimension label schema used
by the #327 and #328 integration PRs.

## Testing

- make bpf-build
- make build
- targeted profiler, API, context and service unit/race tests
- make check

Part of #329.