### PR TITLE
fix(flamegraph): keep symbols out of inline scripts

### DIFF
--- a/internal/profiler/output/flamegraph/render.go
+++ b/internal/profiler/output/flamegraph/render.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"strings"
 )
 
 type frame struct {
@@ -157,9 +156,12 @@ func (r *renderer) drawFrame(f frame, ew *errWriter) {
 	x := r.style.XMargin + (f.LeftPercent / 100 * usableWidth)
 	y := r.style.FramesYOffset + (r.maxFrameDepth-f.Depth-1)*r.style.FrameHeight
 
-	jsTitle := strings.ReplaceAll(html.EscapeString(title), "'", "&#39;")
+	// Keep symbol data out of JavaScript source. XML entities are decoded
+	// before event handlers run, so escaping a quote inside s('...') would not
+	// prevent a crafted symbol from terminating that string.
+	attributeTitle := html.EscapeString(title)
 
-	ew.printf(`<g class="func_g" onmouseover="s('%s')" onmouseout="c()" onclick="zoom(this)">`+"\n", jsTitle)
+	ew.printf(`<g class="func_g" data-title="%s" onmouseover="s(this.getAttribute('data-title'))" onmouseout="c()" onclick="zoom(this)">`+"\n", attributeTitle)
 	ew.printf("  <title>%s</title>\n", html.EscapeString(title))
 	ew.printf(`  <rect x="%.1f" y="%d" width="%.1f" height="%d" fill="%s" rx="2" ry="2"/>`+"\n",
 		x, y, w, h, color)

--- a/internal/profiler/output/flamegraph/render_test.go
+++ b/internal/profiler/output/flamegraph/render_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flamegraph
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderStyleKeepsSymbolsOutOfJavaScript(t *testing.T) {
+	symbol := `');alert(1);//<script>alert(2)</script>`
+	var output bytes.Buffer
+	if err := RenderStyle([]Stack{{
+		Names:   []string{"root", symbol},
+		Samples: 1,
+	}}, &output, DefaultStyle); err != nil {
+		t.Fatalf("RenderStyle() error = %v", err)
+	}
+
+	content := output.String()
+	if strings.Contains(content, `onmouseover="s('`) ||
+		strings.Contains(content, "<script>alert(2)</script>") {
+		t.Fatalf("SVG embeds an untrusted symbol as executable markup: %s", content)
+	}
+	if !strings.Contains(content, `data-title="`) ||
+		!strings.Contains(content, "&lt;script&gt;alert(2)&lt;/script&gt;") {
+		t.Fatalf("SVG does not preserve the escaped symbol as data: %s", content)
+	}
+}


### PR DESCRIPTION
## Summary

- keep untrusted profile symbols in an escaped SVG data attribute
- read the label from the element instead of embedding it in JavaScript source
- cover quote and script-tag payloads with a regression test

## Independence

This fix is based directly on the current main branch and does not require the documentation or dashboard pull requests.

## Validation

- make check on Ubuntu 22.04 / Linux 5.15
- go test -race ./internal/profiler/output/flamegraph

Refs #328