### PR TITLE
fix(profiler): resolve valid zero stack ids

### DIFF
--- a/cmd/profiler/provider/native_bpf_context.go
+++ b/cmd/profiler/provider/native_bpf_context.go
@@ -49,6 +49,16 @@ type ProfilerEventBase struct {
 	Value     int64 // CPU: always 1 (sample count), Memory: page/byte delta
 }
 
+func (e *ProfilerEventBase) hasStack() bool {
+	return e != nil && (e.Kernstack >= 0 || e.Userstack >= 0)
+}
+
+type userStackCacheKey uint64
+
+func newUserStackCacheKey(stackID int32, pid uint32) userStackCacheKey {
+	return userStackCacheKey(uint64(pid)<<32 | uint64(uint32(stackID)))
+}
+
 // ringBufferContext holds the shared ring buffer state for A/B buffer management.
 // It encapsulates all the common infrastructure needed for dual-buffer profiling
 // (readers, state map, stack maps) so profilers don't need to pass these around.
@@ -203,7 +213,7 @@ func (r *ringBufferContext) drainActiveRingBuffer(
 			base := (*ProfilerEventBase)(unsafe.Pointer(ptrValue.Pointer()))
 
 			// Skip events without valid stacks
-			if base.Kernstack <= 0 && base.Userstack <= 0 {
+			if !base.hasStack() {
 				continue
 			}
 
@@ -287,7 +297,7 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 	convertValue func(int64) int64,
 ) {
 	kstackCache := make(map[int32]string)
-	ustackCache := make(map[int32]string)
+	ustackCache := make(map[userStackCacheKey]string)
 
 	var records int
 	for pidName, stacks := range stackCountsByProc {
@@ -301,20 +311,23 @@ func (r *ringBufferContext) aggregateStacksAndEnqueue(
 				continue
 			}
 
-			if stackID.KernelID > 0 {
+			if stackID.KernelID >= 0 {
 				if _, ok := kstackCache[stackID.KernelID]; !ok {
 					kstackCache[stackID.KernelID] = r.resolveKstackWithFallback(ring, stackID.KernelID)
 				}
 			}
-			if stackID.UserID > 0 {
-				if _, ok := ustackCache[stackID.UserID]; !ok {
-					ustackCache[stackID.UserID] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
+			userStack := ""
+			if stackID.UserID >= 0 {
+				key := newUserStackCacheKey(stackID.UserID, pidName.Pid)
+				if _, ok := ustackCache[key]; !ok {
+					ustackCache[key] = r.resolveUstackWithFallback(ring, stackID.UserID, pidName.Pid)
 				}
+				userStack = ustackCache[key]
 			}
 
 			record := &stackEntry{
 				Proc:    &processIDName{Pid: pidName.Pid, Name: pidName.Name},
-				User:    ustackCache[stackID.UserID],
+				User:    userStack,
 				Kernel:  kstackCache[stackID.KernelID],
 				Samples: value,
 			}

--- a/cmd/profiler/provider/native_bpf_context_test.go
+++ b/cmd/profiler/provider/native_bpf_context_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import "testing"
+
+func TestProfilerEventBaseHasStackAcceptsStackIDZero(t *testing.T) {
+	tests := []struct {
+		name string
+		base *ProfilerEventBase
+		want bool
+	}{
+		{name: "nil", base: nil, want: false},
+		{name: "no stack", base: &ProfilerEventBase{Kernstack: -1, Userstack: -1}, want: false},
+		{name: "kernel stack zero", base: &ProfilerEventBase{Kernstack: 0, Userstack: -1}, want: true},
+		{name: "user stack zero", base: &ProfilerEventBase{Kernstack: -1, Userstack: 0}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.hasStack(); got != tt.want {
+				t.Fatalf("hasStack() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserStackCacheKeyIncludesPID(t *testing.T) {
+	cache := map[userStackCacheKey]string{
+		newUserStackCacheKey(7, 100): "first process",
+		newUserStackCacheKey(7, 200): "second process",
+	}
+	if len(cache) != 2 {
+		t.Fatalf("cache entries = %d, want stack ID reused independently by two processes", len(cache))
+	}
+}


### PR DESCRIPTION
## Summary

- treat stack ID zero as valid and keep only negative IDs as missing sentinels
- resolve kernel and user stacks when their stack-map key is zero
- include PID in the user-stack cache key so identical IDs from different processes cannot alias
- cover zero-ID acceptance and cross-process cache isolation

## Testing

- `go test ./cmd/profiler/provider -run 'TestProfilerEventBaseHasStackAcceptsStackIDZero|TestUserStackCacheKeyIncludesPID' -count=1`
- `make check` (all 26 linters passed on Ubuntu 22.04)

Part of #329.
