### PR TITLE
fix(autotracing): protect containersCPUIdle global map with mutex

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	"huatuo-bamai/internal/cgroups"
@@ -89,13 +90,19 @@ type cpuIdleThreshold struct {
 // containersCPUIdleMap is the container information
 type containersCPUIdleMap map[string]*containerCPUInfo
 
-var containersCPUIdle = make(containersCPUIdleMap)
+var (
+	containersCPUIdle   = make(containersCPUIdleMap)
+	containersCPUIdleMu sync.Mutex
+)
 
 func updateContainersCPUIdle(f *matcher.ContainerMatcher) error {
 	containers, err := pod.NormalContainers()
 	if err != nil {
 		return err
 	}
+
+	containersCPUIdleMu.Lock()
+	defer containersCPUIdleMu.Unlock()
 
 	for _, container := range containers {
 		if !f.Match(container) {
@@ -120,6 +127,9 @@ func updateContainersCPUIdle(f *matcher.ContainerMatcher) error {
 }
 
 func (c *cpuIdleTracing) detectCPUIdleContainer(threshold *cpuIdleThreshold) (*containerCPUInfo, error) {
+	containersCPUIdleMu.Lock()
+	defer containersCPUIdleMu.Unlock()
+
 	for id, container := range containersCPUIdle {
 		if !container.alive {
 			delete(containersCPUIdle, id)

--- a/core/autotracing/cpuidle_test.go
+++ b/core/autotracing/cpuidle_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025, 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestContainersCPUIdleConcurrentAccess verifies that the global
+// containersCPUIdle map is safe under concurrent read/write/delete
+// from multiple goroutines. Run with -race to detect data races.
+func TestContainersCPUIdleConcurrentAccess(t *testing.T) {
+	// Reset the global map to a clean state.
+	containersCPUIdleMu.Lock()
+	containersCPUIdle = make(containersCPUIdleMap)
+	containersCPUIdleMu.Unlock()
+
+	const (
+		numWriters = 4
+		numReaders = 4
+		numDeletes = 2
+		numEntries = 100
+	)
+
+	var wg sync.WaitGroup
+
+	// Writers: insert entries into the global map.
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for i := 0; i < numEntries; i++ {
+				id := fmt.Sprintf("container-w%d-%d", writerID, i)
+				containersCPUIdleMu.Lock()
+				containersCPUIdle[id] = &containerCPUInfo{
+					id:   id,
+					path: fmt.Sprintf("/sys/fs/cgroup/%s", id),
+				}
+				containersCPUIdleMu.Unlock()
+			}
+		}(w)
+	}
+
+	// Readers: iterate over the map while writers are active.
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < numEntries; i++ {
+				containersCPUIdleMu.Lock()
+				for id, info := range containersCPUIdle {
+					_ = id
+					_ = info.alive
+				}
+				containersCPUIdleMu.Unlock()
+			}
+		}()
+	}
+
+	// Deleters: remove entries while others read/write.
+	for d := 0; d < numDeletes; d++ {
+		wg.Add(1)
+		go func(delID int) {
+			defer wg.Done()
+			for i := 0; i < numEntries; i++ {
+				id := fmt.Sprintf("container-w%d-%d", delID, i)
+				containersCPUIdleMu.Lock()
+				delete(containersCPUIdle, id)
+				containersCPUIdleMu.Unlock()
+			}
+		}(d)
+	}
+
+	wg.Wait()
+}
+
+// TestContainersCPUIdleConcurrentUpdateAndDetect simulates the real
+// production pattern: updateContainersCPUIdle and detectCPUIdleContainer
+// called from different goroutine contexts on the same global map.
+func TestContainersCPUIdleConcurrentUpdateAndDetect(t *testing.T) {
+	containersCPUIdleMu.Lock()
+	containersCPUIdle = make(containersCPUIdleMap)
+	containersCPUIdleMu.Unlock()
+
+	const numIterations = 50
+	var wg sync.WaitGroup
+
+	// Simulate updateContainersCPUIdle: writes entries.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			id := fmt.Sprintf("c-%d", i)
+			containersCPUIdleMu.Lock()
+			if existing, ok := containersCPUIdle[id]; ok {
+				existing.alive = true
+				existing.path = "/updated"
+			} else {
+				containersCPUIdle[id] = &containerCPUInfo{
+					id:    id,
+					path:  "/test",
+					alive: true,
+				}
+			}
+			containersCPUIdleMu.Unlock()
+		}
+	}()
+
+	// Simulate detectCPUIdleContainer: iterates and deletes dead entries.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			containersCPUIdleMu.Lock()
+			for id, container := range containersCPUIdle {
+				if !container.alive {
+					delete(containersCPUIdle, id)
+				} else {
+					container.alive = false
+				}
+			}
+			containersCPUIdleMu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
containersCPUIdle 是包级全局 map，被
updateContainersCPUIdle（写入）和
detectCPUIdleContainer（迭代+删除）无锁并发访问。

当 tracing 框架创建多个 cpuIdleTracing 实例、或
重启 tracing 时，两个 goroutine 同时操作该 map，
触发 Go runtime fatal：

  fatal error: concurrent map writes
  fatal error: concurrent map iteration and map write

这不是数据竞争，而是进程级崩溃，无法被 recover。

修复方案：添加 containersCPUIdleMu
两个函数入口处加锁，确保 map 操作串行化。

同步添加两个回归测试：
- 多 goroutine 并发写入/读取/删除
- 模拟 update + detect 生产调用模式
均通过 -race 验证。

Closes #378

Signed-off-by: wegjgwioj <hjy813163@gmail.com>