### PR TITLE
fix(metrics): guard cpu_stat deltaThrottledSum and deltaInnerWaitSum against uint64 underflow

### DIFF
--- a/core/metrics/cpu_stat.go
+++ b/core/metrics/cpu_stat.go
@@ -118,8 +118,14 @@ func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Containe
 		deltaExterWaitSum = 0
 	} else {
 		deltaHierarchyWaitSum = stat.hierarchyWaitSum - cpu.hierarchyWaitSum
-		deltaThrottledSum = stat.throttledTime - cpu.throttledTime
-		deltaInnerWaitSum = stat.innerWaitSum - cpu.innerWaitSum
+
+		if stat.throttledTime >= cpu.throttledTime {
+			deltaThrottledSum = stat.throttledTime - cpu.throttledTime
+		}
+
+		if stat.innerWaitSum >= cpu.innerWaitSum {
+			deltaInnerWaitSum = stat.innerWaitSum - cpu.innerWaitSum
+		}
 
 		if deltaHierarchyWaitSum < deltaThrottledSum+deltaInnerWaitSum {
 			deltaHierarchyWaitSum = deltaThrottledSum + deltaInnerWaitSum


### PR DESCRIPTION
## Problem

Fixes #466

In `core/metrics/cpu_stat.go`, `updateDataCache()` computes `deltaThrottledSum` and `deltaInnerWaitSum` without counter-reset guards when `stat.hierarchyWaitSum > cpu.hierarchyWaitSum` (line 119-122):

```go
deltaThrottledSum = stat.throttledTime - cpu.throttledTime
deltaInnerWaitSum = stat.innerWaitSum - cpu.innerWaitSum
```

When a container's cgroup is recreated, `throttledTime` and `innerWaitSum` reset to 0 while `hierarchyWaitSum` may not. The raw uint64 subtraction underflows to near `MaxUint64`, corrupting all wait-rate metrics.

## Fix

Add individual counter-reset guards, consistent with the existing pattern for `hierarchyWaitSum` (line 114), `waitSum` (line 131), and `cpuTotal` (line 136):

```go
if stat.throttledTime >= cpu.throttledTime {
    deltaThrottledSum = stat.throttledTime - cpu.throttledTime
}

if stat.innerWaitSum >= cpu.innerWaitSum {
    deltaInnerWaitSum = stat.innerWaitSum - cpu.innerWaitSum
}
```

When the guard fails (counter reset), the delta stays at 0 (the zero value), which is the correct behavior — no wait time is attributed to throttled/inner wait for that collection cycle.

The downstream `deltaExterWaitSum` computation remains safe because the existing adjustment at line 124 ensures `deltaHierarchyWaitSum >= deltaThrottledSum + deltaInnerWaitSum`.

## Verification

- `go build ./core/metrics/` — pass
- `golangci-lint run ./core/metrics/... --timeout=5m --config .golangci.yaml` — pass (no warnings)

Fixes #466