### PR TITLE
feat(profiling): forward external profiler tool path

### DIFF
--- a/apis/v1/types.go
+++ b/apis/v1/types.go
@@ -21,13 +21,14 @@ import (
 
 // CreateProfilingJobRequest represents a request to create a profiling job.
 type CreateProfilingJobRequest struct {
-	ProfilingType   string `json:"type"`              // cpu or memory
-	BinaryMatchPath string `json:"binary_match_path"` // executable path used to match target processes
-	Language        string `json:"language"`          // programming language of the target process
-	MemoryMode      string `json:"memory_mode"`       // memory profiling mode
-	DurationSeconds int    `json:"duration_seconds"`  // profiling duration in seconds
-	ContainerID     string `json:"container_id"`      // container ID
-	Hostname        string `json:"hostname"`          // host name
+	ProfilingType   string `json:"type"`                       // cpu or memory
+	BinaryMatchPath string `json:"binary_match_path"`          // executable path used to match target processes
+	BinaryToolPath  string `json:"binary_tool_path,omitempty"` // Java or Python profiler installation directory
+	Language        string `json:"language"`                   // programming language of the target process
+	MemoryMode      string `json:"memory_mode"`                // memory profiling mode
+	DurationSeconds int    `json:"duration_seconds"`           // profiling duration in seconds
+	ContainerID     string `json:"container_id"`               // container ID
+	Hostname        string `json:"hostname"`                   // host name
 }
 
 // CreateProfilingJobResponse represents a response to create a profiling job.
@@ -44,6 +45,7 @@ type ProfilingJob struct {
 	MemoryMode      string     `json:"memory_mode,omitempty"`       // memory profiling mode
 	Language        string     `json:"language"`                    // programming language of the target process
 	BinaryMatchPath string     `json:"binary_match_path,omitempty"` // executable path used to match target processes
+	BinaryToolPath  string     `json:"binary_tool_path,omitempty"`  // Java or Python profiler installation directory
 	Status          string     `json:"status"`                      // job status
 	DurationSeconds int        `json:"duration_seconds"`            // profiling duration in seconds
 	CreatedAt       time.Time  `json:"created_at"`                  // job creation time

--- a/apis/v1/types_test.go
+++ b/apis/v1/types_test.go
@@ -31,12 +31,14 @@ func TestCreateJobRequestJSONFields(t *testing.T) {
 			request: CreateProfilingJobRequest{
 				ProfilingType:   "cpu",
 				BinaryMatchPath: "/usr/bin/example",
+				BinaryToolPath:  "/opt/async-profiler",
 				Language:        "go",
 				ContainerID:     "container-id",
 			},
 			fields: []string{
 				"type",
 				"binary_match_path",
+				"binary_tool_path",
 				"language",
 				"memory_mode",
 				"duration_seconds",
@@ -114,10 +116,12 @@ func TestStandardizedJobJSONFields(t *testing.T) {
 			value: ProfilingJob{
 				ContainerID:     "container-2026",
 				BinaryMatchPath: "/usr/bin/example",
+				BinaryToolPath:  "/opt/async-profiler",
 			},
 			fields: []string{
 				"container_id",
 				"binary_match_path",
+				"binary_tool_path",
 				"language",
 			},
 		},
@@ -163,6 +167,7 @@ func TestProfilingJobJSONFields(t *testing.T) {
 		ContainerID:     "container-2026",
 		MemoryMode:      "object_alloc",
 		BinaryMatchPath: "/usr/bin/example",
+		BinaryToolPath:  "/opt/async-profiler",
 	})
 	if err != nil {
 		t.Fatalf("json.Marshal() error = %v", err)
@@ -181,6 +186,7 @@ func TestProfilingJobJSONFields(t *testing.T) {
 		"memory_mode",
 		"language",
 		"binary_match_path",
+		"binary_tool_path",
 		"status",
 		"duration_seconds",
 		"created_at",

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling.go
@@ -203,6 +203,7 @@ func buildProfilingJob(jobResult *job.Job, flameGraphBaseURL string) (v1.Profili
 		StatusReason:    optionalString(jobResult.ErrorMessage),
 		MemoryMode:      privateData.MemoryMode,
 		BinaryMatchPath: privateData.BinaryMatchPath,
+		BinaryToolPath:  privateData.BinaryToolPath,
 		Language:        privateData.Language,
 	}
 

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -161,6 +161,7 @@ func TestCapabilitiesReturnsIndependentMemoryModeMap(t *testing.T) {
 func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 	data, err := newProfilingPrivateData(&v1.CreateProfilingJobRequest{
 		BinaryMatchPath: "/usr/bin/example",
+		BinaryToolPath:  " /opt/async-profiler ",
 		DurationSeconds: 60,
 		Language:        "go",
 		MemoryMode:      "object_alloc",
@@ -174,6 +175,7 @@ func TestProfilingPrivateDataUsesRequestJSONNames(t *testing.T) {
 		t.Fatalf("json.Unmarshal() error=%v", err)
 	}
 	if fields["binary_match_path"] != "/usr/bin/example" ||
+		fields["binary_tool_path"] != "/opt/async-profiler" ||
 		fields["duration_seconds"] != float64(60) ||
 		fields["language"] != "go" ||
 		fields["memory_mode"] != "object_alloc" {
@@ -187,6 +189,7 @@ func TestBuildProfilingJobReadsPrivateData(t *testing.T) {
 		Status: job.JobStatusRunning,
 		PrivateData: json.RawMessage(`{
 			"binary_match_path":"/usr/bin/example",
+			"binary_tool_path":"/opt/async-profiler",
 			"duration_seconds":60,
 			"language":"go",
 			"memory_mode":"object_alloc"
@@ -198,6 +201,9 @@ func TestBuildProfilingJobReadsPrivateData(t *testing.T) {
 
 	if resp.BinaryMatchPath != "/usr/bin/example" {
 		t.Errorf("BinaryMatchPath=%q, want %q", resp.BinaryMatchPath, "/usr/bin/example")
+	}
+	if resp.BinaryToolPath != "/opt/async-profiler" {
+		t.Errorf("BinaryToolPath=%q, want %q", resp.BinaryToolPath, "/opt/async-profiler")
 	}
 	if resp.Language != "go" {
 		t.Errorf("Language=%q, want %q", resp.Language, "go")

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -176,7 +176,7 @@ func appendBinaryToolPath(
 		return fmt.Errorf("language %q requires binary_tool_path", language)
 	}
 
-	taskReq.TracerArgs = append(taskReq.TracerArgs, "--tool-path", binaryToolPath)
+	taskReq.TracerArgs = append(taskReq.TracerArgs, "--tool-path-dir", binaryToolPath)
 	return nil
 }
 

--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -46,6 +46,7 @@ type patchProfilingJobRequest struct {
 
 type profilingJobPrivateData struct {
 	BinaryMatchPath string `json:"binary_match_path"`
+	BinaryToolPath  string `json:"binary_tool_path,omitempty"`
 	DurationSeconds int    `json:"duration_seconds"`
 	Language        string `json:"language"`
 	MemoryMode      string `json:"memory_mode"`
@@ -128,6 +129,9 @@ func buildProfilingTracerArgs(
 			)
 		}
 		taskReq.TracerArgs = append(taskReq.TracerArgs, "-l", string(language))
+		if err := appendBinaryToolPath(taskReq, req.BinaryToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingCPU, nil
 	case string(profiling.TypeMemory):
 		language, err := profiling.ParseLanguage(req.Language)
@@ -143,15 +147,43 @@ func buildProfilingTracerArgs(
 			"--memory-mode", string(mode),
 			"-l", string(language),
 		}
+		if err := appendBinaryToolPath(taskReq, req.BinaryToolPath, language); err != nil {
+			return "", err
+		}
 		return job.JobTypeProfilingMemory, nil
 	default:
 		return "", fmt.Errorf("unsupported profiling type %q", req.ProfilingType)
 	}
 }
 
+func appendBinaryToolPath(
+	taskReq *job.AgentTaskRequest,
+	binaryToolPath string,
+	language profiling.Language,
+) error {
+	implementation, ok := profiling.ImplementationFor(language)
+	if !ok {
+		return fmt.Errorf("profiling implementation not found for %q", language)
+	}
+	binaryToolPath = strings.TrimSpace(binaryToolPath)
+	if implementation == profiling.ImplementationNative {
+		if binaryToolPath != "" {
+			return errors.New("binary_tool_path is supported only by Java and Python profiling")
+		}
+		return nil
+	}
+	if binaryToolPath == "" {
+		return fmt.Errorf("language %q requires binary_tool_path", language)
+	}
+
+	taskReq.TracerArgs = append(taskReq.TracerArgs, "--tool-path", binaryToolPath)
+	return nil
+}
+
 func newProfilingPrivateData(req *v1.CreateProfilingJobRequest) (json.RawMessage, error) {
 	data, err := json.Marshal(profilingJobPrivateData{
 		BinaryMatchPath: req.BinaryMatchPath,
+		BinaryToolPath:  strings.TrimSpace(req.BinaryToolPath),
 		DurationSeconds: req.DurationSeconds,
 		Language:        req.Language,
 		MemoryMode:      req.MemoryMode,

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -86,7 +86,7 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				"-t", "memory",
 				"--memory-mode", "object_usage",
 				"-l", "java",
-				"--tool-path", "/opt/async-profiler",
+				"--tool-path-dir", "/opt/async-profiler",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",
@@ -106,7 +106,7 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			wantTracerArgs: []string{
 				"-t", "cpu",
 				"-l", "python",
-				"--tool-path", "/opt/py-spy",
+				"--tool-path-dir", "/opt/py-spy",
 				"--duration", "30",
 				"--aggr-interval", "10",
 				"--max-concurrent-procs", "2",

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -73,6 +73,48 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "Java profiler tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "memory",
+				Language:        "java",
+				MemoryMode:      "object_usage",
+				BinaryToolPath:  " /opt/async-profiler ",
+				DurationSeconds: 30,
+			},
+			wantType: ProfilingMemory,
+			wantTracerArgs: []string{
+				"-t", "memory",
+				"--memory-mode", "object_usage",
+				"-l", "java",
+				"--tool-path", "/opt/async-profiler",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
+			name: "Python profiler tool",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "python",
+				BinaryToolPath:  "/opt/py-spy",
+				DurationSeconds: 30,
+			},
+			wantType: ProfilingCPU,
+			wantTracerArgs: []string{
+				"-t", "cpu",
+				"-l", "python",
+				"--tool-path", "/opt/py-spy",
+				"--duration", "30",
+				"--aggr-interval", "10",
+				"--max-concurrent-procs", "2",
+				"--output-format", "remote",
+				"--output-storage", "/var/run/huatuo-toolstream.sock",
+			},
+		},
+		{
 			name: "unsupported type",
 			req: v1.CreateProfilingJobRequest{
 				ProfilingType:   "offcpu",
@@ -88,6 +130,35 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				DurationSeconds: 19,
 			},
 			wantErr: "duration_seconds must cover at least two profiling intervals",
+		},
+		{
+			name: "Java tool required",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "java",
+				DurationSeconds: 30,
+			},
+			wantErr: `language "java" requires binary_tool_path`,
+		},
+		{
+			name: "Python tool required",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "python",
+				BinaryToolPath:  "  ",
+				DurationSeconds: 30,
+			},
+			wantErr: `language "python" requires binary_tool_path`,
+		},
+		{
+			name: "native tool rejected",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				BinaryToolPath:  "/opt/profiler",
+				DurationSeconds: 30,
+			},
+			wantErr: "binary_tool_path is supported only by Java and Python profiling",
 		},
 	}
 

--- a/cmd/profiler/flags.go
+++ b/cmd/profiler/flags.go
@@ -117,8 +117,9 @@ var appFlags = []cli.Flag{
 		Usage: "Serve Go runtime profiles on port 6000",
 	},
 	&cli.StringFlag{
-		Name:  "tool-path",
-		Usage: "Profiling tool root; Java expects bin/asprof and lib/libasyncProfiler.so",
+		Name:    "tool-path-dir",
+		Aliases: []string{"tool-path"},
+		Usage:   "Profiling tool directory; Java expects bin/asprof and lib/libasyncProfiler.so, Python expects py-spy",
 	},
 	&cli.StringFlag{
 		Name:  "binary-match-path",

--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -129,14 +129,14 @@ func validateLanguageOptions(ctx *cli.Context, lang profiling.Language, typ prof
 		return nil
 
 	case profiling.LanguageJava:
-		if ctx.String("tool-path") == "" {
-			return fmt.Errorf("language=%s requires --tool-path", lang)
+		if ctx.String("tool-path-dir") == "" {
+			return fmt.Errorf("language=%s requires --tool-path-dir", lang)
 		}
 
 		return validateExactlyOneTarget(ctx)
 
 	case profiling.LanguagePython:
-		if err := ensurePythonToolPath(ctx); err != nil {
+		if err := ensurePythonToolPathDir(ctx); err != nil {
 			return err
 		}
 		return validateExactlyOneTarget(ctx)
@@ -166,11 +166,11 @@ func validatePythonProfileOptions(lang profiling.Language, typ profiling.Type, d
 	return nil
 }
 
-func ensurePythonToolPath(ctx *cli.Context) error {
-	if ctx.String("tool-path") != "" {
+func ensurePythonToolPathDir(ctx *cli.Context) error {
+	if ctx.String("tool-path-dir") != "" {
 		return nil
 	}
-	return fmt.Errorf("language=python requires --tool-path")
+	return fmt.Errorf("language=python requires --tool-path-dir")
 }
 
 func validateExactlyOneTarget(ctx *cli.Context) error {
@@ -231,14 +231,14 @@ func validateCommonOptions(ctx *cli.Context) error {
 		return err
 	}
 
-	if toolPath := ctx.String("tool-path"); toolPath != "" {
-		info, err := os.Stat(toolPath)
+	if toolPathDir := ctx.String("tool-path-dir"); toolPathDir != "" {
+		info, err := os.Stat(toolPathDir)
 		if err != nil {
-			return fmt.Errorf("tool-path does not exist: %s", toolPath)
+			return fmt.Errorf("--tool-path-dir does not exist: %s", toolPathDir)
 		}
 
 		if !info.IsDir() {
-			return fmt.Errorf("tool-path must be a directory: %s", toolPath)
+			return fmt.Errorf("--tool-path-dir must be a directory: %s", toolPathDir)
 		}
 	}
 
@@ -286,8 +286,8 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	if ctx.String("binary-match-path") != "" && native {
 		return fmt.Errorf("--binary-match-path is not supported by native profilers")
 	}
-	if ctx.String("tool-path") != "" && native {
-		return fmt.Errorf("--tool-path is supported only by Java and Python profiling")
+	if ctx.String("tool-path-dir") != "" && native {
+		return fmt.Errorf("--tool-path-dir is supported only by Java and Python profiling")
 	}
 	if ctx.IsSet("physical-memory-probability") {
 		physicalMemory := nativeMemory &&

--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -286,6 +286,9 @@ func validateProfilerFlagCompatibility(ctx *cli.Context, lang profiling.Language
 	if ctx.String("binary-match-path") != "" && native {
 		return fmt.Errorf("--binary-match-path is not supported by native profilers")
 	}
+	if ctx.String("tool-path") != "" && native {
+		return fmt.Errorf("--tool-path is supported only by Java and Python profiling")
+	}
 	if ctx.IsSet("physical-memory-probability") {
 		physicalMemory := nativeMemory &&
 			profiling.MemoryMode(ctx.String("memory-mode")) != profiling.MemoryModeVirtualAlloc

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -292,6 +292,13 @@ func TestValidateProfilerFlagCompatibility(t *testing.T) {
 			wantError: "--binary-match-path is not supported by native profilers",
 		},
 		{
+			name:      "native tool path",
+			language:  "go",
+			typ:       "cpu",
+			args:      []string{"--tool-path", "/opt/profiler"},
+			wantError: "--tool-path is supported only by Java and Python profiling",
+		},
+		{
 			name:      "Python physical memory probability",
 			language:  "python",
 			typ:       "cpu",

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -104,6 +104,11 @@ func TestCLIProfileTypeAndRemovedFlags(t *testing.T) {
 			args:      []string{"--type", "cpu", "--language", "c", "--cpusys-metadata", "sys=1"},
 			wantError: "flag provided but not defined: -cpusys-metadata",
 		},
+		{
+			name:      "deprecated tool path alias",
+			args:      []string{"--type", "cpu", "--language", "c", "--tool-path", "/opt/profiler"},
+			wantError: "--tool-path-dir is supported only by Java and Python profiling",
+		},
 	}
 
 	for _, tt := range tests {
@@ -292,11 +297,11 @@ func TestValidateProfilerFlagCompatibility(t *testing.T) {
 			wantError: "--binary-match-path is not supported by native profilers",
 		},
 		{
-			name:      "native tool path",
+			name:      "native tool path directory",
 			language:  "go",
 			typ:       "cpu",
-			args:      []string{"--tool-path", "/opt/profiler"},
-			wantError: "--tool-path is supported only by Java and Python profiling",
+			args:      []string{"--tool-path-dir", "/opt/profiler"},
+			wantError: "--tool-path-dir is supported only by Java and Python profiling",
 		},
 		{
 			name:      "Python physical memory probability",

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -295,7 +295,7 @@ Build all artifacts from the repository root:
 make all
 ```
 
-The resulting executable is `_output/bin/profiler`. Native profiling depends on Linux eBPF, perf events, and the BPF objects built from this repository. It generally requires root privileges and a `kernel.perf_event_paranoid` setting that permits sampling. Java profiling requires async-profiler; `--tool-path` must point to a directory containing `bin/asprof` and `lib/libasyncProfiler.so`. Python profiling requires py-spy; `--tool-path` must point to a directory containing the `py-spy` executable.
+The resulting executable is `_output/bin/profiler`. Native profiling depends on Linux eBPF, perf events, and the BPF objects built from this repository. It generally requires root privileges and a `kernel.perf_event_paranoid` setting that permits sampling. Java profiling resolves `bin/asprof` and `lib/libasyncProfiler.so` under `--tool-path-dir`. Python profiling resolves `py-spy` under the same option. The deprecated `--tool-path` alias remains available for compatibility.
 
 Display the complete help for the current version:
 
@@ -333,7 +333,7 @@ sudo _output/bin/profiler \
 | `--output-format` | `collapsed` | All | `collapsed`, `flamegraph`, `svg`, or `remote` |
 | `--output-storage` | `/var/run/huatuo-toolstream.sock` | `remote` | Unix socket used for remote upload |
 | `--max-concurrent-procs` | `0` | Java, Python | Maximum concurrent collector subprocesses; `0` means unlimited |
-| `--tool-path` | None | Java, Python | Third-party profiler root directory; required |
+| `--tool-path-dir` | None | Java, Python | Third-party profiler root directory; required |
 | `--binary-match-path` | None | Java, Python | Executable path used to match target processes |
 | `--huatuo-api-address` | `127.0.0.1:19704` | Container targets | HUATUO API address used to resolve container metadata |
 | `--tracer-id` | Empty; generated internally for local output | All; required for `remote` | Stable profiling task ID used by toolstream and remote storage |
@@ -426,7 +426,7 @@ _output/bin/profiler \
   --type cpu \
   --language java \
   --pid 12345,12346 \
-  --tool-path /opt/async-profiler \
+  --tool-path-dir /opt/async-profiler \
   --max-concurrent-procs 2 \
   --duration 30 \
   --aggr-interval 10 \
@@ -448,7 +448,7 @@ _output/bin/profiler \
   --language java \
   --memory-mode object_usage \
   --pid 12345 \
-  --tool-path /opt/async-profiler \
+  --tool-path-dir /opt/async-profiler \
   --duration 30 \
   --aggr-interval 10 \
   --output-format flamegraph \
@@ -459,14 +459,14 @@ To target a container, replace `--pid` with `--container-id <container-id>`. If 
 
 ### 5. Observing Python
 
-Python currently supports CPU profiling only. `--aggr-interval` must equal `--duration`, so one collection produces one aggregation window. `--tool-path` must point to the directory containing `py-spy`.
+Python currently supports CPU profiling only. `--aggr-interval` must equal `--duration`, so one collection produces one aggregation window. The profiler runs `py-spy` from `--tool-path-dir/py-spy`.
 
 ```bash
 _output/bin/profiler \
   --type cpu \
   --language python \
   --pid 12345,12346 \
-  --tool-path /opt/py-spy \
+  --tool-path-dir /opt/py-spy \
   --max-concurrent-procs 2 \
   --duration 30 \
   --aggr-interval 30 \

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -88,9 +88,14 @@ CPU profiling currently supports `c`, `c++`, `go`, `java`, and `python`. Memory 
 | `hostname` | Yes | Hostname of the node running the target process; used for job scheduling |
 | `container_id` | No | Target container ID; omit it to profile the host |
 | `binary_match_path` | No | Executable path matcher for Java/Python CPU profiling; native profiling does not support it |
+| `binary_tool_path` | For Java/Python | Profiler installation directory on the target Agent; native profiling rejects it |
 | `memory_mode` | For memory profiling | Memory profiling mode; it must be supported by `language` |
 
 `duration_seconds` must cover at least two `aggregation_interval_seconds` periods, and their sum must be less than 3600 seconds. If the same user already has a running profiling job on the same node, the server returns `409 Conflict`.
+
+For Java, `binary_tool_path` is the async-profiler installation root
+containing `bin/asprof` and `lib/libasyncProfiler.so`. For Python, it is the
+directory containing `py-spy`.
 
 Create a Go CPU profiling job on a host:
 
@@ -119,6 +124,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "binary_tool_path": "/opt/async-profiler",
     "duration_seconds": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -191,6 +197,7 @@ The `data` object contains the job details:
 | `language` | Target process language |
 | `memory_mode` | Memory profiling mode; omitted for CPU jobs |
 | `binary_match_path` | Executable path matcher; omitted when unused |
+| `binary_tool_path` | Java/Python profiler installation directory; omitted when unused |
 | `status` | Current job status |
 | `duration_seconds` | Requested profiling duration in seconds |
 | `created_at` | Job creation time |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -86,9 +86,14 @@ curl -sS \
 | `hostname` | 是 | 运行目标进程的节点主机名，用于任务调度 |
 | `container_id` | 否 | 目标容器 ID；不传表示对宿主机剖析 |
 | `binary_match_path` | 否 | Java/Python CPU 剖析的目标可执行文件路径匹配条件；原生剖析不支持 |
+| `binary_tool_path` | Java/Python 必需 | 目标 Agent 上的 Profiler 安装目录；原生剖析不接受此参数 |
 | `memory_mode` | 内存剖析必需 | 内存剖析模式，必须与 `language` 匹配 |
 
 `duration_seconds` 必须不小于两个 `aggregation_interval_seconds`，且二者之和必须小于 3600 秒。同一用户在同一节点上已有运行中的剖析任务时，服务端返回 `409 Conflict`。
+
+Java 的 `binary_tool_path` 是 async-profiler 安装根目录，其中应包含
+`bin/asprof` 和 `lib/libasyncProfiler.so`。Python 的该字段是包含
+`py-spy` 的目录。
 
 创建宿主机 Go CPU 剖析任务：
 
@@ -117,6 +122,7 @@ curl -sS -i \
     "type": "memory",
     "language": "java",
     "memory_mode": "object_usage",
+    "binary_tool_path": "/opt/async-profiler",
     "duration_seconds": 60,
     "container_id": "9f4c2f1a8b7d",
     "hostname": "node-01"
@@ -189,6 +195,7 @@ curl -sS \
 | `language` | 目标进程语言 |
 | `memory_mode` | 内存剖析模式；CPU 任务不返回该字段 |
 | `binary_match_path` | 可执行文件匹配路径；未使用时不返回该字段 |
+| `binary_tool_path` | Java/Python Profiler 安装目录；未使用时不返回该字段 |
 | `status` | 当前任务状态 |
 | `duration_seconds` | 请求的剖析时长，单位为秒 |
 | `created_at` | 任务创建时间 |

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -293,7 +293,7 @@ C、C++ 和 Go 使用基于 eBPF 的原生采集器，可观测 CPU、虚拟内�
 make all
 ```
 
-生成的命令位于 `_output/bin/profiler`。原生采集依赖 Linux eBPF、perf event 和仓库构建出的 BPF 对象，通常需要 root 权限，并要求 `kernel.perf_event_paranoid` 允许采样。Java 需要 async-profiler，`--tool-path` 指向包含 `bin/asprof` 和 `lib/libasyncProfiler.so` 的目录。Python 需要 py-spy，`--tool-path` 指向包含可执行文件 `py-spy` 的目录。
+生成的命令位于 `_output/bin/profiler`。原生采集依赖 Linux eBPF、perf event 和仓库构建出的 BPF 对象，通常需要 root 权限，并要求 `kernel.perf_event_paranoid` 允许采样。Java 从 `--tool-path-dir` 下解析 `bin/asprof` 和 `lib/libasyncProfiler.so`；Python 复用同一参数，从该目录下解析 `py-spy`。已弃用的 `--tool-path` 别名仍可用于兼容旧命令。
 
 查看当前版本的完整帮助：
 
@@ -331,7 +331,7 @@ sudo _output/bin/profiler \
 | `--output-format` | `collapsed` | 全部 | `collapsed`、`flamegraph`、`svg` 或 `remote` |
 | `--output-storage` | `/var/run/huatuo-toolstream.sock` | `remote` | 远端上传使用的 Unix socket |
 | `--max-concurrent-procs` | `0` | Java、Python | 并发采集子进程上限；`0` 表示不限制 |
-| `--tool-path` | 无 | Java、Python | 第三方采集工具根目录，必填 |
+| `--tool-path-dir` | 无 | Java、Python | 第三方采集工具根目录，必填 |
 | `--binary-match-path` | 无 | Java、Python | 按可执行文件路径匹配容器内目标进程 |
 | `--huatuo-api-address` | `127.0.0.1:19704` | 容器目标 | 用于解析容器元数据的 HUATUO API 地址 |
 | `--tracer-id` | 空；本地输出时内部生成 | 全部；`remote` 必填 | toolstream 和远端存储共用的稳定采集任务 ID |
@@ -424,7 +424,7 @@ _output/bin/profiler \
   --type cpu \
   --language java \
   --pid 12345,12346 \
-  --tool-path /opt/async-profiler \
+  --tool-path-dir /opt/async-profiler \
   --max-concurrent-procs 2 \
   --duration 30 \
   --aggr-interval 10 \
@@ -446,7 +446,7 @@ _output/bin/profiler \
   --language java \
   --memory-mode object_usage \
   --pid 12345 \
-  --tool-path /opt/async-profiler \
+  --tool-path-dir /opt/async-profiler \
   --duration 30 \
   --aggr-interval 10 \
   --output-format flamegraph \
@@ -457,14 +457,14 @@ _output/bin/profiler \
 
 ### 5. Python 观测
 
-Python 当前仅支持 CPU 观测。`--aggr-interval` 必须与 `--duration` 相等，即一次采集只生成一个聚合窗口。`--tool-path` 指向包含 `py-spy` 的目录。
+Python 当前仅支持 CPU 观测。`--aggr-interval` 必须与 `--duration` 相等，即一次采集只生成一个聚合窗口。Profiler 运行的程序路径为 `--tool-path-dir/py-spy`。
 
 ```bash
 _output/bin/profiler \
   --type cpu \
   --language python \
   --pid 12345,12346 \
-  --tool-path /opt/py-spy \
+  --tool-path-dir /opt/py-spy \
   --max-concurrent-procs 2 \
   --duration 30 \
   --aggr-interval 30 \

--- a/integration/test_profiler_java_cpu_container.sh
+++ b/integration/test_profiler_java_cpu_container.sh
@@ -67,7 +67,7 @@ run_profile_case() {
 		--type cpu \
 		--language java \
 		--container-id "${target_id}" \
-		--tool-path "${JAVA_PROFILER_TOOL_PATH}" \
+		--tool-path-dir "${JAVA_PROFILER_TOOL_PATH}" \
 		--duration "${PROFILER_DURATION}" \
 		--aggr-interval "${PROFILER_DURATION}" \
 		--freq 99 \

--- a/integration/test_profiler_java_cpu_multi_pid.sh
+++ b/integration/test_profiler_java_cpu_multi_pid.sh
@@ -69,7 +69,7 @@ if ! "${TOOL_BIN}" \
 	--type cpu \
 	--language java \
 	--pid "${PROFILER_TARGET_PID0},${PROFILER_TARGET_PID1}" \
-	--tool-path "${JAVA_PROFILER_TOOL_PATH}" \
+	--tool-path-dir "${JAVA_PROFILER_TOOL_PATH}" \
 	--duration "${PROFILER_DURATION}" \
 	--freq "${PROFILER_FREQ}" \
 	--aggr-interval "${PROFILER_AGGR_INTERVAL}" \

--- a/integration/test_profiler_java_memory_usage_alloc.sh
+++ b/integration/test_profiler_java_memory_usage_alloc.sh
@@ -65,7 +65,7 @@ run_profile_case() {
 		--language java \
 		--memory-mode "${mode}" \
 		--pid "${PROFILER_TARGET_PID}" \
-		--tool-path "${JAVA_PROFILER_TOOL_PATH}" \
+		--tool-path-dir "${JAVA_PROFILER_TOOL_PATH}" \
 		--duration "${PROFILER_DURATION}" \
 		--aggr-interval "${PROFILER_AGGR_INTERVAL}" \
 		--output-format collapsed \

--- a/integration/test_profiler_python_cpu_multi_pid.sh
+++ b/integration/test_profiler_python_cpu_multi_pid.sh
@@ -63,7 +63,7 @@ if ! "${TOOL_BIN}" \
 	--type cpu \
 	--language python \
 	--pid "${PROFILER_PARENT_PID},${PROFILER_CHILD_PID},${PROFILER_INDEPENDENT_PID}" \
-	--tool-path "${PYTHON_PROFILER_TOOL_PATH}" \
+	--tool-path-dir "${PYTHON_PROFILER_TOOL_PATH}" \
 	--max-concurrent-procs 2 \
 	--duration "${PROFILER_DURATION}" \
 	--aggr-interval "${PROFILER_DURATION}" \

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -162,7 +162,7 @@ func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerCon
 		ContainerID:               cliCtx.String("container-id"),
 		ExecPath:                  cliCtx.String("binary-match-path"),
 		ThreadGroup:               cliCtx.Bool("thread-group"),
-		ToolPath:                  cliCtx.String("tool-path"),
+		ToolPath:                  cliCtx.String("tool-path-dir"),
 		LogBpfDebug:               cliCtx.Bool("log-bpf-debug"),
 		OutputPath:                cliCtx.String("output-path"),
 		OutputFormat:              outputFormat,

--- a/internal/profiler/runtime/python/memray.go
+++ b/internal/profiler/runtime/python/memray.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ func (v PythonVersion) RuntimeKey() string {
 }
 
 // ResolveMemrayBundlePath returns the host-visible memray bundle directory.
-// When the caller does not provide --tool-path, profiler falls back to the
+// When the caller does not provide --tool-path-dir, profiler falls back to the
 // bundle that is laid out next to the built binary under _output/tools.
 func ResolveMemrayBundlePath(hostBundlePath string) (string, error) {
 	if hostBundlePath != "" {


### PR DESCRIPTION
## Summary

- replace language-specific profiler paths with one `binary_tool_path` API field
- require and trim the field for Java and Python jobs before forwarding `--tool-path`
- reject tool paths for native profilers instead of silently ignoring them
- update the Profiles API documentation and examples in English and Chinese

## Testing

- `go test ./apis/v1 ./cmd/huatuo-apiserver/handlers/profiling ./cmd/profiler`
- matching race tests and `go vet`
- `make check` (26 linters, 0 issues)

Refs #329