### PR TITLE
[3/5] feat(profiling): add mutex contention profiling

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -17,22 +17,27 @@ package v1
 import (
 	"time"
 
+	"huatuo-bamai/pkg/profiling"
+
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 )
 
 // CreateProfilingJobRequest represents a request to create a profiling job.
 type CreateProfilingJobRequest struct {
-	ProfilingType   string `json:"type"`                   // cpu or memory
-	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
-	ToolPath        string `json:"tool_path"`              // external profiler installation directory
-	Language        string `json:"language"`               // programming language of the target process
-	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
-	Duration        int    `json:"duration"`               // profiling duration in seconds
-	ContainerID     string `json:"container_id"`           // container ID
-	Hostname        string `json:"hostname"`               // host name
-	CPUIDs          []int  `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
-	PID             int    `json:"pid,omitempty"`          // exact PID selected for native profiling
-	ThreadGroup     bool   `json:"thread_group,omitempty"` // include the PID's thread group
+	ProfilingType     string             `json:"type"`                          // cpu, memory, or lock
+	BinaryMatchPath   string             `json:"binary_match_path"`             // executable path used to match target processes
+	ToolPath          string             `json:"tool_path"`                     // external profiler installation directory
+	Language          string             `json:"language"`                      // programming language of the target process
+	MemoryMode        string             `json:"memory_mode"`                   // memory profiling mode
+	Duration          int                `json:"duration"`                      // profiling duration in seconds
+	ContainerID       string             `json:"container_id"`                  // container ID
+	Hostname          string             `json:"hostname"`                      // host name
+	CPUIDs            []int              `json:"cpu_ids,omitempty"`             // CPU IDs selected for native CPU profiling
+	PID               int                `json:"pid,omitempty"`                 // exact PID selected for native profiling
+	ThreadGroup       bool               `json:"thread_group,omitempty"`        // include the PID's thread group
+	LockMode          profiling.LockMode `json:"lock_mode,omitempty"`           // lock profile value
+	LockType          profiling.LockType `json:"lock_type,omitempty"`           // lock primitive
+	LockWaitThreshold string             `json:"lock_wait_threshold,omitempty"` // minimum recorded contention wait
 }
 
 // CreateProfilingJobResponse represents a response to create a profiling job.
@@ -42,25 +47,28 @@ type CreateProfilingJobResponse struct {
 
 // ProfilingJobResponse represents a profiling job response.
 type ProfilingJobResponse struct {
-	ID              string           `json:"id"`                     // profiling job ID
-	AgentTaskID     string           `json:"agent_task_id"`          // agent task ID
-	ContainerID     string           `json:"container_id"`           // container ID
-	Hostname        string           `json:"hostname"`               // host name
-	Type            string           `json:"type"`                   // cpu or memory
-	MemoryMode      string           `json:"memory_mode"`            // memory profiling mode
-	Language        string           `json:"language"`               // programming language of the target process
-	BinaryMatchPath string           `json:"binary_match_path"`      // executable path used to match target processes
-	ToolPath        string           `json:"tool_path"`              // external profiler installation directory
-	Status          string           `json:"status"`                 // job status
-	StartTime       string           `json:"start_time"`             // start time
-	EndTime         string           `json:"end_time"`               // end time
-	TracerArgs      []string         `json:"tracer_args"`            // tracer arguments
-	Duration        int              `json:"duration"`               // profiling duration
-	Results         ProfilingResults `json:"results"`                // profiling results
-	ErrorMessage    string           `json:"error_message"`          // error message if any
-	CPUIDs          []int            `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
-	PID             int              `json:"pid,omitempty"`          // exact PID selected for native profiling
-	ThreadGroup     bool             `json:"thread_group,omitempty"` // include the PID's thread group
+	ID                string             `json:"id"`                            // profiling job ID
+	AgentTaskID       string             `json:"agent_task_id"`                 // agent task ID
+	ContainerID       string             `json:"container_id"`                  // container ID
+	Hostname          string             `json:"hostname"`                      // host name
+	Type              string             `json:"type"`                          // cpu, memory, or lock
+	MemoryMode        string             `json:"memory_mode"`                   // memory profiling mode
+	Language          string             `json:"language"`                      // programming language of the target process
+	BinaryMatchPath   string             `json:"binary_match_path"`             // executable path used to match target processes
+	ToolPath          string             `json:"tool_path"`                     // external profiler installation directory
+	Status            string             `json:"status"`                        // job status
+	StartTime         string             `json:"start_time"`                    // start time
+	EndTime           string             `json:"end_time"`                      // end time
+	TracerArgs        []string           `json:"tracer_args"`                   // tracer arguments
+	Duration          int                `json:"duration"`                      // profiling duration
+	Results           ProfilingResults   `json:"results"`                       // profiling results
+	ErrorMessage      string             `json:"error_message"`                 // error message if any
+	CPUIDs            []int              `json:"cpu_ids,omitempty"`             // CPU IDs selected for native CPU profiling
+	PID               int                `json:"pid,omitempty"`                 // exact PID selected for native profiling
+	ThreadGroup       bool               `json:"thread_group,omitempty"`        // include the PID's thread group
+	LockMode          profiling.LockMode `json:"lock_mode,omitempty"`           // lock profile value
+	LockType          profiling.LockType `json:"lock_type,omitempty"`           // lock primitive
+	LockWaitThreshold string             `json:"lock_wait_threshold,omitempty"` // minimum recorded contention wait
 }
 
 // ProfilingResults represents profiling results
@@ -170,11 +178,14 @@ type ProfilingJobListResponse struct {
 // ProfilingCapabilitiesResponse describes the profiling capabilities
 // supported by the server and their default configurations.
 type ProfilingCapabilitiesResponse struct {
-	Types               []string          `json:"types"`                // supported profiling types, e.g. ["cpu", "memory"]
-	CPULanguages        []string          `json:"cpu_languages"`        // languages supported by CPU profiling
-	MemoryLanguages     []string          `json:"memory_languages"`     // languages supported by memory profiling
-	MemoryModes         map[string]string `json:"memory_modes"`         // supported memory modes (key: display name, value: internal mode)
-	AggregationInterval int               `json:"aggregation_interval"` // default aggregation interval in seconds
-	ExecutionTimeout    int               `json:"execution_timeout"`    // default profiler execution timeout in seconds
-	MaxProfilerProcs    int               `json:"max_profiler_procs"`   // maximum concurrent profiler subprocesses
+	Types               []string             `json:"types"`                // supported profiling types
+	CPULanguages        []string             `json:"cpu_languages"`        // languages supported by CPU profiling
+	MemoryLanguages     []string             `json:"memory_languages"`     // languages supported by memory profiling
+	LockLanguages       []string             `json:"lock_languages"`       // languages supported by lock profiling
+	LockModes           []profiling.LockMode `json:"lock_modes"`           // supported lock profile values
+	LockTypes           []profiling.LockType `json:"lock_types"`           // supported lock primitives
+	MemoryModes         map[string]string    `json:"memory_modes"`         // supported memory modes (key: display name, value: internal mode)
+	AggregationInterval int                  `json:"aggregation_interval"` // default aggregation interval in seconds
+	ExecutionTimeout    int                  `json:"execution_timeout"`    // default profiler execution timeout in seconds
+	MaxProfilerProcs    int                  `json:"max_profiler_procs"`   // maximum concurrent profiler subprocesses
 }

--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -24,6 +24,7 @@ import (
 type CreateProfilingJobRequest struct {
 	ProfilingType   string `json:"type"`                   // cpu or memory
 	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
+	ToolPath        string `json:"tool_path"`              // external profiler installation directory
 	Language        string `json:"language"`               // programming language of the target process
 	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
 	Duration        int    `json:"duration"`               // profiling duration in seconds
@@ -49,6 +50,7 @@ type ProfilingJobResponse struct {
 	MemoryMode      string           `json:"memory_mode"`            // memory profiling mode
 	Language        string           `json:"language"`               // programming language of the target process
 	BinaryMatchPath string           `json:"binary_match_path"`      // executable path used to match target processes
+	ToolPath        string           `json:"tool_path"`              // external profiler installation directory
 	Status          string           `json:"status"`                 // job status
 	StartTime       string           `json:"start_time"`             // start time
 	EndTime         string           `json:"end_time"`               // end time

--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -22,13 +22,16 @@ import (
 
 // CreateProfilingJobRequest represents a request to create a profiling job.
 type CreateProfilingJobRequest struct {
-	ProfilingType   string `json:"type"`              // cpu or memory
-	BinaryMatchPath string `json:"binary_match_path"` // executable path used to match target processes
-	Language        string `json:"language"`          // programming language of the target process
-	MemoryMode      string `json:"memory_mode"`       // memory profiling mode
-	Duration        int    `json:"duration"`          // profiling duration in seconds
-	ContainerID     string `json:"container_id"`      // container ID
-	Hostname        string `json:"hostname"`          // host name
+	ProfilingType   string `json:"type"`                   // cpu or memory
+	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
+	Language        string `json:"language"`               // programming language of the target process
+	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
+	Duration        int    `json:"duration"`               // profiling duration in seconds
+	ContainerID     string `json:"container_id"`           // container ID
+	Hostname        string `json:"hostname"`               // host name
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	PID             int    `json:"pid,omitempty"`          // exact PID selected for native profiling
+	ThreadGroup     bool   `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // CreateProfilingJobResponse represents a response to create a profiling job.
@@ -38,21 +41,24 @@ type CreateProfilingJobResponse struct {
 
 // ProfilingJobResponse represents a profiling job response.
 type ProfilingJobResponse struct {
-	ID              string           `json:"id"`                // profiling job ID
-	AgentTaskID     string           `json:"agent_task_id"`     // agent task ID
-	ContainerID     string           `json:"container_id"`      // container ID
-	Hostname        string           `json:"hostname"`          // host name
-	Type            string           `json:"type"`              // cpu or memory
-	MemoryMode      string           `json:"memory_mode"`       // memory profiling mode
-	Language        string           `json:"language"`          // programming language of the target process
-	BinaryMatchPath string           `json:"binary_match_path"` // executable path used to match target processes
-	Status          string           `json:"status"`            // job status
-	StartTime       string           `json:"start_time"`        // start time
-	EndTime         string           `json:"end_time"`          // end time
-	TracerArgs      []string         `json:"tracer_args"`       // tracer arguments
-	Duration        int              `json:"duration"`          // profiling duration
-	Results         ProfilingResults `json:"results"`           // profiling results
-	ErrorMessage    string           `json:"error_message"`     // error message if any
+	ID              string           `json:"id"`                     // profiling job ID
+	AgentTaskID     string           `json:"agent_task_id"`          // agent task ID
+	ContainerID     string           `json:"container_id"`           // container ID
+	Hostname        string           `json:"hostname"`               // host name
+	Type            string           `json:"type"`                   // cpu or memory
+	MemoryMode      string           `json:"memory_mode"`            // memory profiling mode
+	Language        string           `json:"language"`               // programming language of the target process
+	BinaryMatchPath string           `json:"binary_match_path"`      // executable path used to match target processes
+	Status          string           `json:"status"`                 // job status
+	StartTime       string           `json:"start_time"`             // start time
+	EndTime         string           `json:"end_time"`               // end time
+	TracerArgs      []string         `json:"tracer_args"`            // tracer arguments
+	Duration        int              `json:"duration"`               // profiling duration
+	Results         ProfilingResults `json:"results"`                // profiling results
+	ErrorMessage    string           `json:"error_message"`          // error message if any
+	CPUIDs          []int            `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	PID             int              `json:"pid,omitempty"`          // exact PID selected for native profiling
+	ThreadGroup     bool             `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // ProfilingResults represents profiling results

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -32,6 +32,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				BinaryMatchPath: "/usr/bin/example",
 				Language:        "go",
 				ContainerID:     "container-id",
+				CPUIDs:          []int{1},
+				PID:             4242,
+				ThreadGroup:     true,
 			},
 			fields: []string{
 				"type",
@@ -41,6 +44,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				"duration",
 				"container_id",
 				"hostname",
+				"cpu_ids",
+				"pid",
+				"thread_group",
 			},
 		},
 		{
@@ -110,12 +116,19 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 		fields []string
 	}{
 		{
-			name:  "profiling response",
-			value: ProfilingJobResponse{},
+			name: "profiling response",
+			value: ProfilingJobResponse{
+				CPUIDs:      []int{1},
+				PID:         4242,
+				ThreadGroup: true,
+			},
 			fields: []string{
 				"container_id",
 				"binary_match_path",
 				"language",
+				"cpu_ids",
+				"pid",
+				"thread_group",
 			},
 		},
 		{

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -39,6 +39,7 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 			fields: []string{
 				"type",
 				"binary_match_path",
+				"tool_path",
 				"language",
 				"memory_mode",
 				"duration",
@@ -125,6 +126,7 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 			fields: []string{
 				"container_id",
 				"binary_match_path",
+				"tool_path",
 				"language",
 				"cpu_ids",
 				"pid",

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -17,6 +17,8 @@ package v1
 import (
 	"encoding/json"
 	"testing"
+
+	"huatuo-bamai/pkg/profiling"
 )
 
 func TestCreateJobRequestJSONFields(t *testing.T) {
@@ -28,13 +30,16 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 		{
 			name: "profiling job",
 			request: CreateProfilingJobRequest{
-				ProfilingType:   "cpu",
-				BinaryMatchPath: "/usr/bin/example",
-				Language:        "go",
-				ContainerID:     "container-id",
-				CPUIDs:          []int{1},
-				PID:             4242,
-				ThreadGroup:     true,
+				ProfilingType:     "cpu",
+				BinaryMatchPath:   "/usr/bin/example",
+				Language:          "go",
+				ContainerID:       "container-id",
+				CPUIDs:            []int{1},
+				PID:               4242,
+				ThreadGroup:       true,
+				LockMode:          profiling.LockModeWaitTime,
+				LockType:          profiling.LockTypeMutex,
+				LockWaitThreshold: "10us",
 			},
 			fields: []string{
 				"type",
@@ -48,6 +53,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				"cpu_ids",
 				"pid",
 				"thread_group",
+				"lock_mode",
+				"lock_type",
+				"lock_wait_threshold",
 			},
 		},
 		{
@@ -95,6 +103,9 @@ func TestProfilingCapabilitiesResponseJSONFields(t *testing.T) {
 		"types",
 		"cpu_languages",
 		"memory_languages",
+		"lock_languages",
+		"lock_modes",
+		"lock_types",
 		"memory_modes",
 		"aggregation_interval",
 		"execution_timeout",

--- a/bpf/native_mutex_profiler.c
+++ b/bpf/native_mutex_profiler.c
@@ -1,0 +1,136 @@
+#include "vmlinux.h"
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "bpf_profiler.h"
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+/* Flags exported by lock:contention_begin since Linux 5.19. */
+#define LCB_F_MUTEX (1U << 5)
+
+static volatile const u64 mutex_wait_threshold_ns = 1000;
+
+struct mutex_wait_start_t {
+	u64 started_ns;
+	u64 lock;
+};
+
+struct mutex_event_t {
+	struct profiler_event_base_t base;
+	u64 lock;
+};
+
+/*
+ * A task can migrate between CPUs while blocked. Keying in-flight waits by
+ * pid_tgid in an LRU hash keeps enter/exit correlation correct across that
+ * migration; a per-CPU map would lose or mismatch the start record.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 65536);
+	__type(key, u64);
+	__type(value, struct mutex_wait_start_t);
+} mutex_wait_starts SEC(".maps");
+
+DEFINE_PROFILER_MAPS(struct mutex_event_t);
+
+static __always_inline int mutex_wait_begin(u64 pid_tgid, u64 lock)
+{
+	u64 cpu_css = current_task_cpu_css_addr();
+	if (!profiler_should_trace(pid_tgid, cpu_css))
+		return 0;
+
+	struct mutex_wait_start_t start = {
+		.started_ns = bpf_ktime_get_ns(),
+		.lock = lock,
+	};
+	bpf_map_update_elem(&mutex_wait_starts, &pid_tgid, &start,
+			    COMPAT_BPF_ANY);
+	return 0;
+}
+
+static __always_inline int mutex_wait_end(void *ctx, u64 pid_tgid, bool success)
+{
+	struct mutex_wait_start_t *found =
+		bpf_map_lookup_elem(&mutex_wait_starts, &pid_tgid);
+	if (!found)
+		return 0;
+
+	struct mutex_wait_start_t start = *found;
+	bpf_map_delete_elem(&mutex_wait_starts, &pid_tgid);
+	if (!success)
+		return 0;
+
+	u64 wait_ns = bpf_ktime_get_ns() - start.started_ns;
+	if (wait_ns < mutex_wait_threshold_ns)
+		return 0;
+
+	u64 *transfer_count_ptr;
+	u64 *sample_count_ptrs[2];
+	void *select_profiler_stack_map;
+	void *select_profiler_output;
+	u64 *select_profiler_sample_count_ptr;
+
+	if (!profiler_init_state(&profiler_state_map, &transfer_count_ptr,
+				 sample_count_ptrs))
+		return 0;
+
+	SELECT_PROFILER_AB();
+
+	u32 idx = 0;
+	struct mutex_event_t *event = bpf_map_lookup_elem(&event_buf, &idx);
+	if (!event)
+		return 0;
+
+	__builtin_memset(event, 0, sizeof(*event));
+	event->base.value = wait_ns;
+	event->lock = start.lock;
+	if (profiler_fill_event_base(&event->base, pid_tgid, ctx,
+				     select_profiler_stack_map) < 0)
+		return 0;
+
+	profiler_emit_event(ctx, select_profiler_output,
+			    select_profiler_sample_count_ptr, event,
+			    sizeof(*event));
+	return 0;
+}
+
+SEC("kprobe/huatuo_mutex_lock_slowpath")
+int trace_mutex_lock_slowpath(struct pt_regs *ctx)
+{
+	return mutex_wait_begin(bpf_get_current_pid_tgid(), PT_REGS_PARM1(ctx));
+}
+
+SEC("kretprobe/huatuo_mutex_lock_slowpath")
+int trace_mutex_lock_slowpath_return(struct pt_regs *ctx)
+{
+	return mutex_wait_end(ctx, bpf_get_current_pid_tgid(), true);
+}
+
+struct lock_contention_begin_ctx {
+	u64 common;
+	u64 lock_addr;
+	u32 flags;
+};
+
+struct lock_contention_end_ctx {
+	u64 common;
+	u64 lock_addr;
+	s32 ret;
+};
+
+SEC("tracepoint/lock/contention_begin")
+int trace_mutex_contention_begin(struct lock_contention_begin_ctx *ctx)
+{
+	if (!(ctx->flags & LCB_F_MUTEX))
+		return 0;
+	return mutex_wait_begin(bpf_get_current_pid_tgid(), ctx->lock_addr);
+}
+
+SEC("tracepoint/lock/contention_end")
+int trace_mutex_contention_end(struct lock_contention_end_ctx *ctx)
+{
+	return mutex_wait_end(ctx, bpf_get_current_pid_tgid(), ctx->ret == 0);
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/capabilities.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/capabilities.go
@@ -31,6 +31,9 @@ func buildCapabilitiesResponse(h *Handler) v1.ProfilingCapabilitiesResponse {
 	memoryLanguages := languageStrings(profiling.LanguagesFor(profiling.TypeMemory))
 	sort.Strings(memoryLanguages)
 
+	lockLanguages := languageStrings(profiling.LanguagesFor(profiling.TypeLock))
+	sort.Strings(lockLanguages)
+
 	memoryModes := map[string]string{}
 	for _, language := range profiling.LanguagesFor(profiling.TypeMemory) {
 		implementation, _ := profiling.ImplementationFor(language)
@@ -46,9 +49,12 @@ func buildCapabilitiesResponse(h *Handler) v1.ProfilingCapabilitiesResponse {
 	cfg := h.profilingConfig
 
 	return v1.ProfilingCapabilitiesResponse{
-		Types:               []string{string(profiling.TypeCPU), string(profiling.TypeMemory)},
+		Types:               []string{string(profiling.TypeCPU), string(profiling.TypeMemory), string(profiling.TypeLock)},
 		CPULanguages:        cpuLanguages,
 		MemoryLanguages:     memoryLanguages,
+		LockLanguages:       lockLanguages,
+		LockModes:           []profiling.LockMode{profiling.LockModeWaitTime},
+		LockTypes:           []profiling.LockType{profiling.LockTypeMutex},
 		MemoryModes:         memoryModes,
 		AggregationInterval: cfg.AggregationInterval,
 		ExecutionTimeout:    cfg.ExecutionTimeout,

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -33,6 +33,7 @@ import (
 const (
 	ProfilingMemory = job.JobTypeProfilingMemory
 	ProfilingCPU    = job.JobTypeProfilingCPU
+	ProfilingLock   = job.JobTypeProfilingLock
 )
 
 // create creates a profiling job.
@@ -76,7 +77,9 @@ func (h *Handler) patchOne(ctx *server.Context) error {
 	}
 	taskID := req.ID
 
-	jobResult, err := h.jobManager.GetByTypesContext(ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory)
+	jobResult, err := h.jobManager.GetByTypesContext(
+		ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory, ProfilingLock,
+	)
 	if err != nil {
 		if errors.Is(err, job.ErrNotFound) {
 			return response.ErrNotFound
@@ -93,7 +96,9 @@ func (h *Handler) patchOne(ctx *server.Context) error {
 		return response.ErrInvalidRequest.WithMessage("job already completed")
 	}
 
-	if err := h.jobManager.StopByTypesContext(ctx.Request().Context(), taskID, false, ProfilingCPU, ProfilingMemory); err != nil {
+	if err := h.jobManager.StopByTypesContext(
+		ctx.Request().Context(), taskID, false, ProfilingCPU, ProfilingMemory, ProfilingLock,
+	); err != nil {
 		log.WithError(err).WithField("job_id", taskID).Error("failed to stop profiling job")
 		return response.ErrInternal
 	}
@@ -149,7 +154,9 @@ func (h *Handler) get(ctx *server.Context) error {
 		return response.ErrInvalidRequest.WithMessage(err.Error())
 	}
 
-	jobResult, err := h.jobManager.GetByTypesContext(ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory)
+	jobResult, err := h.jobManager.GetByTypesContext(
+		ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory, ProfilingLock,
+	)
 	if err != nil {
 		if errors.Is(err, job.ErrNotFound) {
 			return response.ErrNotFound
@@ -204,21 +211,24 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		Results: v1.ProfilingResults{
 			URL: resultURL,
 		},
-		ErrorMessage:    jobResult.ErrorMessage,
-		MemoryMode:      privateData.MemoryMode,
-		BinaryMatchPath: privateData.BinaryMatchPath,
-		ToolPath:        privateData.ToolPath,
-		Language:        privateData.Language,
-		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
-		PID:             privateData.PID,
-		ThreadGroup:     privateData.ThreadGroup,
+		ErrorMessage:      jobResult.ErrorMessage,
+		MemoryMode:        privateData.MemoryMode,
+		BinaryMatchPath:   privateData.BinaryMatchPath,
+		ToolPath:          privateData.ToolPath,
+		Language:          privateData.Language,
+		CPUIDs:            append([]int(nil), privateData.CPUIDs...),
+		PID:               privateData.PID,
+		ThreadGroup:       privateData.ThreadGroup,
+		LockMode:          privateData.LockMode,
+		LockType:          privateData.LockType,
+		LockWaitThreshold: privateData.LockWaitThreshold,
 	}
 
 	return resp, nil
 }
 
 func isProfilingJobType(jobType job.JobType) bool {
-	return jobType == ProfilingCPU || jobType == ProfilingMemory
+	return jobType == ProfilingCPU || jobType == ProfilingMemory || jobType == ProfilingLock
 }
 
 func profilingAPIType(jobType job.JobType) (string, error) {
@@ -227,6 +237,8 @@ func profilingAPIType(jobType job.JobType) (string, error) {
 		return string(profiling.TypeMemory), nil
 	case ProfilingCPU:
 		return string(profiling.TypeCPU), nil
+	case ProfilingLock:
+		return string(profiling.TypeLock), nil
 	default:
 		return "", fmt.Errorf("job %q is not a profiling job", jobType)
 	}
@@ -309,7 +321,9 @@ func (h *Handler) delete(ctx *server.Context) error {
 		return response.ErrInvalidRequest.WithMessage(err.Error())
 	}
 
-	jobResult, err := h.jobManager.GetByTypesContext(ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory)
+	jobResult, err := h.jobManager.GetByTypesContext(
+		ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory, ProfilingLock,
+	)
 	if err != nil {
 		if errors.Is(err, job.ErrNotFound) {
 			return response.ErrNotFound
@@ -322,7 +336,9 @@ func (h *Handler) delete(ctx *server.Context) error {
 		return response.ErrForbidden
 	}
 
-	if err := h.jobManager.DeleteByTypesContext(ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory); err != nil {
+	if err := h.jobManager.DeleteByTypesContext(
+		ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory, ProfilingLock,
+	); err != nil {
 		if errors.Is(err, job.ErrCannotDeleteRunning) {
 			return response.ErrConflict.WithMessage("cannot delete running job")
 		}
@@ -345,7 +361,9 @@ func (h *Handler) getRawData(ctx *server.Context) error {
 		return response.ErrInvalidRequest.WithMessage(err.Error())
 	}
 
-	jobResult, err := h.jobManager.GetByTypesContext(ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory)
+	jobResult, err := h.jobManager.GetByTypesContext(
+		ctx.Request().Context(), taskID, ProfilingCPU, ProfilingMemory, ProfilingLock,
+	)
 	if err != nil {
 		if errors.Is(err, job.ErrNotFound) {
 			return response.ErrNotFound

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -207,6 +207,7 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		ErrorMessage:    jobResult.ErrorMessage,
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
+		ToolPath:        privateData.ToolPath,
 		Language:        privateData.Language,
 		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
 		PID:             privateData.PID,

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -208,6 +208,9 @@ func buildProfilingJobResponse(jobResult *job.Job, flameGraphBaseURL string) (v1
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
 		Language:        privateData.Language,
+		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
+		PID:             privateData.PID,
+		ThreadGroup:     privateData.ThreadGroup,
 	}
 
 	return resp, nil

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -134,6 +134,7 @@ func TestCapabilitiesReturnsIndependentMemoryModeMap(t *testing.T) {
 func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	data, err := newProfilingPrivateData(&v1.CreateProfilingJobRequest{
 		BinaryMatchPath: "/usr/bin/example",
+		ToolPath:        "/opt/profiler",
 		Duration:        60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
@@ -150,6 +151,7 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error=%v", err)
 	}
 	if fields["binary_match_path"] != "/usr/bin/example" ||
+		fields["tool_path"] != "/opt/profiler" ||
 		fields["duration"] != float64(60) ||
 		fields["language"] != "go" ||
 		fields["memory_mode"] != "object_alloc" ||
@@ -169,6 +171,7 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 		Status: job.JobStatusRunning,
 		PrivateData: json.RawMessage(`{
 			"binary_match_path":"/usr/bin/example",
+			"tool_path":"/opt/profiler",
 			"duration":60,
 			"language":"go",
 			"memory_mode":"object_alloc",
@@ -183,6 +186,9 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 
 	if resp.BinaryMatchPath != "/usr/bin/example" {
 		t.Errorf("BinaryMatchPath=%q, want %q", resp.BinaryMatchPath, "/usr/bin/example")
+	}
+	if resp.ToolPath != "/opt/profiler" {
+		t.Errorf("ToolPath=%q, want %q", resp.ToolPath, "/opt/profiler")
 	}
 	if resp.Language != "go" {
 		t.Errorf("Language=%q, want %q", resp.Language, "go")

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -137,6 +137,9 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		Duration:        60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
+		CPUIDs:          []int{1, 3},
+		PID:             4242,
+		ThreadGroup:     true,
 	})
 	if err != nil {
 		t.Fatalf("newProfilingPrivateData() error=%v", err)
@@ -149,8 +152,14 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	if fields["binary_match_path"] != "/usr/bin/example" ||
 		fields["duration"] != float64(60) ||
 		fields["language"] != "go" ||
-		fields["memory_mode"] != "object_alloc" {
+		fields["memory_mode"] != "object_alloc" ||
+		fields["pid"] != float64(4242) ||
+		fields["thread_group"] != true {
 		t.Errorf("newProfilingPrivateData()=%s, want request fields", data)
+	}
+	cpuIDs, ok := fields["cpu_ids"].([]any)
+	if !ok || len(cpuIDs) != 2 || cpuIDs[0] != float64(1) || cpuIDs[1] != float64(3) {
+		t.Errorf("newProfilingPrivateData() cpu_ids=%v, want [1 3]", fields["cpu_ids"])
 	}
 }
 
@@ -162,7 +171,10 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 			"binary_match_path":"/usr/bin/example",
 			"duration":60,
 			"language":"go",
-			"memory_mode":"object_alloc"
+			"memory_mode":"object_alloc",
+			"cpu_ids":[1,3],
+			"pid":4242,
+			"thread_group":true
 		}`),
 	}, "")
 	if err != nil {
@@ -180,6 +192,15 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 	}
 	if resp.Duration != 60 {
 		t.Errorf("Duration=%d, want 60", resp.Duration)
+	}
+	if len(resp.CPUIDs) != 2 || resp.CPUIDs[0] != 1 || resp.CPUIDs[1] != 3 {
+		t.Errorf("CPUIDs=%v, want [1 3]", resp.CPUIDs)
+	}
+	if resp.PID != 4242 {
+		t.Errorf("PID=%d, want 4242", resp.PID)
+	}
+	if !resp.ThreadGroup {
+		t.Error("ThreadGroup=false, want true")
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -16,6 +16,7 @@ package profiling
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
 	profileService "huatuo-bamai/internal/profiler/service"
+	profiletypes "huatuo-bamai/pkg/profiling"
 )
 
 func TestGetFlameGraphURLEscapesLabelValue(t *testing.T) {
@@ -61,11 +63,12 @@ func TestCapabilities(t *testing.T) {
 	}}
 	resp := buildCapabilitiesResponse(h)
 
-	if len(resp.Types) != 2 {
-		t.Errorf("Types len = %d, want 2", len(resp.Types))
+	if len(resp.Types) != 3 {
+		t.Errorf("Types len = %d, want 3", len(resp.Types))
 	}
 	hasCPU := false
 	hasMemory := false
+	hasLock := false
 	for _, pt := range resp.Types {
 		if pt == "cpu" {
 			hasCPU = true
@@ -73,9 +76,12 @@ func TestCapabilities(t *testing.T) {
 		if pt == "memory" {
 			hasMemory = true
 		}
+		if pt == "lock" {
+			hasLock = true
+		}
 	}
-	if !hasCPU || !hasMemory {
-		t.Errorf("Types = %v, want contain both cpu and memory", resp.Types)
+	if !hasCPU || !hasMemory || !hasLock {
+		t.Errorf("Types = %v, want contain cpu, memory, and lock", resp.Types)
 	}
 
 	if len(resp.CPULanguages) != 5 {
@@ -93,6 +99,15 @@ func TestCapabilities(t *testing.T) {
 
 	if len(resp.MemoryLanguages) != 4 {
 		t.Errorf("MemoryLanguages len = %d, want 4 (c++, c, go, java)", len(resp.MemoryLanguages))
+	}
+	if len(resp.LockLanguages) != 3 {
+		t.Errorf("LockLanguages len = %d, want 3 (c++, c, go)", len(resp.LockLanguages))
+	}
+	if !slices.Equal(resp.LockModes, []profiletypes.LockMode{profiletypes.LockModeWaitTime}) {
+		t.Errorf("LockModes = %v, want wait_time", resp.LockModes)
+	}
+	if !slices.Equal(resp.LockTypes, []profiletypes.LockType{profiletypes.LockTypeMutex}) {
+		t.Errorf("LockTypes = %v, want mutex", resp.LockTypes)
 	}
 
 	if len(resp.MemoryModes) != 5 {
@@ -133,14 +148,17 @@ func TestCapabilitiesReturnsIndependentMemoryModeMap(t *testing.T) {
 
 func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	data, err := newProfilingPrivateData(&v1.CreateProfilingJobRequest{
-		BinaryMatchPath: "/usr/bin/example",
-		ToolPath:        "/opt/profiler",
-		Duration:        60,
-		Language:        "go",
-		MemoryMode:      "object_alloc",
-		CPUIDs:          []int{1, 3},
-		PID:             4242,
-		ThreadGroup:     true,
+		BinaryMatchPath:   "/usr/bin/example",
+		ToolPath:          "/opt/profiler",
+		Duration:          60,
+		Language:          "go",
+		MemoryMode:        "object_alloc",
+		CPUIDs:            []int{1, 3},
+		PID:               4242,
+		ThreadGroup:       true,
+		LockMode:          profiletypes.LockModeWaitTime,
+		LockType:          profiletypes.LockTypeMutex,
+		LockWaitThreshold: "10us",
 	})
 	if err != nil {
 		t.Fatalf("newProfilingPrivateData() error=%v", err)
@@ -156,7 +174,10 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		fields["language"] != "go" ||
 		fields["memory_mode"] != "object_alloc" ||
 		fields["pid"] != float64(4242) ||
-		fields["thread_group"] != true {
+		fields["thread_group"] != true ||
+		fields["lock_mode"] != "wait_time" ||
+		fields["lock_type"] != "mutex" ||
+		fields["lock_wait_threshold"] != "10us" {
 		t.Errorf("newProfilingPrivateData()=%s, want request fields", data)
 	}
 	cpuIDs, ok := fields["cpu_ids"].([]any)
@@ -167,7 +188,7 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 
 func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 	resp, err := buildProfilingJobResponse(&job.Job{
-		Type:   ProfilingMemory,
+		Type:   ProfilingCPU,
 		Status: job.JobStatusRunning,
 		PrivateData: json.RawMessage(`{
 			"binary_match_path":"/usr/bin/example",
@@ -202,11 +223,38 @@ func TestConvertJobToProfilingResponseReadsRequestJSONNames(t *testing.T) {
 	if len(resp.CPUIDs) != 2 || resp.CPUIDs[0] != 1 || resp.CPUIDs[1] != 3 {
 		t.Errorf("CPUIDs=%v, want [1 3]", resp.CPUIDs)
 	}
+	if !resp.ThreadGroup {
+		t.Error("ThreadGroup=false, want true")
+	}
 	if resp.PID != 4242 {
 		t.Errorf("PID=%d, want 4242", resp.PID)
 	}
-	if !resp.ThreadGroup {
-		t.Error("ThreadGroup=false, want true")
+}
+
+func TestConvertLockJobToProfilingResponse(t *testing.T) {
+	resp, err := buildProfilingJobResponse(&job.Job{
+		Type:   ProfilingLock,
+		Status: job.JobStatusRunning,
+		PrivateData: json.RawMessage(`{
+			"duration":60,
+			"language":"go",
+			"pid":4242,
+			"lock_mode":"wait_time",
+			"lock_type":"mutex",
+			"lock_wait_threshold":"10us"
+		}`),
+	}, "")
+	if err != nil {
+		t.Fatalf("buildProfilingJobResponse() error = %v", err)
+	}
+	if resp.Type != string(profiletypes.TypeLock) {
+		t.Errorf("Type=%q, want lock", resp.Type)
+	}
+	if resp.PID != 4242 ||
+		resp.LockMode != profiletypes.LockModeWaitTime ||
+		resp.LockType != profiletypes.LockTypeMutex ||
+		resp.LockWaitThreshold != "10us" {
+		t.Errorf("lock response fields = %+v, want persisted lock selection", resp)
 	}
 }
 
@@ -235,6 +283,7 @@ func TestIsProfilingJobType(t *testing.T) {
 	}{
 		{name: "cpu profiling", jobType: ProfilingCPU, want: true},
 		{name: "memory profiling", jobType: ProfilingMemory, want: true},
+		{name: "lock profiling", jobType: ProfilingLock, want: true},
 		{name: "trace job", jobType: job.JobType("trace"), want: false},
 		{name: "empty type", want: false},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -78,13 +78,15 @@ func buildCreateProfilingJobRequest(
 		TraceTimeout: cfg.ExecutionTimeout,
 	}
 
+	targetArgs, err := profilingTargetArgs(req)
+	if err != nil {
+		return nil, err
+	}
 	jobType, err := buildProfilingTracerArgs(&taskReq, req)
 	if err != nil {
 		return nil, err
 	}
-	if err := appendProfilingTargetArgs(&taskReq, req); err != nil {
-		return nil, err
-	}
+	taskReq.TracerArgs = append(taskReq.TracerArgs, targetArgs...)
 	if req.Duration < taskReq.Interval*2 {
 		return nil, errors.New("duration must cover at least two profiling intervals")
 	}
@@ -183,66 +185,73 @@ func appendProfilingToolPath(
 	return nil
 }
 
-func appendProfilingTargetArgs(
-	taskReq *job.AgentTaskRequest,
-	req *v1.CreateProfilingJobRequest,
-) error {
+func profilingTargetArgs(req *v1.CreateProfilingJobRequest) ([]string, error) {
+	switch req.ProfilingType {
+	case string(profiling.TypeCPU), string(profiling.TypeMemory):
+	default:
+		return nil, nil
+	}
 	language, err := profiling.ParseLanguage(req.Language)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	implementation, ok := profiling.ImplementationFor(language)
 	if !ok {
-		return fmt.Errorf("profiling implementation not found for %q", language)
+		return nil, fmt.Errorf("profiling implementation not found for %q", language)
 	}
 	native := implementation == profiling.ImplementationNative
 	hasNativeSelection := req.PID != 0 || req.ThreadGroup || len(req.CPUIDs) > 0
 	if hasNativeSelection && !native {
-		return errors.New("pid, cpu_ids, and thread_group are supported only by native profiling")
+		return nil, errors.New(
+			"pid, cpu_ids, and thread_group are supported only by native profiling",
+		)
 	}
 
+	targetArgs := make([]string, 0, 6)
 	if req.ContainerID != "" {
-		taskReq.TracerArgs = append(taskReq.TracerArgs, "--container-id", req.ContainerID)
+		targetArgs = append(targetArgs, "--container-id", req.ContainerID)
 	}
 	if !native {
-		return nil
+		return targetArgs, nil
 	}
 
 	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
-		return fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+		return nil, fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
 	}
 	if req.PID != 0 && req.ContainerID != "" {
-		return errors.New("pid and container_id are mutually exclusive")
+		return nil, errors.New("pid and container_id are mutually exclusive")
 	}
 	if req.ThreadGroup && req.PID == 0 {
-		return errors.New("thread_group requires pid")
+		return nil, errors.New("thread_group requires pid")
 	}
 	if req.ProfilingType == string(profiling.TypeMemory) &&
 		req.PID == 0 && req.ContainerID == "" {
-		return errors.New("native memory profiling requires pid or container_id")
+		return nil, errors.New(
+			"native memory profiling requires pid or container_id",
+		)
 	}
 
 	if req.PID != 0 {
-		taskReq.TracerArgs = append(taskReq.TracerArgs, "--pid", strconv.Itoa(req.PID))
+		targetArgs = append(targetArgs, "--pid", strconv.Itoa(req.PID))
 	}
 	if req.ThreadGroup {
-		taskReq.TracerArgs = append(taskReq.TracerArgs, "--thread-group")
+		targetArgs = append(targetArgs, "--thread-group")
 	}
 	if len(req.CPUIDs) == 0 {
-		return nil
+		return targetArgs, nil
 	}
 	if req.ProfilingType != string(profiling.TypeCPU) {
-		return errors.New("cpu_ids are supported only by CPU profiling")
+		return nil, errors.New("cpu_ids are supported only by CPU profiling")
 	}
 
 	cpuIDs := append([]int(nil), req.CPUIDs...)
 	sort.Ints(cpuIDs)
 	for i, cpuID := range cpuIDs {
 		if cpuID < 0 {
-			return fmt.Errorf("cpu_id must not be negative: %d", cpuID)
+			return nil, fmt.Errorf("cpu_id must not be negative: %d", cpuID)
 		}
 		if i > 0 && cpuIDs[i-1] == cpuID {
-			return fmt.Errorf("duplicate cpu_id %d", cpuID)
+			return nil, fmt.Errorf("duplicate cpu_id %d", cpuID)
 		}
 	}
 	req.CPUIDs = cpuIDs
@@ -250,8 +259,8 @@ func appendProfilingTargetArgs(
 	for i, cpuID := range cpuIDs {
 		values[i] = strconv.Itoa(cpuID)
 	}
-	taskReq.TracerArgs = append(taskReq.TracerArgs, "--cpuid", strings.Join(values, ","))
-	return nil
+	targetArgs = append(targetArgs, "--cpuid", strings.Join(values, ","))
+	return targetArgs, nil
 }
 
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -22,9 +22,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
+	"huatuo-bamai/internal/pod"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/pkg/profiling"
 )
@@ -35,6 +37,8 @@ type profilingJobListQuery struct {
 	Status      string `form:"status"`
 	Type        string `form:"type"`
 }
+
+const defaultLockWaitThreshold = "1us"
 
 type profilingJobListRequest struct {
 	ListParams server.ListParams
@@ -47,14 +51,17 @@ type patchProfilingJobRequest struct {
 }
 
 type profilingJobPrivateData struct {
-	BinaryMatchPath string `json:"binary_match_path"`
-	ToolPath        string `json:"tool_path"`
-	Duration        int    `json:"duration"`
-	Language        string `json:"language"`
-	MemoryMode      string `json:"memory_mode"`
-	CPUIDs          []int  `json:"cpu_ids,omitempty"`
-	PID             int    `json:"pid,omitempty"`
-	ThreadGroup     bool   `json:"thread_group,omitempty"`
+	BinaryMatchPath   string             `json:"binary_match_path"`
+	ToolPath          string             `json:"tool_path"`
+	Duration          int                `json:"duration"`
+	Language          string             `json:"language"`
+	MemoryMode        string             `json:"memory_mode"`
+	CPUIDs            []int              `json:"cpu_ids,omitempty"`
+	PID               int                `json:"pid,omitempty"`
+	ThreadGroup       bool               `json:"thread_group,omitempty"`
+	LockMode          profiling.LockMode `json:"lock_mode,omitempty"`
+	LockType          profiling.LockType `json:"lock_type,omitempty"`
+	LockWaitThreshold string             `json:"lock_wait_threshold,omitempty"`
 }
 
 func parseCreateProfilingJobRequest(ctx *server.Context) (*v1.CreateProfilingJobRequest, error) {
@@ -78,11 +85,20 @@ func buildCreateProfilingJobRequest(
 		TraceTimeout: cfg.ExecutionTimeout,
 	}
 
-	targetArgs, err := profilingTargetArgs(req)
-	if err != nil {
-		return nil, err
+	var targetArgs []string
+	var jobType job.JobType
+	var err error
+	if req.ProfilingType == string(profiling.TypeLock) {
+		jobType, err = buildProfilingTracerArgs(&taskReq, req)
+		if err == nil {
+			targetArgs, err = profilingTargetArgs(req)
+		}
+	} else {
+		targetArgs, err = profilingTargetArgs(req)
+		if err == nil {
+			jobType, err = buildProfilingTracerArgs(&taskReq, req)
+		}
 	}
-	jobType, err := buildProfilingTracerArgs(&taskReq, req)
 	if err != nil {
 		return nil, err
 	}
@@ -164,6 +180,8 @@ func buildProfilingTracerArgs(
 			return "", err
 		}
 		return job.JobTypeProfilingMemory, nil
+	case string(profiling.TypeLock):
+		return buildLockProfilingTracerArgs(taskReq, req)
 	default:
 		return "", fmt.Errorf("unsupported profiling type %q", req.ProfilingType)
 	}
@@ -187,7 +205,8 @@ func appendProfilingToolPath(
 
 func profilingTargetArgs(req *v1.CreateProfilingJobRequest) ([]string, error) {
 	switch req.ProfilingType {
-	case string(profiling.TypeCPU), string(profiling.TypeMemory):
+	case string(profiling.TypeCPU), string(profiling.TypeMemory),
+		string(profiling.TypeLock):
 	default:
 		return nil, nil
 	}
@@ -208,27 +227,47 @@ func profilingTargetArgs(req *v1.CreateProfilingJobRequest) ([]string, error) {
 	}
 
 	targetArgs := make([]string, 0, 6)
+	if native {
+		if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
+			return nil, fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+		}
+		if req.PID != 0 && req.ContainerID != "" {
+			if req.ProfilingType == string(profiling.TypeLock) {
+				return nil, errors.New(
+					"lock profiling requires exactly one of pid or container_id",
+				)
+			}
+			return nil, errors.New("pid and container_id are mutually exclusive")
+		}
+		if req.ThreadGroup && req.PID == 0 {
+			return nil, errors.New("thread_group requires pid")
+		}
+		switch req.ProfilingType {
+		case string(profiling.TypeMemory):
+			if req.PID == 0 && req.ContainerID == "" {
+				return nil, errors.New(
+					"native memory profiling requires pid or container_id",
+				)
+			}
+		case string(profiling.TypeLock):
+			if req.PID == 0 && req.ContainerID == "" {
+				return nil, errors.New(
+					"lock profiling requires exactly one of pid or container_id",
+				)
+			}
+			if req.ContainerID != "" {
+				if err := pod.ValidateContainerID(req.ContainerID); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	if req.ContainerID != "" {
 		targetArgs = append(targetArgs, "--container-id", req.ContainerID)
 	}
 	if !native {
 		return targetArgs, nil
-	}
-
-	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
-		return nil, fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
-	}
-	if req.PID != 0 && req.ContainerID != "" {
-		return nil, errors.New("pid and container_id are mutually exclusive")
-	}
-	if req.ThreadGroup && req.PID == 0 {
-		return nil, errors.New("thread_group requires pid")
-	}
-	if req.ProfilingType == string(profiling.TypeMemory) &&
-		req.PID == 0 && req.ContainerID == "" {
-		return nil, errors.New(
-			"native memory profiling requires pid or container_id",
-		)
 	}
 
 	if req.PID != 0 {
@@ -263,16 +302,76 @@ func profilingTargetArgs(req *v1.CreateProfilingJobRequest) ([]string, error) {
 	return targetArgs, nil
 }
 
+func buildLockProfilingTracerArgs(
+	taskReq *job.AgentTaskRequest,
+	req *v1.CreateProfilingJobRequest,
+) (job.JobType, error) {
+	language, err := profiling.ParseLanguage(req.Language)
+	if err != nil || !profiling.IsSupported(language, profiling.TypeLock) {
+		return "", fmt.Errorf("lock profiling not supported for %q", req.Language)
+	}
+	if req.BinaryMatchPath != "" {
+		return "", errors.New("binary_match_path is not supported by lock profiling")
+	}
+	if req.MemoryMode != "" {
+		return "", errors.New("memory_mode is not supported by lock profiling")
+	}
+
+	mode := req.LockMode
+	if mode == profiling.LockModeUnknown {
+		mode = profiling.LockModeWaitTime
+	}
+	if mode != profiling.LockModeWaitTime {
+		return "", fmt.Errorf("unsupported lock mode %q", mode)
+	}
+	lockType := req.LockType
+	if lockType == profiling.LockTypeUnknown {
+		lockType = profiling.LockTypeMutex
+	}
+	if lockType != profiling.LockTypeMutex {
+		return "", fmt.Errorf("unsupported lock type %q", lockType)
+	}
+
+	threshold := strings.TrimSpace(req.LockWaitThreshold)
+	if threshold == "" {
+		threshold = defaultLockWaitThreshold
+	}
+	waitThreshold, err := time.ParseDuration(threshold)
+	if err != nil {
+		return "", fmt.Errorf("invalid lock_wait_threshold %q: %w", threshold, err)
+	}
+	if waitThreshold < 0 || waitThreshold > time.Hour {
+		return "", errors.New("lock_wait_threshold must be between 0 and 1h")
+	}
+
+	taskReq.TracerArgs = []string{
+		"-t", string(profiling.TypeLock),
+		"-l", string(language),
+	}
+	taskReq.TracerArgs = append(
+		taskReq.TracerArgs,
+		"--lock-type", string(lockType),
+		"--lock-wait-threshold", threshold,
+	)
+	req.LockMode = mode
+	req.LockType = lockType
+	req.LockWaitThreshold = threshold
+	return job.JobTypeProfilingLock, nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
-		BinaryMatchPath: req.BinaryMatchPath,
-		ToolPath:        strings.TrimSpace(req.ToolPath),
-		Duration:        req.Duration,
-		Language:        req.Language,
-		MemoryMode:      req.MemoryMode,
-		CPUIDs:          req.CPUIDs,
-		PID:             req.PID,
-		ThreadGroup:     req.ThreadGroup,
+		BinaryMatchPath:   req.BinaryMatchPath,
+		ToolPath:          strings.TrimSpace(req.ToolPath),
+		Duration:          req.Duration,
+		Language:          req.Language,
+		MemoryMode:        req.MemoryMode,
+		CPUIDs:            req.CPUIDs,
+		PID:               req.PID,
+		ThreadGroup:       req.ThreadGroup,
+		LockMode:          req.LockMode,
+		LockType:          req.LockType,
+		LockWaitThreshold: req.LockWaitThreshold,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encoding profiling private data: %w", err)
@@ -313,11 +412,17 @@ func buildProfilingJobQuery(query profilingJobListQuery) (job.JobQuery, error) {
 	}
 	switch query.Type {
 	case "":
-		jobQuery.Types = []job.JobType{job.JobTypeProfilingMemory, job.JobTypeProfilingCPU}
+		jobQuery.Types = []job.JobType{
+			job.JobTypeProfilingMemory,
+			job.JobTypeProfilingCPU,
+			job.JobTypeProfilingLock,
+		}
 	case "cpu":
 		jobQuery.Types = []job.JobType{job.JobTypeProfilingCPU}
 	case "memory":
 		jobQuery.Types = []job.JobType{job.JobTypeProfilingMemory}
+	case "lock":
+		jobQuery.Types = []job.JobType{job.JobTypeProfilingLock}
 	default:
 		return job.JobQuery{}, fmt.Errorf("invalid type %q", query.Type)
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -49,6 +51,9 @@ type profilingJobPrivateData struct {
 	Duration        int    `json:"duration"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`
+	PID             int    `json:"pid,omitempty"`
+	ThreadGroup     bool   `json:"thread_group,omitempty"`
 }
 
 func parseCreateProfilingJobRequest(ctx *server.Context) (*v1.CreateProfilingJobRequest, error) {
@@ -74,6 +79,9 @@ func buildCreateProfilingJobRequest(
 
 	jobType, err := buildProfilingTracerArgs(&taskReq, req)
 	if err != nil {
+		return nil, err
+	}
+	if err := appendProfilingTargetArgs(&taskReq, req); err != nil {
 		return nil, err
 	}
 	if req.Duration < taskReq.Interval*2 {
@@ -152,12 +160,86 @@ func buildProfilingTracerArgs(
 	}
 }
 
+func appendProfilingTargetArgs(
+	taskReq *job.AgentTaskRequest,
+	req *v1.CreateProfilingJobRequest,
+) error {
+	language, err := profiling.ParseLanguage(req.Language)
+	if err != nil {
+		return err
+	}
+	implementation, ok := profiling.ImplementationFor(language)
+	if !ok {
+		return fmt.Errorf("profiling implementation not found for %q", language)
+	}
+	native := implementation == profiling.ImplementationNative
+	hasNativeSelection := req.PID != 0 || req.ThreadGroup || len(req.CPUIDs) > 0
+	if hasNativeSelection && !native {
+		return errors.New("pid, cpu_ids, and thread_group are supported only by native profiling")
+	}
+
+	if req.ContainerID != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--container-id", req.ContainerID)
+	}
+	if !native {
+		return nil
+	}
+
+	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
+		return fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+	}
+	if req.PID != 0 && req.ContainerID != "" {
+		return errors.New("pid and container_id are mutually exclusive")
+	}
+	if req.ThreadGroup && req.PID == 0 {
+		return errors.New("thread_group requires pid")
+	}
+	if req.ProfilingType == string(profiling.TypeMemory) &&
+		req.PID == 0 && req.ContainerID == "" {
+		return errors.New("native memory profiling requires pid or container_id")
+	}
+
+	if req.PID != 0 {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--pid", strconv.Itoa(req.PID))
+	}
+	if req.ThreadGroup {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--thread-group")
+	}
+	if len(req.CPUIDs) == 0 {
+		return nil
+	}
+	if req.ProfilingType != string(profiling.TypeCPU) {
+		return errors.New("cpu_ids are supported only by CPU profiling")
+	}
+
+	cpuIDs := append([]int(nil), req.CPUIDs...)
+	sort.Ints(cpuIDs)
+	for i, cpuID := range cpuIDs {
+		if cpuID < 0 {
+			return fmt.Errorf("cpu_id must not be negative: %d", cpuID)
+		}
+		if i > 0 && cpuIDs[i-1] == cpuID {
+			return fmt.Errorf("duplicate cpu_id %d", cpuID)
+		}
+	}
+	req.CPUIDs = cpuIDs
+	values := make([]string, len(cpuIDs))
+	for i, cpuID := range cpuIDs {
+		values[i] = strconv.Itoa(cpuID)
+	}
+	taskReq.TracerArgs = append(taskReq.TracerArgs, "--cpuid", strings.Join(values, ","))
+	return nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
 		Duration:        req.Duration,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,
+		CPUIDs:          req.CPUIDs,
+		PID:             req.PID,
+		ThreadGroup:     req.ThreadGroup,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encoding profiling private data: %w", err)

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -48,6 +48,7 @@ type patchProfilingJobRequest struct {
 
 type profilingJobPrivateData struct {
 	BinaryMatchPath string `json:"binary_match_path"`
+	ToolPath        string `json:"tool_path"`
 	Duration        int    `json:"duration"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
@@ -139,6 +140,9 @@ func buildProfilingTracerArgs(
 			)
 		}
 		taskReq.TracerArgs = append(taskReq.TracerArgs, "-l", string(language))
+		if err := appendProfilingToolPath(taskReq, req.ToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingCPU, nil
 	case string(profiling.TypeMemory):
 		language, err := profiling.ParseLanguage(req.Language)
@@ -154,10 +158,29 @@ func buildProfilingTracerArgs(
 			"--memory-mode", string(mode),
 			"-l", string(language),
 		}
+		if err := appendProfilingToolPath(taskReq, req.ToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingMemory, nil
 	default:
 		return "", fmt.Errorf("unsupported profiling type %q", req.ProfilingType)
 	}
+}
+
+func appendProfilingToolPath(
+	taskReq *job.AgentTaskRequest,
+	toolPath string,
+	language profiling.Language,
+) error {
+	toolPath = strings.TrimSpace(toolPath)
+	implementation, _ := profiling.ImplementationFor(language)
+	if implementation != profiling.ImplementationNative && toolPath == "" {
+		return fmt.Errorf("language %q requires tool_path", language)
+	}
+	if toolPath != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--tool-path", toolPath)
+	}
+	return nil
 }
 
 func appendProfilingTargetArgs(
@@ -234,6 +257,7 @@ func appendProfilingTargetArgs(
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
+		ToolPath:        strings.TrimSpace(req.ToolPath),
 		Duration:        req.Duration,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
+	profiletypes "huatuo-bamai/pkg/profiling"
 )
 
 func TestBuildCreateProfilingJobRequest(t *testing.T) {
@@ -130,6 +131,31 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			wantErr: `language "java" requires tool_path`,
 		},
 		{
+			name: "mutex wait profiling by PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:     "lock",
+				Language:          "go",
+				Duration:          30,
+				PID:               4242,
+				LockMode:          profiletypes.LockModeWaitTime,
+				LockType:          profiletypes.LockTypeMutex,
+				LockWaitThreshold: "10us",
+			},
+			wantType: ProfilingLock,
+			wantTracerArgs: []string{
+				"-t", "lock",
+				"-l", "go",
+				"--lock-type", "mutex",
+				"--lock-wait-threshold", "10us",
+				"--pid", "4242",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
 			name: "native PID and container are mutually exclusive",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType: "cpu",
@@ -181,6 +207,148 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				PID:           4242,
 			},
 			wantErr: "pid, cpu_ids, and thread_group are supported only by native profiling",
+		},
+		{
+			name: "mutex wait profiling by container uses defaults",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "c++",
+				Duration:      30,
+				ContainerID:   "0123456789abcdef",
+			},
+			wantType: ProfilingLock,
+			wantTracerArgs: []string{
+				"-t", "lock",
+				"-l", "c++",
+				"--lock-type", "mutex",
+				"--lock-wait-threshold", "1us",
+				"--container-id", "0123456789abcdef",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "lock profiling rejects host-wide target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "c",
+				Duration:      30,
+			},
+			wantErr: "lock profiling requires exactly one of pid or container_id",
+		},
+		{
+			name: "lock profiling rejects multiple targets",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "c",
+				Duration:      30,
+				PID:           4242,
+				ContainerID:   "0123456789abcdef",
+			},
+			wantErr: "lock profiling requires exactly one of pid or container_id",
+		},
+		{
+			name: "lock profiling rejects non-native language",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "java",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantErr: `lock profiling not supported for "java"`,
+		},
+		{
+			name: "lock profiling rejects negative PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "go",
+				Duration:      30,
+				PID:           -1,
+			},
+			wantErr: "pid must be between 1 and 2147483647",
+		},
+		{
+			name: "lock profiling rejects invalid threshold",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:     "lock",
+				Language:          "go",
+				Duration:          30,
+				PID:               4242,
+				LockWaitThreshold: "later",
+			},
+			wantErr: `invalid lock_wait_threshold "later": time: invalid duration "later"`,
+		},
+		{
+			name: "lock profiling rejects unsupported mode",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "go",
+				Duration:      30,
+				PID:           4242,
+				LockMode:      profiletypes.LockMode("count"),
+			},
+			wantErr: `unsupported lock mode "count"`,
+		},
+		{
+			name: "lock profiling rejects unsupported lock type",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "go",
+				Duration:      30,
+				PID:           4242,
+				LockType:      profiletypes.LockType("semaphore"),
+			},
+			wantErr: `unsupported lock type "semaphore"`,
+		},
+		{
+			name: "mutex profiling accepts thread group target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "go",
+				Duration:      30,
+				PID:           4242,
+				ThreadGroup:   true,
+				LockType:      profiletypes.LockTypeMutex,
+			},
+			wantType: ProfilingLock,
+			wantTracerArgs: []string{
+				"-t", "lock",
+				"-l", "go",
+				"--lock-type", "mutex",
+				"--lock-wait-threshold", "1us",
+				"--pid", "4242",
+				"--thread-group",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "rwlock profiling is not available",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "go",
+				Duration:      30,
+				PID:           4242,
+				LockType:      profiletypes.LockType("rwlock"),
+			},
+			wantErr: `unsupported lock type "rwlock"`,
+		},
+		{
+			name: "spinlock profiling is not available",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "lock",
+				Language:      "c",
+				Duration:      30,
+				PID:           4242,
+				LockType:      profiletypes.LockType("spinlock"),
+			},
+			wantErr: `unsupported lock type "spinlock"`,
 		},
 		{
 			name: "native memory requires a target",
@@ -267,10 +435,11 @@ func TestBuildProfilingJobQueries(t *testing.T) {
 				Hostname:    "huatuo-dev",
 				Status:      string(job.JobStatusRunning),
 			},
-			wantTypes: []job.JobType{ProfilingMemory, ProfilingCPU},
+			wantTypes: []job.JobType{ProfilingMemory, ProfilingCPU, ProfilingLock},
 		},
 		{name: "cpu profiling", query: profilingJobListQuery{Type: "cpu"}, wantTypes: []job.JobType{ProfilingCPU}},
 		{name: "memory profiling", query: profilingJobListQuery{Type: "memory"}, wantTypes: []job.JobType{ProfilingMemory}},
+		{name: "lock profiling", query: profilingJobListQuery{Type: "lock"}, wantTypes: []job.JobType{ProfilingLock}},
 		{name: "invalid type", query: profilingJobListQuery{Type: "offcpu"}, wantErr: `invalid type "offcpu"`},
 		{name: "invalid status", query: profilingJobListQuery{Status: "unknown"}, wantErr: `invalid status "unknown"`},
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -15,6 +15,7 @@
 package profiling
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -31,20 +32,23 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 		wantErr        string
 	}{
 		{
-			name: "cpu profiling",
+			name: "native CPU profiling by thread group and CPU IDs",
 			req: v1.CreateProfilingJobRequest{
-				ProfilingType:   "cpu",
-				Language:        "go",
-				BinaryMatchPath: "/usr/bin/example",
-				Duration:        30,
-				ContainerID:     "container-2026",
-				Hostname:        "huatuo-dev",
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				Hostname:      "huatuo-dev",
+				CPUIDs:        []int{3, 1},
+				PID:           4242,
+				ThreadGroup:   true,
 			},
 			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
 				"-t", "cpu",
-				"--binary-match-path", "/usr/bin/example",
 				"-l", "go",
+				"--pid", "4242",
+				"--thread-group",
+				"--cpuid", "1,3",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
@@ -53,24 +57,110 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "memory profiling",
+			name: "native CPU profiling by container",
 			req: v1.CreateProfilingJobRequest{
-				ProfilingType: "memory",
+				ProfilingType: "cpu",
 				Language:      "c",
-				MemoryMode:    "physical_usage",
 				Duration:      30,
+				ContainerID:   "0123456789ab",
+				Hostname:      "huatuo-dev",
 			},
-			wantType: ProfilingMemory,
+			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
-				"-t", "memory",
-				"--memory-mode", "physical_usage",
+				"-t", "cpu",
 				"-l", "c",
+				"--container-id", "0123456789ab",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
 				"--output-format", "remote",
 				"--output-storage", "/var/run/huatuo-toolstream.sock",
 			},
+		},
+		{
+			name: "native memory profiling by exact PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "c",
+				MemoryMode:    "physical_usage",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantType: ProfilingMemory,
+			wantTracerArgs: []string{
+				"-t", "memory",
+				"--memory-mode", "physical_usage",
+				"-l", "c",
+				"--pid", "4242",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "native PID and container are mutually exclusive",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				ContainerID:   "0123456789ab",
+				PID:           4242,
+			},
+			wantErr: "pid and container_id are mutually exclusive",
+		},
+		{
+			name: "thread group requires PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				ThreadGroup:   true,
+			},
+			wantErr: "thread_group requires pid",
+		},
+		{
+			name: "CPU IDs require CPU profiling",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "go",
+				MemoryMode:    "virtual_alloc",
+				Duration:      30,
+				PID:           4242,
+				CPUIDs:        []int{1},
+			},
+			wantErr: "cpu_ids are supported only by CPU profiling",
+		},
+		{
+			name: "CPU IDs reject duplicates",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "go",
+				Duration:      30,
+				CPUIDs:        []int{1, 1},
+			},
+			wantErr: "duplicate cpu_id 1",
+		},
+		{
+			name: "non-native profiling rejects native selection",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				Duration:      30,
+				PID:           4242,
+			},
+			wantErr: "pid, cpu_ids, and thread_group are supported only by native profiling",
+		},
+		{
+			name: "native memory requires a target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "memory",
+				Language:      "go",
+				MemoryMode:    "virtual_alloc",
+				Duration:      30,
+			},
+			wantErr: "native memory profiling requires pid or container_id",
 		},
 		{
 			name: "unsupported type",
@@ -119,6 +209,15 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			}
 			if !slices.Equal(got.AgentTask.TracerArgs, tt.wantTracerArgs) {
 				t.Errorf("TracerArgs=%q, want %q", got.AgentTask.TracerArgs, tt.wantTracerArgs)
+			}
+			var privateData profilingJobPrivateData
+			if err := json.Unmarshal(got.PrivateData, &privateData); err != nil {
+				t.Fatalf("json.Unmarshal(PrivateData) error=%v", err)
+			}
+			if !slices.Equal(privateData.CPUIDs, tt.req.CPUIDs) ||
+				privateData.PID != tt.req.PID ||
+				privateData.ThreadGroup != tt.req.ThreadGroup {
+				t.Errorf("PrivateData=%+v, want native target from request", privateData)
 			}
 		})
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -78,6 +78,26 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "java profiling with external tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				ToolPath:      "/opt/async-profiler",
+				Duration:      30,
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"-l", "java",
+				"--tool-path", "/opt/async-profiler",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
 			name: "native memory profiling by exact PID",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType: "memory",
@@ -98,6 +118,16 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				"--output-format", "remote",
 				"--output-storage", "/var/run/huatuo-toolstream.sock",
 			},
+		},
+		{
+			name: "java profiling requires external tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType: "cpu",
+				Language:      "java",
+				ToolPath:      "   ",
+				Duration:      30,
+			},
+			wantErr: `language "java" requires tool_path`,
 		},
 		{
 			name: "native PID and container are mutually exclusive",

--- a/cmd/huatuo-apiserver/jobs.go
+++ b/cmd/huatuo-apiserver/jobs.go
@@ -48,6 +48,7 @@ func setupJobManagers(ctx context.Context, d *Daemon) (func(context.Context) err
 		TypePolicies: map[job.JobType]job.TypePolicy{
 			job.JobTypeProfilingCPU:    profilingPolicy,
 			job.JobTypeProfilingMemory: profilingPolicy,
+			job.JobTypeProfilingLock:   profilingPolicy,
 			job.JobTypeTracing:         tracingPolicy,
 		},
 	})

--- a/cmd/profiler/flags.go
+++ b/cmd/profiler/flags.go
@@ -14,13 +14,17 @@
 
 package main
 
-import "github.com/urfave/cli/v2"
+import (
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
 
 var appFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "type",
 		Aliases: []string{"t"},
-		Usage:   "Profiling type: cpu|memory",
+		Usage:   "Profiling type: cpu|memory|lock",
 	},
 	&cli.StringFlag{
 		Name:    "language",
@@ -47,6 +51,11 @@ var appFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  "thread-group",
 		Usage: "Profile the target thread group; supported only by native profiling",
+	},
+	&cli.DurationFlag{
+		Name:  "lock-wait-threshold",
+		Usage: "Minimum mutex contention wait to record",
+		Value: time.Microsecond,
 	},
 	&cli.IntFlag{
 		Name:    "freq",

--- a/cmd/profiler/provider/native_aggregator.go
+++ b/cmd/profiler/provider/native_aggregator.go
@@ -70,7 +70,7 @@ type lockStackEntry struct {
 	User      string
 	Kernel    string
 	WaitTime  uint64
-	Contended uint32
+	Contended uint64
 }
 
 type nativeAggregator struct {
@@ -128,7 +128,14 @@ func (a *nativeAggregator) Aggregate(rec any) {
 		}
 
 	case *lockStackEntry:
-		key := fmt.Sprintf("%s\x00%d", v.User, v.Proc.Lock)
+		key := fmt.Sprintf(
+			"%d\x00%s\x00%s\x00%s\x00%d",
+			v.Proc.Pid,
+			v.Proc.Name,
+			v.User,
+			v.Kernel,
+			v.Proc.Lock,
+		)
 		if existed, ok := a.lockAggrMap[key]; ok {
 			existed.Contended += v.Contended
 			existed.WaitTime += v.WaitTime
@@ -329,7 +336,15 @@ func profileTypeOptions(pctx *pcontext.ProfilerContext) (*profiler.ParseOption, 
 	case profiling.TypeMemory:
 		return &profiler.ParseOption{SampleRate: profiler.NoSampleRate}, profiler.ProfileTypeMemSample, nil
 	case profiling.TypeLock:
-		return &profiler.ParseOption{SampleRate: profiler.NoSampleRate}, profiler.ProfileTypeLockTimeSample, nil
+		if pctx.LockMode != profiling.LockModeUnknown &&
+			pctx.LockMode != profiling.LockModeWaitTime {
+			return nil, "", fmt.Errorf(
+				"unsupported lock mode %q",
+				pctx.LockMode,
+			)
+		}
+		return &profiler.ParseOption{SampleRate: profiler.NoSampleRate},
+			profiler.ProfileTypeLockTimeSample, nil
 	default:
 		return nil, "", fmt.Errorf("unsupported profile type %q", pctx.Type)
 	}

--- a/cmd/profiler/provider/native_aggregator_test.go
+++ b/cmd/profiler/provider/native_aggregator_test.go
@@ -47,7 +47,44 @@ func TestNativeAggregatorAggregatesLockTime(t *testing.T) {
 	}
 }
 
-func requireSingleLockRecord(t *testing.T, aggregator *nativeAggregator, waitTime uint64, contended uint32) {
+func TestNativeAggregatorKeepsDistinctLockMetadata(t *testing.T) {
+	aggregator := &nativeAggregator{
+		aggrMap:     map[string]*stackEntry{},
+		lockAggrMap: map[string]*lockStackEntry{},
+	}
+	base := &lockStackEntry{
+		Proc:      &processIDNameLock{Pid: 12, Name: "app", Lock: 0xab},
+		User:      "foo;bar",
+		Kernel:    "mutex_lock",
+		WaitTime:  10,
+		Contended: 1,
+	}
+	differentPID := *base
+	differentPID.Proc = &processIDNameLock{
+		Pid:  13,
+		Name: "app",
+		Lock: 0xab,
+	}
+	differentKernel := *base
+	differentKernel.Kernel = "mutex_lock_nested"
+
+	aggregator.Aggregate(base)
+	aggregator.Aggregate(&differentPID)
+	aggregator.Aggregate(&differentKernel)
+
+	if len(aggregator.lockAggrMap) != 3 {
+		t.Fatalf(
+			"lock records = %d, want 3 distinct metadata groups",
+			len(aggregator.lockAggrMap),
+		)
+	}
+}
+
+func requireSingleLockRecord(
+	t *testing.T,
+	aggregator *nativeAggregator,
+	waitTime, contended uint64,
+) {
 	t.Helper()
 	if len(aggregator.lockAggrMap) != 1 {
 		t.Fatalf("lock records = %d, want 1", len(aggregator.lockAggrMap))

--- a/cmd/profiler/provider/native_bpf_context.go
+++ b/cmd/profiler/provider/native_bpf_context.go
@@ -49,6 +49,16 @@ type ProfilerEventBase struct {
 	Value     int64 // CPU: always 1 (sample count), Memory: page/byte delta
 }
 
+func (e *ProfilerEventBase) hasStack() bool {
+	return e != nil && (e.Kernstack >= 0 || e.Userstack >= 0)
+}
+
+type userStackCacheKey uint64
+
+func newUserStackCacheKey(stackID int32, pid uint32) userStackCacheKey {
+	return userStackCacheKey(uint64(pid)<<32 | uint64(uint32(stackID)))
+}
+
 // ringBufferContext holds the shared ring buffer state for A/B buffer management.
 // It encapsulates all the common infrastructure needed for dual-buffer profiling
 // (readers, state map, stack maps) so profilers don't need to pass these around.
@@ -203,7 +213,7 @@ func (r *ringBufferContext) drainActiveRingBuffer(
 			base := (*ProfilerEventBase)(unsafe.Pointer(ptrValue.Pointer()))
 
 			// Skip events without valid stacks
-			if base.Kernstack <= 0 && base.Userstack <= 0 {
+			if !base.hasStack() {
 				continue
 			}
 
@@ -287,7 +297,7 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 	convertValue func(int64) int64,
 ) {
 	kstackCache := make(map[int32]string)
-	ustackCache := make(map[int32]string)
+	ustackCache := make(map[userStackCacheKey]string)
 
 	var records int
 	for pidName, stacks := range stackCountsByProc {
@@ -301,20 +311,23 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 				continue
 			}
 
-			if stackID.KernelID > 0 {
+			if stackID.KernelID >= 0 {
 				if _, ok := kstackCache[stackID.KernelID]; !ok {
 					kstackCache[stackID.KernelID] = r.resolveKstackWithFallback(ring, stackID.KernelID)
 				}
 			}
-			if stackID.UserID > 0 {
-				if _, ok := ustackCache[stackID.UserID]; !ok {
-					ustackCache[stackID.UserID] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
+			userStack := ""
+			if stackID.UserID >= 0 {
+				key := newUserStackCacheKey(stackID.UserID, pidName.Pid)
+				if _, ok := ustackCache[key]; !ok {
+					ustackCache[key] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
 				}
+				userStack = ustackCache[key]
 			}
 
 			record := &stackEntry{
 				Proc:    &processIDName{Pid: pidName.Pid, Name: pidName.Name},
-				User:    ustackCache[stackID.UserID],
+				User:    userStack,
 				Kernel:  kstackCache[stackID.KernelID],
 				Samples: value,
 			}

--- a/cmd/profiler/provider/native_bpf_context_test.go
+++ b/cmd/profiler/provider/native_bpf_context_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import "testing"
+
+func TestProfilerEventBaseHasStackAcceptsStackIDZero(t *testing.T) {
+	tests := []struct {
+		name string
+		base *ProfilerEventBase
+		want bool
+	}{
+		{name: "nil", base: nil, want: false},
+		{name: "no stack", base: &ProfilerEventBase{Kernstack: -1, Userstack: -1}, want: false},
+		{name: "kernel stack zero", base: &ProfilerEventBase{Kernstack: 0, Userstack: -1}, want: true},
+		{name: "user stack zero", base: &ProfilerEventBase{Kernstack: -1, Userstack: 0}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.hasStack(); got != tt.want {
+				t.Fatalf("hasStack() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserStackCacheKeyIncludesPID(t *testing.T) {
+	cache := map[userStackCacheKey]string{
+		newUserStackCacheKey(7, 100): "first process",
+		newUserStackCacheKey(7, 200): "second process",
+	}
+	if len(cache) != 2 {
+		t.Fatalf("cache entries = %d, want stack ID reused independently by two processes", len(cache))
+	}
+}

--- a/cmd/profiler/provider/native_mutex_profiler.go
+++ b/cmd/profiler/provider/native_mutex_profiler.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler/aggregator"
+	"huatuo-bamai/internal/profiler/bpfmap"
+	pcontext "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/profiler/procutil"
+	"huatuo-bamai/internal/profiler/registry"
+	"huatuo-bamai/pkg/profiling"
+	"huatuo-bamai/pkg/types"
+)
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/native_mutex_profiler.c -o $BPF_DIR/native_mutex_profiler.o
+
+const (
+	mutexBackendContentionTracepoints = "contention tracepoints"
+	mutexBackendSlowpathKprobe        = "mutex slowpath"
+	mutexSlowpathSymbol               = "__mutex_lock_slowpath"
+)
+
+type mutexEvent struct {
+	ProfilerEventBase
+	Lock uint64
+}
+
+type mutexAggregateKey struct {
+	Pid       uint32
+	Comm      [TaskCommLen]byte
+	Kernstack int32
+	Userstack int32
+	Lock      uint64
+}
+
+type mutexAggregateValue struct {
+	WaitTime  uint64
+	Contended uint64
+}
+
+type mutexNativeProfiler struct {
+	bpf bpf.BPF
+}
+
+var (
+	hasMutexKprobeFunction        = bpf.HasKprobeFunction
+	hasMutexContentionTracepoints = mutexContentionTracepointsAvailable
+)
+
+func init() {
+	impl := &mutexNativeProfiler{}
+	registry.Register(registry.ProfilerMeta{
+		Type:           profiling.TypeLock,
+		Implementation: profiling.ImplementationNative,
+		Description:    "Native kernel mutex contention profiler using eBPF",
+		Impl:           impl,
+		NewAggregator:  impl.NewAggregator,
+	})
+}
+
+func (p *mutexNativeProfiler) NewAggregator(
+	pctx *pcontext.ProfilerContext,
+) (aggregator.Aggregator, error) {
+	return newNativeAggregator(pctx)
+}
+
+func (p *mutexNativeProfiler) Start(pctx *pcontext.ProfilerContext) error {
+	if err := validateMutexTarget(pctx); err != nil {
+		return err
+	}
+	if err := requireRoot(); err != nil {
+		return err
+	}
+	if pctx.LockType != profiling.LockTypeMutex {
+		return fmt.Errorf("native lock profiler supports only mutex contention")
+	}
+	if pctx.LockMode != profiling.LockModeWaitTime {
+		return fmt.Errorf("native lock profiler supports only wait-time mode")
+	}
+
+	cssAddr, err := resolveContainerCgroupCss(
+		pctx,
+		subsystem.SubsystemCPU,
+	)
+	if err != nil {
+		return err
+	}
+	constants := newNativeBPFConstants(
+		pctx.PID(),
+		cssAddr,
+		pctx.ThreadGroup,
+	)
+	constants["mutex_wait_threshold_ns"] = uint64(pctx.LockWaitThreshold.Nanoseconds())
+
+	attachOptions, backend, err := mutexAttachOptions()
+	if err != nil {
+		return err
+	}
+
+	loaded, err := bpf.LoadBpf("native_mutex_profiler.o", constants)
+	if err != nil {
+		return fmt.Errorf("load native mutex profiler BPF: %w", err)
+	}
+	if err := loaded.AttachWithOptions(attachOptions); err != nil {
+		_ = loaded.Close()
+		return fmt.Errorf("attach mutex contention probes: %w", err)
+	}
+
+	p.bpf = loaded
+	log.Infof("native mutex contention profiler attached via %s", backend)
+	return nil
+}
+
+func (p *mutexNativeProfiler) Stop(*pcontext.ProfilerContext) error {
+	return closeBpfSafe(p.bpf)
+}
+
+func (p *mutexNativeProfiler) ReadDataLoop(
+	ctx context.Context,
+	enqueue func(any),
+) error {
+	log.Infof("data reading loop started")
+	defer log.Infof("data reading loop ended")
+
+	ringCtx, err := newRingBufferContext(
+		p.bpf,
+		ctx,
+		4096*257,
+		false,
+	)
+	if err != nil {
+		return err
+	}
+	defer ringCtx.Close()
+
+	ticker := time.NewTicker(drainTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := drainMutexEvents(ringCtx, enqueue); err != nil {
+			if errors.Is(err, types.ErrExitByCancelCtx) {
+				return nil
+			}
+			log.Warnf("drain mutex contention events: %v", err)
+		}
+	}
+}
+
+func validateMutexTarget(pctx *pcontext.ProfilerContext) error {
+	if err := validateNativePIDs("lock", pctx.PIDs); err != nil {
+		return err
+	}
+	hasPID := len(pctx.PIDs) == 1
+	hasContainer := pctx.ContainerID != ""
+	if hasPID == hasContainer {
+		return fmt.Errorf(
+			"native lock profiler requires exactly one PID or container target",
+		)
+	}
+	return nil
+}
+
+func mutexContentionTracepointsAvailable() bool {
+	for _, root := range []string{
+		"/sys/kernel/tracing/events/lock",
+		"/sys/kernel/debug/tracing/events/lock",
+	} {
+		if _, err := os.Stat(root + "/contention_begin/id"); err != nil {
+			continue
+		}
+		if _, err := os.Stat(root + "/contention_end/id"); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func mutexAttachOptions() ([]bpf.AttachOption, string, error) {
+	if hasMutexContentionTracepoints() {
+		return []bpf.AttachOption{
+			{
+				ProgramName: "trace_mutex_contention_begin",
+				Symbol:      "lock/contention_begin",
+			},
+			{
+				ProgramName: "trace_mutex_contention_end",
+				Symbol:      "lock/contention_end",
+			},
+		}, mutexBackendContentionTracepoints, nil
+	}
+
+	if !hasMutexKprobeFunction(mutexSlowpathSymbol) {
+		return nil, "", fmt.Errorf(
+			"kernel exposes neither lock contention tracepoints nor %s",
+			mutexSlowpathSymbol,
+		)
+	}
+	return []bpf.AttachOption{
+		{
+			ProgramName: "trace_mutex_lock_slowpath",
+			Symbol:      mutexSlowpathSymbol,
+		},
+		{
+			ProgramName: "trace_mutex_lock_slowpath_return",
+			Symbol:      mutexSlowpathSymbol,
+		},
+	}, mutexBackendSlowpathKprobe, nil
+}
+
+func drainMutexEvents(
+	ringCtx *ringBufferContext,
+	enqueue func(any),
+) error {
+	ring, err := ringCtx.advanceSwapParity()
+	if err != nil {
+		return err
+	}
+
+	aggregates := make(map[mutexAggregateKey]mutexAggregateValue)
+	totalRead := uint64(0)
+	for {
+		batch, err := ring.reader.ReadBatch(&mutexEvent{})
+		if err != nil {
+			return err
+		}
+		totalRead += uint64(len(batch))
+		aggregateMutexBatch(aggregates, batch)
+		if len(batch) == 0 {
+			break
+		}
+
+		count, err := bpfmap.ReadUint64(
+			ringCtx.bpf,
+			ringCtx.transferStateMapID,
+			ring.sampleCountIdx,
+		)
+		if err != nil {
+			return fmt.Errorf("read mutex event count: %w", err)
+		}
+		if totalRead >= count {
+			break
+		}
+	}
+	if err := bpfmap.WriteUint64(
+		ringCtx.bpf,
+		ringCtx.transferStateMapID,
+		ring.sampleCountIdx,
+		0,
+	); err != nil {
+		return fmt.Errorf("reset mutex event count: %w", err)
+	}
+
+	enqueueMutexAggregates(ringCtx, ring, aggregates, enqueue)
+	return nil
+}
+
+func aggregateMutexBatch(
+	aggregates map[mutexAggregateKey]mutexAggregateValue,
+	batch []any,
+) {
+	for _, raw := range batch {
+		event, ok := raw.(*mutexEvent)
+		if !ok || event.Value <= 0 {
+			continue
+		}
+		key := mutexAggregateKey{
+			Pid:       uint32(event.PidTgid >> 32),
+			Comm:      event.Comm,
+			Kernstack: event.Kernstack,
+			Userstack: event.Userstack,
+			Lock:      event.Lock,
+		}
+		value := aggregates[key]
+		value.WaitTime += uint64(event.Value)
+		value.Contended++
+		aggregates[key] = value
+	}
+}
+
+func enqueueMutexAggregates(
+	ringCtx *ringBufferContext,
+	ring activeRingBuffer,
+	aggregates map[mutexAggregateKey]mutexAggregateValue,
+	enqueue func(any),
+) {
+	kstackCache := make(map[int32]string)
+	ustackCache := make(map[struct {
+		id  int32
+		pid uint32
+	}]string)
+	for key, value := range aggregates {
+		if key.Kernstack >= 0 {
+			if _, ok := kstackCache[key.Kernstack]; !ok {
+				kstackCache[key.Kernstack] = ringCtx.resolveKstackWithFallback(ring, key.Kernstack)
+			}
+		}
+		ukey := struct {
+			id  int32
+			pid uint32
+		}{key.Userstack, key.Pid}
+		if key.Userstack >= 0 {
+			if _, ok := ustackCache[ukey]; !ok {
+				ustackCache[ukey] = ringCtx.resolveUstackWithFallback(
+					ring,
+					key.Userstack,
+					key.Pid,
+				)
+			}
+		}
+		if key.Kernstack < 0 && key.Userstack < 0 {
+			continue
+		}
+
+		enqueue(&lockStackEntry{
+			Proc: &processIDNameLock{
+				Pid:  key.Pid,
+				Name: procutil.CommToString(key.Comm),
+				Lock: key.Lock,
+			},
+			User:      ustackCache[ukey],
+			Kernel:    kstackCache[key.Kernstack],
+			WaitTime:  value.WaitTime,
+			Contended: value.Contended,
+		})
+	}
+}

--- a/cmd/profiler/provider/native_mutex_profiler_test.go
+++ b/cmd/profiler/provider/native_mutex_profiler_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	pcontext "huatuo-bamai/internal/profiler/context"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMutexTarget(t *testing.T) {
+	require.NoError(t, validateMutexTarget(&pcontext.ProfilerContext{
+		PIDs: []int{42},
+	}))
+	require.NoError(t, validateMutexTarget(&pcontext.ProfilerContext{
+		ContainerID: "container",
+	}))
+	require.EqualError(
+		t,
+		validateMutexTarget(&pcontext.ProfilerContext{}),
+		"native lock profiler requires exactly one PID or container target",
+	)
+	require.EqualError(
+		t,
+		validateMutexTarget(&pcontext.ProfilerContext{
+			PIDs:        []int{42},
+			ContainerID: "container",
+		}),
+		"native lock profiler requires exactly one PID or container target",
+	)
+}
+
+func TestMutexAttachOptions(t *testing.T) {
+	oldTracepoints := hasMutexContentionTracepoints
+	oldKprobe := hasMutexKprobeFunction
+	t.Cleanup(func() {
+		hasMutexContentionTracepoints = oldTracepoints
+		hasMutexKprobeFunction = oldKprobe
+	})
+
+	hasMutexContentionTracepoints = func() bool { return true }
+	hasMutexKprobeFunction = func(string) bool { return false }
+	options, backend, err := mutexAttachOptions()
+	require.NoError(t, err)
+	require.Equal(t, mutexBackendContentionTracepoints, backend)
+	require.Len(t, options, 2)
+	require.Equal(t, "trace_mutex_contention_begin", options[0].ProgramName)
+
+	hasMutexContentionTracepoints = func() bool { return false }
+	hasMutexKprobeFunction = func(symbol string) bool {
+		return symbol == mutexSlowpathSymbol
+	}
+	options, backend, err = mutexAttachOptions()
+	require.NoError(t, err)
+	require.Equal(t, mutexBackendSlowpathKprobe, backend)
+	require.Len(t, options, 2)
+	require.Equal(t, mutexSlowpathSymbol, options[0].Symbol)
+
+	hasMutexKprobeFunction = func(string) bool { return false }
+	_, _, err = mutexAttachOptions()
+	require.EqualError(
+		t,
+		err,
+		"kernel exposes neither lock contention tracepoints nor "+
+			mutexSlowpathSymbol,
+	)
+}
+
+func TestAggregateMutexBatch(t *testing.T) {
+	comm := [TaskCommLen]byte{'a', 'p', 'p'}
+	first := &mutexEvent{
+		ProfilerEventBase: ProfilerEventBase{
+			PidTgid:   uint64(42) << 32,
+			Comm:      comm,
+			Kernstack: 0,
+			Userstack: 1,
+			Value:     15,
+		},
+		Lock: 0xab,
+	}
+	second := *first
+	second.Value = 5
+
+	aggregates := make(map[mutexAggregateKey]mutexAggregateValue)
+	aggregateMutexBatch(aggregates, []any{
+		first,
+		&second,
+		&mutexEvent{ProfilerEventBase: ProfilerEventBase{Value: 0}},
+		"unexpected",
+	})
+
+	require.Equal(t, map[mutexAggregateKey]mutexAggregateValue{
+		{
+			Pid:       42,
+			Comm:      comm,
+			Kernstack: 0,
+			Userstack: 1,
+			Lock:      0xab,
+		}: {
+			WaitTime:  20,
+			Contended: 2,
+		},
+	}, aggregates)
+}

--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/urfave/cli/v2"
 
@@ -122,7 +123,7 @@ func validateLanguageOptions(ctx *cli.Context, lang profiling.Language, typ prof
 		if err := validateSinglePID(ctx, "native"); err != nil {
 			return err
 		}
-		if typ == profiling.TypeMemory {
+		if typ == profiling.TypeMemory || typ == profiling.TypeLock {
 			return validateExactlyOneTarget(ctx)
 		}
 
@@ -267,6 +268,7 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	native := implementation == profiling.ImplementationNative
 	nativeCPU := native && typ == profiling.TypeCPU
 	nativeMemory := native && typ == profiling.TypeMemory
+	nativeLock := native && typ == profiling.TypeLock
 
 	if lang == profiling.LanguageJava && typ == profiling.TypeCPU && ctx.Int("freq") > 1000 {
 		return fmt.Errorf("Java profiler frequency must not exceed 1000 samples per second")
@@ -280,6 +282,11 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	if ctx.Bool("thread-group") && !native {
 		return fmt.Errorf("--thread-group is supported only by native profiling")
 	}
+	if ctx.IsSet("lock-wait-threshold") && !nativeLock {
+		return fmt.Errorf(
+			"--lock-wait-threshold is supported only by native lock profiling",
+		)
+	}
 	if ctx.String("binary-match-path") != "" && native {
 		return fmt.Errorf("--binary-match-path is not supported by native profilers")
 	}
@@ -292,6 +299,14 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 		probability := ctx.Uint("physical-memory-probability")
 		if probability < 1 || probability > 100 {
 			return fmt.Errorf("physical memory probability must be between 1 and 100")
+		}
+	}
+	if nativeLock {
+		threshold := ctx.Duration("lock-wait-threshold")
+		if threshold < 0 || threshold > time.Hour {
+			return fmt.Errorf(
+				"--lock-wait-threshold must be between 0 and 1h",
+			)
 		}
 	}
 	return nil

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -55,6 +55,20 @@ func TestCLIProfileTypeAndRemovedFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "native mutex contention",
+			args: []string{
+				"--type", "lock",
+				"--language", "c",
+				"--pid", strconv.Itoa(os.Getpid()),
+				"--lock-wait-threshold", "10us",
+			},
+		},
+		{
+			name:      "native mutex contention requires a target",
+			args:      []string{"--type", "lock", "--language", "c"},
+			wantError: "exactly one of --container-id or --pid must be provided",
+		},
+		{
 			name: "tracer ID",
 			args: []string{
 				"--type", "cpu",
@@ -66,7 +80,7 @@ func TestCLIProfileTypeAndRemovedFlags(t *testing.T) {
 		{
 			name:      "legacy mem type",
 			args:      []string{"--type", "mem", "--language", "c"},
-			wantError: `unsupported profiling type "mem" (expected: cpu or memory)`,
+			wantError: `unsupported profiling type "mem" (expected: cpu, memory, or lock)`,
 		},
 		{
 			name:      "removed flags option",
@@ -273,6 +287,19 @@ func TestValidateProfilerFlagCompatibility(t *testing.T) {
 		},
 		{name: "native CPU thread group", language: "go", typ: "cpu", args: []string{"--thread-group"}},
 		{name: "native memory thread group", language: "c", typ: "memory", args: []string{"--thread-group"}},
+		{
+			name:     "native mutex wait threshold",
+			language: "c",
+			typ:      "lock",
+			args:     []string{"--lock-wait-threshold", "10us"},
+		},
+		{
+			name:      "CPU mutex wait threshold",
+			language:  "c",
+			typ:       "cpu",
+			args:      []string{"--lock-wait-threshold", "10us"},
+			wantError: "--lock-wait-threshold is supported only by native lock profiling",
+		},
 		{
 			name:      "native exec path",
 			language:  "c",

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -92,6 +92,7 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` |
 | `cpu_ids` | No | CPU IDs selected for native CPU profiling |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
+| `tool_path` | For Java/Python profiling | Tool installation directory on the Agent host: async-profiler for Java or py-spy for Python |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
@@ -130,6 +131,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "tool_path": "/opt/async-profiler",
     "duration": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -203,6 +205,7 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
+| `tool_path` | External profiler installation directory specified when the job was created |
 | `pid` | Exact native target PID; empty for container or host-wide jobs |
 | `thread_group` | Whether native profiling includes the PID's thread group |
 | `cpu_ids` | CPU IDs selected for native CPU profiling |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -59,9 +59,12 @@ The `data` object contains these fields:
 
 | Field | Description |
 | --- | --- |
-| `types` | Supported profiling types: `cpu` and `memory` |
+| `types` | Supported profiling types: `cpu`, `memory`, and `lock` |
 | `cpu_languages` | Languages supported by CPU profiling |
 | `memory_languages` | Languages supported by memory profiling |
+| `lock_languages` | Languages supported by lock profiling |
+| `lock_modes` | Lock profile values; currently only `wait_time` |
+| `lock_types` | Lock primitives; currently only `mutex` |
 | `memory_modes` | Memory profiling modes; keys are display names and values are used when creating jobs |
 | `aggregation_interval` | Server-side data aggregation interval in seconds |
 | `execution_timeout` | Execution timeout for one profiler subprocess in seconds |
@@ -77,28 +80,34 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `java` | `object_alloc` | JVM object allocation |
 | `java` | `object_usage` | JVM live objects |
 
+Lock profiling supports only native `c`, `c++`, and `go` targets. It records
+contended mutex wait time and never enables host-wide lock instrumentation.
+
 ### 3. Create a Profiling Job
 
 `POST /v1/profiles` accepts the following JSON fields:
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `type` | Yes | Profiling type: `cpu` or `memory` |
+| `type` | Yes | Profiling type: `cpu`, `memory`, or `lock` |
 | `language` | Yes | Target process language; it must support the selected profiling type |
 | `duration` | Yes | Profiling duration in seconds |
 | `hostname` | Yes | Hostname of the node running the target process; used for job scheduling |
 | `container_id` | No | Target container ID; omit it to profile the host |
-| `pid` | No | Exact target PID for native profiling; mutually exclusive with `container_id` |
-| `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` |
+| `pid` | For PID-targeted native jobs | Exact target PID; native memory and lock jobs require it unless `container_id` is set |
+| `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` and is not accepted for lock jobs |
 | `cpu_ids` | No | CPU IDs selected for native CPU profiling |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
 | `tool_path` | For Java/Python profiling | Tool installation directory on the Agent host: async-profiler for Java or py-spy for Python |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
+| `lock_mode` | No | Lock profile value; only `wait_time` is supported and is the default |
+| `lock_type` | No | Lock primitive; only `mutex` is supported and is the default |
+| `lock_wait_threshold` | No | Minimum contention wait; Go duration such as `10us`, default `1us` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
 
 Native CPU profiling can omit both `pid` and `container_id` to sample the
-host. Native memory profiling requires exactly one of them. Without
+host. Native memory and lock profiling require exactly one of them. Without
 `thread_group`, `pid` keeps its exact-thread meaning.
 
 Create a Go CPU profiling job for a thread group on selected CPUs:
@@ -139,6 +148,29 @@ curl -sS -i \
   "${API_BASE}/v1/profiles"
 ```
 
+Create a targeted Go mutex contention profile:
+
+```bash
+curl -sS -i \
+  -X POST \
+  -H "Authorization: Bearer ${USER_ID}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "lock",
+    "language": "go",
+    "duration": 60,
+    "pid": 4242,
+    "lock_mode": "wait_time",
+    "lock_type": "mutex",
+    "lock_wait_threshold": "10us",
+    "hostname": "node-01"
+  }' \
+  "${API_BASE}/v1/profiles"
+```
+
+Lock jobs require exactly one `pid` or `container_id`. The API rejects
+host-wide lock jobs and non-native languages.
+
 A successful request returns `201 Created`. The `Location` response header identifies the new job, and the response body contains the job ID used by subsequent requests:
 
 ```json
@@ -164,7 +196,7 @@ JOB_ID="<profile-job-id>"
 | `container_id` | None | Exact container ID filter (`containerID` remains accepted for compatibility) |
 | `hostname` | None | Exact node hostname filter |
 | `status` | None | `pending`, `running`, `completed`, `failed`, `stopped`, or `timeout` |
-| `type` | None | `cpu` or `memory`; omit it to return both types |
+| `type` | None | `cpu`, `memory`, or `lock`; omit it to return all types |
 | `limit` | `50` | Page size; must be greater than 0 and is capped at 500 |
 | `offset` | `0` | Starting offset; must be greater than or equal to 0 |
 | `sort` | `-start_time` | `start_time`, `end_time`, `host`, or `container`; prefix with `-` for descending order |
@@ -201,7 +233,7 @@ The `data` object contains the job details:
 | `agent_task_id` | HUATUO Agent task ID |
 | `container_id` | Target container ID; empty for host jobs |
 | `hostname` | Target node hostname |
-| `type` | `cpu` or `memory` |
+| `type` | `cpu`, `memory`, or `lock` |
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
@@ -209,6 +241,9 @@ The `data` object contains the job details:
 | `pid` | Exact native target PID; empty for container or host-wide jobs |
 | `thread_group` | Whether native profiling includes the PID's thread group |
 | `cpu_ids` | CPU IDs selected for native CPU profiling |
+| `lock_mode` | Lock profile value; `wait_time` for current lock jobs |
+| `lock_type` | Lock primitive; `mutex` for current lock jobs |
+| `lock_wait_threshold` | Minimum mutex contention wait recorded by the profiler |
 | `status` | Current job status |
 | `start_time`, `end_time` | Job start and end times; empty until available |
 | `tracer_args` | Command-line arguments sent by huatuo-apiserver to profiler |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -404,6 +404,23 @@ sudo _output/bin/profiler \
   --output-format flamegraph --output-path ./profiles/host
 ```
 
+Remote profiles preserve their collection selectors as both profile metadata
+and pprof sample labels. This keeps the dimensions available to
+Pyroscope-compatible label queries and Parca-compatible pprof readers:
+
+| Label | Value |
+| --- | --- |
+| `profiling_scope` | `host`, `container`, `pid`, or `thread_group` |
+| `pid` | Exact PID target, or comma-separated external-profiler targets |
+| `tgid` | Thread-group target used with `--thread-group` |
+| `container_id` | Target supplied through the common container selector |
+| `cpu` | Comma-separated CPU IDs selected with `--cpuid` |
+
+The Pyroscope-compatible API accepts equality matchers for these labels and
+returns their values through the label-values endpoint. A label describes the
+collection filter; it does not replace the per-process frames already present
+in a profile.
+
 Native memory profiling supports these dimensions:
 
 | `--memory-mode` | Measurement | Suitable for |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -88,12 +88,19 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `duration` | Yes | Profiling duration in seconds |
 | `hostname` | Yes | Hostname of the node running the target process; used for job scheduling |
 | `container_id` | No | Target container ID; omit it to profile the host |
+| `pid` | No | Exact target PID for native profiling; mutually exclusive with `container_id` |
+| `thread_group` | No | Include every thread in `pid`'s thread group (TGID); requires `pid` |
+| `cpu_ids` | No | CPU IDs selected for native CPU profiling |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration` must cover at least two `aggregation_interval` periods, and `duration + aggregation_interval` must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
 
-Create a Go CPU profiling job on a host:
+Native CPU profiling can omit both `pid` and `container_id` to sample the
+host. Native memory profiling requires exactly one of them. Without
+`thread_group`, `pid` keeps its exact-thread meaning.
+
+Create a Go CPU profiling job for a thread group on selected CPUs:
 
 ```bash
 curl -sS -i \
@@ -104,6 +111,9 @@ curl -sS -i \
     "type": "cpu",
     "language": "go",
     "duration": 60,
+    "pid": 4242,
+    "thread_group": true,
+    "cpu_ids": [1, 3],
     "hostname": "node-01"
   }' \
   "${API_BASE}/v1/profiles"
@@ -193,6 +203,9 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; empty for CPU jobs |
 | `binary_match_path` | Executable path matcher specified when the job was created |
+| `pid` | Exact native target PID; empty for container or host-wide jobs |
+| `thread_group` | Whether native profiling includes the PID's thread group |
+| `cpu_ids` | CPU IDs selected for native CPU profiling |
 | `status` | Current job status |
 | `start_time`, `end_time` | Job start and end times; empty until available |
 | `tracer_args` | Command-line arguments sent by huatuo-apiserver to profiler |

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -318,7 +318,7 @@ The basic command structure is:
 
 ```bash
 sudo _output/bin/profiler \
-  --type <cpu|memory> \
+  --type <cpu|memory|lock> \
   --language <c|c++|go|java|python> \
   --pid <pid> \
   --duration 30 \
@@ -327,13 +327,13 @@ sudo _output/bin/profiler \
   --output-path ./profiles
 ```
 
-`--type` and `--language` are required. Java, Python, and native memory profiling require exactly one target specified with either `--pid` or `--container-id`. Native CPU profiling can sample the entire host when neither target is specified.
+`--type` and `--language` are required. Java, Python, native memory, and native lock profiling require exactly one target specified with either `--pid` or `--container-id`. Native CPU profiling can sample the entire host when neither target is specified.
 
 ### 2. General CLI Options
 
 | Option | Default | Scope | Description |
 | --- | --- | --- | --- |
-| `--type`, `-t` | None | All | Profile type: `cpu` or `memory`; required |
+| `--type`, `-t` | None | All | Profile type: `cpu`, `memory`, or `lock`; required |
 | `--language`, `-l` | None | All | Target language: `c`, `c++`, `go`, `java`, or `python`; required |
 | `--pid`, `-p` | None | All | Target PID; Java and Python accept comma-separated PIDs, while native profiling accepts at most one PID |
 | `--container-id` | None | All | Target container ID; mutually exclusive with `--pid` |
@@ -360,6 +360,7 @@ Native profiling options:
 | `--memory-mode` | None | Native memory, Java memory | Memory profiling mode; required with `--type memory` |
 | `--cpuid` | All CPUs | Native CPU | Comma-separated CPU list or ranges, for example `1,3,5-10` |
 | `--thread-group` | `false` | Native | Also profile other threads in the target PID's thread group |
+| `--lock-wait-threshold` | `1us` | Native lock | Minimum mutex contention wait included in the profile |
 | `--physical-memory-probability` | `100` | Native physical memory | Physical memory event sampling probability from 1 to 100 |
 | `--log-bpf-debug` | `false` | Native | Emit BPF debug events; not recommended for normal profiling |
 
@@ -444,6 +445,24 @@ sudo _output/bin/profiler \
 ```
 
 `--physical-memory-probability` applies only to `physical_alloc` and `physical_usage`. Lowering it reduces processing for high-frequency memory events, but flame-graph values are then estimates based on sampled events rather than counts of every event.
+
+Native lock profiling currently records mutex wait time only. It attaches to the
+kernel lock contention tracepoints when available and otherwise uses the mutex
+slow path. A PID or container target is mandatory to prevent accidental
+host-wide lock instrumentation.
+
+```bash
+sudo _output/bin/profiler \
+  --type lock \
+  --language c \
+  --pid 12345 \
+  --thread-group \
+  --lock-wait-threshold 10us \
+  --duration 30 \
+  --aggr-interval 10 \
+  --output-format flamegraph \
+  --output-path ./profiles/mutex-wait
+```
 
 ### 4. Observing Java
 

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -90,6 +90,7 @@ curl -sS \
 | `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须同时指定 `pid` |
 | `cpu_ids` | 否 | 原生 CPU 剖析限定的 CPU ID |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
+| `tool_path` | Java/Python 剖析必需 | Agent 主机上的工具安装目录：Java 使用 async-profiler，Python 使用 py-spy |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
@@ -126,6 +127,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "tool_path": "/opt/async-profiler",
     "duration": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -199,6 +201,7 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
+| `tool_path` | 创建任务时指定的外部 profiler 安装目录 |
 | `pid` | 原生剖析的精确目标 PID；容器任务或宿主机级任务为空 |
 | `thread_group` | 是否采集该 PID 所在线程组 |
 | `cpu_ids` | 原生 CPU 剖析限定的 CPU ID |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -400,6 +400,20 @@ sudo _output/bin/profiler \
   --output-format flamegraph --output-path ./profiles/host
 ```
 
+远端 profile 会同时在 profile 元数据和每个 pprof sample 中保留采集选择器，
+因此 Pyroscope 兼容的序列查询和 Parca 兼容的 pprof 读取器都可以使用这些维度：
+
+| 标签 | 取值 |
+| --- | --- |
+| `profiling_scope` | `host`、`container`、`pid` 或 `thread_group` |
+| `pid` | 精确 PID；外部 profiler 多目标时为逗号分隔的 PID 列表 |
+| `tgid` | 使用 `--thread-group` 时的线程组目标 |
+| `container_id` | 通过统一容器选择器指定的容器 ID |
+| `cpu` | `--cpuid` 选择的逗号分隔 CPU ID |
+
+Pyroscope 兼容 API 支持这些标签的等值匹配，并通过 label-values 接口返回聚合值。
+标签描述采集过滤条件，不会替代 profile 中已有的进程帧。
+
 原生内存支持以下维度：
 
 | `--memory-mode` | 统计内容 | 适用问题 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -57,9 +57,12 @@ curl -sS \
 
 | 字段 | 说明 |
 | --- | --- |
-| `types` | 支持的剖析类型：`cpu`、`memory` |
+| `types` | 支持的剖析类型：`cpu`、`memory`、`lock` |
 | `cpu_languages` | CPU 剖析支持的语言 |
 | `memory_languages` | 内存剖析支持的语言 |
+| `lock_languages` | 锁剖析支持的语言 |
+| `lock_modes` | 锁剖析的统计值；当前仅支持 `wait_time` |
+| `lock_types` | 锁原语；当前仅支持 `mutex` |
 | `memory_modes` | 内存剖析模式；键用于界面展示，值用于创建任务 |
 | `aggregation_interval` | 服务端采集数据的聚合周期，单位为秒 |
 | `execution_timeout` | 单个 profiler 子进程的执行超时，单位为秒 |
@@ -75,27 +78,33 @@ curl -sS \
 | `java` | `object_alloc` | JVM 对象分配 |
 | `java` | `object_usage` | JVM 存活对象 |
 
+锁剖析仅支持原生 `c`、`c++`、`go` 目标，只记录发生竞争的 mutex
+等待时间，不会启用宿主机级锁插桩。
+
 ### 3. 创建剖析任务
 
 `POST /v1/profiles` 的 JSON 参数如下：
 
 | 参数 | 是否必需 | 说明 |
 | --- | --- | --- |
-| `type` | 是 | 剖析类型：`cpu` 或 `memory` |
+| `type` | 是 | 剖析类型：`cpu`、`memory` 或 `lock` |
 | `language` | 是 | 目标进程语言，必须与剖析类型匹配 |
 | `duration` | 是 | 采集时长，单位为秒 |
 | `hostname` | 是 | 运行目标进程的节点主机名，用于任务调度 |
 | `container_id` | 否 | 目标容器 ID；不传表示对宿主机剖析 |
-| `pid` | 否 | 原生剖析的精确目标 PID；不能与 `container_id` 同时使用 |
-| `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须同时指定 `pid` |
+| `pid` | 按 PID 采集原生任务时 | 精确目标 PID；原生内存和锁任务未指定 `container_id` 时必需 |
+| `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须指定 `pid`，锁任务不支持 |
 | `cpu_ids` | 否 | 原生 CPU 剖析限定的 CPU ID |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
 | `tool_path` | Java/Python 剖析必需 | Agent 主机上的工具安装目录：Java 使用 async-profiler，Python 使用 py-spy |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
+| `lock_mode` | 否 | 锁剖析统计值；仅支持且默认为 `wait_time` |
+| `lock_type` | 否 | 锁原语；仅支持且默认为 `mutex` |
+| `lock_wait_threshold` | 否 | 最小竞争等待时间，使用 `10us` 等 Go 时长，默认为 `1us` |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
 
-原生 CPU 剖析可以同时省略 `pid` 和 `container_id`，对整个宿主机采样。原生内存剖析必须指定其中一个。未启用 `thread_group` 时，`pid` 保持精确线程语义。
+原生 CPU 剖析可以同时省略 `pid` 和 `container_id`，对整个宿主机采样。原生内存和锁剖析必须指定其中一个。未启用 `thread_group` 时，`pid` 保持精确线程语义。
 
 创建限定 CPU 的 Go 线程组剖析任务：
 
@@ -135,6 +144,29 @@ curl -sS -i \
   "${API_BASE}/v1/profiles"
 ```
 
+创建限定 PID 的 Go mutex 竞争剖析任务：
+
+```bash
+curl -sS -i \
+  -X POST \
+  -H "Authorization: Bearer ${USER_ID}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "lock",
+    "language": "go",
+    "duration": 60,
+    "pid": 4242,
+    "lock_mode": "wait_time",
+    "lock_type": "mutex",
+    "lock_wait_threshold": "10us",
+    "hostname": "node-01"
+  }' \
+  "${API_BASE}/v1/profiles"
+```
+
+锁剖析任务必须且只能指定 `pid` 或 `container_id` 之一。API 会拒绝
+宿主机级锁剖析和非原生语言。
+
 创建成功返回 `201 Created`，`Location` 响应头指向新任务，响应体包含后续查询所需的任务 ID：
 
 ```json
@@ -160,7 +192,7 @@ JOB_ID="<profile-job-id>"
 | `container_id` | 无 | 按容器 ID 精确过滤（兼容旧参数 `containerID`） |
 | `hostname` | 无 | 按节点主机名精确过滤 |
 | `status` | 无 | `pending`、`running`、`completed`、`failed`、`stopped` 或 `timeout` |
-| `type` | 无 | `cpu` 或 `memory`；不传时返回两种类型 |
+| `type` | 无 | `cpu`、`memory` 或 `lock`；不传时返回全部类型 |
 | `limit` | `50` | 每页数量，必须大于 0，最大为 500 |
 | `offset` | `0` | 起始偏移量，必须大于或等于 0 |
 | `sort` | `-start_time` | `start_time`、`end_time`、`host` 或 `container`；前置 `-` 表示降序 |
@@ -197,7 +229,7 @@ curl -sS \
 | `agent_task_id` | HUATUO Agent 任务 ID |
 | `container_id` | 目标容器 ID；宿主机任务为空 |
 | `hostname` | 目标节点主机名 |
-| `type` | `cpu` 或 `memory` |
+| `type` | `cpu`、`memory` 或 `lock` |
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
@@ -205,6 +237,9 @@ curl -sS \
 | `pid` | 原生剖析的精确目标 PID；容器任务或宿主机级任务为空 |
 | `thread_group` | 是否采集该 PID 所在线程组 |
 | `cpu_ids` | 原生 CPU 剖析限定的 CPU ID |
+| `lock_mode` | 锁剖析统计值；当前锁任务为 `wait_time` |
+| `lock_type` | 锁原语；当前锁任务为 `mutex` |
+| `lock_wait_threshold` | profiler 记录的最小 mutex 竞争等待时间 |
 | `status` | 当前任务状态 |
 | `start_time`、`end_time` | 任务开始和结束时间；尚未产生时为空 |
 | `tracer_args` | huatuo-apiserver 实际下发给 profiler 的命令行参数 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -86,12 +86,17 @@ curl -sS \
 | `duration` | 是 | 采集时长，单位为秒 |
 | `hostname` | 是 | 运行目标进程的节点主机名，用于任务调度 |
 | `container_id` | 否 | 目标容器 ID；不传表示对宿主机剖析 |
+| `pid` | 否 | 原生剖析的精确目标 PID；不能与 `container_id` 同时使用 |
+| `thread_group` | 否 | 采集 `pid` 所在线程组（TGID）的全部线程；必须同时指定 `pid` |
+| `cpu_ids` | 否 | 原生 CPU 剖析限定的 CPU ID |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration` 必须不小于两个 `aggregation_interval`，且 `duration + aggregation_interval` 必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
 
-创建宿主机 Go CPU 剖析任务：
+原生 CPU 剖析可以同时省略 `pid` 和 `container_id`，对整个宿主机采样。原生内存剖析必须指定其中一个。未启用 `thread_group` 时，`pid` 保持精确线程语义。
+
+创建限定 CPU 的 Go 线程组剖析任务：
 
 ```bash
 curl -sS -i \
@@ -102,6 +107,9 @@ curl -sS -i \
     "type": "cpu",
     "language": "go",
     "duration": 60,
+    "pid": 4242,
+    "thread_group": true,
+    "cpu_ids": [1, 3],
     "hostname": "node-01"
   }' \
   "${API_BASE}/v1/profiles"
@@ -191,6 +199,9 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务为空 |
 | `binary_match_path` | 创建任务时指定的可执行文件匹配路径 |
+| `pid` | 原生剖析的精确目标 PID；容器任务或宿主机级任务为空 |
+| `thread_group` | 是否采集该 PID 所在线程组 |
+| `cpu_ids` | 原生 CPU 剖析限定的 CPU ID |
 | `status` | 当前任务状态 |
 | `start_time`、`end_time` | 任务开始和结束时间；尚未产生时为空 |
 | `tracer_args` | huatuo-apiserver 实际下发给 profiler 的命令行参数 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -314,7 +314,7 @@ _output/bin/profiler --help
 
 ```bash
 sudo _output/bin/profiler \
-  --type <cpu|memory> \
+  --type <cpu|memory|lock> \
   --language <c|c++|go|java|python> \
   --pid <pid> \
   --duration 30 \
@@ -323,13 +323,13 @@ sudo _output/bin/profiler \
   --output-path ./profiles
 ```
 
-`--type` 和 `--language` 为必填参数。Java、Python 和原生内存采集必须在 `--pid` 与 `--container-id` 中指定且仅指定一个目标；原生 CPU 采集未指定目标时可进行宿主机级采样。
+`--type` 和 `--language` 为必填参数。Java、Python、原生内存和原生锁采集必须在 `--pid` 与 `--container-id` 中指定且仅指定一个目标；原生 CPU 采集未指定目标时可进行宿主机级采样。
 
 ### 2. 通用命令参数
 
 | 参数 | 默认值 | 适用范围 | 说明 |
 | --- | --- | --- | --- |
-| `--type`, `-t` | 无 | 全部 | 观测类型：`cpu` 或 `memory`，必填 |
+| `--type`, `-t` | 无 | 全部 | 观测类型：`cpu`、`memory` 或 `lock`，必填 |
 | `--language`, `-l` | 无 | 全部 | 目标语言：`c`、`c++`、`go`、`java` 或 `python`，必填 |
 | `--pid`, `-p` | 无 | 全部 | 目标 PID；Java、Python 可使用逗号分隔多个 PID，原生采集最多一个 PID |
 | `--container-id` | 无 | 全部 | 目标容器 ID；不能与 `--pid` 同时使用 |
@@ -356,6 +356,7 @@ sudo _output/bin/profiler \
 | `--memory-mode` | 无 | 原生内存、Java 内存 | 内存观测维度；使用 `--type memory` 时必填 |
 | `--cpuid` | 全部 CPU | 原生 CPU | CPU 列表或范围，例如 `1,3,5-10` |
 | `--thread-group` | `false` | 原生 | 同时采集目标 PID 所在线程组中的其他线程 |
+| `--lock-wait-threshold` | `1us` | 原生锁 | 纳入结果的最小 mutex 竞争等待时间 |
 | `--physical-memory-probability` | `100` | 原生物理内存 | 物理内存事件采样概率，范围为 1～100 |
 | `--log-bpf-debug` | `false` | 原生 | 输出 BPF 调试事件，常规采集不建议启用 |
 
@@ -437,6 +438,23 @@ sudo _output/bin/profiler \
 ```
 
 `--physical-memory-probability` 仅适用于 `physical_alloc` 和 `physical_usage`。降低该值可减少高频内存事件的处理量，但火焰图中的值由采样事件估算，不再是逐事件统计。
+
+原生锁采集当前仅统计 mutex 等待时间。内核支持时使用锁竞争
+tracepoint，否则使用 mutex 慢路径。必须指定 PID 或容器，避免意外启用
+宿主机级锁插桩。
+
+```bash
+sudo _output/bin/profiler \
+  --type lock \
+  --language c \
+  --pid 12345 \
+  --thread-group \
+  --lock-wait-threshold 10us \
+  --duration 30 \
+  --aggr-interval 10 \
+  --output-format flamegraph \
+  --output-path ./profiles/mutex-wait
+```
 
 ### 4. Java 观测
 

--- a/integration/test_profiler_native_mutex.sh
+++ b/integration/test_profiler_native_mutex.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+
+is_container && skip "native mutex profiler requires bare-metal BPF access"
+[[ ${EUID} -eq 0 ]] || skip "native mutex profiler requires root"
+
+readonly PROFILER_BIN="${ROOT_DIR}/_output/bin/profiler"
+readonly PROFILER_BPF="${ROOT_DIR}/_output/bpf/native_mutex_profiler.o"
+readonly FIXTURE_DIR="${ROOT_DIR}/integration/testdata/mutexprof_fixture"
+readonly KERNEL_BUILD_DIR="/lib/modules/$(uname -r)/build"
+
+[[ -x "${PROFILER_BIN}" ]] || fatal "profiler binary missing: ${PROFILER_BIN}"
+[[ -r "${PROFILER_BPF}" ]] || fatal "BPF object missing: ${PROFILER_BPF}"
+[[ -d "${KERNEL_BUILD_DIR}" ]] || skip "matching kernel headers unavailable"
+command -v timeout > /dev/null || skip "timeout(1) not in PATH"
+command -v insmod > /dev/null || skip "insmod(8) not in PATH"
+command -v rmmod > /dev/null || skip "rmmod(8) not in PATH"
+command -v mknod > /dev/null || skip "mknod(1) not in PATH"
+
+if [[ ! -r /sys/kernel/tracing/events/lock/contention_begin/id ]] \
+	&& [[ ! -r /sys/kernel/debug/tracing/events/lock/contention_begin/id ]] \
+	&& ! kprobe_available __mutex_lock_slowpath; then
+	skip "kernel exposes no supported mutex contention hook"
+fi
+
+WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/profiler-mutex.XXXXXX")
+MODULE_DIR="${WORK_DIR}/module"
+MODULE_NAME="huatuo_mutexprof_test"
+DEVICE_PATH="${WORK_DIR}/huatuo_mutexprof_fixture"
+WORKLOAD_BIN="${WORK_DIR}/mutexprof_workload"
+PROFILER_PID=""
+TARGET_PID=""
+
+cleanup() {
+	[[ -n "${PROFILER_PID}" ]] && stop_by_pid "${PROFILER_PID}" 5 || true
+	[[ -n "${TARGET_PID}" ]] && stop_by_pid "${TARGET_PID}" 5 || true
+	rmmod "${MODULE_NAME}" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+mkdir -p "${MODULE_DIR}"
+cp "${FIXTURE_DIR}/Makefile" "${MODULE_DIR}/"
+cp "${FIXTURE_DIR}/huatuo_mutexprof_test.kernel.c" \
+	"${MODULE_DIR}/huatuo_mutexprof_test.c"
+if ! make -s -C "${KERNEL_BUILD_DIR}" M="${MODULE_DIR}" modules \
+	> "${WORK_DIR}/module-build.log" 2>&1; then
+	fatal "failed to build kernel mutex fixture"
+fi
+
+rmmod "${MODULE_NAME}" > /dev/null 2>&1 || true
+insmod "${MODULE_DIR}/${MODULE_NAME}.ko" \
+	|| fatal "failed to load ${MODULE_NAME}.ko"
+
+readonly DEVICE_SYSFS="/sys/class/misc/huatuo_mutexprof_fixture/dev"
+wait_until 5 1 test -r "${DEVICE_SYSFS}" \
+	|| fatal "fixture miscdevice did not appear"
+readonly DEVICE_NUMBER=$(< "${DEVICE_SYSFS}")
+mknod "${DEVICE_PATH}" c "${DEVICE_NUMBER%:*}" "${DEVICE_NUMBER#*:}"
+chmod 600 "${DEVICE_PATH}"
+
+compile_user_fixture \
+	"${FIXTURE_DIR}/mutexprof_workload.user.c" \
+	"${WORKLOAD_BIN}" \
+	-pthread
+
+readonly DMESG_START=$(dmesg 2> /dev/null | wc -l)
+"${WORKLOAD_BIN}" "${DEVICE_PATH}" \
+	> "${WORK_DIR}/workload.out" 2> "${WORK_DIR}/workload.err" &
+TARGET_PID=$!
+
+timeout --signal=TERM --kill-after=5s 20s \
+	"${PROFILER_BIN}" \
+	--type lock \
+	--language c \
+	--pid "${TARGET_PID}" \
+	--thread-group \
+	--lock-wait-threshold 1us \
+	--duration 8 \
+	--aggr-interval 2 \
+	--output-format collapsed \
+	--output-path "${WORK_DIR}" \
+	--verbose \
+	> "${WORK_DIR}/profiler.out" 2> "${WORK_DIR}/profiler.err" &
+PROFILER_PID=$!
+
+wait_until 10 1 profiler_ready "${WORK_DIR}/profiler.out" \
+	|| fatal "mutex profiler did not enter its read loop"
+if ! wait "${PROFILER_PID}"; then
+	PROFILER_PID=""
+	fatal "mutex profiler failed or timed out"
+fi
+PROFILER_PID=""
+
+stop_by_pid "${TARGET_PID}" 5
+wait "${TARGET_PID}" || fatal "mutex workload exited non-zero"
+TARGET_PID=""
+
+mapfile -t folded_files < <(
+	find "${WORK_DIR}" -maxdepth 1 -name 'perf_*.folded' -type f
+)
+[[ ${#folded_files[@]} -gt 0 ]] || fatal "no folded output produced"
+grep -q "lock:" "${folded_files[@]}" \
+	|| fatal "mutex lock frame not found"
+awk 'NF && $NF ~ /^[0-9]+$/ && $NF > 0 { found=1 } END { exit !found }' \
+	"${folded_files[@]}" \
+	|| fatal "no positive mutex wait value found"
+
+if dmesg 2> /dev/null | tail -n "+$((DMESG_START + 1))" \
+	| grep -Eiq 'soft lockup|rcu[^:]*stall|hung task|watchdog: BUG'; then
+	fatal "kernel reported a stall while profiling mutex contention"
+fi
+
+log_info "native mutex contention profile passed without kernel stalls"

--- a/integration/testdata/mutexprof_fixture/Makefile
+++ b/integration/testdata/mutexprof_fixture/Makefile
@@ -1,0 +1,1 @@
+obj-m += huatuo_mutexprof_test.o

--- a/integration/testdata/mutexprof_fixture/huatuo_mutexprof_test.kernel.c
+++ b/integration/testdata/mutexprof_fixture/huatuo_mutexprof_test.kernel.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0
+/* Deterministic mutex contention fixture for the Huatuo integration test. */
+
+#include <linux/delay.h>
+#include <linux/fs.h>
+#include <linux/ioctl.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+
+#define HUATUO_MUTEXPROF_IOC_MAGIC 0xb7
+#define HUATUO_MUTEXPROF_CONTEND _IO(HUATUO_MUTEXPROF_IOC_MAGIC, 1)
+
+static DEFINE_MUTEX(fixture_mutex);
+
+static long huatuo_mutexprof_ioctl(struct file *file, unsigned int cmd,
+				   unsigned long arg)
+{
+	(void)file;
+	(void)arg;
+
+	if (cmd != HUATUO_MUTEXPROF_CONTEND)
+		return -ENOTTY;
+
+	mutex_lock(&fixture_mutex);
+	usleep_range(1000, 1500);
+	mutex_unlock(&fixture_mutex);
+	return 0;
+}
+
+static const struct file_operations huatuo_mutexprof_fops = {
+	.owner = THIS_MODULE,
+	.unlocked_ioctl = huatuo_mutexprof_ioctl,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl = huatuo_mutexprof_ioctl,
+#endif
+};
+
+static struct miscdevice huatuo_mutexprof_device = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = "huatuo_mutexprof_fixture",
+	.fops = &huatuo_mutexprof_fops,
+	.mode = 0600,
+};
+
+static int __init huatuo_mutexprof_init(void)
+{
+	return misc_register(&huatuo_mutexprof_device);
+}
+
+static void __exit huatuo_mutexprof_exit(void)
+{
+	misc_deregister(&huatuo_mutexprof_device);
+}
+
+module_init(huatuo_mutexprof_init);
+module_exit(huatuo_mutexprof_exit);
+
+MODULE_AUTHOR("The HuaTuo Authors");
+MODULE_DESCRIPTION("Kernel mutex contention integration fixture");
+MODULE_LICENSE("GPL");

--- a/integration/testdata/mutexprof_fixture/mutexprof_workload.user.c
+++ b/integration/testdata/mutexprof_fixture/mutexprof_workload.user.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define HUATUO_MUTEXPROF_IOC_MAGIC 0xb7
+#define HUATUO_MUTEXPROF_CONTEND _IO(HUATUO_MUTEXPROF_IOC_MAGIC, 1)
+#define WORKER_COUNT 8
+
+static volatile sig_atomic_t stopping;
+static volatile sig_atomic_t failed;
+static volatile sig_atomic_t failure_errno;
+
+static void stop_workload(int signo)
+{
+	(void)signo;
+	stopping = 1;
+}
+
+static void *worker(void *opaque)
+{
+	const int fd = *(int *)opaque;
+
+	while (!stopping) {
+		if (ioctl(fd, HUATUO_MUTEXPROF_CONTEND, 0) == 0)
+			continue;
+		if (errno == EINTR)
+			continue;
+		failure_errno = errno;
+		failed = 1;
+		stopping = 1;
+	}
+	return NULL;
+}
+
+int main(int argc, char **argv)
+{
+	pthread_t threads[WORKER_COUNT];
+	struct sigaction action = {.sa_handler = stop_workload};
+	int fd;
+	int i;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s <device>\n", argv[0]);
+		return 2;
+	}
+
+	sigemptyset(&action.sa_mask);
+	sigaction(SIGTERM, &action, NULL);
+	sigaction(SIGINT, &action, NULL);
+
+	fd = open(argv[1], O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		perror("open fixture device");
+		return 1;
+	}
+
+	for (i = 0; i < WORKER_COUNT; i++) {
+		if (pthread_create(&threads[i], NULL, worker, &fd) == 0)
+			continue;
+		perror("pthread_create");
+		stopping = 1;
+		failed = 1;
+		break;
+	}
+
+	while (!stopping)
+		sleep(1);
+	for (int joined = 0; joined < i; joined++)
+		pthread_join(threads[joined], NULL);
+	close(fd);
+	if (failed && failure_errno != 0)
+		fprintf(stderr, "ioctl failed: %s\n", strerror(failure_errno));
+	return failed ? 1 : 0;
+}

--- a/internal/bpf/bpf_kprobe.go
+++ b/internal/bpf/bpf_kprobe.go
@@ -16,6 +16,7 @@ package bpf
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -25,21 +26,17 @@ var (
 	kprobeOnce   sync.Mutex
 	kprobeCache  map[string]struct{}
 	kprobeCached bool
+
+	// Tracefs has its own mount point on current kernels, while older systems
+	// commonly expose the same file through debugfs. Check both layouts.
+	kprobeFunctionFiles = []string{
+		"/sys/kernel/tracing/available_filter_functions",
+		"/sys/kernel/debug/tracing/available_filter_functions",
+	}
 )
 
-// loadKprobeFunctions reads /sys/kernel/debug/tracing/available_filter_functions
-// and populates kprobeCache. On success kprobeCached is set so subsequent
-// calls skip the file read; on failure the cache remains unset and the next
-// call retries.
-func loadKprobeFunctions() {
-	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	cache := make(map[string]struct{})
-	scanner := bufio.NewScanner(file)
+func scanKprobeFunctions(r io.Reader, cache map[string]struct{}) error {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -47,23 +44,41 @@ func loadKprobeFunctions() {
 		}
 		cache[strings.Fields(line)[0]] = struct{}{}
 	}
+	return scanner.Err()
+}
 
-	if err := scanner.Err(); err != nil {
-		return
+// loadKprobeFunctions reads the available function list and populates
+// kprobeCache. On success kprobeCached is set so subsequent calls skip the
+// file read; if neither tracefs nor debugfs is readable, the next call retries.
+func loadKprobeFunctions() {
+	cache := make(map[string]struct{})
+	readOK := false
+	for _, path := range kprobeFunctionFiles {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		err = scanKprobeFunctions(file, cache)
+		_ = file.Close()
+		if err == nil {
+			readOK = true
+		}
 	}
 
-	kprobeCache = cache
-	kprobeCached = true
+	if readOK {
+		kprobeCache = cache
+		kprobeCached = true
+	}
 }
 
 // HasKprobeFunction returns whether the given symbol is reported as
 // attachable in the kernel's available_filter_functions list.
 func HasKprobeFunction(name string) bool {
 	kprobeOnce.Lock()
+	defer kprobeOnce.Unlock()
 	if !kprobeCached {
 		loadKprobeFunctions()
 	}
-	kprobeOnce.Unlock()
 
 	_, ok := kprobeCache[name]
 	return ok

--- a/internal/bpf/bpf_kprobe_test.go
+++ b/internal/bpf/bpf_kprobe_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanKprobeFunctions(t *testing.T) {
+	cache := make(map[string]struct{})
+	input := "  mutex_lock\n_raw_spin_lock   [kernel]\n\n_raw_read_lock\t[kernel]\n"
+	if err := scanKprobeFunctions(strings.NewReader(input), cache); err != nil {
+		t.Fatalf("scanKprobeFunctions() error = %v", err)
+	}
+	for _, symbol := range []string{"mutex_lock", "_raw_spin_lock", "_raw_read_lock"} {
+		if _, ok := cache[symbol]; !ok {
+			t.Errorf("symbol %q missing from cache", symbol)
+		}
+	}
+}

--- a/internal/job/types.go
+++ b/internal/job/types.go
@@ -37,6 +37,8 @@ const (
 	JobTypeProfilingCPU JobType = "profiling_cpu"
 	// JobTypeProfilingMemory identifies memory profiling jobs.
 	JobTypeProfilingMemory JobType = "profiling_memory"
+	// JobTypeProfilingLock identifies lock profiling jobs.
+	JobTypeProfilingLock JobType = "profiling_lock"
 	// JobTypeTracing identifies tracing jobs.
 	JobTypeTracing JobType = "tracing"
 )

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -33,9 +33,9 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 		return fmt.Errorf("toolstream client not initialized")
 	}
 
-	flameData, ok := data.(*profiler.ProfileData)
-	if !ok {
-		return fmt.Errorf("invalid pprof data for uploading: %T", data)
+	flameData, err := applyCollectionDimensionLabels(p.pctx, data)
+	if err != nil {
+		return err
 	}
 
 	tracerData := &profctx.TracerData{
@@ -60,4 +60,22 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	log.WithField("tracer_id", p.tracerID).Infof("profiling event sent via toolstream")
 
 	return nil
+}
+
+func applyCollectionDimensionLabels(
+	pctx *profctx.ProfilerContext,
+	data any,
+) (*profiler.ProfileData, error) {
+	flameData, ok := data.(*profiler.ProfileData)
+	if !ok {
+		return nil, fmt.Errorf("invalid pprof data for uploading: %T", data)
+	}
+	if err := profiler.ApplyLabels(
+		flameData,
+		pctx.CollectionDimensionLabels(),
+	); err != nil {
+		return nil, fmt.Errorf("apply collection dimension labels: %w", err)
+	}
+
+	return flameData, nil
 }

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+)
+
+func TestApplyCollectionDimensionLabelsUsesProfilerContext(t *testing.T) {
+	data, err := profiler.ParseTree(
+		time.Unix(1, 0),
+		profiler.ProfileTypeCpuSample,
+		[]*profiler.TreeItem{{Stack: [][]byte{[]byte("work")}, Value: 1}},
+		&profiler.ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	got, err := applyCollectionDimensionLabels(&profctx.ProfilerContext{
+		PIDs:        []int{42},
+		ThreadGroup: true,
+	}, data)
+	if err != nil {
+		t.Fatalf("applyCollectionDimensionLabels() error = %v", err)
+	}
+	if got.Labels[profiler.LabelProfilingScope] != "thread_group" {
+		t.Fatalf("profiling_scope = %q, want thread_group", got.Labels[profiler.LabelProfilingScope])
+	}
+	if got.Labels[profiler.LabelTGID] != "42" {
+		t.Fatalf("tgid = %q, want 42", got.Labels[profiler.LabelTGID])
+	}
+	if len(got.Profile.Sample) != 1 ||
+		len(got.Profile.Sample[0].Label) != len(got.Labels) {
+		t.Fatalf("sample labels = %#v, profile labels = %#v", got.Profile.Sample, got.Labels)
+	}
+}

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/output"
@@ -46,6 +47,7 @@ type ProfilerContext struct {
 	AggrInterval         int
 	IsOneShotAgg         bool
 	CPUIDs               []int
+	LockWaitThreshold    time.Duration
 
 	ServerAddress             string
 	OutputFormat              output.OutputFormat
@@ -59,6 +61,8 @@ type ProfilerContext struct {
 	LogBpfDebug               bool
 	MemoryMode                profiling.MemoryMode
 	PhysicalMemoryProbability uint
+	LockMode                  profiling.LockMode
+	LockType                  profiling.LockType
 
 	TracerID string
 
@@ -155,6 +159,7 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 		MaxProfilerProcesses: cliCtx.Int("max-concurrent-procs"),
 		AggrInterval:         cliCtx.Int("aggr-interval"),
 		CPUIDs:               cpuIDs,
+		LockWaitThreshold:    cliCtx.Duration("lock-wait-threshold"),
 
 		ServerAddress:             cliCtx.String("huatuo-api-address"),
 		Type:                      typ,
@@ -168,6 +173,8 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 		OutputFormat:              outputFormat,
 		MemoryMode:                mode,
 		PhysicalMemoryProbability: cliCtx.Uint("physical-memory-probability"),
+		LockMode:                  lockModeForType(typ),
+		LockType:                  lockTypeForType(typ),
 
 		TracerID: cliCtx.String("tracer-id"),
 
@@ -175,6 +182,20 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 	}
 	succeeded = true
 	return profilerContext, nil
+}
+
+func lockModeForType(typ profiling.Type) profiling.LockMode {
+	if typ == profiling.TypeLock {
+		return profiling.LockModeWaitTime
+	}
+	return profiling.LockModeUnknown
+}
+
+func lockTypeForType(typ profiling.Type) profiling.LockType {
+	if typ == profiling.TypeLock {
+		return profiling.LockTypeMutex
+	}
+	return profiling.LockTypeUnknown
 }
 
 func initToolstreamClient(cliCtx *cli.Context, format output.OutputFormat) (*toolstream.Client, error) {

--- a/internal/profiler/context/labels.go
+++ b/internal/profiler/context/labels.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+const (
+	profilingScopeHost        = "host"
+	profilingScopeContainer   = "container"
+	profilingScopePID         = "pid"
+	profilingScopeThreadGroup = "thread_group"
+)
+
+// CollectionDimensionLabels describes the filters that produced a profile.
+func (pctx *ProfilerContext) CollectionDimensionLabels() map[string]string {
+	if pctx == nil {
+		return nil
+	}
+
+	labels := map[string]string{
+		profiler.LabelProfilingScope: profilingScopeHost,
+	}
+	if pctx.ContainerID != "" {
+		labels[profiler.LabelProfilingScope] = profilingScopeContainer
+		labels[profiler.LabelContainerID] = pctx.ContainerID
+	} else if len(pctx.PIDs) > 0 {
+		label := profiler.LabelPID
+		labels[profiler.LabelProfilingScope] = profilingScopePID
+		if pctx.ThreadGroup {
+			label = profiler.LabelTGID
+			labels[profiler.LabelProfilingScope] = profilingScopeThreadGroup
+		}
+		labels[label] = formatDimensionInts(pctx.PIDs)
+	}
+	if len(pctx.CPUIDs) > 0 {
+		labels[profiler.LabelCPU] = formatDimensionInts(pctx.CPUIDs)
+	}
+
+	return labels
+}
+
+func formatDimensionInts(values []int) string {
+	values = append([]int(nil), values...)
+	sort.Ints(values)
+
+	var result strings.Builder
+	for i, value := range values {
+		if i > 0 {
+			result.WriteByte(',')
+		}
+		result.WriteString(strconv.Itoa(value))
+	}
+	return result.String()
+}

--- a/internal/profiler/context/labels_test.go
+++ b/internal/profiler/context/labels_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"reflect"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+func TestCollectionDimensionLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		pctx *ProfilerContext
+		want map[string]string
+	}{
+		{
+			name: "host",
+			pctx: &ProfilerContext{},
+			want: map[string]string{profiler.LabelProfilingScope: profilingScopeHost},
+		},
+		{
+			name: "exact pid and CPUs",
+			pctx: &ProfilerContext{PIDs: []int{42}, CPUIDs: []int{3, 1}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42",
+				profiler.LabelCPU:            "1,3",
+			},
+		},
+		{
+			name: "thread group",
+			pctx: &ProfilerContext{PIDs: []int{42}, ThreadGroup: true},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeThreadGroup,
+				profiler.LabelTGID:           "42",
+			},
+		},
+		{
+			name: "container",
+			pctx: &ProfilerContext{ContainerID: "containerd://abc"},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeContainer,
+				profiler.LabelContainerID:    "containerd://abc",
+			},
+		},
+		{
+			name: "multiple external profiler targets",
+			pctx: &ProfilerContext{PIDs: []int{42, 99}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42,99",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.pctx.CollectionDimensionLabels(); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("CollectionDimensionLabels() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var (
+	collectionDimensionLabels = [...]string{
+		LabelProfilingScope,
+		LabelCPU,
+		LabelPID,
+		LabelTGID,
+		LabelContainerID,
+	}
+	labelNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+)
+
+// CollectionDimensionLabelNames returns labels managed by collection filters.
+func CollectionDimensionLabelNames() []string {
+	labels := make([]string, len(collectionDimensionLabels))
+	copy(labels, collectionDimensionLabels[:])
+	return labels
+}
+
+// IsCollectionDimensionLabel reports whether name is managed by the profiler.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}
+
+// ApplyLabels injects profile-wide string labels into every pprof sample.
+func ApplyLabels(data *ProfileData, labels map[string]string) error {
+	if data == nil || len(labels) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		if value == "" {
+			continue
+		}
+		if !labelNamePattern.MatchString(key) {
+			return fmt.Errorf("invalid profiling label name %q", key)
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	sort.Strings(keys)
+
+	if len(data.Profile.StringTable) == 0 {
+		data.Profile.StringTable = append(data.Profile.StringTable, "")
+	} else if data.Profile.StringTable[0] != "" {
+		return fmt.Errorf("invalid pprof string table: first entry must be empty")
+	}
+
+	if data.Labels == nil {
+		data.Labels = make(map[string]string, len(keys))
+	}
+	for _, key := range keys {
+		data.Labels[key] = labels[key]
+	}
+
+	stringIndexes := make(map[string]int64, len(data.Profile.StringTable)+len(keys)*2)
+	for i, value := range data.Profile.StringTable {
+		stringIndexes[value] = int64(i)
+	}
+	stringIndex := func(value string) int64 {
+		if index, ok := stringIndexes[value]; ok {
+			return index
+		}
+		index := int64(len(data.Profile.StringTable))
+		data.Profile.StringTable = append(data.Profile.StringTable, value)
+		stringIndexes[value] = index
+		return index
+	}
+
+	keyNames := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keyNames[key] = struct{}{}
+		stringIndex(key)
+	}
+	keyIndexes := make(map[int64]struct{}, len(keys))
+	for index, value := range data.Profile.StringTable {
+		if _, replaced := keyNames[value]; replaced {
+			keyIndexes[int64(index)] = struct{}{}
+		}
+	}
+
+	for _, sample := range data.Profile.Sample {
+		if sample == nil {
+			continue
+		}
+
+		kept := sample.Label[:0]
+		for _, label := range sample.Label {
+			if label == nil {
+				continue
+			}
+			if _, replaced := keyIndexes[label.Key]; !replaced {
+				kept = append(kept, label)
+			}
+		}
+		sample.Label = kept
+		for _, key := range keys {
+			sample.Label = append(sample.Label, &ptree.Label{
+				Key: stringIndex(key),
+				Str: stringIndex(labels[key]),
+			})
+		}
+		sort.Slice(sample.Label, func(i, j int) bool {
+			if sample.Label[i].Key != sample.Label[j].Key {
+				return sample.Label[i].Key < sample.Label[j].Key
+			}
+			return sample.Label[i].Str < sample.Label[j].Str
+		})
+	}
+
+	return nil
+}

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestApplyLabelsInjectsAndReplacesPprofLabels(t *testing.T) {
+	data, err := ParseTree(time.Unix(1, 0), ProfileTypeCpuSample, []*TreeItem{
+		{
+			Stack: [][]byte{[]byte("process"), []byte("work")},
+			Value: 1,
+		},
+		{
+			Stack: [][]byte{[]byte("process"), []byte("wait")},
+			Value: 2,
+		},
+	}, &ParseOption{SampleRate: 99})
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	if err := ApplyLabels(data, map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "4242",
+	}); err != nil {
+		t.Fatalf("ApplyLabels() error = %v", err)
+	}
+	if err := ApplyLabels(data, map[string]string{LabelTGID: "5252"}); err != nil {
+		t.Fatalf("ApplyLabels() replacement error = %v", err)
+	}
+
+	if got, want := data.Labels, map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "5252",
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("profile labels = %#v, want %#v", got, want)
+	}
+	if len(data.Profile.Sample) != 2 {
+		t.Fatalf("samples = %d, want 2", len(data.Profile.Sample))
+	}
+
+	for _, sample := range data.Profile.Sample {
+		resolved := make(map[string]string)
+		for _, label := range sample.Label {
+			resolved[data.Profile.StringTable[label.Key]] = data.Profile.StringTable[label.Str]
+		}
+		if !reflect.DeepEqual(resolved, data.Labels) {
+			t.Fatalf("pprof labels = %#v, want %#v", resolved, data.Labels)
+		}
+		if got := len(sample.Label); got != len(resolved) {
+			t.Fatalf("pprof label entries = %d, unique labels = %d", got, len(resolved))
+		}
+	}
+}
+
+func TestApplyLabelsValidatesBeforeMutation(t *testing.T) {
+	data := &ProfileData{}
+	err := ApplyLabels(data, map[string]string{
+		LabelPID:   "42",
+		"bad-name": "value",
+	})
+	if err == nil {
+		t.Fatal("ApplyLabels() error = nil, want invalid label error")
+	}
+	if data.Labels != nil || len(data.Profile.StringTable) != 0 {
+		t.Fatalf("profile mutated after validation error: %#v", data)
+	}
+}
+
+func TestApplyLabelsRejectsMalformedStringTable(t *testing.T) {
+	data := &ProfileData{}
+	data.Profile.StringTable = []string{"not-empty"}
+
+	err := ApplyLabels(data, map[string]string{LabelPID: "42"})
+	if err == nil {
+		t.Fatal("ApplyLabels() error = nil, want malformed string table error")
+	}
+	if data.Labels != nil || len(data.Profile.StringTable) != 1 {
+		t.Fatalf("profile mutated after string table error: %#v", data)
+	}
+}
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	labels := CollectionDimensionLabelNames()
+	labels[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 
 	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -111,8 +112,15 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 		}
 	}
 
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
+	if filter.ID == "" &&
+		filter.Hostname == "" &&
+		filter.ContainerID == "" &&
+		filter.ContainerHostname == "" &&
+		len(filter.Labels) == 0 {
+		return nil, fmt.Errorf(
+			"%w: id, hostname, container, or collection dimension must be specified",
+			ErrInvalidQuery,
+		)
 	}
 
 	// search
@@ -242,7 +250,13 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:
-		return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		if !profiler.IsCollectionDimensionLabel(matcher.Name) {
+			return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		}
+		if filter.Labels == nil {
+			filter.Labels = make(map[string]string)
+		}
+		filter.Labels[matcher.Name] = matcher.Value
 	}
 	return nil
 }
@@ -300,8 +314,25 @@ func (s *Service) ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesR
 //	request: typesv1.LabelNamesRequest
 //	response: typesv1.LabelNamesResponse
 func (s *Service) LabelNames(context.Context, *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error) {
+	names := []string{
+		"region",
+		"hostname",
+		"container_id",
+		"container_hostname",
+		"container_host_namespace",
+	}
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		seen[name] = struct{}{}
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		names = append(names, name)
+	}
 	response := &typesv1.LabelNamesResponse{
-		Names: []string{"region", "hostname", "container_id", "container_hostname", "container_host_namespace"},
+		Names: names,
 	}
 	return response, nil
 }

--- a/internal/profiler/service/flamegraph_test.go
+++ b/internal/profiler/service/flamegraph_test.go
@@ -17,6 +17,10 @@ package service
 import (
 	"strings"
 	"testing"
+
+	"huatuo-bamai/internal/profiler"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 func TestServiceReadyRejectsUninitializedStorage(t *testing.T) {
@@ -42,5 +46,33 @@ func TestBuildProfileSearchQueryIncludesPage(t *testing.T) {
 	query := buildProfileSearchQuery(&SearchFilter{TracerID: "task-2026", Limit: 25, Offset: 50})
 	if query.Limit != 25 || query.Offset != 50 {
 		t.Fatalf("query page=(%d,%d), want (25,50)", query.Limit, query.Offset)
+	}
+}
+
+func TestApplyProfileMatcherAcceptsCollectionDimensions(t *testing.T) {
+	filter := &SearchFilter{}
+	matcher := labels.MustNewMatcher(labels.MatchEqual, profiler.LabelTGID, "4242")
+
+	if err := applyProfileMatcher(filter, matcher); err != nil {
+		t.Fatalf("applyProfileMatcher() error = %v", err)
+	}
+	if got := filter.Labels[profiler.LabelTGID]; got != "4242" {
+		t.Fatalf("tgid matcher = %q, want 4242", got)
+	}
+}
+
+func TestLabelNamesIncludesCollectionDimensions(t *testing.T) {
+	response, err := (&Service{}).LabelNames(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("LabelNames() error = %v", err)
+	}
+	names := make(map[string]struct{}, len(response.Names))
+	for _, name := range response.Names {
+		names[name] = struct{}{}
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if _, ok := names[name]; !ok {
+			t.Errorf("LabelNames() missing %q", name)
+		}
 	}
 }

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/timeutil"
 	"huatuo-bamai/internal/storage"
 	"huatuo-bamai/internal/storage/driver"
@@ -74,6 +75,7 @@ type ProfileDocument struct {
 	TracerData struct {
 		Flamedata struct {
 			ProfileType string            `json:"profile_type,omitempty"`
+			Labels      map[string]string `json:"labels,omitempty"`
 			Profile     profilev1.Profile `json:"profile,omitempty"`
 		} `json:"flamedata,omitempty"`
 		// others
@@ -90,6 +92,7 @@ type SearchFilter struct {
 	StartTime         time.Time
 	EndTime           time.Time
 	ProfileType       string
+	Labels            map[string]string
 	Limit             int
 	Offset            int
 }
@@ -214,7 +217,7 @@ func (profileDocumentMapper) Decode(data []byte) (*ProfileDocument, error) {
 }
 
 func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, error) {
-	return map[string]any{
+	fields := map[string]any{
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
@@ -229,11 +232,20 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldTracerTime:        parseProfileDocumentTime(document.TracerTime, document.UploadedTime),
 		profileFieldTracerType:        document.TracerRunType,
 		profileFieldProfileType:       document.TracerData.Flamedata.ProfileType,
-	}, nil
+	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label == profiler.LabelContainerID {
+			continue
+		}
+		if value := document.TracerData.Flamedata.Labels[label]; value != "" {
+			fields[profileLabelField(label)] = value
+		}
+	}
+	return fields, nil
 }
 
 func (profileDocumentMapper) Indexes() []driver.Index {
-	return []driver.Index{
+	indexes := []driver.Index{
 		{Field: profileFieldTracerID},
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
@@ -249,6 +261,12 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldTracerType},
 		{Field: profileFieldProfileType},
 	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label != profiler.LabelContainerID {
+			indexes = append(indexes, driver.Index{Field: profileLabelField(label)})
+		}
+	}
+	return indexes
 }
 
 func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
@@ -335,11 +353,29 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Value: filter.ProfileType,
 		})
 	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name == profiler.LabelContainerID {
+			continue
+		}
+		if value := filter.Labels[name]; value != "" {
+			query.Filters = append(query.Filters, driver.Filter{
+				Field: profileLabelKeywordField(name),
+				Op:    driver.OpEq,
+				Value: value,
+			})
+		}
+	}
 
 	return query
 }
 
 func normalizeProfileAggregationField(field string) (string, error) {
+	if profiler.IsCollectionDimensionLabel(field) {
+		if field == profiler.LabelContainerID {
+			return profileFieldContainerID + ".keyword", nil
+		}
+		return profileLabelKeywordField(field), nil
+	}
 	switch field {
 	case "id":
 		return profileFieldTracerID, nil
@@ -358,6 +394,14 @@ func normalizeProfileAggregationField(field string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}
+}
+
+func profileLabelField(name string) string {
+	return "tracer_data.flamedata.labels." + name
+}
+
+func profileLabelKeywordField(name string) string {
+	return profileLabelField(name) + ".keyword"
 }
 
 func normalizeProfileSearchLimit(filter *SearchFilter) int {

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/storage/driver"
 )
 
@@ -56,5 +57,78 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 
 	if !reflect.DeepEqual(query.Filters, want) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestProfileDocumentMapperIndexesCollectionDimensions(t *testing.T) {
+	document := &ProfileDocument{}
+	document.ContainerID = "containerd://abc"
+	document.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelTGID:           "4242",
+		profiler.LabelContainerID:    document.ContainerID,
+	}
+
+	fields, err := (profileDocumentMapper{}).Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
+	if got := fields[profileLabelField(profiler.LabelProfilingScope)]; got != "thread_group" {
+		t.Fatalf("profiling_scope field = %v, want thread_group", got)
+	}
+	if got := fields[profileLabelField(profiler.LabelTGID)]; got != "4242" {
+		t.Fatalf("tgid field = %v, want 4242", got)
+	}
+	if _, duplicated := fields[profileLabelField(profiler.LabelContainerID)]; duplicated {
+		t.Fatal("container_id duplicated under profile labels")
+	}
+}
+
+func TestBuildProfileAggregationQueryAddsDimensionMatchers(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		ContainerID: "containerd://abc",
+		Labels: map[string]string{
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelTGID:           "4242",
+			"unmanaged":                  "ignored",
+		},
+	})
+	want := []driver.Filter{
+		{
+			Field: profileFieldContainerID + ".keyword",
+			Op:    driver.OpEq,
+			Value: "containerd://abc",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelProfilingScope),
+			Op:    driver.OpEq,
+			Value: "thread_group",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelTGID),
+			Op:    driver.OpEq,
+			Value: "4242",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldSupportsDimensions(t *testing.T) {
+	tests := map[string]string{
+		profiler.LabelPID:         profileLabelKeywordField(profiler.LabelPID),
+		profiler.LabelTGID:        profileLabelKeywordField(profiler.LabelTGID),
+		profiler.LabelContainerID: profileFieldContainerID + ".keyword",
+	}
+	for input, want := range tests {
+		got, err := normalizeProfileAggregationField(input)
+		if err != nil {
+			t.Fatalf("normalizeProfileAggregationField(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("normalizeProfileAggregationField(%q) = %q, want %q", input, got, want)
+		}
 	}
 }

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -36,6 +36,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels are mirrored into pprof samples and indexed for label queries.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends

--- a/pkg/profiling/capability.go
+++ b/pkg/profiling/capability.go
@@ -88,7 +88,7 @@ func newNativeCapability(language Language) capability {
 	return capability{
 		Language:       language,
 		Implementation: ImplementationNative,
-		Types:          []Type{TypeCPU, TypeMemory},
+		Types:          []Type{TypeCPU, TypeMemory, TypeLock},
 		MemoryModes: []MemoryMode{
 			MemoryModeVirtualAlloc,
 			MemoryModePhysicalAlloc,
@@ -99,10 +99,13 @@ func newNativeCapability(language Language) capability {
 
 func ParseType(value string) (Type, error) {
 	typ := Type(value)
-	if typ == TypeCPU || typ == TypeMemory {
+	if typ == TypeCPU || typ == TypeMemory || typ == TypeLock {
 		return typ, nil
 	}
-	return TypeUnknown, fmt.Errorf("unsupported profiling type %q (expected: cpu or memory)", value)
+	return TypeUnknown, fmt.Errorf(
+		"unsupported profiling type %q (expected: cpu, memory, or lock)",
+		value,
+	)
 }
 
 func ParseLanguage(value string) (Language, error) {

--- a/pkg/profiling/capability_test.go
+++ b/pkg/profiling/capability_test.go
@@ -33,9 +33,9 @@ func TestCapabilities(t *testing.T) {
 		types          []Type
 		memoryModes    []MemoryMode
 	}{
-		{LanguageC, ImplementationNative, []Type{TypeCPU, TypeMemory}, nativeModes},
-		{LanguageCPP, ImplementationNative, []Type{TypeCPU, TypeMemory}, nativeModes},
-		{LanguageGo, ImplementationNative, []Type{TypeCPU, TypeMemory}, nativeModes},
+		{LanguageC, ImplementationNative, []Type{TypeCPU, TypeMemory, TypeLock}, nativeModes},
+		{LanguageCPP, ImplementationNative, []Type{TypeCPU, TypeMemory, TypeLock}, nativeModes},
+		{LanguageGo, ImplementationNative, []Type{TypeCPU, TypeMemory, TypeLock}, nativeModes},
 		{
 			LanguageJava,
 			ImplementationJava,
@@ -75,7 +75,7 @@ func TestCapabilities(t *testing.T) {
 		[]Language{LanguageC, LanguageCPP, LanguageGo, LanguageJava},
 		LanguagesFor(TypeMemory),
 	)
-	require.Empty(t, LanguagesFor(TypeLock))
+	require.Equal(t, []Language{LanguageC, LanguageCPP, LanguageGo}, LanguagesFor(TypeLock))
 }
 
 func TestMemoryModesForReturnsCopy(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCapabilityDefinitionsAreUnique(t *testing.T) {
 }
 
 func TestParsers(t *testing.T) {
-	for _, typ := range []Type{TypeCPU, TypeMemory} {
+	for _, typ := range []Type{TypeCPU, TypeMemory, TypeLock} {
 		parsed, err := ParseType(string(typ))
 		require.NoError(t, err)
 		require.Equal(t, typ, parsed)
@@ -128,7 +128,11 @@ func TestParsers(t *testing.T) {
 
 func TestParseTypeRejectsLegacyMemoryValue(t *testing.T) {
 	_, err := ParseType("mem")
-	require.EqualError(t, err, `unsupported profiling type "mem" (expected: cpu or memory)`)
+	require.EqualError(
+		t,
+		err,
+		`unsupported profiling type "mem" (expected: cpu, memory, or lock)`,
+	)
 }
 
 func allMemoryModes() []MemoryMode {

--- a/pkg/profiling/lock.go
+++ b/pkg/profiling/lock.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+// LockMode identifies the value represented by a lock profile.
+type LockMode string
+
+const (
+	LockModeUnknown  LockMode = ""
+	LockModeWaitTime LockMode = "wait_time"
+)
+
+// LockType identifies the kernel lock primitive being profiled.
+type LockType string
+
+const (
+	LockTypeUnknown LockType = ""
+	LockTypeMutex   LockType = "mutex"
+)


### PR DESCRIPTION
## Summary

- profile contended mutex wait time and event counts
- restrict collection to explicit PID or container targets
- apply the lock wait threshold before aggregation
- expose mutex jobs through the profiling task pipeline

## Dependencies

This PR is stacked on #449.

## Testing

- make bpf-build
- make build
- targeted profiler and profiling API unit/race tests
- runtime validation on Ubuntu 22.04 with Linux 5.15
- make check

Part of #329.