### PR TITLE
feat(profiling): expose native target dimensions

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -21,13 +21,16 @@ import (
 
 // CreateProfilingJobRequest represents a request to create a profiling job.
 type CreateProfilingJobRequest struct {
-	ProfilingType   string `json:"type"`              // cpu or memory
-	BinaryMatchPath string `json:"binary_match_path"` // executable path used to match target processes
-	Language        string `json:"language"`          // programming language of the target process
-	MemoryMode      string `json:"memory_mode"`       // memory profiling mode
-	DurationSeconds int    `json:"duration_seconds"`  // profiling duration in seconds
-	ContainerID     string `json:"container_id"`      // container ID
-	Hostname        string `json:"hostname"`          // host name
+	ProfilingType   string `json:"type"`                   // cpu or memory
+	BinaryMatchPath string `json:"binary_match_path"`      // executable path used to match target processes
+	Language        string `json:"language"`               // programming language of the target process
+	MemoryMode      string `json:"memory_mode"`            // memory profiling mode
+	DurationSeconds int    `json:"duration_seconds"`       // profiling duration in seconds
+	ContainerID     string `json:"container_id"`           // container ID
+	Hostname        string `json:"hostname"`               // host name
+	PID             int    `json:"pid,omitempty"`          // target process or thread ID
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`      // CPU IDs selected for native CPU profiling
+	ThreadGroup     bool   `json:"thread_group,omitempty"` // include the PID's thread group
 }
 
 // CreateProfilingJobResponse represents a response to create a profiling job.
@@ -44,6 +47,9 @@ type ProfilingJob struct {
 	MemoryMode      string     `json:"memory_mode,omitempty"`       // memory profiling mode
 	Language        string     `json:"language"`                    // programming language of the target process
 	BinaryMatchPath string     `json:"binary_match_path,omitempty"` // executable path used to match target processes
+	PID             int        `json:"pid,omitempty"`               // target process or thread ID
+	CPUIDs          []int      `json:"cpu_ids,omitempty"`           // CPU IDs selected for native CPU profiling
+	ThreadGroup     bool       `json:"thread_group,omitempty"`      // include the PID's thread group
 	Status          string     `json:"status"`                      // job status
 	DurationSeconds int        `json:"duration_seconds"`            // profiling duration in seconds
 	CreatedAt       time.Time  `json:"created_at"`                  // job creation time

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -33,6 +33,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				BinaryMatchPath: "/usr/bin/example",
 				Language:        "go",
 				ContainerID:     "container-id",
+				PID:             1234,
+				CPUIDs:          []int{1, 3},
+				ThreadGroup:     true,
 			},
 			fields: []string{
 				"type",
@@ -42,6 +45,9 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 				"duration_seconds",
 				"container_id",
 				"hostname",
+				"pid",
+				"cpu_ids",
+				"thread_group",
 			},
 		},
 		{
@@ -114,11 +120,17 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 			value: ProfilingJob{
 				ContainerID:     "container-2026",
 				BinaryMatchPath: "/usr/bin/example",
+				PID:             1234,
+				CPUIDs:          []int{1, 3},
+				ThreadGroup:     true,
 			},
 			fields: []string{
 				"container_id",
 				"binary_match_path",
 				"language",
+				"pid",
+				"cpu_ids",
+				"thread_group",
 			},
 		},
 		{
@@ -163,6 +175,9 @@ func TestProfilingJobJSONFields(t *testing.T) {
 		ContainerID:     "container-2026",
 		MemoryMode:      "object_alloc",
 		BinaryMatchPath: "/usr/bin/example",
+		PID:             1234,
+		CPUIDs:          []int{1, 3},
+		ThreadGroup:     true,
 	})
 	if err != nil {
 		t.Fatalf("json.Marshal() error = %v", err)
@@ -181,6 +196,9 @@ func TestProfilingJobJSONFields(t *testing.T) {
 		"memory_mode",
 		"language",
 		"binary_match_path",
+		"pid",
+		"cpu_ids",
+		"thread_group",
 		"status",
 		"duration_seconds",
 		"created_at",

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -204,6 +204,9 @@ func buildProfilingJob(jobResult *job.Job, flameGraphBaseURL string) (v1.Profili
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
 		Language:        privateData.Language,
+		PID:             privateData.PID,
+		CPUIDs:          append([]int(nil), privateData.CPUIDs...),
+		ThreadGroup:     privateData.ThreadGroup,
 	}
 
 	return resp, nil

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -164,6 +164,9 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		DurationSeconds: 60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
+		PID:             4321,
+		CPUIDs:          []int{1, 3},
+		ThreadGroup:     true,
 	})
 	if err != nil {
 		t.Fatalf("newProfilingPrivateData() error=%v", err)
@@ -176,8 +179,15 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	if fields["binary_match_path"] != "/usr/bin/example" ||
 		fields["duration_seconds"] != float64(60) ||
 		fields["language"] != "go" ||
-		fields["memory_mode"] != "object_alloc" {
+		fields["memory_mode"] != "object_alloc" ||
+		fields["pid"] != float64(4321) ||
+		fields["thread_group"] != true {
 		t.Errorf("newProfilingPrivateData()=%s, want request fields", data)
+	}
+	cpuIDs, ok := fields["cpu_ids"].([]any)
+	if !ok || len(cpuIDs) != 2 ||
+		cpuIDs[0] != float64(1) || cpuIDs[1] != float64(3) {
+		t.Errorf("newProfilingPrivateData() CPU IDs=%v, want [1 3]", fields["cpu_ids"])
 	}
 }
 
@@ -189,7 +199,10 @@ func TestBuildProfilingJobReadsPrivateData(t *testing.T) {
 			"binary_match_path":"/usr/bin/example",
 			"duration_seconds":60,
 			"language":"go",
-			"memory_mode":"object_alloc"
+			"memory_mode":"object_alloc",
+			"pid":4321,
+			"cpu_ids":[1,3],
+			"thread_group":true
 		}`),
 	}, "")
 	if err != nil {
@@ -207,6 +220,15 @@ func TestBuildProfilingJobReadsPrivateData(t *testing.T) {
 	}
 	if resp.DurationSeconds != 60 {
 		t.Errorf("DurationSeconds=%d, want 60", resp.DurationSeconds)
+	}
+	if resp.PID != 4321 {
+		t.Errorf("PID=%d, want 4321", resp.PID)
+	}
+	if len(resp.CPUIDs) != 2 || resp.CPUIDs[0] != 1 || resp.CPUIDs[1] != 3 {
+		t.Errorf("CPUIDs=%v, want [1 3]", resp.CPUIDs)
+	}
+	if !resp.ThreadGroup {
+		t.Error("ThreadGroup=false, want true")
 	}
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -49,6 +51,9 @@ type profilingJobPrivateData struct {
 	DurationSeconds int    `json:"duration_seconds"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
+	PID             int    `json:"pid,omitempty"`
+	CPUIDs          []int  `json:"cpu_ids,omitempty"`
+	ThreadGroup     bool   `json:"thread_group,omitempty"`
 }
 
 func parseCreateProfilingJobRequest(ctx *server.Context) (*v1.CreateProfilingJobRequest, error) {
@@ -64,50 +69,80 @@ func buildCreateProfilingJobRequest(
 	userID string,
 	cfg *Config,
 ) (*job.CreateJobRequest, error) {
-	taskReq := job.AgentTaskRequest{
-		TracerName:  "profiler",
-		DataType:    "db-json",
-		ContainerID: req.ContainerID,
-		Interval:    cfg.AggregationIntervalSeconds,
-	}
-
-	jobType, err := buildProfilingTracerArgs(&taskReq, req)
+	normalizedReq, err := normalizeProfilingJobRequest(req)
 	if err != nil {
 		return nil, err
 	}
-	if req.DurationSeconds < taskReq.Interval*2 {
+
+	taskReq := job.AgentTaskRequest{
+		TracerName:  "profiler",
+		DataType:    "db-json",
+		ContainerID: normalizedReq.ContainerID,
+		Interval:    cfg.AggregationIntervalSeconds,
+	}
+
+	jobType, err := buildProfilingTracerArgs(&taskReq, normalizedReq)
+	if err != nil {
+		return nil, err
+	}
+	if err := appendProfilingTargetArgs(&taskReq, normalizedReq); err != nil {
+		return nil, err
+	}
+	if normalizedReq.DurationSeconds < taskReq.Interval*2 {
 		return nil, errors.New("duration_seconds must cover at least two profiling intervals")
 	}
-	if req.DurationSeconds+taskReq.Interval >= 3600 {
+	if normalizedReq.DurationSeconds+taskReq.Interval >= 3600 {
 		return nil, errors.New("duration_seconds plus profiling interval must be less than 3600 seconds")
 	}
-	taskReq.TraceTimeout = req.DurationSeconds + taskReq.Interval
+	taskReq.TraceTimeout = normalizedReq.DurationSeconds + taskReq.Interval
 
 	// The job duration controls profiling lifetime while the agent task remains
 	// alive long enough to be stopped externally.
-	taskReq.Duration = req.DurationSeconds * 2
+	taskReq.Duration = normalizedReq.DurationSeconds * 2
 	taskReq.TracerArgs = append(
 		taskReq.TracerArgs,
-		"--duration", strconv.Itoa(req.DurationSeconds),
+		"--duration", strconv.Itoa(normalizedReq.DurationSeconds),
 		"--aggr-interval", strconv.Itoa(taskReq.Interval),
 		"--max-concurrent-procs", strconv.Itoa(cfg.MaxConcurrentProfilerProcesses),
 		"--output-format", "remote",
 		"--output-storage", "/var/run/huatuo-toolstream.sock",
 	)
 
-	privateData, err := newProfilingPrivateData(req)
+	privateData, err := newProfilingPrivateData(normalizedReq)
 	if err != nil {
 		return nil, err
 	}
 
 	return &job.CreateJobRequest{
 		UserID:      userID,
-		ContainerID: req.ContainerID,
-		Hostname:    req.Hostname,
+		ContainerID: normalizedReq.ContainerID,
+		Hostname:    normalizedReq.Hostname,
 		Type:        jobType,
 		AgentTask:   &taskReq,
 		PrivateData: privateData,
 	}, nil
+}
+
+func normalizeProfilingJobRequest(
+	req *v1.CreateProfilingJobRequest,
+) (*v1.CreateProfilingJobRequest, error) {
+	if req == nil {
+		return nil, errors.New("profiling job request is required")
+	}
+
+	normalized := *req
+	normalized.CPUIDs = append([]int(nil), req.CPUIDs...)
+	sort.Ints(normalized.CPUIDs)
+	for i, cpuID := range normalized.CPUIDs {
+		if cpuID < 0 {
+			return nil, fmt.Errorf("cpu_id must not be negative: %d", cpuID)
+		}
+		if i > 0 && normalized.CPUIDs[i-1] == cpuID {
+			return nil, fmt.Errorf("duplicate cpu_id %d", cpuID)
+		}
+	}
+
+	return &normalized, nil
 }
 
 func buildProfilingTracerArgs(
@@ -149,12 +184,70 @@ func buildProfilingTracerArgs(
 	}
 }
 
+func appendProfilingTargetArgs(
+	taskReq *job.AgentTaskRequest,
+	req *v1.CreateProfilingJobRequest,
+) error {
+	language, err := profiling.ParseLanguage(req.Language)
+	if err != nil {
+		return err
+	}
+	implementation, ok := profiling.ImplementationFor(language)
+	if !ok {
+		return fmt.Errorf("profiling implementation not found for %q", language)
+	}
+	native := implementation == profiling.ImplementationNative
+
+	if !native && (req.ThreadGroup || len(req.CPUIDs) > 0) {
+		return errors.New("cpu_ids and thread_group are supported only by native profiling")
+	}
+	if req.PID < 0 || int64(req.PID) > math.MaxInt32 {
+		return fmt.Errorf("pid must be between 1 and %d", math.MaxInt32)
+	}
+	if req.PID != 0 && req.ContainerID != "" {
+		return errors.New("pid and container_id are mutually exclusive")
+	}
+	if req.ThreadGroup && req.PID == 0 {
+		return errors.New("thread_group requires pid")
+	}
+	if len(req.CPUIDs) > 0 && (!native || req.ProfilingType != string(profiling.TypeCPU)) {
+		return errors.New("cpu_ids are supported only by native CPU profiling")
+	}
+
+	requiresTarget := !native || req.ProfilingType == string(profiling.TypeMemory)
+	if requiresTarget && req.PID == 0 && req.ContainerID == "" {
+		return errors.New("exactly one of pid or container_id must be provided")
+	}
+
+	if req.ContainerID != "" {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--container-id", req.ContainerID)
+	}
+	if req.PID != 0 {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--pid", strconv.Itoa(req.PID))
+	}
+	if req.ThreadGroup {
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--thread-group")
+	}
+	if len(req.CPUIDs) > 0 {
+		values := make([]string, len(req.CPUIDs))
+		for i, cpuID := range req.CPUIDs {
+			values[i] = strconv.Itoa(cpuID)
+		}
+		taskReq.TracerArgs = append(taskReq.TracerArgs, "--cpuid", strings.Join(values, ","))
+	}
+
+	return nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
 		DurationSeconds: req.DurationSeconds,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,
+		PID:             req.PID,
+		CPUIDs:          append([]int(nil), req.CPUIDs...),
+		ThreadGroup:     req.ThreadGroup,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("encoding profiling private data: %w", err)

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -15,6 +15,7 @@
 package profiling
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -31,20 +32,21 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 		wantErr        string
 	}{
 		{
-			name: "cpu profiling",
+			name: "native CPU container and CPU selection",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType:   "cpu",
 				Language:        "go",
-				BinaryMatchPath: "/usr/bin/example",
 				DurationSeconds: 30,
 				ContainerID:     "container-2026",
 				Hostname:        "huatuo-dev",
+				CPUIDs:          []int{3, 1},
 			},
 			wantType: ProfilingCPU,
 			wantTracerArgs: []string{
 				"-t", "cpu",
-				"--binary-match-path", "/usr/bin/example",
 				"-l", "go",
+				"--container-id", "container-2026",
+				"--cpuid", "1,3",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
@@ -53,18 +55,88 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
-			name: "memory profiling",
+			name: "native memory PID",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType:   "memory",
 				Language:        "c",
 				MemoryMode:      "physical_usage",
 				DurationSeconds: 30,
+				PID:             4321,
 			},
 			wantType: ProfilingMemory,
 			wantTracerArgs: []string{
 				"-t", "memory",
 				"--memory-mode", "physical_usage",
 				"-l", "c",
+				"--pid", "4321",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "native CPU thread group",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 30,
+				PID:             4321,
+				ThreadGroup:     true,
+				CPUIDs:          []int{4, 1},
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"-l", "go",
+				"--pid", "4321",
+				"--thread-group",
+				"--cpuid", "1,4",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "external container target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "java",
+				BinaryMatchPath: "/usr/bin/java",
+				DurationSeconds: 30,
+				ContainerID:     "container-2026",
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"--binary-match-path", "/usr/bin/java",
+				"-l", "java",
+				"--container-id", "container-2026",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "external PID target",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "java",
+				BinaryMatchPath: "/usr/bin/java",
+				DurationSeconds: 30,
+				PID:             4321,
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"--binary-match-path", "/usr/bin/java",
+				"-l", "java",
+				"--pid", "4321",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
@@ -88,6 +160,99 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				DurationSeconds: 19,
 			},
 			wantErr: "duration_seconds must cover at least two profiling intervals",
+		},
+		{
+			name: "native memory target required",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "memory",
+				Language:        "c",
+				MemoryMode:      "physical_usage",
+				DurationSeconds: 30,
+			},
+			wantErr: "exactly one of pid or container_id must be provided",
+		},
+		{
+			name: "PID and container conflict",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 30,
+				PID:             4321,
+				ContainerID:     "container-2026",
+			},
+			wantErr: "pid and container_id are mutually exclusive",
+		},
+		{
+			name: "thread group requires PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 30,
+				ThreadGroup:     true,
+			},
+			wantErr: "thread_group requires pid",
+		},
+		{
+			name: "thread group requires native profiler",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "java",
+				DurationSeconds: 30,
+				PID:             4321,
+				ThreadGroup:     true,
+			},
+			wantErr: "cpu_ids and thread_group are supported only by native profiling",
+		},
+		{
+			name: "external profiler target required",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "java",
+				DurationSeconds: 30,
+			},
+			wantErr: "exactly one of pid or container_id must be provided",
+		},
+		{
+			name: "CPU IDs require native CPU profiler",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "memory",
+				Language:        "c",
+				MemoryMode:      "physical_usage",
+				DurationSeconds: 30,
+				PID:             4321,
+				CPUIDs:          []int{1},
+			},
+			wantErr: "cpu_ids are supported only by native CPU profiling",
+		},
+		{
+			name: "negative CPU ID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 30,
+				CPUIDs:          []int{-1},
+			},
+			wantErr: "cpu_id must not be negative: -1",
+		},
+		{
+			name: "duplicate CPU ID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 30,
+				CPUIDs:          []int{1, 1},
+			},
+			wantErr: "duplicate cpu_id 1",
+		},
+		{
+			name: "invalid PID",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 30,
+				PID:             -1,
+			},
+			wantErr: "pid must be between 1 and 2147483647",
 		},
 	}
 
@@ -132,6 +297,35 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				t.Errorf("TracerArgs=%q, want %q", got.AgentTask.TracerArgs, tt.wantTracerArgs)
 			}
 		})
+	}
+}
+
+func TestBuildCreateProfilingJobRequestDoesNotMutateInput(t *testing.T) {
+	req := v1.CreateProfilingJobRequest{
+		ProfilingType:   "cpu",
+		Language:        "go",
+		DurationSeconds: 30,
+		CPUIDs:          []int{3, 1},
+	}
+	cfg := Config{
+		AggregationIntervalSeconds:     10,
+		MaxConcurrentProfilerProcesses: 2,
+	}
+
+	got, err := buildCreateProfilingJobRequest(&req, "operator-2026", &cfg)
+	if err != nil {
+		t.Fatalf("buildCreateProfilingJobRequest() error=%v", err)
+	}
+	if !slices.Equal(req.CPUIDs, []int{3, 1}) {
+		t.Fatalf("request CPU IDs mutated to %v", req.CPUIDs)
+	}
+
+	var privateData profilingJobPrivateData
+	if err := json.Unmarshal(got.PrivateData, &privateData); err != nil {
+		t.Fatalf("json.Unmarshal() error=%v", err)
+	}
+	if !slices.Equal(privateData.CPUIDs, []int{1, 3}) {
+		t.Errorf("private CPU IDs=%v, want [1 3]", privateData.CPUIDs)
 	}
 }
 

--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -283,6 +283,9 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	if ctx.Bool("thread-group") && !native {
 		return fmt.Errorf("--thread-group is supported only by native profiling")
 	}
+	if ctx.Bool("thread-group") && ctx.String("pid") == "" {
+		return fmt.Errorf("--thread-group requires --pid")
+	}
 	if ctx.String("binary-match-path") != "" && native {
 		return fmt.Errorf("--binary-match-path is not supported by native profilers")
 	}

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -282,8 +282,26 @@ func TestValidateProfilerFlagCompatibility(t *testing.T) {
 			args:      []string{"--thread-group"},
 			wantError: "--thread-group is supported only by native profiling",
 		},
-		{name: "native CPU thread group", language: "go", typ: "cpu", args: []string{"--thread-group"}},
-		{name: "native memory thread group", language: "c", typ: "memory", args: []string{"--thread-group"}},
+		{
+			name:      "native CPU thread group without PID",
+			language:  "go",
+			typ:       "cpu",
+			args:      []string{"--thread-group"},
+			wantError: "--thread-group requires --pid",
+		},
+		{
+			name:      "native memory thread group without PID",
+			language:  "c",
+			typ:       "memory",
+			args:      []string{"--thread-group"},
+			wantError: "--thread-group requires --pid",
+		},
+		{
+			name:     "native CPU thread group",
+			language: "go",
+			typ:      "cpu",
+			args:     []string{"--thread-group", "--pid", "123"},
+		},
 		{
 			name:      "native exec path",
 			language:  "c",

--- a/docs/development/profiling-native-targets_en.md
+++ b/docs/development/profiling-native-targets_en.md
@@ -1,0 +1,28 @@
+# Native profiling target selectors
+
+The Profiles API accepts the following optional native profiling selectors:
+
+| Field | Meaning |
+| --- | --- |
+| `container_id` | Select a container through its resolved cgroup metadata |
+| `pid` | Select one process or thread ID |
+| `thread_group` | Treat `pid` as a thread-group member and profile its TGID |
+| `cpu_ids` | Restrict native CPU profiling to the listed CPU IDs |
+
+`pid` and `container_id` are mutually exclusive. Native memory profiling
+requires exactly one of them. Native CPU profiling may omit both for
+host-wide collection.
+
+Java and Python profiling also require exactly one `pid` or `container_id`.
+CPU selection and thread-group expansion remain native-only options.
+
+`thread_group` requires `pid`. The Agent reads `/proc/<pid>/status` and uses
+its `Tgid` value, so callers may provide a non-leader thread ID. There is no
+separate process-group selector.
+
+CPU IDs must be unique and non-negative. The API sorts them for a stable
+request, while the Agent validates them against the target host's CPU count.
+
+The control plane forwards `container_id` to the profiler. The profiler
+resolves the container's cgroup subsystem metadata; callers do not provide a
+cgroup filesystem path.

--- a/docs/development/profiling-native-targets_zh.md
+++ b/docs/development/profiling-native-targets_zh.md
@@ -1,0 +1,26 @@
+# Native Profiling 目标选择器
+
+Profiles API 支持以下可选的 native profiling 目标选择器：
+
+| 字段 | 含义 |
+| --- | --- |
+| `container_id` | 通过解析后的 cgroup 元数据选择容器 |
+| `pid` | 选择一个进程或线程 ID |
+| `thread_group` | 将 `pid` 视为线程组成员，并按其 TGID 采集 |
+| `cpu_ids` | 将 native CPU profiling 限制到指定 CPU |
+
+`pid` 和 `container_id` 互斥。Native memory profiling 必须且只能指定其中
+一个；native CPU profiling 可同时省略两者，从而进行主机级采集。
+
+Java 和 Python profiling 同样必须且只能指定 `pid` 或 `container_id`。
+CPU 选择和线程组扩展仍然只适用于 native profiler。
+
+`thread_group` 必须与 `pid` 一起使用。Agent 会读取
+`/proc/<pid>/status` 中的 `Tgid`，因此调用者可以传入非主线程 ID。不提供
+单独的 process-group 选择器。
+
+CPU ID 必须非负且不能重复。API 会排序以保证请求稳定，Agent 会根据目标
+主机的 CPU 数量进行最终范围校验。
+
+控制面会将 `container_id` 传递给 profiler。Profiler 使用容器对应的 cgroup
+子系统元数据进行过滤，调用者不需要提供 cgroup 文件系统路径。

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -27,6 +27,7 @@ import (
 	"huatuo-bamai/internal/profiler/output"
 	_ "huatuo-bamai/internal/profiler/output/flamegraph"
 	_ "huatuo-bamai/internal/profiler/output/raw"
+	"huatuo-bamai/internal/profiler/procutil"
 	psignal "huatuo-bamai/internal/profiler/signal"
 	"huatuo-bamai/internal/toolstream"
 	"huatuo-bamai/pkg/profiling"
@@ -69,6 +70,8 @@ type TracerData struct {
 	MetricData any                   `json:"metric_data,omitempty"`
 	FlameData  *profiler.ProfileData `json:"flamedata"`
 }
+
+var threadGroupID = procutil.ThreadGroupID
 
 func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerContext, error) {
 	ctx, cancel := context.WithCancel(cliCtx.Context)
@@ -129,6 +132,10 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 	if err != nil {
 		return nil, err
 	}
+	pids, err = normalizeThreadGroupTarget(pids, cliCtx.Bool("thread-group"))
+	if err != nil {
+		return nil, err
+	}
 	typ, err := profiling.ParseType(cliCtx.String("type"))
 	if err != nil {
 		return nil, err
@@ -175,6 +182,20 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 	}
 	succeeded = true
 	return profilerContext, nil
+}
+
+func normalizeThreadGroupTarget(pids []int, threadGroup bool) ([]int, error) {
+	if !threadGroup || len(pids) != 1 {
+		return pids, nil
+	}
+	tgid, err := threadGroupID(pids[0])
+	if err != nil {
+		return nil, err
+	}
+
+	normalized := append([]int(nil), pids...)
+	normalized[0] = tgid
+	return normalized, nil
 }
 
 func initToolstreamClient(cliCtx *cli.Context, format output.OutputFormat) (*toolstream.Client, error) {

--- a/internal/profiler/context/context_test.go
+++ b/internal/profiler/context/context_test.go
@@ -16,6 +16,7 @@ package context
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"testing"
 	"time"
@@ -45,5 +46,40 @@ func TestProfilerContextCancelStopsSignalListener(t *testing.T) {
 	case <-pctx.Ctx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("ProfilerContext.Cancel() did not cancel context")
+	}
+}
+
+func TestNormalizeThreadGroupTarget(t *testing.T) {
+	previous := threadGroupID
+	threadGroupID = func(pid int) (int, error) {
+		if pid != 4243 {
+			t.Fatalf("threadGroupID() pid=%d, want 4243", pid)
+		}
+		return 4242, nil
+	}
+	t.Cleanup(func() { threadGroupID = previous })
+
+	input := []int{4243}
+	got, err := normalizeThreadGroupTarget(input, true)
+	if err != nil {
+		t.Fatalf("normalizeThreadGroupTarget() error=%v", err)
+	}
+	if got[0] != 4242 {
+		t.Errorf("normalizeThreadGroupTarget()=%v, want [4242]", got)
+	}
+	if input[0] != 4243 {
+		t.Errorf("input mutated to %v", input)
+	}
+}
+
+func TestNormalizeThreadGroupTargetReturnsResolverError(t *testing.T) {
+	previous := threadGroupID
+	wantErr := errors.New("status unavailable")
+	threadGroupID = func(int) (int, error) { return 0, wantErr }
+	t.Cleanup(func() { threadGroupID = previous })
+
+	_, err := normalizeThreadGroupTarget([]int{4243}, true)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("normalizeThreadGroupTarget() error=%v, want %v", err, wantErr)
 	}
 }

--- a/internal/profiler/procutil/procutil.go
+++ b/internal/profiler/procutil/procutil.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,17 @@
 package procutil
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
+	"strings"
 
 	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/procfs"
 )
 
 // CheckExecPath validates whether the actual exec path of pid matches expectedPath.
@@ -42,4 +48,39 @@ func CommToString(c [bpf.TaskCommLen]byte) string {
 		n = len(c)
 	}
 	return string(c[:n])
+}
+
+// ThreadGroupID returns the TGID for pid, which may be a non-leader thread.
+func ThreadGroupID(pid int) (int, error) {
+	path := procfs.Path(strconv.Itoa(pid), "status")
+	status, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open status for pid %d: %w", pid, err)
+	}
+	defer status.Close()
+
+	tgid, err := parseThreadGroupID(status)
+	if err != nil {
+		return 0, fmt.Errorf("read TGID for pid %d: %w", pid, err)
+	}
+	return tgid, nil
+}
+
+func parseThreadGroupID(status io.Reader) (int, error) {
+	scanner := bufio.NewScanner(status)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 || fields[0] != "Tgid:" {
+			continue
+		}
+		tgid, err := strconv.Atoi(fields[1])
+		if err != nil || tgid < 1 {
+			return 0, fmt.Errorf("invalid Tgid value %q", fields[1])
+		}
+		return tgid, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan status: %w", err)
+	}
+	return 0, errors.New("Tgid field not found")
 }

--- a/internal/profiler/procutil/procutil_test.go
+++ b/internal/profiler/procutil/procutil_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package procutil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseThreadGroupID(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  string
+		want    int
+		wantErr string
+	}{
+		{
+			name:   "thread group",
+			status: "Name:\tworker\nTgid:\t4242\nPid:\t4243\n",
+			want:   4242,
+		},
+		{name: "missing", status: "Name:\tworker\nPid:\t4243\n", wantErr: "Tgid field not found"},
+		{name: "invalid", status: "Tgid:\tzero\n", wantErr: `invalid Tgid value "zero"`},
+		{name: "non-positive", status: "Tgid:\t0\n", wantErr: `invalid Tgid value "0"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseThreadGroupID(strings.NewReader(tt.status))
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("parseThreadGroupID() error=%v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseThreadGroupID() error=%v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseThreadGroupID()=%d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseThreadGroupIDReturnsReadError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	_, err := parseThreadGroupID(errorReader{err: wantErr})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("parseThreadGroupID() error=%v, want wrapped %v", err, wantErr)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}


### PR DESCRIPTION
## Summary

- expose PID, CPU, thread-group, and container targets through the Profiles API
- reuse the native profiler's existing target filters and normalize non-leader TIDs to TGIDs
- validate incompatible selector combinations across API and CLI paths
- document the supported collection dimensions in English and Chinese

## Testing

- targeted package tests
- targeted race tests
- targeted `go vet`
- `make import-fmt`
- `git diff --check`

Refs #329