### PR TITLE
feat(profiling): add multidimensional display views

### DIFF
--- a/.github/workflows/sync-web-on-change.yml
+++ b/.github/workflows/sync-web-on-change.yml
@@ -19,6 +19,9 @@ on:
 
 jobs:
   sync:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: checkout huatuo

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -31,11 +31,13 @@ services:
     environment:
       GF_INSTALL_PLUGINS: "yesoreyeram-infinity-datasource ${INFINITY_DATA_SOURCE:-3.4.1}"
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/autotracing-event.json
+      HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}
     volumes:
       - ./grafana/datasources/elasticsearch.yaml:/etc/grafana/provisioning/datasources/elasticsearch.yaml:ro
       - ./grafana/datasources/prometheus.yaml:/etc/grafana/provisioning/datasources/prometheus.yaml:ro
       - ./grafana/datasources/infinity.yaml:/etc/grafana/provisioning/datasources/infinity.yaml:ro
       - ./grafana/datasources/pyroscope.yaml:/etc/grafana/provisioning/datasources/pyroscope.yaml:ro
+      - ./grafana/datasources/profiling-json.yaml:/etc/grafana/provisioning/datasources/profiling-json.yaml:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
     depends_on:
       - prometheus

--- a/build/docker/grafana/dashboards/continuous-profiling-compare.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-compare.json
@@ -1,0 +1,306 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "The selected Grafana time range is the current (right) window. It is compared with the immediately preceding window of the same duration. Select a container ID for container profiles; otherwise the exact hostname is used.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "12.0.3",
+      "title": "Comparison window",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "huatuo-apiserver-profile-json"
+      },
+      "description": "Compares the selected window with the immediately preceding window of the same duration.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {},
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "level",
+              "text": "level",
+              "type": "number"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "self",
+              "text": "self",
+              "type": "number"
+            },
+            {
+              "selector": "valueRight",
+              "text": "valueRight",
+              "type": "number"
+            },
+            {
+              "selector": "selfRight",
+              "text": "selfRight",
+              "type": "number"
+            },
+            {
+              "selector": "label",
+              "text": "label",
+              "type": "string"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "huatuo-apiserver-profile-json"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data",
+          "source": "url",
+          "type": "json",
+          "url": "/v1/profiles/flamegraph/diff-rows",
+          "url_options": {
+            "body_content_type": "application/json",
+            "body_type": "raw",
+            "data": "{\n  \"profile_type_id\": ${type:json},\n  \"hostname\": ${hostname:json},\n  \"container_id\": ${container_id:json},\n  \"profiling_scope\": ${profiling_scope:json},\n  \"cpu\": ${cpu:json},\n  \"pid\": ${pid:json},\n  \"tgid\": ${tgid:json},\n  \"start\": ${__from},\n  \"end\": ${__to},\n  \"max_nodes\": 5000\n}",
+            "method": "POST"
+          }
+        }
+      ],
+      "title": "Current versus previous window",
+      "type": "flamegraph"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [
+    "profiling",
+    "continuous profiling"
+  ],
+  "templating": {
+    "list": [
+      {
+        "description": "profiling type",
+        "label": "type",
+        "name": "type",
+        "options": [
+          {
+            "selected": true,
+            "text": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+            "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+          },
+          {
+            "selected": false,
+            "text": "memory:alloc_space:bytes:space:bytes",
+            "value": "memory:alloc_space:bytes:space:bytes"
+          }
+        ],
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "description": "Used when no container ID is selected.",
+        "label": "hostname",
+        "name": "hostname",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND NOT _exists_:container_hostname\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Overrides hostname when a stable container ID is selected.",
+        "includeAll": true,
+        "label": "container ID",
+        "multi": false,
+        "name": "container_id",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact collection-scope filter.",
+        "includeAll": true,
+        "label": "scope",
+        "multi": false,
+        "name": "profiling_scope",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact logical CPU-set filter.",
+        "includeAll": true,
+        "label": "CPU set",
+        "multi": false,
+        "name": "cpu",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact process or thread target filter.",
+        "includeAll": true,
+        "label": "PID",
+        "multi": false,
+        "name": "pid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "description": "Optional exact thread-group target filter.",
+        "includeAll": true,
+        "label": "TGID",
+        "multi": false,
+        "name": "tgid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Continuous profiling comparison",
+  "uid": "continuous-profiling-compare",
+  "version": 1,
+  "weekStart": ""
+}

--- a/build/docker/grafana/dashboards/continuous-profiling-container.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-container.json
@@ -24,7 +24,32 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host profiles",
+      "tooltip": "Open the host profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-host/continuous-profiling-host"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Compare windows",
+      "tooltip": "Compare the selected window with its preceding window.",
+      "type": "link",
+      "url": "/d/continuous-profiling-compare/continuous-profiling-compare"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -135,12 +160,119 @@
               "type": "count"
             }
           ],
-          "query": "hostname.keyword:$hostname\nAND container_hostname.keyword:$container_hostname\nAND tracer_data.flamedata.profile_type.keyword:$type",
+          "query": "hostname.keyword:$hostname\nAND container_id.keyword:$container_id\nAND tracer_data.flamedata.profile_type.keyword:$type",
           "refId": "A",
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Total profile value in each time bucket for the selected container.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{container_id=\"$container_id\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
+          "limit": 1,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Profile value over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Ten highest-value profiling jobs in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [
+            "$group_by"
+          ],
+          "labelSelector": "{container_id=\"$container_id\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
+          "limit": 10,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 by tracer",
       "type": "timeseries"
     },
     {
@@ -156,7 +288,7 @@
         "h": 20,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 12
       },
       "id": 1,
       "maxPerRow": 2,
@@ -171,14 +303,15 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{container_hostname=\"$container_hostname\"}",
+          "labelSelector": "{container_id=\"$container_id\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "title": "$container_hostname",
+      "description": "Merged profile for the selected container ID, type, and time range.",
+      "title": "$container_id flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -194,12 +327,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
-        "description": "Selects container-level profiles.",
-        "label": "container hostname",
-        "name": "container_hostname",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "description": "Selects one container by its stable ID.",
+        "label": "container ID",
+        "name": "container_id",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"container_id.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -210,12 +343,12 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
-        "description": "Read-only. Displays the host where the selected container resides. Not used as a query filter; filtering is by container_hostname only.",
-        "label": "hostname(Read-only)",
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
+        "description": "Selects the host that reported the container profile.",
+        "label": "hostname",
         "name": "hostname",
         "options": [],
-        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_hostname.keyword:$container_hostname\",\n  \"size\": 5000\n}",
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"hostname.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 5000\n}",
         "refresh": 1,
         "regex": "",
         "type": "query"
@@ -234,29 +367,134 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact collection-scope filter.",
+        "includeAll": true,
+        "label": "scope",
+        "multi": false,
+        "name": "profiling_scope",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact logical CPU-set filter.",
+        "includeAll": true,
+        "label": "CPU set",
+        "multi": false,
+        "name": "cpu",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact process or thread target filter.",
+        "includeAll": true,
+        "label": "PID",
+        "multi": false,
+        "name": "pid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "description": "Optional exact thread-group target filter.",
+        "includeAll": true,
+        "label": "TGID",
+        "multi": false,
+        "name": "tgid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND container_id.keyword:$container_id\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "description": "Dimension used by the bounded Top 10 series.",
+        "label": "Top 10 group",
+        "name": "group_by",
+        "options": [
+          {
+            "selected": true,
+            "text": "tracer",
+            "value": "tracer"
+          },
+          {
+            "selected": false,
+            "text": "profiling_scope",
+            "value": "profiling_scope"
+          },
+          {
+            "selected": false,
+            "text": "cpu",
+            "value": "cpu"
+          },
+          {
+            "selected": false,
+            "text": "pid",
+            "value": "pid"
+          },
+          {
+            "selected": false,
+            "text": "tgid",
+            "value": "tgid"
+          },
+          {
+            "selected": false,
+            "text": "container_id",
+            "value": "container_id"
+          }
+        ],
+        "query": "tracer,profiling_scope,cpu,pid,tgid,container_id",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(container)",
+  "title": "Continuous Profiling (Container)",
   "uid": "continuous-profiling-container"
 }

--- a/build/docker/grafana/dashboards/continuous-profiling-host.json
+++ b/build/docker/grafana/dashboards/continuous-profiling-host.json
@@ -24,7 +24,32 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Container profiles",
+      "tooltip": "Open the container profiling dashboard.",
+      "type": "link",
+      "url": "/d/continuous-profiling-container/continuous-profiling-container"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Compare windows",
+      "tooltip": "Compare the selected window with its preceding window.",
+      "type": "link",
+      "url": "/d/continuous-profiling-compare/continuous-profiling-compare"
+    }
+  ],
   "panels": [
     {
       "datasource": {
@@ -140,7 +165,114 @@
           "timeField": "uploaded_time"
         }
       ],
-      "title": "",
+      "description": "Number of profile snapshots stored in each time bucket.",
+      "title": "Profile documents ingested",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Total profile value in each time bucket for the selected host.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [],
+          "labelSelector": "{hostname=\"$hostname\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
+          "limit": 1,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Profile value over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-pyroscope-datasource",
+        "uid": "huatuo-apiserver-pyroscope"
+      },
+      "description": "Ten highest-value profiling jobs in the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-pyroscope-datasource",
+            "uid": "huatuo-apiserver-pyroscope"
+          },
+          "groupBy": [
+            "$group_by"
+          ],
+          "labelSelector": "{hostname=\"$hostname\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
+          "limit": 10,
+          "profileTypeId": "$type",
+          "queryType": "metrics",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 by tracer",
       "type": "timeseries"
     },
     {
@@ -156,7 +288,7 @@
         "h": 20,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 12
       },
       "id": 1,
       "maxPerRow": 2,
@@ -171,14 +303,15 @@
             "uid": "huatuo-apiserver-pyroscope"
           },
           "groupBy": [],
-          "labelSelector": "{hostname=\"$hostname\"}",
+          "labelSelector": "{hostname=\"$hostname\",profiling_scope=\"$profiling_scope\",cpu=\"$cpu\",pid=\"$pid\",tgid=\"$tgid\"}",
           "profileTypeId": "$type",
           "queryType": "profile",
           "refId": "A",
           "spanSelector": []
         }
       ],
-      "title": "$hostname",
+      "description": "Merged profile for the selected host, type, and time range.",
+      "title": "$hostname flame graph and Top table",
       "type": "flamegraph"
     }
   ],
@@ -219,29 +352,134 @@
             "selected": false,
             "text": "memory:alloc_space:bytes:space:bytes",
             "value": "memory:alloc_space:bytes:space:bytes"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:count:lock:count",
-            "value": "process_lock:lock:count:lock:count"
-          },
-          {
-            "selected": false,
-            "text": "process_lock:lock:nanoseconds:lock:nanoseconds",
-            "value": "process_lock:lock:nanoseconds:lock:nanoseconds"
           }
         ],
-        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes,process_lock:lock:count:lock:count,process_lock:lock:nanoseconds:lock:nanoseconds",
+        "query": "process_cpu:cpu:nanoseconds:cpu:nanoseconds,memory:alloc_space:bytes:space:bytes",
+        "type": "custom"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact collection-scope filter.",
+        "includeAll": true,
+        "label": "scope",
+        "multi": false,
+        "name": "profiling_scope",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.profiling_scope.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact logical CPU-set filter.",
+        "includeAll": true,
+        "label": "CPU set",
+        "multi": false,
+        "name": "cpu",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.cpu.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact process or thread target filter.",
+        "includeAll": true,
+        "label": "PID",
+        "multi": false,
+        "name": "pid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.pid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": "",
+        "allowCustomValue": true,
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "huatuo-bamai-es"
+        },
+        "definition": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "description": "Optional exact thread-group target filter.",
+        "includeAll": true,
+        "label": "TGID",
+        "multi": false,
+        "name": "tgid",
+        "options": [],
+        "query": "{\n  \"find\": \"terms\",\n  \"field\": \"tracer_data.flamedata.labels.tgid.keyword\",\n  \"query\": \"tracer_data.flamedata.profile_type.keyword:$type AND hostname.keyword:$hostname AND NOT _exists_:container_hostname\",\n  \"size\": 500\n}",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "description": "Dimension used by the bounded Top 10 series.",
+        "label": "Top 10 group",
+        "name": "group_by",
+        "options": [
+          {
+            "selected": true,
+            "text": "tracer",
+            "value": "tracer"
+          },
+          {
+            "selected": false,
+            "text": "profiling_scope",
+            "value": "profiling_scope"
+          },
+          {
+            "selected": false,
+            "text": "cpu",
+            "value": "cpu"
+          },
+          {
+            "selected": false,
+            "text": "pid",
+            "value": "pid"
+          },
+          {
+            "selected": false,
+            "text": "tgid",
+            "value": "tgid"
+          },
+          {
+            "selected": false,
+            "text": "container_id",
+            "value": "container_id"
+          }
+        ],
+        "query": "tracer,profiling_scope,cpu,pid,tgid,container_id",
         "type": "custom"
       }
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Continuous Profiling(host)",
+  "title": "Continuous Profiling (Host)",
   "uid": "continuous-profiling-host"
 }

--- a/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
+++ b/build/docker/grafana/dashboards/continuous_profiling_contract_test.go
@@ -1,0 +1,362 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"encoding/json"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	cpuProfileType    = "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+	memoryProfileType = "memory:alloc_space:bytes:space:bytes"
+)
+
+type dashboardVariable struct {
+	Name       string `json:"name"`
+	Definition string `json:"definition"`
+	Query      string `json:"query"`
+	AllValue   string `json:"allValue"`
+	IncludeAll bool   `json:"includeAll"`
+	Options    []struct {
+		Value string `json:"value"`
+	} `json:"options"`
+}
+
+type dashboardContract struct {
+	UID        string `json:"uid"`
+	Templating struct {
+		List []dashboardVariable `json:"list"`
+	} `json:"templating"`
+}
+
+func loadDashboard(t *testing.T, filename string) (dashboardContract, any, string) {
+	t.Helper()
+
+	payload, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+
+	var contract dashboardContract
+	if err := json.Unmarshal(payload, &contract); err != nil {
+		t.Fatalf("decode %s: %v", filename, err)
+	}
+
+	var raw any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatalf("decode raw %s: %v", filename, err)
+	}
+
+	return contract, raw, string(payload)
+}
+
+func dashboardStrings(value any, field string, values *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				if text, ok := item.(string); ok {
+					*values = append(*values, text)
+				}
+			}
+			dashboardStrings(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardStrings(item, field, values)
+		}
+	}
+}
+
+func dashboardValues(value any, field string, values *[]any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for name, item := range typed {
+			if name == field {
+				*values = append(*values, item)
+			}
+			dashboardValues(item, field, values)
+		}
+	case []any:
+		for _, item := range typed {
+			dashboardValues(item, field, values)
+		}
+	}
+}
+
+func findDashboardVariable(t *testing.T, dashboard dashboardContract, name string) dashboardVariable {
+	t.Helper()
+
+	for _, variable := range dashboard.Templating.List {
+		if variable.Name == name {
+			return variable
+		}
+	}
+	t.Fatalf("dashboard %q has no %q variable", dashboard.UID, name)
+	return dashboardVariable{}
+}
+
+func requireSupportedProfileTypes(t *testing.T, dashboard dashboardContract) {
+	t.Helper()
+
+	variable := findDashboardVariable(t, dashboard, "type")
+	values := make([]string, 0, len(variable.Options))
+	for _, option := range variable.Options {
+		values = append(values, option.Value)
+	}
+	if !slices.Equal(values, []string{cpuProfileType, memoryProfileType}) {
+		t.Fatalf("profile types = %v, want only CPU and memory", values)
+	}
+}
+
+func requireExactProfileQueries(
+	t *testing.T,
+	raw any,
+	selector string,
+) {
+	t.Helper()
+
+	var selectors []string
+	dashboardStrings(raw, "labelSelector", &selectors)
+	if !slices.Equal(selectors, []string{selector, selector, selector}) {
+		t.Fatalf("profile selectors = %v, want exact %s selectors", selectors, selector)
+	}
+
+	var queryTypes []string
+	dashboardStrings(raw, "queryType", &queryTypes)
+	if !slices.Equal(queryTypes, []string{"metrics", "metrics", "profile"}) {
+		t.Fatalf("query types = %v, want two series and one profile query", queryTypes)
+	}
+
+	var groupBys []any
+	dashboardValues(raw, "groupBy", &groupBys)
+	if len(groupBys) != 3 {
+		t.Fatalf("profile groupBy values = %v, want three", groupBys)
+	}
+	if grouped, ok := groupBys[1].([]any); !ok ||
+		len(grouped) != 1 ||
+		grouped[0] != "$group_by" {
+		t.Fatalf("Top series groupBy = %v, want dashboard dimension", groupBys[1])
+	}
+
+	var limits []any
+	dashboardValues(raw, "limit", &limits)
+	profileLimits := make([]float64, 0, len(limits))
+	for _, limit := range limits {
+		if number, ok := limit.(float64); ok {
+			profileLimits = append(profileLimits, number)
+		}
+	}
+	if !slices.Contains(profileLimits, float64(10)) {
+		t.Fatalf("dashboard limits = %v, want Top 10 bound", profileLimits)
+	}
+}
+
+func requireDimensionVariables(
+	t *testing.T,
+	dashboard dashboardContract,
+) {
+	t.Helper()
+
+	fields := map[string]string{
+		"profiling_scope": "tracer_data.flamedata.labels.profiling_scope.keyword",
+		"cpu":             "tracer_data.flamedata.labels.cpu.keyword",
+		"pid":             "tracer_data.flamedata.labels.pid.keyword",
+		"tgid":            "tracer_data.flamedata.labels.tgid.keyword",
+	}
+	for name, field := range fields {
+		variable := findDashboardVariable(t, dashboard, name)
+		if !variable.IncludeAll || variable.AllValue != "" {
+			t.Fatalf("%s must provide an empty exact-match All value", name)
+		}
+		if !strings.Contains(variable.Definition, field) ||
+			!strings.Contains(variable.Definition, `"size": 500`) {
+			t.Fatalf("%s query is unbounded or uses the wrong field: %s", name, variable.Definition)
+		}
+	}
+}
+
+func requireNoUnsupportedSelectors(t *testing.T, payload string) {
+	t.Helper()
+
+	for _, unsupported := range []string{
+		"cgroup",
+		"process_group",
+		"process_lock",
+		"lock_type",
+		`=~`,
+		`!~`,
+	} {
+		if strings.Contains(payload, unsupported) {
+			t.Fatalf("dashboard contains unsupported selector %q", unsupported)
+		}
+	}
+}
+
+func TestContinuousProfilingHostDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-host.json")
+	if dashboard.UID != "continuous-profiling-host" {
+		t.Fatalf("UID = %q, want continuous-profiling-host", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+	requireDimensionVariables(t, dashboard)
+
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "NOT _exists_:container_hostname") {
+		t.Fatalf("hostname query can select container profiles: %s", hostname.Definition)
+	}
+
+	requireExactProfileQueries(
+		t,
+		raw,
+		`{hostname="$hostname",profiling_scope="$profiling_scope",`+
+			`cpu="$cpu",pid="$pid",tgid="$tgid"}`,
+	)
+	requireNoUnsupportedSelectors(t, payload)
+}
+
+func TestContinuousProfilingContainerDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(t, "continuous-profiling-container.json")
+	if dashboard.UID != "continuous-profiling-container" {
+		t.Fatalf("UID = %q, want continuous-profiling-container", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+	requireDimensionVariables(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+	hostname := findDashboardVariable(t, dashboard, "hostname")
+	if !strings.Contains(hostname.Definition, "container_id.keyword:$container_id") {
+		t.Fatalf("hostname variable is not container scoped: %s", hostname.Definition)
+	}
+
+	requireExactProfileQueries(
+		t,
+		raw,
+		`{container_id="$container_id",profiling_scope="$profiling_scope",`+
+			`cpu="$cpu",pid="$pid",tgid="$tgid"}`,
+	)
+	if strings.Contains(payload, "container_hostname") {
+		t.Fatal("dashboard uses non-unique container hostname")
+	}
+	requireNoUnsupportedSelectors(t, payload)
+}
+
+func TestContinuousProfilingComparisonDashboardContract(t *testing.T) {
+	dashboard, raw, payload := loadDashboard(
+		t,
+		"continuous-profiling-compare.json",
+	)
+	if dashboard.UID != "continuous-profiling-compare" {
+		t.Fatalf("UID = %q, want continuous-profiling-compare", dashboard.UID)
+	}
+	requireSupportedProfileTypes(t, dashboard)
+	requireDimensionVariables(t, dashboard)
+
+	containerID := findDashboardVariable(t, dashboard, "container_id")
+	if !strings.Contains(containerID.Definition, `"field": "container_id.keyword"`) {
+		t.Fatalf("container variable does not use container ID: %s", containerID.Definition)
+	}
+
+	var urls []string
+	dashboardStrings(raw, "url", &urls)
+	if !slices.Contains(urls, "/v1/profiles/flamegraph/diff-rows") {
+		t.Fatalf("comparison URLs = %v, want bounded diff adapter", urls)
+	}
+	var roots []string
+	dashboardStrings(raw, "root_selector", &roots)
+	if !slices.Equal(roots, []string{"data"}) {
+		t.Fatalf("root selectors = %v, want data", roots)
+	}
+	var columns []string
+	dashboardStrings(raw, "selector", &columns)
+	if !slices.Equal(
+		columns,
+		[]string{"level", "value", "self", "valueRight", "selfRight", "label"},
+	) {
+		t.Fatalf("comparison columns = %v", columns)
+	}
+	var bodies []string
+	dashboardStrings(raw, "data", &bodies)
+	if len(bodies) != 1 ||
+		!strings.Contains(bodies[0], `"max_nodes": 5000`) ||
+		!strings.Contains(bodies[0], `${hostname:json}`) ||
+		!strings.Contains(bodies[0], `${container_id:json}`) ||
+		!strings.Contains(bodies[0], `${profiling_scope:json}`) ||
+		!strings.Contains(bodies[0], `${cpu:json}`) ||
+		!strings.Contains(bodies[0], `${pid:json}`) ||
+		!strings.Contains(bodies[0], `${tgid:json}`) {
+		t.Fatalf("comparison request is not bounded or JSON-escaped: %v", bodies)
+	}
+	requireNoUnsupportedSelectors(t, payload)
+}
+
+func TestContinuousProfilingDatasourceAuthenticationContract(t *testing.T) {
+	for _, filename := range []string{
+		"../datasources/pyroscope.yaml",
+		"../datasources/profiling-json.yaml",
+	} {
+		datasource, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("read %s: %v", filename, err)
+		}
+		datasourceText := string(datasource)
+		if !strings.Contains(
+			datasourceText,
+			"'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'",
+		) {
+			t.Fatalf("%s does not use the runtime bearer token", filename)
+		}
+		if strings.Contains(datasourceText, "REPLACE_WITH_RANDOM_HEX") {
+			t.Fatalf("%s contains a placeholder credential", filename)
+		}
+	}
+	pyroscope, err := os.ReadFile("../datasources/pyroscope.yaml")
+	if err != nil {
+		t.Fatalf("read Pyroscope datasources: %v", err)
+	}
+	pyroscopeText := string(pyroscope)
+	for _, expected := range []string{
+		"uid: huatuo-apiserver-pyroscope",
+		"url: http://127.0.0.1:12740/v1/profiles/flamegraph/",
+	} {
+		if !strings.Contains(pyroscopeText, expected) {
+			t.Fatalf("Pyroscope datasources missing %q", expected)
+		}
+	}
+
+	compose, err := os.ReadFile("../../docker-compose.yml")
+	if err != nil {
+		t.Fatalf("read Docker Compose config: %v", err)
+	}
+	if !strings.Contains(
+		string(compose),
+		"HUATUO_GRAFANA_PROFILE_TOKEN: ${HUATUO_GRAFANA_PROFILE_TOKEN:-}",
+	) {
+		t.Fatal("Grafana container does not receive the profile query token")
+	}
+	if !strings.Contains(
+		string(compose),
+		"./grafana/datasources/profiling-json.yaml:",
+	) {
+		t.Fatal("Grafana does not provision the profile JSON datasource")
+	}
+}

--- a/build/docker/grafana/datasources/profiling-json.yaml
+++ b/build/docker/grafana/datasources/profiling-json.yaml
@@ -1,14 +1,15 @@
 apiVersion: 1
 
 datasources:
-  - name: huatuo-apiserver-pyroscope
-    type: grafana-pyroscope-datasource
-    uid: huatuo-apiserver-pyroscope
+  - name: huatuo-apiserver-profile-json
+    type: yesoreyeram-infinity-datasource
+    uid: huatuo-apiserver-profile-json
     access: proxy
     orgId: 1
-    url: http://127.0.0.1:12740/v1/profiles/flamegraph/
+    url: http://127.0.0.1:12740
     jsonData:
-      minStep: '15s'
+      allowedHosts:
+        - http://127.0.0.1:12740
       httpHeaderName1: 'Authorization'
     secureJsonData:
       httpHeaderValue1: 'Bearer $HUATUO_GRAFANA_PROFILE_TOKEN'

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows.go
@@ -1,0 +1,412 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/server"
+	"huatuo-bamai/internal/server/response"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	diffFlamegraphNodeWidth     = 7
+	defaultProfileDiffMaxNodes  = 5000
+	maxProfileDiffMaxNodes      = 10000
+	maxProfileDiffTargetLength  = 512
+	maxProfileDiffTypeLength    = 256
+	maxProfileDiffResponseBytes = 8 << 20
+)
+
+type profileDiffRowsRequest struct {
+	ProfileTypeID  string `json:"profile_type_id"`
+	Hostname       string `json:"hostname"`
+	ContainerID    string `json:"container_id"`
+	ProfilingScope string `json:"profiling_scope"`
+	CPU            string `json:"cpu"`
+	PID            string `json:"pid"`
+	TGID           string `json:"tgid"`
+	Start          int64  `json:"start"`
+	End            int64  `json:"end"`
+	MaxNodes       int64  `json:"max_nodes"`
+}
+
+type profileDiffRow struct {
+	Level      int    `json:"level"`
+	Value      int64  `json:"value"`
+	Self       int64  `json:"self"`
+	ValueRight int64  `json:"valueRight"`
+	SelfRight  int64  `json:"selfRight"`
+	Label      string `json:"label"`
+}
+
+type profileDiffNode struct {
+	row        profileDiffRow
+	leftStart  int64
+	rightStart int64
+	children   []*profileDiffNode
+}
+
+func (h *Handler) displayDiffRows(ctx *server.Context) error {
+	var request profileDiffRowsRequest
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		return response.ErrInvalidRequest.WithMessage(
+			"invalid profile diff request",
+		)
+	}
+
+	diffRequest, err := buildAdjacentProfileDiffRequest(&request)
+	if err != nil {
+		return response.ErrInvalidRequest.WithMessage(err.Error())
+	}
+	diffResponse, err := h.profileService.Diff(
+		ctx.Request().Context(),
+		diffRequest,
+	)
+	if err != nil {
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField(
+				"operation",
+				"display_diff_rows",
+			).Error("profile query failed")
+		}
+		ctx.JSON(status, map[string]any{"message": message})
+		return nil
+	}
+
+	rows, err := profileDiffRows(diffResponse.GetFlamegraph())
+	if err != nil {
+		log.WithError(err).Error("invalid profile diff response")
+		ctx.JSON(
+			http.StatusInternalServerError,
+			map[string]any{"message": "internal error"},
+		)
+		return nil
+	}
+	tooLarge, err := profileDiffResponseExceedsLimit(rows)
+	if err != nil {
+		log.WithError(err).Error("encode profile diff response")
+		ctx.JSON(
+			http.StatusInternalServerError,
+			map[string]any{"message": "internal error"},
+		)
+		return nil
+	}
+	if tooLarge {
+		ctx.JSON(http.StatusUnprocessableEntity, map[string]any{
+			"message": fmt.Sprintf(
+				"profile diff response exceeds %d bytes",
+				maxProfileDiffResponseBytes,
+			),
+		})
+		return nil
+	}
+	response.Success(ctx, rows)
+	return nil
+}
+
+func profileDiffResponseExceedsLimit(rows []profileDiffRow) (bool, error) {
+	payload, err := json.Marshal(response.Response{
+		Code:    0,
+		Message: "success",
+		Data:    rows,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(payload) > maxProfileDiffResponseBytes, nil
+}
+
+func buildAdjacentProfileDiffRequest(
+	request *profileDiffRowsRequest,
+) (*querierv1.DiffRequest, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	if request.ProfileTypeID == "" {
+		return nil, fmt.Errorf("profile_type_id is required")
+	}
+	if len(request.ProfileTypeID) > maxProfileDiffTypeLength {
+		return nil, fmt.Errorf(
+			"profile_type_id must not exceed %d bytes",
+			maxProfileDiffTypeLength,
+		)
+	}
+	if request.Start < 0 || request.End <= request.Start {
+		return nil, fmt.Errorf("end must be later than a non-negative start")
+	}
+	window := request.End - request.Start
+	if window > request.Start {
+		return nil, fmt.Errorf("selected range has no preceding window")
+	}
+	if request.MaxNodes < 0 ||
+		request.MaxNodes > maxProfileDiffMaxNodes {
+		return nil, fmt.Errorf(
+			"max_nodes must be between 0 and %d",
+			maxProfileDiffMaxNodes,
+		)
+	}
+
+	targetName := "hostname"
+	targetValue := request.Hostname
+	if request.ContainerID != "" {
+		targetName = "container_id"
+		targetValue = request.ContainerID
+	}
+	if strings.TrimSpace(targetValue) == "" {
+		return nil, fmt.Errorf("hostname or container_id is required")
+	}
+	selectors := []struct {
+		name  string
+		value string
+	}{
+		{name: targetName, value: targetValue},
+		{name: "profiling_scope", value: request.ProfilingScope},
+		{name: "cpu", value: request.CPU},
+		{name: "pid", value: request.PID},
+		{name: "tgid", value: request.TGID},
+	}
+	matchers := make([]string, 0, len(selectors))
+	for _, selector := range selectors {
+		if selector.value == "" {
+			continue
+		}
+		if len(selector.value) > maxProfileDiffTargetLength {
+			return nil, fmt.Errorf(
+				"%s must not exceed %d bytes",
+				selector.name,
+				maxProfileDiffTargetLength,
+			)
+		}
+		matcher, err := labels.NewMatcher(
+			labels.MatchEqual,
+			selector.name,
+			selector.value,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"build %s selector: %w",
+				selector.name,
+				err,
+			)
+		}
+		matchers = append(matchers, matcher.String())
+	}
+	selector := "{" + strings.Join(matchers, ",") + "}"
+
+	maxNodesValue := request.MaxNodes
+	if maxNodesValue == 0 {
+		maxNodesValue = defaultProfileDiffMaxNodes
+	}
+	maxNodes := &maxNodesValue
+	return &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: request.ProfileTypeID,
+			LabelSelector: selector,
+			Start:         request.Start - window,
+			End:           request.Start - 1,
+			MaxNodes:      maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: request.ProfileTypeID,
+			LabelSelector: selector,
+			Start:         request.Start,
+			End:           request.End,
+			MaxNodes:      maxNodes,
+		},
+	}, nil
+}
+
+func profileDiffRows(graph *querierv1.FlameGraphDiff) ([]profileDiffRow, error) {
+	if graph == nil || len(graph.Levels) == 0 {
+		return []profileDiffRow{}, nil
+	}
+
+	levels := make([][]*profileDiffNode, len(graph.Levels))
+	nodeCount := 0
+	for levelIndex, level := range graph.Levels {
+		if level == nil ||
+			len(level.Values)%diffFlamegraphNodeWidth != 0 {
+			return nil, fmt.Errorf(
+				"invalid diff flame graph level %d",
+				levelIndex,
+			)
+		}
+		nodeCount += len(level.Values) / diffFlamegraphNodeWidth
+		if nodeCount > maxProfileDiffMaxNodes {
+			return nil, fmt.Errorf(
+				"diff flame graph exceeds %d nodes",
+				maxProfileDiffMaxNodes,
+			)
+		}
+		nodes := make(
+			[]*profileDiffNode,
+			0,
+			len(level.Values)/diffFlamegraphNodeWidth,
+		)
+		var leftOffset int64
+		var rightOffset int64
+		for index := 0; index < len(level.Values); index += diffFlamegraphNodeWidth {
+			leftStart, ok := addProfileDiffValue(
+				leftOffset,
+				level.Values[index],
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"invalid left offset in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			rightStart, ok := addProfileDiffValue(
+				rightOffset,
+				level.Values[index+3],
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"invalid right offset in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			nameIndex := level.Values[index+6]
+			if nameIndex < 0 || nameIndex >= int64(len(graph.Names)) {
+				return nil, fmt.Errorf(
+					"invalid diff flame graph name index %d",
+					nameIndex,
+				)
+			}
+			node := &profileDiffNode{
+				row: profileDiffRow{
+					Level:      levelIndex,
+					Value:      level.Values[index+1],
+					Self:       level.Values[index+2],
+					ValueRight: level.Values[index+4],
+					SelfRight:  level.Values[index+5],
+					Label:      graph.Names[nameIndex],
+				},
+				leftStart:  leftStart,
+				rightStart: rightStart,
+			}
+			if node.row.Value < 0 ||
+				node.row.Self < 0 ||
+				node.row.ValueRight < 0 ||
+				node.row.SelfRight < 0 ||
+				node.row.Self > node.row.Value ||
+				node.row.SelfRight > node.row.ValueRight {
+				return nil, fmt.Errorf(
+					"invalid values in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			nodes = append(nodes, node)
+			leftOffset, ok = addProfileDiffValue(leftStart, node.row.Value)
+			if !ok {
+				return nil, fmt.Errorf(
+					"left range overflows in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+			rightOffset, ok = addProfileDiffValue(
+				rightStart,
+				node.row.ValueRight,
+			)
+			if !ok {
+				return nil, fmt.Errorf(
+					"right range overflows in diff flame graph level %d",
+					levelIndex,
+				)
+			}
+		}
+		levels[levelIndex] = nodes
+	}
+	if len(levels[0]) != 1 {
+		return nil, fmt.Errorf("diff flame graph must have one root")
+	}
+
+	for levelIndex := 1; levelIndex < len(levels); levelIndex++ {
+		for _, node := range levels[levelIndex] {
+			parent := profileDiffParent(levels[levelIndex-1], node)
+			if parent == nil {
+				return nil, fmt.Errorf(
+					"diff flame graph level %d node %q has no parent",
+					levelIndex,
+					node.row.Label,
+				)
+			}
+			parent.children = append(parent.children, node)
+		}
+	}
+
+	rows := make([]profileDiffRow, 0, nodeCount)
+	var appendNode func(*profileDiffNode)
+	appendNode = func(node *profileDiffNode) {
+		rows = append(rows, node.row)
+		for _, child := range node.children {
+			appendNode(child)
+		}
+	}
+	appendNode(levels[0][0])
+	return rows, nil
+}
+
+func profileDiffParent(
+	parents []*profileDiffNode,
+	child *profileDiffNode,
+) *profileDiffNode {
+	for _, parent := range parents {
+		if profileDiffRangeContains(
+			parent.leftStart,
+			parent.row.Value,
+			child.leftStart,
+			child.row.Value,
+		) || profileDiffRangeContains(
+			parent.rightStart,
+			parent.row.ValueRight,
+			child.rightStart,
+			child.row.ValueRight,
+		) {
+			return parent
+		}
+	}
+	return nil
+}
+
+func profileDiffRangeContains(
+	parentStart, parentValue, childStart, childValue int64,
+) bool {
+	parentEnd, parentOK := addProfileDiffValue(parentStart, parentValue)
+	childEnd, childOK := addProfileDiffValue(childStart, childValue)
+	return childValue > 0 &&
+		parentValue >= childValue &&
+		parentOK &&
+		childOK &&
+		childStart >= parentStart &&
+		childEnd <= parentEnd
+}
+
+func addProfileDiffValue(left, right int64) (int64, bool) {
+	if left < 0 || right < 0 || left > math.MaxInt64-right {
+		return 0, false
+	}
+	return left + right, true
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/diff_rows_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+)
+
+func TestBuildAdjacentProfileDiffRequest(t *testing.T) {
+	request, err := buildAdjacentProfileDiffRequest(&profileDiffRowsRequest{
+		ProfileTypeID:  profiler.ProfileTypeCpuSample,
+		Hostname:       "node-a",
+		ContainerID:    `container\"a`,
+		ProfilingScope: "container",
+		CPU:            "2,4-7",
+		PID:            "4242",
+		TGID:           "4200",
+		Start:          2000,
+		End:            3000,
+		MaxNodes:       500,
+	})
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+
+	if request.Left.Start != 1000 || request.Left.End != 1999 {
+		t.Fatalf(
+			"left range = %d..%d, want 1000..1999",
+			request.Left.Start,
+			request.Left.End,
+		)
+	}
+	if request.Right.Start != 2000 || request.Right.End != 3000 {
+		t.Fatalf(
+			"right range = %d..%d, want 2000..3000",
+			request.Right.Start,
+			request.Right.End,
+		)
+	}
+	wantSelector := `{container_id="container\\\"a",` +
+		`profiling_scope="container",cpu="2,4-7",pid="4242",tgid="4200"}`
+	if request.Left.LabelSelector != wantSelector ||
+		request.Right.LabelSelector != wantSelector {
+		t.Fatalf(
+			"selectors = %q and %q, want %q",
+			request.Left.LabelSelector,
+			request.Right.LabelSelector,
+			wantSelector,
+		)
+	}
+	if request.Left.GetMaxNodes() != 500 || request.Right.GetMaxNodes() != 500 {
+		t.Fatal("max_nodes was not forwarded to both selections")
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestRequiresTargetAndPreviousWindow(t *testing.T) {
+	if _, err := buildAdjacentProfileDiffRequest(nil); err == nil {
+		t.Fatal("buildAdjacentProfileDiffRequest(nil) succeeded")
+	}
+	tests := []profileDiffRowsRequest{
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         500,
+			End:           1500,
+		},
+	}
+	for _, request := range tests {
+		if _, err := buildAdjacentProfileDiffRequest(&request); err == nil {
+			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
+		}
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestDefaultsAndBounds(t *testing.T) {
+	valid := profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node-a",
+		Start:         2000,
+		End:           3000,
+	}
+	request, err := buildAdjacentProfileDiffRequest(&valid)
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+	if request.Left.GetMaxNodes() != defaultProfileDiffMaxNodes ||
+		request.Right.GetMaxNodes() != defaultProfileDiffMaxNodes {
+		t.Fatal("default max_nodes was not applied to both selections")
+	}
+
+	tests := []profileDiffRowsRequest{
+		{ProfileTypeID: "", Hostname: "node-a", Start: 2000, End: 3000},
+		{
+			ProfileTypeID: strings.Repeat("p", maxProfileDiffTypeLength+1),
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      strings.Repeat("h", maxProfileDiffTargetLength+1),
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			CPU:           strings.Repeat("1", maxProfileDiffTargetLength+1),
+			Start:         2000,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         -1,
+			End:           3000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           2000,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+			MaxNodes:      -1,
+		},
+		{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			Hostname:      "node-a",
+			Start:         2000,
+			End:           3000,
+			MaxNodes:      maxProfileDiffMaxNodes + 1,
+		},
+	}
+	for _, request := range tests {
+		if _, err := buildAdjacentProfileDiffRequest(&request); err == nil {
+			t.Fatalf("buildAdjacentProfileDiffRequest(%+v) succeeded", request)
+		}
+	}
+}
+
+func TestBuildAdjacentProfileDiffRequestEscapesSelectorInput(t *testing.T) {
+	request, err := buildAdjacentProfileDiffRequest(&profileDiffRowsRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		Hostname:      "node\n\"a\\b",
+		Start:         2000,
+		End:           3000,
+	})
+	if err != nil {
+		t.Fatalf("buildAdjacentProfileDiffRequest() error = %v", err)
+	}
+	if request.Left.LabelSelector != `{hostname="node\n\"a\\b"}` {
+		t.Fatalf("selector = %q", request.Left.LabelSelector)
+	}
+}
+
+func TestProfileDiffRowsBuildsNestedSetOrder(t *testing.T) {
+	graph := &querierv1.FlameGraphDiff{
+		Names: []string{"total", "a", "b", "a-child"},
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 30, 0, 0, 40, 0, 0}},
+			{Values: []int64{
+				0, 10, 5, 0, 30, 10, 1,
+				0, 20, 20, 0, 10, 10, 2,
+			}},
+			{Values: []int64{5, 5, 5, 10, 20, 20, 3}},
+		},
+	}
+
+	rows, err := profileDiffRows(graph)
+	if err != nil {
+		t.Fatalf("profileDiffRows() error = %v", err)
+	}
+	want := []profileDiffRow{
+		{Level: 0, Value: 30, ValueRight: 40, Label: "total"},
+		{
+			Level: 1, Value: 10, Self: 5,
+			ValueRight: 30, SelfRight: 10, Label: "a",
+		},
+		{
+			Level: 2, Value: 5, Self: 5,
+			ValueRight: 20, SelfRight: 20, Label: "a-child",
+		},
+		{
+			Level: 1, Value: 20, Self: 20,
+			ValueRight: 10, SelfRight: 10, Label: "b",
+		},
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Fatalf("rows = %#v, want %#v", rows, want)
+	}
+}
+
+func TestProfileDiffRowsRejectsMalformedLevel(t *testing.T) {
+	_, err := profileDiffRows(&querierv1.FlameGraphDiff{
+		Names:  []string{"total"},
+		Levels: []*querierv1.Level{{Values: []int64{0, 1}}},
+	})
+	if err == nil {
+		t.Fatal("profileDiffRows() succeeded for a malformed level")
+	}
+}
+
+func TestProfileDiffRowsRejectsMaliciousValues(t *testing.T) {
+	tests := []*querierv1.FlameGraphDiff{
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, -1, 0, 0, 1, 0, 0}}},
+		},
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, 1, 2, 0, 1, 0, 0}}},
+		},
+		{
+			Names:  []string{"total"},
+			Levels: []*querierv1.Level{{Values: []int64{0, 1, 0, 0, 1, 0, 1}}},
+		},
+		{
+			Names: []string{"total", "orphan"},
+			Levels: []*querierv1.Level{
+				{Values: []int64{0, 1, 0, 0, 1, 0, 0}},
+				{Values: []int64{2, 1, 0, 2, 1, 0, 1}},
+			},
+		},
+		{
+			Names: []string{"total", "overflow"},
+			Levels: []*querierv1.Level{
+				{Values: []int64{0, math.MaxInt64, 0, 0, 1, 0, 0}},
+				{Values: []int64{math.MaxInt64, 1, 0, 0, 1, 0, 1}},
+			},
+		},
+	}
+	for index, graph := range tests {
+		if _, err := profileDiffRows(graph); err == nil {
+			t.Fatalf("profileDiffRows(test %d) succeeded", index)
+		}
+	}
+}
+
+func TestProfileDiffRowsLimitsTotalNodes(t *testing.T) {
+	level := &querierv1.Level{
+		Values: make([]int64, 0, maxProfileDiffMaxNodes*diffFlamegraphNodeWidth),
+	}
+	for range maxProfileDiffMaxNodes {
+		level.Values = append(level.Values, 0, 0, 0, 0, 0, 0, 0)
+	}
+
+	_, err := profileDiffRows(&querierv1.FlameGraphDiff{
+		Names: []string{"total"},
+		Levels: []*querierv1.Level{
+			{Values: []int64{0, 1, 0, 0, 1, 0, 0}},
+			level,
+		},
+	})
+	if err == nil {
+		t.Fatal("profileDiffRows() accepted more than the node limit")
+	}
+}
+
+func TestProfileDiffResponseSizeLimit(t *testing.T) {
+	tooLarge, err := profileDiffResponseExceedsLimit([]profileDiffRow{{
+		Label: strings.Repeat("x", maxProfileDiffResponseBytes),
+	}})
+	if err != nil {
+		t.Fatalf("profileDiffResponseExceedsLimit() error = %v", err)
+	}
+	if !tooLarge {
+		t.Fatal("profile diff response exceeded the byte limit")
+	}
+}

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -43,6 +43,9 @@ type Config struct {
 // ProfileQueryService defines profile query operations consumed by the handler.
 type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
+	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
+	Diff(ctx context.Context, req *querierv1.DiffRequest) (*querierv1.DiffResponse, error)
+	MarshalPprof(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) ([]byte, error)
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -83,6 +86,11 @@ func NewHandler(
 			h.Handlers,
 			server.Handle{Typ: server.HttpGet, Uri: "/:id/raw", Handle: h.getRawData},
 			server.Handle{
+				Typ:    server.HttpGet,
+				Uri:    "/flamegraph/export/pprof",
+				Handle: h.displayPprofExport,
+			},
+			server.Handle{
 				Typ:    server.HttpPost,
 				Uri:    "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces",
 				Handle: h.displaySelectMergeStacktraces,
@@ -91,6 +99,21 @@ func NewHandler(
 				Typ:    server.HttpPost,
 				Uri:    "/flamegraph/querier.v1.QuerierService/ProfileTypes",
 				Handle: h.displayProfileTypes,
+			},
+			server.Handle{
+				Typ:    server.HttpPost,
+				Uri:    "/flamegraph/querier.v1.QuerierService/SelectSeries",
+				Handle: h.displaySelectSeries,
+			},
+			server.Handle{
+				Typ:    server.HttpPost,
+				Uri:    "/flamegraph/querier.v1.QuerierService/Diff",
+				Handle: h.displayDiff,
+			},
+			server.Handle{
+				Typ:    server.HttpPost,
+				Uri:    "/flamegraph/diff-rows",
+				Handle: h.displayDiffRows,
 			},
 			server.Handle{
 				Typ:    server.HttpPost,

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -24,6 +24,7 @@ import (
 	v1 "huatuo-bamai/apis/v1"
 	"huatuo-bamai/internal/job"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 	"huatuo-bamai/internal/server/response"
@@ -259,34 +260,28 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	var dashboardSlug string
 	var labelKey string
 	var labelVal string
+	var profileTypeID string
 
 	from := jobResult.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z")
 	to := jobResult.FinishedAt.UTC().Format("2006-01-02T15:04:05.000Z")
 
+	switch jobResult.Type {
+	case ProfilingMemory:
+		profileTypeID = profiler.ProfileTypeMemSample
+	case ProfilingCPU:
+		profileTypeID = profiler.ProfileTypeCpuSample
+	default:
+		return ""
+	}
+
 	if jobResult.ContainerID != "" {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "container-memory-profiling"
-			dashboardSlug = "e5aeb9-e599a8-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "container-cpu-profiling"
-			dashboardSlug = "e5aeb9-e599a8-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-container"
+		dashboardSlug = "continuous-profiling-container"
 		labelKey = "var-container_id"
 		labelVal = jobResult.ContainerID
 	} else {
-		switch jobResult.Type {
-		case ProfilingMemory:
-			dashboardUID = "host-memory-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-memory-profiling"
-		case ProfilingCPU:
-			dashboardUID = "host-cpu-profiling"
-			dashboardSlug = "e5aebf-e4b8bb-e69cba-cpu-profiling"
-		default:
-			return ""
-		}
+		dashboardUID = "continuous-profiling-host"
+		dashboardSlug = "continuous-profiling-host"
 		labelKey = "var-hostname"
 		labelVal = jobResult.Hostname
 	}
@@ -297,6 +292,7 @@ func getFlameGraphURL(base string, jobResult *job.Job) string {
 	query.Set("to", to)
 	query.Set("timezone", "browser")
 	query.Set(labelKey, labelVal)
+	query.Set("var-type", profileTypeID)
 
 	return fmt.Sprintf("%s/%s/%s?%s", base, dashboardUID, dashboardSlug, query.Encode())
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -44,8 +44,12 @@ func TestNewHandlerRegistersStorageRoutesWhenEnabled(t *testing.T) {
 
 	want := []string{
 		"/:id/raw",
+		"/flamegraph/export/pprof",
+		"/flamegraph/diff-rows",
 		"/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces",
 		"/flamegraph/querier.v1.QuerierService/ProfileTypes",
+		"/flamegraph/querier.v1.QuerierService/SelectSeries",
+		"/flamegraph/querier.v1.QuerierService/Diff",
 		"/flamegraph/querier.v1.QuerierService/LabelNames",
 		"/flamegraph/querier.v1.QuerierService/LabelValues",
 	}
@@ -56,16 +60,48 @@ func TestNewHandlerRegistersStorageRoutesWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestGetFlameGraphURLEscapesLabelValue(t *testing.T) {
-	url := getFlameGraphURL("http://grafana.example/d", &job.Job{
-		Type:        ProfilingCPU,
-		ContainerID: "container+2026&debug",
-		CreatedAt:   time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC),
-		FinishedAt:  time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC),
-	})
+func TestGetFlameGraphURLTargetsProvisionedDashboards(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           job.Job
+		wantPath      string
+		wantSelection string
+		wantType      string
+	}{
+		{
+			name: "host CPU",
+			job: job.Job{
+				Type:     ProfilingCPU,
+				Hostname: "node+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-host/continuous-profiling-host?",
+			wantSelection: "var-hostname=node%2B2026%26debug",
+			wantType:      "var-type=process_cpu%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds",
+		},
+		{
+			name: "container memory",
+			job: job.Job{
+				Type:        ProfilingMemory,
+				ContainerID: "container+2026&debug",
+			},
+			wantPath:      "/continuous-profiling-container/continuous-profiling-container?",
+			wantSelection: "var-container_id=container%2B2026%26debug",
+			wantType:      "var-type=memory%3Aalloc_space%3Abytes%3Aspace%3Abytes",
+		},
+	}
 
-	if !strings.Contains(url, "var-container_id=container%2B2026%26debug") {
-		t.Fatalf("url = %q, want escaped container label value", url)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.job.CreatedAt = time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+			tc.job.FinishedAt = time.Date(2026, 6, 24, 10, 5, 0, 0, time.UTC)
+			url := getFlameGraphURL("http://grafana.example/d", &tc.job)
+
+			for _, want := range []string{tc.wantPath, tc.wantSelection, tc.wantType} {
+				if !strings.Contains(url, want) {
+					t.Fatalf("url = %q, want %q", url, want)
+				}
+			}
+		})
 	}
 }
 
@@ -79,6 +115,21 @@ func TestNewHandlerSnapshotsProfilingConfig(t *testing.T) {
 			"AggregationIntervalSeconds = %d, want 15",
 			h.profilingConfig.AggregationIntervalSeconds,
 		)
+	}
+}
+
+func TestNewHandlerRegistersProfileExports(t *testing.T) {
+	h := NewHandler(nil, &profileService.Service{}, Config{})
+	routes := make(map[string]bool, len(h.Handlers))
+	for _, handler := range h.Handlers {
+		routes[handler.Uri] = true
+	}
+	for _, route := range []string{
+		"/flamegraph/export/pprof",
+	} {
+		if !routes[route] {
+			t.Errorf("profile export route %q is not registered", route)
+		}
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -17,13 +17,17 @@ package profiling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"huatuo-bamai/internal/log"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 
 	"github.com/gin-gonic/gin/binding"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 )
 
 func handleProto[Request, Response any](
@@ -39,22 +43,30 @@ func handleProto[Request, Response any](
 
 	resp, err := invoke(ctx.Request().Context(), req)
 	if err != nil {
-		if errors.Is(err, profileService.ErrInvalidQuery) {
-			ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
-			return nil
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField("operation", operation).Error("profile query failed")
 		}
-		if errors.Is(err, profileService.ErrProfilesAbsent) {
-			ctx.JSON(http.StatusNotFound, map[string]any{"message": "profiles not found"})
-			return nil
-		}
-		log.WithError(err).WithField("operation", operation).Error("profile query failed")
-		ctx.JSON(http.StatusInternalServerError, map[string]any{"message": "internal error"})
+		ctx.JSON(status, map[string]any{"message": message})
 		return nil
 	}
 
 	ctx.Header("Content-Type", "application/proto")
 	ctx.ProtoBuf(http.StatusOK, resp)
 	return nil
+}
+
+func profileQueryHTTPError(err error) (int, string) {
+	switch {
+	case errors.Is(err, profileService.ErrInvalidQuery):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, profileService.ErrProfilesAbsent):
+		return http.StatusNotFound, "profiles not found"
+	case errors.Is(err, profileService.ErrProfileQueryLimitExceeded):
+		return http.StatusUnprocessableEntity, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal error"
+	}
 }
 
 func (h *Handler) displaySelectMergeStacktraces(ctx *server.Context) error {
@@ -65,10 +77,77 @@ func (h *Handler) displayProfileTypes(ctx *server.Context) error {
 	return handleProto(ctx, "profile_types", h.profileService.ProfileTypes)
 }
 
+func (h *Handler) displaySelectSeries(ctx *server.Context) error {
+	return handleProto(ctx, "select_series", h.profileService.SelectSeries)
+}
+
+func (h *Handler) displayDiff(ctx *server.Context) error {
+	return handleProto(ctx, "diff", h.profileService.Diff)
+}
+
 func (h *Handler) displayLabelNames(ctx *server.Context) error {
 	return handleProto(ctx, "label_names", h.profileService.LabelNames)
 }
 
 func (h *Handler) displayLabelValues(ctx *server.Context) error {
 	return handleProto(ctx, "label_values", h.profileService.LabelValues)
+}
+
+func profileExportRequest(
+	query func(string) string,
+) (*querierv1.SelectMergeStacktracesRequest, error) {
+	profileType := strings.TrimSpace(query("profile_type"))
+	if profileType == "" {
+		return nil, errors.New("profile_type is required")
+	}
+	selector := strings.TrimSpace(query("selector"))
+	if selector == "" {
+		return nil, errors.New("selector is required")
+	}
+	start, err := strconv.ParseInt(query("start"), 10, 64)
+	if err != nil {
+		return nil, errors.New("start must be a Unix timestamp in milliseconds")
+	}
+	end, err := strconv.ParseInt(query("end"), 10, 64)
+	if err != nil {
+		return nil, errors.New("end must be a Unix timestamp in milliseconds")
+	}
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profileType,
+		LabelSelector: selector,
+		Start:         start,
+		End:           end,
+	}, nil
+}
+
+func writeProfileServiceError(ctx *server.Context, operation string, err error) {
+	status, message := profileQueryHTTPError(err)
+	if status == http.StatusInternalServerError {
+		log.WithError(err).WithField("operation", operation).Error("profile query failed")
+	}
+	ctx.JSON(status, map[string]any{"message": message})
+}
+
+func (h *Handler) displayPprofExport(ctx *server.Context) error {
+	req, err := profileExportRequest(ctx.Query)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
+		return nil
+	}
+	payload, err := h.profileService.MarshalPprof(ctx.Request().Context(), req)
+	if err != nil {
+		writeProfileServiceError(ctx, "export_pprof", err)
+		return nil
+	}
+	ctx.Header("Content-Type", "application/octet-stream")
+	ctx.Header(
+		"Content-Disposition",
+		`attachment; filename="huatuo-profile.pb.gz"`,
+	)
+	ctx.Header("X-Content-Type-Options", "nosniff")
+	ctx.Writer().WriteHeader(http.StatusOK)
+	if _, err := ctx.Writer().Write(payload); err != nil {
+		return fmt.Errorf("write pprof export: %w", err)
+	}
+	return nil
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	profileService "huatuo-bamai/internal/profiler/service"
+)
+
+func TestProfileQueryHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "invalid query",
+			err:         errors.Join(profileService.ErrInvalidQuery, errors.New("bad selector")),
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "bad selector",
+		},
+		{
+			name:        "not found",
+			err:         profileService.ErrProfilesAbsent,
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "profiles not found",
+		},
+		{
+			name: "selection too large",
+			err: errors.Join(
+				profileService.ErrProfileQueryLimitExceeded,
+				errors.New("10001 documents"),
+			),
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: "10001 documents",
+		},
+		{
+			name:        "internal",
+			err:         errors.New("elasticsearch unavailable"),
+			wantStatus:  http.StatusInternalServerError,
+			wantMessage: "internal error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := profileQueryHTTPError(test.err)
+			if status != test.wantStatus {
+				t.Fatalf("status = %d, want %d", status, test.wantStatus)
+			}
+			if !strings.Contains(message, test.wantMessage) {
+				t.Fatalf("message = %q, want it to contain %q", message, test.wantMessage)
+			}
+		})
+	}
+}
+
+func TestProfileExportRequest(t *testing.T) {
+	values := map[string]string{
+		"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		"selector":     `{hostname="node-a"}`,
+		"start":        "1784944800000",
+		"end":          "1784944860000",
+	}
+	req, err := profileExportRequest(func(name string) string {
+		return values[name]
+	})
+	if err != nil {
+		t.Fatalf("profileExportRequest() error = %v", err)
+	}
+	if req.ProfileTypeID != values["profile_type"] ||
+		req.LabelSelector != values["selector"] ||
+		req.Start != 1784944800000 ||
+		req.End != 1784944860000 {
+		t.Fatalf("profileExportRequest() = %#v, want query values", req)
+	}
+}
+
+func TestProfileExportRequestRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   string
+	}{
+		{
+			name:   "profile type",
+			values: map[string]string{},
+			want:   "profile_type is required",
+		},
+		{
+			name: "selector",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			},
+			want: "selector is required",
+		},
+		{
+			name: "start",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "yesterday",
+			},
+			want: "start must be a Unix timestamp in milliseconds",
+		},
+		{
+			name: "end",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "1784944800000",
+				"end":          "tomorrow",
+			},
+			want: "end must be a Unix timestamp in milliseconds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := profileExportRequest(func(name string) string {
+				return test.values[name]
+			})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf(
+					"profileExportRequest() error = %v, want %q",
+					err,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -338,7 +338,46 @@ Profiling jobs use these statuses:
 | `failed` | The job failed; inspect `status_reason` for the cause |
 | `timeout` | The job exceeded its allowed execution time |
 
-### 6. Get Raw Profiling Data
+### 6. Inspect Profiles in Grafana
+
+Grafana provisioning includes host, container, and comparison continuous
+profiling dashboards. The host and container dashboards show the number of
+stored profile snapshots, total profile value over time, Top 10 series grouped
+by a selected dimension, and a merged flame graph with a Top table:
+
+- The host dashboard selects an exact `hostname` and excludes container
+  profiles.
+- The container dashboard queries profiles by exact `container_id` and shows
+  the reporting `hostname` for context. Container names are not used as
+  identifiers because they are not guaranteed to be unique.
+- Both dashboards can additionally filter exact `profiling_scope`, `cpu`,
+  `pid`, and `tgid` values. The Top 10 panel can group by those dimensions,
+  `container_id`, or tracer.
+
+CPU and memory are the only profile types exposed by these dashboards. A
+completed job's `results.url` opens the corresponding dashboard with its
+target, profile type, and collection window preselected.
+
+The Pyroscope datasource sends queries to huatuo-apiserver. If API
+authentication is enabled, configure a dedicated user with
+`POST /v1/profiles/flamegraph/**` permission and pass the same user ID to the
+Grafana container without committing it:
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+The timeline and Top 10 panels use the Pyroscope-compatible `SelectSeries`
+endpoint. The comparison dashboard uses `Diff` through a bounded JSON adapter
+for Grafana's flame graph panel. The selected range is the current window and
+is compared with the immediately preceding window of the same duration. A
+selected `container_id` takes precedence over `hostname`. The same optional
+collection dimensions are applied to both windows. The adapter defaults to
+5,000 nodes, rejects values above 10,000, and limits its JSON response to
+8 MiB.
+
+### 7. Get Raw Profiling Data
 
 `GET /v1/profiles/:id/raw` returns the raw profiling windows associated with the job. The response can be large, so it can be written directly to a file:
 
@@ -353,7 +392,32 @@ The profiling windows are in `data.items`; `data.limit`, `data.offset`, and
 `data.has_more` describe the page. Each item contains `uploaded_at`,
 `captured_at`, `profile_type`, and the pprof-compatible `profile` payload.
 
-### 7. Stop a Profiling Job
+#### Export merged pprof
+
+The export endpoint merges the stored snapshots selected by profile type, time
+range, and an exact target label:
+
+```bash
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o profile.pb.gz \
+  "${API_BASE}/v1/profiles/flamegraph/export/pprof"
+```
+
+Selectors accept exact `id`, `hostname`, `container_id`,
+`container_hostname`, `profiling_scope`, `cpu`, `pid`, or `tgid` matches. At
+least one target or collection-dimension label is required. The service counts
+matching documents before fetching them, reads them in pages, and returns
+`422 Unprocessable Entity` when more than 10,000 documents match. Narrow the
+time range in that case. The downloaded file can be opened by `go tool pprof`
+or another pprof-compatible viewer.
+
+### 8. Stop a Profiling Job
 
 Only jobs in `pending` or `running` status can be stopped. The `PATCH` request accepts only `stopped` as the `status` value:
 
@@ -368,7 +432,7 @@ curl -sS \
 
 A successful stop returns `200 OK`. A job that has already ended returns `400 Bad Request`.
 
-### 8. Delete a Profiling Job
+### 9. Delete a Profiling Job
 
 Deletion removes only the job record. Jobs in `pending` or `running` status cannot be deleted directly and must be stopped first:
 
@@ -380,6 +444,26 @@ curl -sS -i \
 ```
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
+
+### 10. Pyroscope-compatible Queries
+
+The profiling API implements the Pyroscope `SelectSeries` and `Diff` protobuf
+methods under `/v1/profiles/flamegraph/querier.v1.QuerierService/`. `SelectSeries`
+returns time buckets using sum or average aggregation. `Diff` compares two
+independent time windows and returns a double flame graph.
+
+Selectors are intentionally exact. They accept `id`, `hostname`,
+`container_id`, `container_hostname`, `tracer`, `profiling_scope`, `cpu`,
+`pid`, and `tgid`; the profile type is supplied by the protobuf request.
+`SelectSeries` can group by the same managed dimensions. Regular expressions,
+negative matchers, and arbitrary labels are rejected with `400 Bad Request`.
+
+Each selection is counted before profile data is loaded. Up to 10,000 documents
+are read in stable pages of 1,000. A larger selection returns
+`422 Unprocessable Entity` and must be narrowed by time or target. Merge
+and diff flame graphs default to 5,000 nodes and reject values above 10,000.
+Merge requests, and diff requests with neither side populated, return
+`404 Not Found`; storage failures return `500 Internal Server Error`.
 
 ## 📖 profiler CLI Overview
 

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -340,7 +340,38 @@ curl -sS \
 | `failed` | 任务执行失败，查看 `status_reason` 定位原因 |
 | `timeout` | 任务超过允许的执行时间 |
 
-### 6. 获取原始剖析数据
+### 6. 在 Grafana 中查看剖析结果
+
+Grafana provisioning 提供宿主机、容器和时间窗口对比三张持续剖析
+dashboard。宿主机和容器 dashboard 展示剖析快照数量、剖析值时间线、
+按所选维度分组的 Top 10 序列，以及合并后的火焰图和 Top 表：
+
+- 宿主机 dashboard 按 `hostname` 精确筛选，并排除容器剖析数据。
+- 容器 dashboard 按 `container_id` 精确查询剖析数据，并展示上报节点
+  `hostname` 作为上下文。容器名不保证唯一，因此不作为容器标识。
+- 两张 dashboard 都可继续按精确的 `profiling_scope`、`cpu`、`pid` 和
+  `tgid` 筛选。Top 10 可按这些维度、`container_id` 或 tracer 分组。
+
+dashboard 只提供当前已支持的 CPU 和内存剖析类型。任务完成后，
+`results.url` 会打开对应 dashboard，并预选目标、剖析类型和采集时间窗口。
+
+Pyroscope datasource 通过 huatuo-apiserver 查询数据。启用 API 鉴权时，
+应创建只拥有 `POST /v1/profiles/flamegraph/**` 权限的专用用户，并通过
+环境变量将同一个用户 ID 传给 Grafana，不要把它提交到仓库：
+
+```bash
+export HUATUO_GRAFANA_PROFILE_TOKEN="<Auth.users.ID>"
+docker compose -f build/docker/docker-compose.yml up -d
+```
+
+时间线和 Top 10 面板使用 Pyroscope 兼容的 `SelectSeries` 接口。对比
+dashboard 通过有边界限制的 JSON 适配器调用 `Diff`，并把结果交给 Grafana
+火焰图面板。选定时间范围是当前窗口，对比对象是紧邻其前、长度相同的窗口；
+选择 `container_id` 时优先于 `hostname`，并把相同的可选采集维度应用到
+两侧时间窗。适配器默认最多返回 5,000 个节点，拒绝超过 10,000 的配置，
+并将 JSON 响应限制为 8 MiB。
+
+### 7. 获取原始剖析数据
 
 `GET /v1/profiles/:id/raw` 返回该任务关联的原始剖析窗口。数据量可能较大，可以直接保存到文件：
 
@@ -355,7 +386,29 @@ curl -sS \
 和 `data.has_more` 描述分页。每条记录包含 `uploaded_at`、`captured_at`、
 `profile_type` 和兼容 pprof 的 `profile` 数据。
 
-### 7. 停止任务
+#### 导出合并后的 pprof
+
+导出接口根据剖析类型、时间范围和精确目标标签合并存储中的快照：
+
+```bash
+curl -sS --get \
+  -H "Authorization: Bearer ${USER_ID}" \
+  --data-urlencode \
+  "profile_type=process_cpu:cpu:nanoseconds:cpu:nanoseconds" \
+  --data-urlencode 'selector={hostname="node-a"}' \
+  --data-urlencode "start=${START_MILLISECONDS}" \
+  --data-urlencode "end=${END_MILLISECONDS}" \
+  -o profile.pb.gz \
+  "${API_BASE}/v1/profiles/flamegraph/export/pprof"
+```
+
+选择器接受精确的 `id`、`hostname`、`container_id`、
+`container_hostname`、`profiling_scope`、`cpu`、`pid` 或 `tgid`
+匹配，并且至少需要一个目标或采集维度标签。服务会先统计匹配文档数，再分页
+读取。匹配超过 10,000 个文档时返回 `422 Unprocessable Entity`，此时需要
+缩小时间范围。下载文件可由 `go tool pprof` 或其他兼容 pprof 的查看器打开。
+
+### 8. 停止任务
 
 只有 `pending` 或 `running` 状态的任务可以停止。`PATCH` 请求的 `status` 只接受 `stopped`：
 
@@ -370,7 +423,7 @@ curl -sS \
 
 停止成功返回 `200 OK`。已结束的任务返回 `400 Bad Request`。
 
-### 8. 删除任务
+### 9. 删除任务
 
 删除操作只移除任务记录。`pending` 或 `running` 状态的任务不能直接删除，需要先停止任务：
 
@@ -382,6 +435,26 @@ curl -sS -i \
 ```
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
+
+### 10. Pyroscope 兼容查询
+
+Profiling API 在
+`/v1/profiles/flamegraph/querier.v1.QuerierService/` 下实现 Pyroscope 的
+`SelectSeries` 和 `Diff` protobuf 方法。`SelectSeries` 按时间桶返回求和或
+平均聚合结果；`Diff` 比较两个独立时间窗口并返回双向火焰图。
+
+选择器只支持精确匹配，可使用 `id`、`hostname`、`container_id`、
+`container_hostname`、`tracer`、`profiling_scope`、`cpu`、`pid` 和
+`tgid`；剖析类型由 protobuf 请求单独提供。`SelectSeries` 可按相同的
+managed dimension 分组。正则、否定匹配和任意标签会返回
+`400 Bad Request`。
+
+服务读取剖析数据前会先统计匹配文档数。单次选择最多读取 10,000 条，
+每页 1,000 条并使用稳定排序。超过上限时返回
+`422 Unprocessable Entity`，调用方需要缩小时间范围或目标范围。Merge 和
+Diff 火焰图默认 5,000 个节点，并拒绝超过 10,000 的配置。合并查询没有
+数据，或差异查询两侧都没有数据时返回 `404 Not Found`；存储故障返回
+`500 Internal Server Error`。
 
 ## 📖 profiler 命令行功能概述
 

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var collectionDimensionLabels = [...]string{
+	LabelProfilingScope,
+	LabelCPU,
+	LabelPID,
+	LabelTGID,
+	LabelContainerID,
+}
+
+// CollectionDimensionLabelNames returns labels managed by collection filters.
+func CollectionDimensionLabelNames() []string {
+	names := make([]string, len(collectionDimensionLabels))
+	copy(names, collectionDimensionLabels[:])
+	return names
+}
+
+// IsCollectionDimensionLabel reports whether name is a supported display dimension.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import "testing"
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	names := CollectionDimensionLabelNames()
+	names[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}
+
+func TestIsCollectionDimensionLabel(t *testing.T) {
+	for _, name := range CollectionDimensionLabelNames() {
+		if !IsCollectionDimensionLabel(name) {
+			t.Errorf("IsCollectionDimensionLabel(%q) = false", name)
+		}
+	}
+	if IsCollectionDimensionLabel("arbitrary") {
+		t.Fatal("IsCollectionDimensionLabel(arbitrary) = true")
+	}
+}

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -1,0 +1,579 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	profileQueryLimit    = 10000
+	profileQueryPageSize = 1000
+	profileSeriesLimit   = 100
+	defaultProfileNodes  = 5000
+	profileNodeLimit     = 10000
+)
+
+type profileSelection struct {
+	filter     *SearchFilter
+	sampleType string
+}
+
+func buildProfileSelection(profileType, selector string, start, end int64) (*profileSelection, error) {
+	profileTypeParts := strings.Split(profileType, ":")
+	if len(profileTypeParts) != 5 {
+		return nil, invalidProfileQueryf("invalid profile type %q", profileType)
+	}
+	if end < start {
+		return nil, invalidProfileQueryf("end time precedes start time")
+	}
+
+	matchers, err := parser.ParseMetricSelector(selector)
+	if err != nil {
+		return nil, invalidProfileQueryf("parse matchers: %v", err)
+	}
+	filter := &SearchFilter{
+		StartTime:   time.UnixMilli(start),
+		EndTime:     time.UnixMilli(end),
+		ProfileType: profileType,
+	}
+	for _, matcher := range matchers {
+		if matcher == nil {
+			continue
+		}
+		if matcher.Name == "__profile_type__" && matcher.Value != profileType {
+			return nil, invalidProfileQueryf(
+				"profile type matcher %q does not match request %q",
+				matcher.Value,
+				profileType,
+			)
+		}
+		if err := applyProfileMatcher(filter, matcher); err != nil {
+			return nil, err
+		}
+	}
+	if filter.ID != "" && filter.TracerID != "" && filter.ID != filter.TracerID {
+		return nil, invalidProfileQueryf("id and tracer select different profiles")
+	}
+	if !hasExactProfileTarget(filter) {
+		return nil, invalidProfileQueryf(
+			"id, hostname, container_id, container_hostname, tracer, or a " +
+				"collection dimension must be specified",
+		)
+	}
+	return &profileSelection{filter: filter, sampleType: profileTypeParts[1]}, nil
+}
+
+func invalidProfileQueryf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidQuery, fmt.Sprintf(format, args...))
+}
+
+func hasExactProfileTarget(filter *SearchFilter) bool {
+	if filter == nil {
+		return false
+	}
+	if filter.ID != "" ||
+		filter.Hostname != "" ||
+		filter.ContainerID != "" ||
+		filter.ContainerHostname != "" ||
+		filter.TracerID != "" {
+		return true
+	}
+	for _, value := range filter.Labels {
+		if value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) searchProfileDocuments(
+	ctx context.Context,
+	selection *profileSelection,
+) ([]*ProfileDocument, error) {
+	if s == nil || s.profileStorage == nil {
+		return nil, errorsProfileStorageNotInitialized()
+	}
+	count, err := s.profileStorage.CountProfilesContext(ctx, selection.filter)
+	if err != nil {
+		return nil, fmt.Errorf("count profiles: %w", err)
+	}
+	if count < 0 {
+		return nil, fmt.Errorf("count profiles: storage returned negative count %d", count)
+	}
+	if count > profileQueryLimit {
+		return nil, fmt.Errorf(
+			"%w: matched %d documents; narrow the time range or selector to at most %d",
+			ErrProfileQueryLimitExceeded,
+			count,
+			profileQueryLimit,
+		)
+	}
+
+	documents := make([]*ProfileDocument, 0, int(count))
+	for offset := 0; offset < int(count); offset += profileQueryPageSize {
+		pageFilter := *selection.filter
+		pageFilter.Limit = min(profileQueryPageSize, int(count)-offset)
+		pageFilter.Offset = offset
+		page, err := s.profileStorage.SearchProfilesContext(ctx, &pageFilter)
+		if err != nil {
+			return nil, fmt.Errorf("search profiles at offset %d: %w", offset, err)
+		}
+		if len(page) != pageFilter.Limit {
+			return nil, fmt.Errorf(
+				"search profiles at offset %d: storage returned %d documents, expected %d",
+				offset,
+				len(page),
+				pageFilter.Limit,
+			)
+		}
+		for index, document := range page {
+			if document == nil {
+				return nil, fmt.Errorf(
+					"search profiles at offset %d: storage returned nil document at page index %d",
+					offset,
+					index,
+				)
+			}
+		}
+		documents = append(documents, page...)
+	}
+	if int64(len(documents)) != count {
+		return nil, fmt.Errorf(
+			"search profiles: storage returned %d documents after count reported %d",
+			len(documents),
+			count,
+		)
+	}
+	return documents, nil
+}
+
+func errorsProfileStorageNotInitialized() error {
+	return fmt.Errorf("profile storage is not initialized")
+}
+
+func (s *Service) selectProfileTree(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	allowEmpty bool,
+) (*phlaremodel.Tree, bool, error) {
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(documents) == 0 && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+
+	tree := new(phlaremodel.Tree)
+	hasSamples := false
+	for _, document := range documents {
+		if addProfileDocumentToTree(tree, document, selection.sampleType) {
+			hasSamples = true
+		}
+	}
+	if !hasSamples && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+	return tree, hasSamples, nil
+}
+
+func addProfileDocumentToTree(
+	tree *phlaremodel.Tree,
+	document *ProfileDocument,
+	sampleType string,
+) bool {
+	profile := &document.TracerData.Flamedata.Profile
+	sampleTypeIndex, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return false
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+	inserted := false
+	for _, sample := range profile.Sample {
+		if sample == nil || sampleTypeIndex >= len(sample.Value) {
+			continue
+		}
+		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
+		if len(stack) > 0 {
+			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+			inserted = true
+		}
+	}
+	return inserted
+}
+
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, bool) {
+	for i, valueType := range profile.SampleType {
+		if valueType == nil {
+			continue
+		}
+		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func profileSampleStack(
+	profile *profilev1.Profile,
+	locations map[uint64]*profilev1.Location,
+	functions map[uint64]*profilev1.Function,
+	locationIDs []uint64,
+) []string {
+	stack := make([]string, 0, len(locationIDs))
+	for _, locationID := range locationIDs {
+		location := locations[locationID]
+		if location == nil {
+			continue
+		}
+		for _, line := range location.Line {
+			if line == nil {
+				continue
+			}
+			function := functions[line.FunctionId]
+			if function == nil {
+				continue
+			}
+			name, ok := profileString(profile.StringTable, function.Name)
+			if ok {
+				stack = append(stack, name)
+			}
+		}
+	}
+	for left, right := 0, len(stack)-1; left < right; left, right = left+1, right-1 {
+		stack[left], stack[right] = stack[right], stack[left]
+	}
+	return stack
+}
+
+// Diff compares two independently selected profile windows.
+func (s *Service) Diff(
+	ctx context.Context,
+	req *querierv1.DiffRequest,
+) (*querierv1.DiffResponse, error) {
+	if req == nil || req.Left == nil || req.Right == nil {
+		return nil, invalidProfileQueryf("left and right profile selections are required")
+	}
+	if req.Left.ProfileTypeID != req.Right.ProfileTypeID {
+		return nil, invalidProfileQueryf("left and right profile types must match")
+	}
+	maxNodes, err := diffMaxNodes(req)
+	if err != nil {
+		return nil, err
+	}
+	left, leftFound, err := s.selectProfileTree(ctx, req.Left, true)
+	if err != nil {
+		return nil, fmt.Errorf("select left profiles: %w", err)
+	}
+	right, rightFound, err := s.selectProfileTree(ctx, req.Right, true)
+	if err != nil {
+		return nil, fmt.Errorf("select right profiles: %w", err)
+	}
+	if !leftFound && !rightFound {
+		return nil, ErrProfilesAbsent
+	}
+	flamegraph, err := phlaremodel.NewFlamegraphDiff(left, right, maxNodes)
+	if err != nil {
+		return nil, fmt.Errorf("build flamegraph diff: %w", err)
+	}
+	return &querierv1.DiffResponse{Flamegraph: flamegraph}, nil
+}
+
+func diffMaxNodes(req *querierv1.DiffRequest) (int64, error) {
+	left, err := normalizeProfileMaxNodes(req.Left.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("left selection: %w", err)
+	}
+	right, err := normalizeProfileMaxNodes(req.Right.GetMaxNodes())
+	if err != nil {
+		return 0, fmt.Errorf("right selection: %w", err)
+	}
+	switch {
+	case right < left:
+		return right, nil
+	default:
+		return left, nil
+	}
+}
+
+func normalizeProfileMaxNodes(maxNodes int64) (int64, error) {
+	if maxNodes == 0 {
+		return defaultProfileNodes, nil
+	}
+	if maxNodes < 0 || maxNodes > profileNodeLimit {
+		return 0, invalidProfileQueryf(
+			"max nodes must be between 0 and %d",
+			profileNodeLimit,
+		)
+	}
+	return maxNodes, nil
+}
+
+// SelectSeries returns sample totals bucketed by time and exact profile labels.
+func (s *Service) SelectSeries(
+	ctx context.Context,
+	req *querierv1.SelectSeriesRequest,
+) (*querierv1.SelectSeriesResponse, error) {
+	if req == nil {
+		return nil, invalidProfileQueryf("request is required")
+	}
+	stepMillis, err := seriesStepMillis(req.Step)
+	if err != nil {
+		return nil, err
+	}
+	aggregation := typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM
+	if req.Aggregation != nil {
+		aggregation = *req.Aggregation
+	}
+	if aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM &&
+		aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+		return nil, invalidProfileQueryf(
+			"unsupported time series aggregation %q",
+			aggregation.String(),
+		)
+	}
+	groupBy, err := normalizeProfileGroupBy(req.GroupBy)
+	if err != nil {
+		return nil, err
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, err
+	}
+
+	type bucketValue struct {
+		sum   float64
+		count int64
+	}
+	type groupedSeries struct {
+		labels  []*typesv1.LabelPair
+		buckets map[int64]*bucketValue
+	}
+	groups := make(map[string]*groupedSeries)
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		value, found := profileDocumentSampleTotal(document, selection.sampleType)
+		if !found {
+			continue
+		}
+		seriesLabels, key := profileSeriesLabels(document, groupBy)
+		group := groups[key]
+		if group == nil {
+			group = &groupedSeries{
+				labels:  seriesLabels,
+				buckets: make(map[int64]*bucketValue),
+			}
+			groups[key] = group
+		}
+		timestamp := profileDocumentTimestamp(document).UnixMilli()
+		bucketTimestamp := req.Start + ((timestamp-req.Start)/stepMillis)*stepMillis
+		bucket := group.buckets[bucketTimestamp]
+		if bucket == nil {
+			bucket = &bucketValue{}
+			group.buckets[bucketTimestamp] = bucket
+		}
+		bucket.sum += value
+		bucket.count++
+	}
+
+	series := make([]*typesv1.Series, 0, len(groups))
+	for _, group := range groups {
+		points := make([]*typesv1.Point, 0, len(group.buckets))
+		for timestamp, value := range group.buckets {
+			pointValue := value.sum
+			if aggregation ==
+				typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+				pointValue /= float64(value.count)
+			}
+			points = append(points, &typesv1.Point{
+				Value:     pointValue,
+				Timestamp: timestamp,
+			})
+		}
+		sort.Slice(points, func(i, j int) bool {
+			return points[i].Timestamp < points[j].Timestamp
+		})
+		series = append(series, &typesv1.Series{
+			Labels: group.labels,
+			Points: points,
+		})
+	}
+	sort.Slice(series, func(i, j int) bool {
+		left, right := profileSeriesValue(series[i]), profileSeriesValue(series[j])
+		if left != right {
+			return left > right
+		}
+		return phlaremodel.CompareLabelPairs(series[i].Labels, series[j].Labels) < 0
+	})
+	if len(series) > profileSeriesLimit {
+		series = series[:profileSeriesLimit]
+	}
+	return &querierv1.SelectSeriesResponse{Series: series}, nil
+}
+
+func seriesStepMillis(step float64) (int64, error) {
+	if math.IsNaN(step) ||
+		math.IsInf(step, 0) ||
+		step <= 0 ||
+		step > float64(math.MaxInt64)/1000 {
+		return 0, invalidProfileQueryf(
+			"step must be a finite positive number of seconds",
+		)
+	}
+	milliseconds := int64(math.Round(step * 1000))
+	if milliseconds < 1 {
+		return 1, nil
+	}
+	return milliseconds, nil
+}
+
+func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(groupBy))
+	result := make([]string, 0, len(groupBy))
+	for _, name := range groupBy {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		switch name {
+		case "id", "hostname", "container_id", "container_hostname", "tracer":
+		default:
+			if !profiler.IsCollectionDimensionLabel(name) {
+				return nil, invalidProfileQueryf("invalid group-by label %q", name)
+			}
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func profileDocumentSampleTotal(
+	document *ProfileDocument,
+	sampleType string,
+) (float64, bool) {
+	profile := &document.TracerData.Flamedata.Profile
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return 0, false
+	}
+	var total float64
+	var found bool
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) {
+			continue
+		}
+		total += float64(sample.Value[index])
+		found = true
+	}
+	return total, found
+}
+
+func profileSeriesLabels(
+	document *ProfileDocument,
+	groupBy []string,
+) ([]*typesv1.LabelPair, string) {
+	pairs := make([]*typesv1.LabelPair, 0, len(groupBy))
+	var key strings.Builder
+	for _, name := range groupBy {
+		value := profileDocumentLabelValue(document, name)
+		pairs = append(pairs, &typesv1.LabelPair{Name: name, Value: value})
+		_, _ = fmt.Fprintf(&key, "%d:%s=%d:%s;", len(name), name, len(value), value)
+	}
+	return pairs, key.String()
+}
+
+func profileDocumentLabelValue(document *ProfileDocument, name string) string {
+	switch name {
+	case "id", "tracer":
+		return document.TracerID
+	case "hostname":
+		return document.Hostname
+	case "container_id":
+		return document.ContainerID
+	case "container_hostname":
+		return document.ContainerHostname
+	default:
+		if profiler.IsCollectionDimensionLabel(name) {
+			return document.TracerData.Flamedata.Labels[name]
+		}
+		return ""
+	}
+}
+
+func profileDocumentTimestamp(document *ProfileDocument) time.Time {
+	if !document.UploadedTime.IsZero() {
+		return document.UploadedTime
+	}
+	return parseProfileDocumentTime(document.TracerTime, time.Unix(0, 0))
+}
+
+func profileSeriesValue(series *typesv1.Series) float64 {
+	var total float64
+	for _, point := range series.GetPoints() {
+		total += point.GetValue()
+	}
+	return total
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -1,0 +1,624 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+type fakeProfileQueryStorage struct {
+	documents   []*ProfileDocument
+	count       int64
+	countErr    error
+	searchErr   error
+	searchCalls []SearchFilter
+	pages       map[int][]*ProfileDocument
+}
+
+func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
+func (*fakeProfileQueryStorage) Ready(context.Context) error { return nil }
+
+func (s *fakeProfileQueryStorage) SearchProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) ([]*ProfileDocument, error) {
+	if s.searchErr != nil {
+		return nil, s.searchErr
+	}
+	s.searchCalls = append(s.searchCalls, *filter)
+	if s.pages != nil {
+		return s.pages[filter.Offset], nil
+	}
+	documents := s.matchingDocuments(filter)
+	if filter.Offset >= len(documents) {
+		return nil, nil
+	}
+	end := min(filter.Offset+filter.Limit, len(documents))
+	return documents[filter.Offset:end], nil
+}
+
+func (s *fakeProfileQueryStorage) CountProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) (int64, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	if s.count != 0 {
+		return s.count, nil
+	}
+	return int64(len(s.matchingDocuments(filter))), nil
+}
+
+func (*fakeProfileQueryStorage) AggregationsByFieldContext(
+	context.Context,
+	*SearchFilter,
+	string,
+) ([]string, error) {
+	return nil, nil
+}
+
+func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*ProfileDocument {
+	documents := make([]*ProfileDocument, 0, len(s.documents))
+documentLoop:
+	for _, document := range s.documents {
+		if document == nil {
+			continue
+		}
+		timestamp := profileDocumentTimestamp(document)
+		if !filter.StartTime.IsZero() && timestamp.Before(filter.StartTime) {
+			continue
+		}
+		if !filter.EndTime.IsZero() && timestamp.After(filter.EndTime) {
+			continue
+		}
+		if filter.ProfileType != "" &&
+			filter.ProfileType != document.TracerData.Flamedata.ProfileType {
+			continue
+		}
+		tracerID := filter.TracerID
+		if tracerID == "" {
+			tracerID = filter.ID
+		}
+		if tracerID != "" && tracerID != document.TracerID {
+			continue
+		}
+		if filter.Hostname != "" &&
+			(filter.Hostname != document.Hostname || document.ContainerHostname != "") {
+			continue
+		}
+		if filter.ContainerID != "" && filter.ContainerID != document.ContainerID {
+			continue
+		}
+		if filter.ContainerHostname != "" &&
+			filter.ContainerHostname != document.ContainerHostname {
+			continue
+		}
+		for name, value := range filter.Labels {
+			if value != "" &&
+				document.TracerData.Flamedata.Labels[name] != value {
+				continue documentLoop
+			}
+		}
+		documents = append(documents, document)
+	}
+	return documents
+}
+
+func newTestProfileService(storage *fakeProfileQueryStorage) *Service {
+	return &Service{profileStorage: storage}
+}
+
+func testProfileDocument(
+	timestamp time.Time,
+	tracerID string,
+	value int64,
+	stack ...string,
+) *ProfileDocument {
+	stringTable := []string{"", "cpu", "nanoseconds"}
+	functions := make([]*profilev1.Function, len(stack))
+	locations := make([]*profilev1.Location, len(stack))
+	locationIDs := make([]uint64, len(stack))
+	for i, name := range stack {
+		stringTable = append(stringTable, name)
+		id := uint64(i + 1)
+		functions[i] = &profilev1.Function{
+			Id:   id,
+			Name: int64(len(stringTable) - 1),
+		}
+		locations[i] = &profilev1.Location{
+			Id:   id,
+			Line: []*profilev1.Line{{FunctionId: id}},
+		}
+		locationIDs[len(stack)-1-i] = id
+	}
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: timestamp,
+		TracerID:     tracerID,
+		TracerTime:   timestamp.Format(profileTimeLayout),
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	document.TracerData.Flamedata.Profile = profilev1.Profile{
+		StringTable: stringTable,
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+			Unit: 2,
+		}},
+		Function: functions,
+		Location: locations,
+		Sample: []*profilev1.Sample{{
+			LocationId: locationIDs,
+			Value:      []int64{value},
+		}},
+	}
+	return document
+}
+
+func TestSearchProfileDocumentsPaginatesWithoutTruncation(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	documents := make([]*ProfileDocument, 1001)
+	for i := range documents {
+		documents[i] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{hostname="node-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	got, err := service.searchProfileDocuments(t.Context(), selection)
+	if err != nil {
+		t.Fatalf("searchProfileDocuments() error = %v", err)
+	}
+	if len(got) != len(documents) {
+		t.Fatalf("documents = %d, want %d", len(got), len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	if storage.searchCalls[0].Limit != 1000 ||
+		storage.searchCalls[0].Offset != 0 ||
+		storage.searchCalls[1].Limit != 1 ||
+		storage.searchCalls[1].Offset != 1000 {
+		t.Fatalf("search pages = %#v, want 1000@0 and 1@1000", storage.searchCalls)
+	}
+}
+
+func TestSearchProfileDocumentsRejectsOversizedQuery(t *testing.T) {
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		count: profileQueryLimit + 1,
+	})
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	_, err = service.searchProfileDocuments(t.Context(), selection)
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf("searchProfileDocuments() error = %v, want query limit error", err)
+	}
+}
+
+func TestSearchProfileDocumentsRejectsInvalidStorageResults(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	tests := []struct {
+		name    string
+		storage *fakeProfileQueryStorage
+	}{
+		{
+			name:    "negative count",
+			storage: &fakeProfileQueryStorage{count: -1},
+		},
+		{
+			name: "empty page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {}},
+			},
+		},
+		{
+			name: "short page",
+			storage: &fakeProfileQueryStorage{
+				count: 2,
+				pages: map[int][]*ProfileDocument{0: {document}},
+			},
+		},
+		{
+			name: "oversized page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {document, document}},
+			},
+		},
+		{
+			name: "nil document",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {nil}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTestProfileService(test.storage)
+			selection, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				`{id="trace-a"}`,
+				0,
+				time.Now().Add(time.Hour).UnixMilli(),
+			)
+			if err != nil {
+				t.Fatalf("buildProfileSelection() error = %v", err)
+			}
+
+			_, err = service.searchProfileDocuments(t.Context(), selection)
+			if err == nil {
+				t.Fatal("searchProfileDocuments() error = nil, want storage contract error")
+			}
+			if errors.Is(err, ErrInvalidQuery) ||
+				errors.Is(err, ErrProfilesAbsent) ||
+				errors.Is(err, ErrProfileQueryLimitExceeded) {
+				t.Fatalf("storage contract error = %v, want internal error", err)
+			}
+		})
+	}
+}
+
+func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
+	for _, selector := range []string{
+		`{hostname=~"node-.*"}`,
+		`{region="ap-guangzhou"}`,
+		`{arbitrary_label="value"}`,
+		`{id="trace-a",tracer="trace-b"}`,
+		`{pid=""}`,
+	} {
+		t.Run(selector, func(t *testing.T) {
+			_, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				selector,
+				0,
+				1,
+			)
+			if !errors.Is(err, ErrInvalidQuery) {
+				t.Fatalf("buildProfileSelection() error = %v, want invalid query", err)
+			}
+		})
+	}
+}
+
+func TestSelectSeriesBucketsAndGroups(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(100*time.Millisecond), "trace-a", 10, "root", "hot"),
+		testProfileDocument(start.Add(1500*time.Millisecond), "trace-a", 20, "root", "hot"),
+		testProfileDocument(start.Add(500*time.Millisecond), "trace-b", 7, "root", "worker"),
+	}}
+	service := newTestProfileService(storage)
+
+	response, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(4 * time.Second).UnixMilli(),
+		GroupBy:       []string{"tracer"},
+		Step:          2,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 2 {
+		t.Fatalf("series = %#v, want two tracer groups", response.Series)
+	}
+	if got := response.Series[0].Labels[0].Value; got != "trace-a" {
+		t.Fatalf("first series tracer = %q, want trace-a", got)
+	}
+	wantPoints := []*typesv1.Point{{
+		Value:     30,
+		Timestamp: start.UnixMilli(),
+	}}
+	if got := response.Series[0].Points; !reflect.DeepEqual(got, wantPoints) {
+		t.Fatalf("trace-a points = %#v, want %#v", got, wantPoints)
+	}
+}
+
+func TestCollectionDimensionsFilterAndGroupFixtureProfiles(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 30, 0, 0, time.UTC)
+	matching := testProfileDocument(
+		start.Add(time.Second),
+		"trace-pid-4242",
+		25,
+		"root",
+		"hot",
+	)
+	matching.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "pid",
+		profiler.LabelCPU:            "2,4,5,6,7",
+		profiler.LabelPID:            "4242",
+	}
+	matching.TracerData.Flamedata.Profile.StringTable = append(
+		matching.TracerData.Flamedata.Profile.StringTable,
+		profiler.LabelProfilingScope,
+		"pid",
+		"2,4,5,6,7",
+		"4242",
+	)
+	matching.TracerData.Flamedata.Profile.Sample[0].Label = []*profilev1.Label{
+		{Key: 5, Str: 6},
+		{Key: 1, Str: 7},
+		{Key: 6, Str: 8},
+	}
+	other := testProfileDocument(
+		start.Add(2*time.Second),
+		"trace-pid-9000",
+		100,
+		"root",
+		"cold",
+	)
+	other.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "pid",
+		profiler.LabelCPU:            "3",
+		profiler.LabelPID:            "9000",
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{matching, other},
+	})
+
+	response, err := service.SelectSeries(
+		t.Context(),
+		&querierv1.SelectSeriesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{profiling_scope="pid",cpu="2,4,5,6,7"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+			GroupBy:       []string{profiler.LabelPID},
+			Step:          10,
+		},
+	)
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 1 ||
+		len(response.Series[0].Labels) != 1 ||
+		response.Series[0].Labels[0].Name != profiler.LabelPID ||
+		response.Series[0].Labels[0].Value != "4242" ||
+		len(response.Series[0].Points) != 1 ||
+		response.Series[0].Points[0].Value != 25 {
+		t.Fatalf("dimensioned series = %#v", response.Series)
+	}
+
+	flamegraph, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{pid="4242"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("SelectMergeStacktraces() error = %v", err)
+	}
+	if flamegraph.GetFlamegraph().GetTotal() != 25 {
+		t.Fatalf(
+			"dimensioned flame graph total = %d, want 25",
+			flamegraph.GetFlamegraph().GetTotal(),
+		)
+	}
+
+	payload, err := service.MarshalPprof(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{pid="4242"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	exported, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("decode exported pprof: %v", err)
+	}
+	if len(exported.Sample) != 1 || len(exported.Sample[0].Label) != 3 {
+		t.Fatalf("exported managed sample labels = %#v", exported.Sample)
+	}
+	exportedLabels := make(map[string]string, len(exported.Sample[0].Label))
+	for _, label := range exported.Sample[0].Label {
+		name, nameOK := profileString(exported.StringTable, label.Key)
+		value, valueOK := profileString(exported.StringTable, label.Str)
+		if nameOK && valueOK {
+			exportedLabels[name] = value
+		}
+	}
+	if !reflect.DeepEqual(
+		exportedLabels,
+		matching.TracerData.Flamedata.Labels,
+	) {
+		t.Fatalf(
+			"exported labels = %#v, want %#v",
+			exportedLabels,
+			matching.TracerData.Flamedata.Labels,
+		)
+	}
+}
+
+func TestProfileNodeLimits(t *testing.T) {
+	if got, err := normalizeProfileMaxNodes(0); err != nil ||
+		got != defaultProfileNodes {
+		t.Fatalf("normalizeProfileMaxNodes(0) = (%d, %v)", got, err)
+	}
+	for _, value := range []int64{-1, profileNodeLimit + 1} {
+		if _, err := normalizeProfileMaxNodes(value); !errors.Is(
+			err,
+			ErrInvalidQuery,
+		) {
+			t.Fatalf(
+				"normalizeProfileMaxNodes(%d) error = %v, want invalid query",
+				value,
+				err,
+			)
+		}
+	}
+}
+
+func TestDiffBuildsDoubleFlamegraph(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(time.Second), "left", 10, "root", "hot"),
+	}})
+	maxNodes := int64(100)
+	response, err := service.Diff(t.Context(), &querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="left"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(5 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="right"}`,
+			Start:         start.Add(10 * time.Second).UnixMilli(),
+			End:           start.Add(15 * time.Second).UnixMilli(),
+			MaxNodes:      &maxNodes,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff() error = %v", err)
+	}
+	if response.Flamegraph == nil || response.Flamegraph.LeftTicks != 10 {
+		t.Fatalf("Diff() response = %#v, want 10 left ticks", response)
+	}
+}
+
+func TestEmptyStoredProfileHasNoUsableSamples(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	_, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="empty-profile"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="empty-profile"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+}
+
+func TestSamplesWithoutValuesAreSkipped(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 13, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "no-values", 1, "root", "leaf")
+	document.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{
+		nil,
+		{LocationId: []uint64{2, 1}},
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="no-values"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+
+	_, err = service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="no-values"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+}
+
+func TestProfileQueryStorageErrorsRemainInternal(t *testing.T) {
+	sentinel := fmt.Errorf("backend unavailable")
+	service := newTestProfileService(&fakeProfileQueryStorage{countErr: sentinel})
+	_, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="trace-a"}`,
+		Start:         0,
+		End:           1,
+		Step:          1,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("SelectSeries() error = %v, want wrapped backend error", err)
+	}
+}

--- a/internal/profiler/service/errors.go
+++ b/internal/profiler/service/errors.go
@@ -17,6 +17,7 @@ package service
 import "errors"
 
 var (
-	ErrInvalidQuery   = errors.New("invalid profile query")
-	ErrProfilesAbsent = errors.New("profiles not found")
+	ErrInvalidQuery              = errors.New("invalid profile query")
+	ErrProfilesAbsent            = errors.New("profiles not found")
+	ErrProfileQueryLimitExceeded = errors.New("profile query limit exceeded")
 )

--- a/internal/profiler/service/export.go
+++ b/internal/profiler/service/export.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+// SelectMergePprof returns the standard pprof profile for an exact target
+// selection. Broad and unsupported label queries are rejected before storage
+// access.
+func (s *Service) SelectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, error) {
+	profile, _, err := s.selectMergePprof(ctx, req)
+	return profile, err
+}
+
+func (s *Service) selectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, string, error) {
+	if req == nil {
+		return nil, "", invalidProfileQueryf("request is required")
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	documents, err := s.searchProfileDocuments(ctx, selection)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(documents) == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+
+	var merged pprof.ProfileMerge
+	mergedProfiles := 0
+	for _, document := range documents {
+		if _, found := profileDocumentSampleTotal(
+			document,
+			selection.sampleType,
+		); !found {
+			continue
+		}
+		profile := document.TracerData.Flamedata.Profile.CloneVT()
+		if profile == nil {
+			continue
+		}
+		// Pyroscope's merge helper requires a value even though pprof makes it
+		// optional.
+		if profile.PeriodType == nil {
+			profile.PeriodType = &profilev1.ValueType{}
+		}
+		if err := merged.Merge(profile); err != nil {
+			return nil, "", fmt.Errorf("merge profile: %w", err)
+		}
+		mergedProfiles++
+	}
+	if mergedProfiles == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+	profile := merged.Profile()
+	if profile == nil {
+		return nil, "", ErrProfilesAbsent
+	}
+	return profile, selection.sampleType, nil
+}
+
+// MarshalPprof serializes a selected profile as gzip-compressed pprof data.
+func (s *Service) MarshalPprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) ([]byte, error) {
+	profile, err := s.SelectMergePprof(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := pprof.Marshal(profile, true)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pprof: %w", err)
+	}
+	return payload, nil
+}

--- a/internal/profiler/service/export_test.go
+++ b/internal/profiler/service/export_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+func exportTestRequest(start time.Time) *querierv1.SelectMergeStacktracesRequest {
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(time.Minute).UnixMilli(),
+	}
+}
+
+func TestSelectMergePprofUsesBoundedProfileLoader(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "trace-a", 1, "root", "worker")
+	documents := make([]*ProfileDocument, profileQueryPageSize+1)
+	for index := range documents {
+		documents[index] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+
+	profile, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if err != nil {
+		t.Fatalf("SelectMergePprof() error = %v", err)
+	}
+	var total int64
+	for _, sample := range profile.Sample {
+		if sample != nil && len(sample.Value) > 0 {
+			total += sample.Value[0]
+		}
+	}
+	if total != int64(len(documents)) {
+		t.Fatalf("merged sample total = %d, want %d", total, len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	first, second := storage.searchCalls[0], storage.searchCalls[1]
+	if first.Offset != 0 ||
+		first.Limit != profileQueryPageSize ||
+		second.Offset != profileQueryPageSize ||
+		second.Limit != 1 {
+		t.Fatalf(
+			"search pages = (%d,%d),(%d,%d), want (0,1000),(1000,1)",
+			first.Offset,
+			first.Limit,
+			second.Offset,
+			second.Limit,
+		)
+	}
+}
+
+func TestSelectMergePprofRejectsOversizedSelectionBeforeFetch(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{count: profileQueryLimit + 1}
+	service := newTestProfileService(storage)
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfileQueryLimitExceeded",
+			err,
+		)
+	}
+	if len(storage.searchCalls) != 0 {
+		t.Fatalf("search calls = %d, want 0", len(storage.searchCalls))
+	}
+}
+
+func TestSelectMergePprofRejectsEmptyStoredProfilesWithoutPanicking(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 30, 0, 0, time.UTC)
+	empty := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	empty.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	empty.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{nil}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{empty},
+	})
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfilesAbsent",
+			err,
+		)
+	}
+}
+
+func TestMarshalPprof(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 14, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{
+			testProfileDocument(start, "trace-a", 10, "root", "hot"),
+		},
+	})
+	req := exportTestRequest(start)
+
+	payload, err := service.MarshalPprof(t.Context(), req)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	decoded, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("RawFromBytes() error = %v", err)
+	}
+	if len(decoded.Sample) != 1 || decoded.Sample[0].Value[0] != 10 {
+		t.Fatalf("pprof samples = %#v, want value 10", decoded.Sample)
+	}
+}

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -22,12 +22,11 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 
-	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
-	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -36,9 +35,21 @@ type ElasticSearchConfig struct {
 	Address, Username, Password, Index string
 }
 
+type profileQueryStorage interface {
+	Close(ctx context.Context) error
+	Ready(ctx context.Context) error
+	SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error)
+	CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error)
+	AggregationsByFieldContext(
+		ctx context.Context,
+		filter *SearchFilter,
+		field string,
+	) ([]string, error)
+}
+
 // Service provides profile query operations.
 type Service struct {
-	profileStorage *ProfileStorage
+	profileStorage profileQueryStorage
 }
 
 // NewService initializes a profile query service.
@@ -77,152 +88,17 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
-	if req.End < req.Start {
-		return nil, fmt.Errorf("%w: end time precedes start time", ErrInvalidQuery)
-	}
-	filter := &SearchFilter{
-		StartTime:   time.UnixMilli(req.Start),
-		EndTime:     time.UnixMilli(req.End),
-		ProfileType: req.ProfileTypeID,
-		Limit:       100,
-	}
-
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
-
-	profileTypes := strings.Split(filter.ProfileType, ":")
-	if len(profileTypes) != 5 {
-		return nil, fmt.Errorf("%w: invalid profile type %q", ErrInvalidQuery, filter.ProfileType)
-	}
-
-	// labels
-	labels, err := parser.ParseMetricSelector(req.LabelSelector)
+	maxNodes, err := normalizeProfileMaxNodes(req.GetMaxNodes())
 	if err != nil {
-		return nil, errors.Join(ErrInvalidQuery, fmt.Errorf("parse matchers: %w", err))
+		return nil, err
 	}
-
-	for _, label := range labels {
-		// skip empty or "All"
-		if label.Value == "" || label.Value == "all" || label.Value == "All" || label.Value == "*" {
-			continue
-		}
-
-		if err := applyProfileMatcher(filter, label); err != nil {
-			return nil, err
-		}
-	}
-
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
-	}
-
-	// search
-	profileDocs, err := s.profileStorage.SearchProfilesContext(ctx, filter)
+	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
-		return nil, fmt.Errorf("search profiles: %w", err)
+		return nil, err
 	}
-	if len(profileDocs) == 0 {
-		return nil, ErrProfilesAbsent
-	}
-
-	// merge profileDocs
-	var profilesMerge pprof.ProfileMerge
-	for _, profileDoc := range profileDocs {
-		profile := &profileDoc.TracerData.Flamedata.Profile
-		if err := profilesMerge.Merge(profile); err != nil {
-			return nil, fmt.Errorf("merge profile: %w", err)
-		}
-	}
-	profile := profilesMerge.Profile()
-	if profile == nil {
-		return nil, ErrProfilesAbsent
-	}
-	sampleType := profileTypes[1]
-
-	// convert profilev1.Profile to phlaremodel.Tree
-	phlaremodelTree := new(phlaremodel.Tree)
-
-	// Find the index of the sample type we're interested in
-	sampleTypeIndex := -1
-	for i, st := range profile.SampleType {
-		if st == nil {
-			continue
-		}
-		if value, ok := profileString(profile.StringTable, st.Type); ok && value == sampleType {
-			sampleTypeIndex = i
-			break
-		}
-	}
-	if sampleTypeIndex == -1 {
-		return nil, fmt.Errorf("%w: sample type %q not found", ErrInvalidQuery, sampleType)
-	}
-
-	// Create a map for quick location lookup
-	locationMap := make(map[uint64]*googlev1.Location, len(profile.Location))
-	for _, loc := range profile.Location {
-		if loc == nil {
-			continue
-		}
-		locationMap[loc.Id] = loc
-	}
-
-	// Create a map for quick function lookup
-	functionMap := make(map[uint64]*googlev1.Function, len(profile.Function))
-	for _, fn := range profile.Function {
-		if fn == nil {
-			continue
-		}
-		functionMap[fn.Id] = fn
-	}
-
-	// Process each sample
-	for _, sample := range profile.Sample {
-		if sample == nil {
-			continue
-		}
-		// Get the value for our sample type
-		if len(sample.Value) <= sampleTypeIndex {
-			continue
-		}
-		value := sample.Value[sampleTypeIndex]
-
-		// Build stack trace string from location ids
-		stack := make([]string, 0, len(sample.LocationId))
-		for _, locId := range sample.LocationId {
-			loc, exists := locationMap[locId]
-			if !exists || len(loc.Line) == 0 {
-				continue
-			}
-
-			// Get the first line entry (primary function)
-			line := loc.Line[0]
-			if line == nil {
-				continue
-			}
-			fn, exists := functionMap[line.FunctionId]
-			if !exists {
-				continue
-			}
-
-			// Get function name from string table
-			funcName, ok := profileString(profile.StringTable, fn.Name)
-			if !ok {
-				continue
-			}
-			stack = append(stack, funcName)
-		}
-
-		// Insert stack into tree (leaf is at stack[0], so we need to reverse for phlaremodel.Tree)
-		if len(stack) > 0 {
-			for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
-				stack[i], stack[j] = stack[j], stack[i]
-			}
-			phlaremodelTree.InsertStack(value, stack...)
-		}
-	}
-
-	// convert phlaremodel.Tree to FlameGraph
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(phlaremodelTree, -1),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, maxNodes),
 	}, nil
 }
 
@@ -239,10 +115,18 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 		filter.ContainerID = matcher.Value
 	case "container_hostname":
 		filter.ContainerHostname = matcher.Value
+	case "tracer":
+		filter.TracerID = matcher.Value
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:
-		return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		if !profiler.IsCollectionDimensionLabel(matcher.Name) {
+			return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		}
+		if filter.Labels == nil {
+			filter.Labels = make(map[string]string)
+		}
+		filter.Labels[matcher.Name] = matcher.Value
 	}
 	return nil
 }
@@ -300,8 +184,20 @@ func (s *Service) ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesR
 //	request: typesv1.LabelNamesRequest
 //	response: typesv1.LabelNamesResponse
 func (s *Service) LabelNames(context.Context, *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error) {
+	names := []string{
+		"region",
+		"hostname",
+		"container_id",
+		"container_hostname",
+		"container_host_namespace",
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name != profiler.LabelContainerID {
+			names = append(names, name)
+		}
+	}
 	response := &typesv1.LabelNamesResponse{
-		Names: []string{"region", "hostname", "container_id", "container_hostname", "container_host_namespace"},
+		Names: names,
 	}
 	return response, nil
 }

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/timeutil"
 	"huatuo-bamai/internal/storage"
 	"huatuo-bamai/internal/storage/driver"
@@ -74,6 +75,7 @@ type ProfileDocument struct {
 	TracerData struct {
 		Flamedata struct {
 			ProfileType string            `json:"profile_type,omitempty"`
+			Labels      map[string]string `json:"labels,omitempty"`
 			Profile     profilev1.Profile `json:"profile,omitempty"`
 		} `json:"flamedata,omitempty"`
 		// others
@@ -95,6 +97,7 @@ type SearchFilter struct {
 	StartTime         time.Time
 	EndTime           time.Time
 	ProfileType       string
+	Labels            map[string]string
 	Limit             int
 	Offset            int
 }
@@ -172,6 +175,14 @@ func (s *ProfileStorage) SearchProfilesContext(ctx context.Context, filter *Sear
 	return documents, nil
 }
 
+// CountProfilesContext counts profiles matching a filter.
+func (s *ProfileStorage) CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error) {
+	if s == nil || s.store == nil {
+		return 0, errors.New("profile storage is not initialized")
+	}
+	return s.store.Count(ctx, buildProfileAggregationQuery(filter))
+}
+
 // AggregationsByField gets aggregations by field.
 func (s *ProfileStorage) AggregationsByField(filter *SearchFilter, field string) ([]string, error) {
 	return s.AggregationsByFieldContext(context.Background(), filter, field)
@@ -219,7 +230,7 @@ func (profileDocumentMapper) Decode(data []byte) (*ProfileDocument, error) {
 }
 
 func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, error) {
-	return map[string]any{
+	fields := map[string]any{
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
@@ -234,11 +245,20 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldTracerTime:        parseProfileDocumentTime(document.TracerTime, document.UploadedTime),
 		profileFieldTracerType:        document.TracerRunType,
 		profileFieldProfileType:       document.TracerData.Flamedata.ProfileType,
-	}, nil
+	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label == profiler.LabelContainerID {
+			continue
+		}
+		if value := document.TracerData.Flamedata.Labels[label]; value != "" {
+			fields[profileLabelField(label)] = value
+		}
+	}
+	return fields, nil
 }
 
 func (profileDocumentMapper) Indexes() []driver.Index {
-	return []driver.Index{
+	indexes := []driver.Index{
 		{Field: profileFieldTracerID},
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
@@ -254,6 +274,12 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldTracerType},
 		{Field: profileFieldProfileType},
 	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label != profiler.LabelContainerID {
+			indexes = append(indexes, driver.Index{Field: profileLabelField(label)})
+		}
+	}
+	return indexes
 }
 
 func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
@@ -264,6 +290,7 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	}
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
 	}
 	return query
 }
@@ -340,11 +367,29 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Value: filter.ProfileType,
 		})
 	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name == profiler.LabelContainerID {
+			continue
+		}
+		if value := filter.Labels[name]; value != "" {
+			query.Filters = append(query.Filters, driver.Filter{
+				Field: profileLabelKeywordField(name),
+				Op:    driver.OpEq,
+				Value: value,
+			})
+		}
+	}
 
 	return query
 }
 
 func normalizeProfileAggregationField(field string) (string, error) {
+	if profiler.IsCollectionDimensionLabel(field) {
+		if field == profiler.LabelContainerID {
+			return profileFieldContainerID + ".keyword", nil
+		}
+		return profileLabelKeywordField(field), nil
+	}
 	switch field {
 	case "id":
 		return profileFieldTracerID, nil
@@ -363,6 +408,14 @@ func normalizeProfileAggregationField(field string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}
+}
+
+func profileLabelField(name string) string {
+	return "tracer_data.flamedata.labels." + name
+}
+
+func profileLabelKeywordField(name string) string {
+	return profileLabelField(name) + ".keyword"
 }
 
 func normalizeProfileSearchLimit(filter *SearchFilter) int {

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/storage/driver"
 )
 
@@ -56,5 +57,90 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 
 	if !reflect.DeepEqual(query.Filters, want) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestProfileDocumentMapperIndexesCollectionDimensions(t *testing.T) {
+	document := &ProfileDocument{}
+	document.ContainerID = "containerd://abc"
+	document.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelTGID:           "4242",
+		profiler.LabelContainerID:    document.ContainerID,
+	}
+
+	fields, err := (profileDocumentMapper{}).Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
+	if got := fields[profileLabelField(profiler.LabelProfilingScope)]; got != "thread_group" {
+		t.Fatalf("profiling_scope field = %v, want thread_group", got)
+	}
+	if got := fields[profileLabelField(profiler.LabelTGID)]; got != "4242" {
+		t.Fatalf("tgid field = %v, want 4242", got)
+	}
+	if _, duplicated := fields[profileLabelField(profiler.LabelContainerID)]; duplicated {
+		t.Fatal("container_id duplicated under profile labels")
+	}
+}
+
+func TestBuildProfileAggregationQueryAddsDimensionMatchers(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		ContainerID: "containerd://abc",
+		Labels: map[string]string{
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelTGID:           "4242",
+			"unmanaged":                  "ignored",
+		},
+	})
+	want := []driver.Filter{
+		{
+			Field: profileFieldContainerID + ".keyword",
+			Op:    driver.OpEq,
+			Value: "containerd://abc",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelProfilingScope),
+			Op:    driver.OpEq,
+			Value: "thread_group",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelTGID),
+			Op:    driver.OpEq,
+			Value: "4242",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldSupportsDimensions(t *testing.T) {
+	tests := map[string]string{
+		profiler.LabelPID:         profileLabelKeywordField(profiler.LabelPID),
+		profiler.LabelTGID:        profileLabelKeywordField(profiler.LabelTGID),
+		profiler.LabelContainerID: profileFieldContainerID + ".keyword",
+	}
+	for input, want := range tests {
+		got, err := normalizeProfileAggregationField(input)
+		if err != nil {
+			t.Fatalf("normalizeProfileAggregationField(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("normalizeProfileAggregationField(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestBuildProfileSearchQueryUsesStablePaginationOrder(t *testing.T) {
+	query := buildProfileSearchQuery(&SearchFilter{Limit: 1000, Offset: 1000})
+	want := []driver.Sort{
+		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID},
+	}
+
+	if !reflect.DeepEqual(query.Sorts, want) {
+		t.Fatalf("query sorts = %#v, want %#v", query.Sorts, want)
 	}
 }

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels expose indexed dimensions to profile display backends.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends


### PR DESCRIPTION
## Summary

- add bounded Pyroscope-compatible SelectSeries and Diff queries
- support exact host, container, CPU, profiling-scope, PID, and TGID selectors
- provision host, container, and adjacent-window comparison dashboards
- add time-series, Top 10, flame graph, Top table, and comparison views
- export merged standard pprof data as a portable second display path
- reject oversized document, node, series, and JSON selections instead of truncating them

The optional dimension-label schema is backward compatible with existing profile documents. This pull request does not include collector, task, or BPF changes from #329.

## Independence

This change is based directly on the current main branch. It has no file overlap or runtime dependency on #461 or #462, so the three #328 pull requests can merge in any order.

## Validation

- make check on Ubuntu 22.04 / Linux 5.15
- make build
- go test -race ./internal/profiler ./internal/profiler/service ./cmd/huatuo-apiserver/handlers/profiling ./build/docker/grafana/dashboards
- dashboard JSON syntax and contract tests

Refs #328