### PR TITLE
fix(bpf): discover kprobe symbols from tracefs

### DIFF
--- a/internal/bpf/bpf_kprobe.go
+++ b/internal/bpf/bpf_kprobe.go
@@ -16,6 +16,7 @@ package bpf
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -25,21 +26,15 @@ var (
 	kprobeOnce   sync.Mutex
 	kprobeCache  map[string]struct{}
 	kprobeCached bool
+
+	kprobeFunctionFiles = []string{
+		"/sys/kernel/tracing/available_filter_functions",
+		"/sys/kernel/debug/tracing/available_filter_functions",
+	}
 )
 
-// loadKprobeFunctions reads /sys/kernel/debug/tracing/available_filter_functions
-// and populates kprobeCache. On success kprobeCached is set so subsequent
-// calls skip the file read; on failure the cache remains unset and the next
-// call retries.
-func loadKprobeFunctions() {
-	file, err := os.Open("/sys/kernel/debug/tracing/available_filter_functions")
-	if err != nil {
-		return
-	}
-	defer file.Close()
-
-	cache := make(map[string]struct{})
-	scanner := bufio.NewScanner(file)
+func scanKprobeFunctions(r io.Reader, cache map[string]struct{}) error {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -47,23 +42,41 @@ func loadKprobeFunctions() {
 		}
 		cache[strings.Fields(line)[0]] = struct{}{}
 	}
+	return scanner.Err()
+}
 
-	if err := scanner.Err(); err != nil {
-		return
+// loadKprobeFunctions checks both tracefs layouts because current kernels
+// commonly mount tracefs independently while older systems expose it through
+// debugfs. A failed read is retried on the next lookup.
+func loadKprobeFunctions() {
+	cache := make(map[string]struct{})
+	readOK := false
+	for _, path := range kprobeFunctionFiles {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		err = scanKprobeFunctions(file, cache)
+		_ = file.Close()
+		if err == nil {
+			readOK = true
+		}
 	}
 
-	kprobeCache = cache
-	kprobeCached = true
+	if readOK {
+		kprobeCache = cache
+		kprobeCached = true
+	}
 }
 
 // HasKprobeFunction returns whether the given symbol is reported as
 // attachable in the kernel's available_filter_functions list.
 func HasKprobeFunction(name string) bool {
 	kprobeOnce.Lock()
+	defer kprobeOnce.Unlock()
 	if !kprobeCached {
 		loadKprobeFunctions()
 	}
-	kprobeOnce.Unlock()
 
 	_, ok := kprobeCache[name]
 	return ok

--- a/internal/bpf/bpf_kprobe_test.go
+++ b/internal/bpf/bpf_kprobe_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScanKprobeFunctions(t *testing.T) {
+	cache := make(map[string]struct{})
+	input := "  mutex_lock\n_raw_spin_lock   [kernel]\n\n_raw_read_lock\t[kernel]\n"
+	if err := scanKprobeFunctions(strings.NewReader(input), cache); err != nil {
+		t.Fatalf("scanKprobeFunctions() error = %v", err)
+	}
+	for _, symbol := range []string{"mutex_lock", "_raw_spin_lock", "_raw_read_lock"} {
+		if _, ok := cache[symbol]; !ok {
+			t.Errorf("symbol %q missing from cache", symbol)
+		}
+	}
+}
+
+func TestHasKprobeFunctionChecksTracefsAndDebugfs(t *testing.T) {
+	dir := t.TempDir()
+	tracefs := filepath.Join(dir, "tracefs")
+	debugfs := filepath.Join(dir, "debugfs")
+	if err := os.WriteFile(tracefs, []byte("tracefs_symbol\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(debugfs, []byte("debugfs_symbol [kernel]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resetKprobeCacheForTest(t, []string{tracefs, debugfs})
+
+	for _, symbol := range []string{"tracefs_symbol", "debugfs_symbol"} {
+		if !HasKprobeFunction(symbol) {
+			t.Errorf("HasKprobeFunction(%q) = false", symbol)
+		}
+	}
+}
+
+func TestHasKprobeFunctionRetriesFailedReads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "available_filter_functions")
+	resetKprobeCacheForTest(t, []string{path})
+
+	if HasKprobeFunction("late_symbol") {
+		t.Fatal("missing symbol reported as available")
+	}
+	if err := os.WriteFile(path, []byte("late_symbol\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !HasKprobeFunction("late_symbol") {
+		t.Fatal("symbol was not found after the source became readable")
+	}
+}
+
+func resetKprobeCacheForTest(t *testing.T, paths []string) {
+	t.Helper()
+
+	kprobeOnce.Lock()
+	oldFiles := kprobeFunctionFiles
+	oldCache := kprobeCache
+	oldCached := kprobeCached
+	kprobeFunctionFiles = paths
+	kprobeCache = nil
+	kprobeCached = false
+	kprobeOnce.Unlock()
+
+	t.Cleanup(func() {
+		kprobeOnce.Lock()
+		defer kprobeOnce.Unlock()
+		kprobeFunctionFiles = oldFiles
+		kprobeCache = oldCache
+		kprobeCached = oldCached
+	})
+}


### PR DESCRIPTION
## Summary

- discover kprobe symbols from both standalone tracefs and debugfs layouts
- merge available symbols across readable mounts and retry transient read failures
- keep old-kernel profiler feature detection safe and deterministic

## Testing

- `go test ./internal/bpf -run 'Test(ScanKprobeFunctions|HasKprobeFunction)' -count=1`
- `go test -race ./internal/bpf -run 'Test(ScanKprobeFunctions|HasKprobeFunction)' -count=1`
- `go vet ./internal/bpf`
- `git diff --check`

Refs #329