### PR TITLE
feat(autotracing): persist CPU profiles

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -250,7 +250,12 @@ func runPerf(parent context.Context, containerId string, timeOut int64) ([]byte,
 	return cmd.CombinedOutput()
 }
 
-func buildAndSaveCPUIdleContainer(container *containerCPUInfo, threshold *cpuIdleThreshold, flamedata []byte) error {
+func buildAndSaveCPUIdleContainer(
+	container *containerCPUInfo,
+	duration time.Duration,
+	threshold *cpuIdleThreshold,
+	flamedata []byte,
+) error {
 	tracerData := CPUIdleTracingData{
 		NowUser:             container.nowUsagePercentage.user,
 		DeltaUser:           container.deltaUsagePercentage.user,
@@ -271,16 +276,13 @@ func buildAndSaveCPUIdleContainer(container *containerCPUInfo, threshold *cpuIdl
 	}
 
 	log.Debugf("cpuidle flamedata %v", tracerData.FlameData)
-	if err := tracing.Save(&tracing.WriteRequest{
+	return saveAutotracingCPUEvent(&tracing.WriteRequest{
 		TracerName:    "cpuidle",
 		ContainerID:   container.id,
 		TracerTime:    container.traceTime,
 		TracerData:    &tracerData,
 		TracerRunType: tracing.TracerRunTypeAutotracing,
-	}); err != nil {
-		log.Warnf("failed to save tracing data: %v", err)
-	}
-	return nil
+	}, duration, tracerData.FlameData)
 }
 
 type CPUIdleTracingData struct {
@@ -350,7 +352,14 @@ func (c *cpuIdleTracing) Start(ctx context.Context) error {
 				continue
 			}
 
-			_ = buildAndSaveCPUIdleContainer(container, threshold, flamedata)
+			if err := buildAndSaveCPUIdleContainer(
+				container,
+				time.Duration(perfRunTimeOut)*time.Second,
+				threshold,
+				flamedata,
+			); err != nil {
+				log.Warnf("failed to save cpuidle tracing data: %v", err)
+			}
 		}
 	}
 }

--- a/core/autotracing/cpusys.go
+++ b/core/autotracing/cpusys.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,7 +142,12 @@ func runPerfSystemWide(parent context.Context, timeOut int64) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-func (c *cpuSysTracing) buildAndSaveCPUSystem(traceTime time.Time, threshold *cpuSysThreshold, flamedata []byte) error {
+func (c *cpuSysTracing) buildAndSaveCPUSystem(
+	traceTime time.Time,
+	duration time.Duration,
+	threshold *cpuSysThreshold,
+	flamedata []byte,
+) error {
 	tracerData := CpuSysTracingData{
 		NowSys:            c.sysPercent,
 		SysThreshold:      threshold.usage,
@@ -155,15 +160,12 @@ func (c *cpuSysTracing) buildAndSaveCPUSystem(traceTime time.Time, threshold *cp
 	}
 
 	log.Debugf("cpuidle flamedata %v", tracerData.FlameData)
-	if err := tracing.Save(&tracing.WriteRequest{
+	return saveAutotracingCPUEvent(&tracing.WriteRequest{
 		TracerName:    "cpusys",
 		TracerTime:    traceTime,
 		TracerData:    &tracerData,
 		TracerRunType: tracing.TracerRunTypeAutotracing,
-	}); err != nil {
-		log.Warnf("failed to save tracing data: %v", err)
-	}
-	return nil
+	}, duration, tracerData.FlameData)
 }
 
 func (c *cpuSysTracing) Start(ctx context.Context) error {
@@ -206,8 +208,13 @@ func (c *cpuSysTracing) Start(ctx context.Context) error {
 				continue
 			}
 
-			if err := c.buildAndSaveCPUSystem(traceTime, threshold, flamedata); err != nil {
-				return err
+			if err := c.buildAndSaveCPUSystem(
+				traceTime,
+				time.Duration(perfRunTimeOut)*time.Second,
+				threshold,
+				flamedata,
+			); err != nil {
+				log.Warnf("failed to save cpusys tracing data: %v", err)
 			}
 		}
 	}

--- a/core/autotracing/profile_store.go
+++ b/core/autotracing/profile_store.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/pkg/tracing"
+
+	"github.com/rs/xid"
+)
+
+const autotracingProfileSampleRate = 99
+
+func saveAutotracingCPUEvent(
+	request *tracing.WriteRequest,
+	duration time.Duration,
+	frames []flamegraph.FrameData,
+) error {
+	if request.TracerID == "" {
+		request.TracerID = xid.New().String()
+	}
+
+	tracingErr := tracing.Save(request)
+	profileData, profileErr := profiler.ParseFlamegraphFrames(
+		request.TracerTime,
+		duration,
+		profiler.ProfileTypeCpuSample,
+		frames,
+		&profiler.ParseOption{SampleRate: autotracingProfileSampleRate},
+	)
+	if profileErr == nil {
+		profileErr = tracing.SaveProfile(&tracing.WriteRequest{
+			TracerName:    request.TracerName,
+			TracerID:      request.TracerID,
+			ContainerID:   request.ContainerID,
+			TracerTime:    request.TracerTime,
+			TracerData:    &profctx.TracerData{FlameData: profileData},
+			TracerRunType: tracing.TracerRunTypeAutotracing,
+		})
+	}
+
+	return errors.Join(
+		wrapAutotracingSaveError("JSON event", tracingErr),
+		wrapAutotracingSaveError("pprof profile", profileErr),
+	)
+}
+
+func wrapAutotracingSaveError(target string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("save AutoTracing %s: %w", target, err)
+}

--- a/core/autotracing/profile_store_test.go
+++ b/core/autotracing/profile_store_test.go
@@ -1,0 +1,396 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/storage"
+	"huatuo-bamai/internal/storage/driver"
+	"huatuo-bamai/pkg/tracing"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestBuildAndSaveCPUSystemWritesJSONAndPprof(t *testing.T) {
+	tracingBackend := &captureProfileBackend{}
+	profileBackend := &captureProfileBackend{}
+	configureAutotracingStores(t, tracingBackend, profileBackend)
+
+	start := time.Unix(1700000000, 123).UTC()
+	duration := 10 * time.Second
+	rawFrames := []byte(`[
+		{"level":0,"value":5,"self":0,"label":"root"},
+		{"level":1,"value":5,"self":5,"label":"leaf"}
+	]`)
+	cpu := &cpuSysTracing{sysPercent: 70, sysPercentDelta: 25}
+	err := cpu.buildAndSaveCPUSystem(
+		start,
+		duration,
+		&cpuSysThreshold{usage: 45, delta: 20},
+		rawFrames,
+	)
+	if err != nil {
+		t.Fatalf("buildAndSaveCPUSystem returned error: %v", err)
+	}
+
+	if len(tracingBackend.records) != 1 {
+		t.Fatalf(
+			"tracing records = %d, want 1",
+			len(tracingBackend.records),
+		)
+	}
+	if len(profileBackend.records) != 1 {
+		t.Fatalf(
+			"profile records = %d, want 1",
+			len(profileBackend.records),
+		)
+	}
+
+	var event struct {
+		TracerID      string            `json:"tracer_id"`
+		TracerName    string            `json:"tracer_name"`
+		TracerRunType string            `json:"tracer_type"`
+		TracerData    CpuSysTracingData `json:"tracer_data"`
+	}
+	if err := json.Unmarshal(tracingBackend.records[0].Data, &event); err != nil {
+		t.Fatalf("decode tracing JSON: %v", err)
+	}
+	if event.TracerID == "" {
+		t.Fatal("tracing event has an empty tracer_id")
+	}
+	if event.TracerName != "cpusys" {
+		t.Errorf("tracer_name = %q, want cpusys", event.TracerName)
+	}
+	if event.TracerRunType != tracing.TracerRunTypeAutotracing {
+		t.Errorf(
+			"tracer_type = %q, want %q",
+			event.TracerRunType,
+			tracing.TracerRunTypeAutotracing,
+		)
+	}
+	if len(event.TracerData.FlameData) != 2 {
+		t.Fatalf(
+			"JSON flame frames = %d, want 2",
+			len(event.TracerData.FlameData),
+		)
+	}
+
+	profileRecord := profileBackend.records[0]
+	assertProfileField(t, profileRecord, "tracer_id", event.TracerID)
+	assertProfileField(t, profileRecord, "tracer_name", "cpusys")
+	assertProfileField(
+		t,
+		profileRecord,
+		"tracer_type",
+		tracing.TracerRunTypeAutotracing,
+	)
+	assertProfileField(
+		t,
+		profileRecord,
+		"profile_type",
+		profiler.ProfileTypeCpuSample,
+	)
+	assertProfileField(t, profileRecord, "hostname", "test-host")
+
+	if got := profileRecord.Fields["profile_start_time"]; got != start {
+		t.Errorf("profile_start_time = %v, want %v", got, start)
+	}
+	if got := profileRecord.Fields["profile_end_time"]; got != start.Add(duration) {
+		t.Errorf(
+			"profile_end_time = %v, want %v",
+			got,
+			start.Add(duration),
+		)
+	}
+
+	var profile ptree.Profile
+	if err := profile.UnmarshalVT(profileRecord.Data); err != nil {
+		t.Fatalf("decode pprof protobuf: %v", err)
+	}
+	if profile.TimeNanos != start.UnixNano() {
+		t.Errorf(
+			"profile TimeNanos = %d, want %d",
+			profile.TimeNanos,
+			start.UnixNano(),
+		)
+	}
+	if profile.DurationNanos != int64(duration) {
+		t.Errorf(
+			"profile DurationNanos = %d, want %d",
+			profile.DurationNanos,
+			duration,
+		)
+	}
+}
+
+func TestSaveAutotracingCPUEventPreservesOneSideOnFailure(t *testing.T) {
+	t.Run("JSON backend fails", func(t *testing.T) {
+		saveErr := errors.New("JSON backend unavailable")
+		tracingBackend := &captureProfileBackend{saveErr: saveErr}
+		profileBackend := &captureProfileBackend{}
+		configureAutotracingStores(t, tracingBackend, profileBackend)
+
+		err := saveAutotracingCPUEvent(
+			&tracing.WriteRequest{
+				TracerName:    "cpusys",
+				TracerTime:    time.Unix(1700000000, 0).UTC(),
+				TracerData:    map[string]any{"flamedata": "preserved"},
+				TracerRunType: tracing.TracerRunTypeAutotracing,
+			},
+			time.Second,
+			validAutotracingFrames(),
+		)
+		if !errors.Is(err, saveErr) {
+			t.Fatalf("error = %v, want JSON backend error", err)
+		}
+		if len(profileBackend.records) != 1 {
+			t.Fatalf(
+				"profile records = %d, want 1 after JSON failure",
+				len(profileBackend.records),
+			)
+		}
+	})
+
+	t.Run("pprof conversion fails", func(t *testing.T) {
+		tracingBackend := &captureProfileBackend{}
+		profileBackend := &captureProfileBackend{}
+		configureAutotracingStores(t, tracingBackend, profileBackend)
+
+		err := saveAutotracingCPUEvent(
+			&tracing.WriteRequest{
+				TracerName:    "cpusys",
+				TracerTime:    time.Unix(1700000000, 0).UTC(),
+				TracerData:    map[string]any{"flamedata": "preserved"},
+				TracerRunType: tracing.TracerRunTypeAutotracing,
+			},
+			time.Second,
+			[]flamegraph.FrameData{
+				{Level: 0, Value: 1, Self: -1, Label: "invalid"},
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "self value") {
+			t.Fatalf("error = %v, want negative self error", err)
+		}
+		if len(tracingBackend.records) != 1 {
+			t.Fatalf(
+				"tracing records = %d, want 1 after conversion failure",
+				len(tracingBackend.records),
+			)
+		}
+		if len(profileBackend.records) != 0 {
+			t.Fatalf(
+				"profile records = %d, want 0 for invalid profile",
+				len(profileBackend.records),
+			)
+		}
+	})
+
+	t.Run("pprof backend fails", func(t *testing.T) {
+		saveErr := errors.New("pprof backend unavailable")
+		tracingBackend := &captureProfileBackend{}
+		profileBackend := &captureProfileBackend{saveErr: saveErr}
+		configureAutotracingStores(t, tracingBackend, profileBackend)
+
+		err := saveAutotracingCPUEvent(
+			&tracing.WriteRequest{
+				TracerName:    "cpusys",
+				TracerTime:    time.Unix(1700000000, 0).UTC(),
+				TracerData:    map[string]any{"flamedata": "preserved"},
+				TracerRunType: tracing.TracerRunTypeAutotracing,
+			},
+			time.Second,
+			validAutotracingFrames(),
+		)
+		if !errors.Is(err, saveErr) {
+			t.Fatalf("error = %v, want pprof backend error", err)
+		}
+		if len(tracingBackend.records) != 1 {
+			t.Fatalf(
+				"tracing records = %d, want 1 after pprof failure",
+				len(tracingBackend.records),
+			)
+		}
+	})
+}
+
+func configureAutotracingStores(
+	t *testing.T,
+	tracingBackend *captureProfileBackend,
+	profileBackend *captureProfileBackend,
+) {
+	t.Helper()
+	tracingStore, err := storage.NewStore[*tracing.Document](
+		context.Background(),
+		"capture-json",
+		tracingBackend,
+		tracing.DocumentCollection,
+		tracing.DocumentStoreMapper{},
+	)
+	if err != nil {
+		t.Fatalf("new tracing store: %v", err)
+	}
+	profileStore, err := storage.NewStore[*tracing.Document](
+		context.Background(),
+		"capture-pprof",
+		profileBackend,
+		profiler.MetadataCollection,
+		captureProfileMapper{},
+	)
+	if err != nil {
+		t.Fatalf("new profile store: %v", err)
+	}
+	options := tracing.DocumentOptions{Hostname: "test-host", Region: "test"}
+	tracing.SetTracingStore(
+		[]*storage.Store[*tracing.Document]{tracingStore},
+		options,
+	)
+	tracing.SetProfileStore(
+		[]*storage.Store[*tracing.Document]{profileStore},
+		options,
+	)
+	t.Cleanup(func() {
+		tracing.SetTracingStore(nil, tracing.DocumentOptions{})
+		tracing.SetProfileStore(nil, tracing.DocumentOptions{})
+	})
+}
+
+func validAutotracingFrames() []flamegraph.FrameData {
+	return []flamegraph.FrameData{
+		{Level: 0, Value: 1, Self: 1, Label: "root"},
+	}
+}
+
+func assertProfileField(
+	t *testing.T,
+	record driver.Record,
+	field string,
+	want string,
+) {
+	t.Helper()
+	if got := record.Fields[field]; got != want {
+		t.Errorf("%s = %v, want %q", field, got, want)
+	}
+}
+
+type captureProfileMapper struct {
+	tracing.ProfileDocumentStoreMapper
+}
+
+func (captureProfileMapper) Encode(document *tracing.Document) ([]byte, error) {
+	data, err := captureProfileData(document)
+	if err != nil {
+		return nil, err
+	}
+	return data.Profile.MarshalVT()
+}
+
+func (captureProfileMapper) Fields(
+	document *tracing.Document,
+) (map[string]any, error) {
+	fields, err := (tracing.ProfileDocumentStoreMapper{}).Fields(document)
+	if err != nil {
+		return nil, err
+	}
+	data, err := captureProfileData(document)
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Unix(0, data.Profile.TimeNanos).UTC()
+	fields["profile_type"] = data.ProfileType
+	fields["profile_start_time"] = start
+	fields["profile_end_time"] = start.Add(
+		time.Duration(data.Profile.DurationNanos),
+	)
+	return fields, nil
+}
+
+func captureProfileData(
+	document *tracing.Document,
+) (*profiler.ProfileData, error) {
+	data, ok := document.TracerData.(*profctx.TracerData)
+	if !ok || data == nil || data.FlameData == nil {
+		return nil, errors.New("capture profile mapper: profile data is missing")
+	}
+	return data.FlameData, nil
+}
+
+type captureProfileBackend struct {
+	records []driver.Record
+	saveErr error
+}
+
+func (*captureProfileBackend) Init(
+	context.Context,
+	string,
+	[]driver.Index,
+) error {
+	return nil
+}
+
+func (b *captureProfileBackend) Save(
+	_ context.Context,
+	record driver.Record,
+) error {
+	b.records = append(b.records, record)
+	return b.saveErr
+}
+
+func (*captureProfileBackend) Get(
+	context.Context,
+	string,
+) (driver.Record, error) {
+	return driver.Record{}, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Delete(context.Context, string) error {
+	return driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Query(
+	context.Context,
+	driver.Query,
+) ([]driver.Record, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Count(
+	context.Context,
+	driver.Query,
+) (int64, error) {
+	return 0, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Values(
+	context.Context,
+	string,
+	driver.Query,
+	int,
+) ([]string, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Close(context.Context) error {
+	return nil
+}

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -216,6 +216,10 @@ BlackList = ["netdev_hw", "metax_gpu"]
 
 The automatic tracing module is one of HUATUO’s intelligent features. It triggers specific performance tracing based on thresholds, reducing manual intervention.
 
+CPUIdle and CPUSys traces keep their existing JSON event and also write a CPU
+pprof profile with the same tracer ID. The profile uses `cpu:nanoseconds`
+samples at 99 Hz. Profile storage failures do not discard the JSON event.
+
 #### 6.1 CPUIdle Automatic Tracing — Sudden High CPU Usage in Containers
 
 ```bash

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -213,6 +213,10 @@ BlackList = ["netdev_hw", "metax_gpu"]
 
 自动追踪模块是 HUATUO 的智能特性之一，可根据阈值自动触发特定性能追踪，减少人工干预。
 
+CPUIdle 和 CPUSys 会保留原有 JSON 事件，并使用相同的 tracer ID 额外写入
+CPU pprof。该 profile 以 99 Hz 采样，样本单位为 `cpu:nanoseconds`。
+profile 存储失败不会丢弃 JSON 事件。
+
 #### 6.1 CPUIdle 自动追踪 — 容器突发高 CPU 使用场景
 
 ```bash

--- a/internal/profiler/flamegraph.go
+++ b/internal/profiler/flamegraph.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+)
+
+// ParseFlamegraphFrames converts depth-first nested flame graph frames into a
+// pprof profile. Only self values are samples because value is the aggregate
+// width of a frame and would otherwise count child samples twice.
+func ParseFlamegraphFrames(
+	startTime time.Time,
+	duration time.Duration,
+	profileType string,
+	frames []flamegraph.FrameData,
+	opt *ParseOption,
+) (*ProfileData, error) {
+	if startTime.IsZero() {
+		return nil, fmt.Errorf("flame graph start time is zero")
+	}
+	if duration <= 0 {
+		return nil, fmt.Errorf("flame graph duration must be positive")
+	}
+	if profileType == ProfileTypeCpuSample &&
+		(opt == nil || opt.SampleRate <= 0) {
+		return nil, fmt.Errorf("CPU flame graph sample rate must be positive")
+	}
+
+	stack := make([][]byte, 0, 32)
+	tree := make([]*TreeItem, 0, len(frames))
+	for i, frame := range frames {
+		if frame.Level < 0 || frame.Level > int64(len(stack)) {
+			return nil, fmt.Errorf(
+				"frame %d: invalid level %d for stack depth %d",
+				i,
+				frame.Level,
+				len(stack),
+			)
+		}
+		if frame.Value < 0 {
+			return nil, fmt.Errorf(
+				"frame %d: aggregate value must not be negative",
+				i,
+			)
+		}
+		if frame.Self < 0 {
+			return nil, fmt.Errorf(
+				"frame %d: self value must not be negative",
+				i,
+			)
+		}
+		if frame.Self > frame.Value {
+			return nil, fmt.Errorf(
+				"frame %d: self value %d exceeds aggregate value %d",
+				i,
+				frame.Self,
+				frame.Value,
+			)
+		}
+
+		stack = stack[:int(frame.Level)]
+		label := frame.Label
+		if label == "" {
+			label = "(unknown)"
+		}
+		stack = append(stack, []byte(label))
+		if frame.Self == 0 {
+			continue
+		}
+
+		itemStack := make([][]byte, len(stack))
+		for j := range stack {
+			itemStack[j] = append([]byte(nil), stack[j]...)
+		}
+		tree = append(tree, &TreeItem{
+			Stack: itemStack,
+			Value: uint64(frame.Self),
+		})
+	}
+
+	if len(tree) == 0 {
+		return nil, fmt.Errorf("flame graph has no positive self samples")
+	}
+
+	profile, err := ParseTree(startTime, profileType, tree, opt)
+	if err != nil {
+		return nil, err
+	}
+	profile.Profile.DurationNanos = int64(duration)
+	return profile, nil
+}

--- a/internal/profiler/flamegraph_test.go
+++ b/internal/profiler/flamegraph_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestParseFlamegraphFramesBuildsCPUProfile(t *testing.T) {
+	start := time.Unix(1700000000, 123).UTC()
+	duration := 10 * time.Second
+	profileData, err := ParseFlamegraphFrames(
+		start,
+		duration,
+		ProfileTypeCpuSample,
+		[]flamegraph.FrameData{
+			{Level: 0, Value: 5, Label: "root"},
+			{Level: 1, Value: 3, Self: 3, Label: "left"},
+			{Level: 1, Value: 2, Self: 2, Label: "right"},
+		},
+		&ParseOption{SampleRate: 100},
+	)
+	if err != nil {
+		t.Fatalf("ParseFlamegraphFrames returned error: %v", err)
+	}
+
+	profile := &profileData.Profile
+	if profileData.ProfileType != ProfileTypeCpuSample {
+		t.Errorf(
+			"ProfileType = %q, want %q",
+			profileData.ProfileType,
+			ProfileTypeCpuSample,
+		)
+	}
+	if got := profile.TimeNanos; got != start.UnixNano() {
+		t.Errorf("TimeNanos = %d, want %d", got, start.UnixNano())
+	}
+	if got := time.Duration(profile.DurationNanos); got != duration {
+		t.Errorf("DurationNanos = %s, want %s", got, duration)
+	}
+	if got := time.Duration(profile.Period); got != 10*time.Millisecond {
+		t.Errorf("Period = %s, want %s", got, 10*time.Millisecond)
+	}
+	if len(profile.Sample) != 2 {
+		t.Fatalf("samples = %d, want 2", len(profile.Sample))
+	}
+
+	assertValueType(
+		t,
+		profile.StringTable,
+		profile.SampleType[0],
+		"cpu",
+		"nanoseconds",
+	)
+	assertValueType(
+		t,
+		profile.StringTable,
+		profile.PeriodType,
+		"cpu",
+		"nanoseconds",
+	)
+
+	var total int64
+	for _, sample := range profile.Sample {
+		if len(sample.Value) != 1 {
+			t.Fatalf("sample values = %v, want one value", sample.Value)
+		}
+		total += sample.Value[0]
+	}
+	if want := int64(50 * time.Millisecond); total != want {
+		t.Errorf("sample total = %d, want %d", total, want)
+	}
+}
+
+func TestParseFlamegraphFramesRejectsInvalidInput(t *testing.T) {
+	start := time.Unix(1700000000, 0).UTC()
+	valid := []flamegraph.FrameData{
+		{Level: 0, Value: 1, Self: 1, Label: "root"},
+	}
+	tests := []struct {
+		name     string
+		start    time.Time
+		duration time.Duration
+		frames   []flamegraph.FrameData
+		opt      *ParseOption
+		wantErr  string
+	}{
+		{
+			name:     "zero timestamp",
+			duration: time.Second,
+			frames:   valid,
+			opt:      &ParseOption{SampleRate: 99},
+			wantErr:  "start time is zero",
+		},
+		{
+			name:    "zero duration",
+			start:   start,
+			frames:  valid,
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "duration must be positive",
+		},
+		{
+			name:     "missing sample rate",
+			start:    start,
+			duration: time.Second,
+			frames:   valid,
+			wantErr:  "sample rate must be positive",
+		},
+		{
+			name:     "level gap",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Label: "root"},
+				{Level: 2, Value: 1, Self: 1, Label: "leaf"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "invalid level",
+		},
+		{
+			name:     "negative aggregate",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: -1, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "aggregate value must not be negative",
+		},
+		{
+			name:     "negative self",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Self: -1, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "self value must not be negative",
+		},
+		{
+			name:     "self exceeds aggregate",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Self: 2, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "exceeds aggregate",
+		},
+		{
+			name:     "empty samples",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "no positive self samples",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseFlamegraphFrames(
+				tt.start,
+				tt.duration,
+				ProfileTypeCpuSample,
+				tt.frames,
+				tt.opt,
+			)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func assertValueType(
+	t *testing.T,
+	stringTable []string,
+	valueType *ptree.ValueType,
+	wantType string,
+	wantUnit string,
+) {
+	t.Helper()
+	if valueType == nil {
+		t.Fatal("value type is nil")
+	}
+	if got := stringTable[valueType.Type]; got != wantType {
+		t.Errorf("type = %q, want %q", got, wantType)
+	}
+	if got := stringTable[valueType.Unit]; got != wantUnit {
+		t.Errorf("unit = %q, want %q", got, wantUnit)
+	}
+}


### PR DESCRIPTION
## Summary

- convert CPUIdle and CPUSys nested flame frames into CPU pprof profiles
- preserve the existing JSON event and write the profile with the same tracer ID
- keep JSON and profile writes independent so one failed output does not suppress the other
- validate malformed frame trees, sample accounting, timestamps, duration, and failure isolation

## Scope

Part of #327.

This PR uses the existing profile-store API and is independent of the Pyroscope backend PR. It contains no storage backend, deployment, Grafana, or collection-dimension changes.

## Testing

- `go test ./internal/profiler ./core/autotracing`
- `make check` (all 26 linters passed on Ubuntu 22.04)
