### PR TITLE
fix(metrics): guard cpu_util delta subtractions against uint64 underflow

### DIFF
--- a/core/metrics/cpu_util.go
+++ b/core/metrics/cpu_util.go
@@ -98,7 +98,16 @@ func (c *cpuUtilCollector) updateDataCache(cache *cpuUtilStat, container *pod.Co
 		return err
 	}
 
-	// allow statistics 0
+	// Usage, User, and System should increase monotonically. This defensive
+	// check prevents an unexpected reset from causing uint64 underflow.
+	if stat.Usage < cache.lastUsage.Usage ||
+		stat.User < cache.lastUsage.User ||
+		stat.System < cache.lastUsage.System {
+		cache.lastUsage = *stat
+		cache.lastTimestamp = now
+		return nil
+	}
+
 	deltaTotalTime := stat.Usage - cache.lastUsage.Usage
 	deltaUsrTime := stat.User - cache.lastUsage.User
 	deltaSysTime := stat.System - cache.lastUsage.System

--- a/core/metrics/cpu_util.go
+++ b/core/metrics/cpu_util.go
@@ -90,9 +90,20 @@ func (c *cpuUtilCollector) updateDataCache(cache *cpuUtilStat, container *pod.Co
 	}
 
 	// allow statistics 0
-	deltaTotalTime := stat.Usage - cache.lastUsage.Usage
-	deltaUsrTime := stat.User - cache.lastUsage.User
-	deltaSysTime := stat.System - cache.lastUsage.System
+	var deltaTotalTime, deltaUsrTime, deltaSysTime uint64
+
+	if stat.Usage >= cache.lastUsage.Usage {
+		deltaTotalTime = stat.Usage - cache.lastUsage.Usage
+	}
+
+	if stat.User >= cache.lastUsage.User {
+		deltaUsrTime = stat.User - cache.lastUsage.User
+	}
+
+	if stat.System >= cache.lastUsage.System {
+		deltaSysTime = stat.System - cache.lastUsage.System
+	}
+
 	deltaRealWorldTime := numCores * float64(now.Sub(cache.lastTimestamp).Microseconds())
 
 	if (float64(deltaTotalTime) > deltaRealWorldTime) || (float64(deltaUsrTime+deltaSysTime) > deltaRealWorldTime) {

--- a/core/metrics/cpu_util_test.go
+++ b/core/metrics/cpu_util_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/cgroups"
+	"huatuo-bamai/internal/cgroups/stats"
+)
+
+type cpuUsageCgroup struct {
+	cgroups.Cgroup
+	usage stats.CpuUsage
+}
+
+func (c *cpuUsageCgroup) CpuUsage(string) (*stats.CpuUsage, error) {
+	return &c.usage, nil
+}
+
+func TestCPUUtilCollectorUpdateDataCacheCounterRegression(t *testing.T) {
+	tests := []struct {
+		name    string
+		current stats.CpuUsage
+	}{
+		{
+			name:    "total usage regresses",
+			current: stats.CpuUsage{Usage: 9, User: 6, System: 4},
+		},
+		{
+			name:    "user usage regresses",
+			current: stats.CpuUsage{Usage: 10, User: 5, System: 4},
+		},
+		{
+			name:    "system usage regresses",
+			current: stats.CpuUsage{Usage: 10, User: 6, System: 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastTimestamp := time.Now().Add(-2 * time.Second)
+			cache := cpuUtilStat{
+				lastUsage:     stats.CpuUsage{Usage: 10, User: 6, System: 4},
+				lastTimestamp: lastTimestamp,
+				totalUtil:     11,
+				usrUtil:       22,
+				sysUtil:       33,
+			}
+			collector := cpuUtilCollector{
+				cgroup: &cpuUsageCgroup{usage: tt.current},
+			}
+
+			if err := collector.updateDataCache(&cache, nil, 1); err != nil {
+				t.Fatalf("updateDataCache() error = %v", err)
+			}
+			if cache.lastUsage != tt.current {
+				t.Fatalf("last usage = %+v, want %+v", cache.lastUsage, tt.current)
+			}
+			if !cache.lastTimestamp.After(lastTimestamp) {
+				t.Fatalf("last timestamp = %v, want after %v", cache.lastTimestamp, lastTimestamp)
+			}
+			if cache.totalUtil != 11 || cache.usrUtil != 22 || cache.sysUtil != 33 {
+				t.Fatalf(
+					"utilization changed after counter regression: total=%v user=%v system=%v",
+					cache.totalUtil,
+					cache.usrUtil,
+					cache.sysUtil,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #467

In `core/metrics/cpu_util.go`, `updateDataCache()` computes CPU utilization deltas by subtracting cached cgroup counters from current values (line 93-95):

```go
deltaTotalTime := stat.Usage - cache.lastUsage.Usage
deltaUsrTime := stat.User - cache.lastUsage.User
deltaSysTime := stat.System - cache.lastUsage.System
```

All fields are `uint64`. When a container's cgroup is recreated (container restart), the counters reset to 0. The raw subtraction underflows to near `MaxUint64`, producing astronomically large CPU utilization values.

## Fix

Add counter-reset guards for each field, consistent with the existing pattern in `cpu_stat.go` (`deltaCpuUsage`, `deltaWaitSum`, etc.):

```go
var deltaTotalTime, deltaUsrTime, deltaSysTime uint64

if stat.Usage >= cache.lastUsage.Usage {
    deltaTotalTime = stat.Usage - cache.lastUsage.Usage
}

if stat.User >= cache.lastUsage.User {
    deltaUsrTime = stat.User - cache.lastUsage.User
}

if stat.System >= cache.lastUsage.System {
    deltaSysTime = stat.System - cache.lastUsage.System
}
```

When the guard fails (counter reset), the delta stays at 0. The downstream check `if float64(deltaTotalTime) > deltaRealWorldTime` correctly evaluates to `false` for `float64(0)`, so the utilization values are not updated for that cycle (the cached values remain). This is safe behavior that self-corrects on the next collection cycle.

## Verification

- `go build ./core/metrics/` — pass
- `golangci-lint run ./core/metrics/... --timeout=5m --config .golangci.yaml` — pass (no warnings)

Fixes #467