### PR TITLE
feat(profiling): inject collection dimension labels

### DIFF
--- a/internal/profiler/aggregator/pipeline_test.go
+++ b/internal/profiler/aggregator/pipeline_test.go
@@ -20,9 +20,15 @@ import (
 	"testing"
 	"time"
 
+	"huatuo-bamai/internal/profiler"
 	profctx "huatuo-bamai/internal/profiler/context"
 	"huatuo-bamai/internal/profiler/output"
+	"huatuo-bamai/internal/toolstream"
 )
+
+type pipelineProfileEvent struct {
+	TracerData *profctx.TracerData `json:"tracer_data"`
+}
 
 func TestNewPipeline_DoesNotMutateContext(t *testing.T) {
 	pctx := &profctx.ProfilerContext{}
@@ -200,4 +206,91 @@ func TestPipelineAggregateAndExport_EmptyFormatter(t *testing.T) {
 	}
 
 	aggr.AssertNotCalled(t, "Reset")
+}
+
+func TestPipelineAggregateAndSnapshotInjectsCollectionDimensionLabels(t *testing.T) {
+	sockPath := t.TempDir() + "/toolstream.sock"
+	server, err := toolstream.NewServer(sockPath)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	events := make(chan pipelineProfileEvent, 1)
+	toolstream.Register(
+		server,
+		"profiler",
+		func(_ *toolstream.Session, event pipelineProfileEvent) error {
+			events <- event
+			return nil
+		},
+	)
+	if err := server.Start(); err != nil {
+		t.Fatalf("server.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("server.Close() error = %v", err)
+		}
+	})
+
+	client, err := toolstream.NewClient(toolstream.ClientOptions{
+		SockPath: sockPath,
+		ToolName: "profiler",
+		Version:  "1",
+		TaskID:   "profile-label-test",
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	t.Cleanup(client.End)
+
+	data, err := profiler.ParseTree(
+		time.Unix(1, 0),
+		profiler.ProfileTypeCpuSample,
+		[]*profiler.TreeItem{{Stack: [][]byte{[]byte("work")}, Value: 1}},
+		&profiler.ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	pctx := &profctx.ProfilerContext{
+		Ctx:              t.Context(),
+		PIDs:             []int{42},
+		ThreadGroup:      true,
+		OutputFormat:     output.FormatRemote,
+		TracerID:         "profile-label-test",
+		ToolstreamClient: client,
+	}
+	aggr := NewMockAggregator(t)
+	aggr.On("Snapshot", pctx).Return(data, nil).Once()
+	aggr.On("Reset").Once()
+	pipeline := NewPipeline(pctx, aggr)
+
+	if err := pipeline.aggregateAndSnapshot(t.Context(), false); err != nil {
+		t.Fatalf("aggregateAndSnapshot() error = %v", err)
+	}
+
+	select {
+	case event := <-events:
+		flameData := event.TracerData.FlameData
+		if got := flameData.Labels[profiler.LabelProfilingScope]; got != "thread_group" {
+			t.Fatalf("profiling_scope = %q, want thread_group", got)
+		}
+		if got := flameData.Labels[profiler.LabelTGID]; got != "42" {
+			t.Fatalf("tgid = %q, want 42", got)
+		}
+		if len(flameData.Profile.Sample) != 1 {
+			t.Fatalf("samples = %d, want 1", len(flameData.Profile.Sample))
+		}
+		got := make(map[string]string)
+		for _, label := range flameData.Profile.Sample[0].Label {
+			got[flameData.Profile.StringTable[label.Key]] = flameData.Profile.StringTable[label.Str]
+		}
+		if got[profiler.LabelProfilingScope] != "thread_group" ||
+			got[profiler.LabelTGID] != "42" {
+			t.Fatalf("sample labels = %#v", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for profiling event")
+	}
 }

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -33,9 +33,9 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 		return fmt.Errorf("toolstream client not initialized")
 	}
 
-	flameData, ok := data.(*profiler.ProfileData)
-	if !ok {
-		return fmt.Errorf("invalid pprof data for uploading: %T", data)
+	flameData, err := applyCollectionDimensionLabels(p.pctx, data)
+	if err != nil {
+		return err
 	}
 
 	tracerData := &profctx.TracerData{
@@ -60,4 +60,22 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	log.WithField("tracer_id", p.tracerID).Infof("profiling event sent via toolstream")
 
 	return nil
+}
+
+func applyCollectionDimensionLabels(
+	pctx *profctx.ProfilerContext,
+	data any,
+) (*profiler.ProfileData, error) {
+	flameData, ok := data.(*profiler.ProfileData)
+	if !ok {
+		return nil, fmt.Errorf("invalid pprof data for uploading: %T", data)
+	}
+	if err := profiler.ApplyCollectionDimensionLabels(
+		flameData,
+		pctx.CollectionDimensionLabels(),
+	); err != nil {
+		return nil, fmt.Errorf("apply collection dimension labels: %w", err)
+	}
+
+	return flameData, nil
 }

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+)
+
+func TestApplyCollectionDimensionLabelsUsesProfilerContext(t *testing.T) {
+	data, err := profiler.ParseTree(
+		time.Unix(1, 0),
+		profiler.ProfileTypeCpuSample,
+		[]*profiler.TreeItem{{Stack: [][]byte{[]byte("work")}, Value: 1}},
+		&profiler.ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	got, err := applyCollectionDimensionLabels(&profctx.ProfilerContext{
+		PIDs:        []int{42},
+		ThreadGroup: true,
+	}, data)
+	if err != nil {
+		t.Fatalf("applyCollectionDimensionLabels() error = %v", err)
+	}
+	if got.Labels[profiler.LabelProfilingScope] != "thread_group" {
+		t.Fatalf(
+			"profiling_scope = %q, want thread_group",
+			got.Labels[profiler.LabelProfilingScope],
+		)
+	}
+	if got.Labels[profiler.LabelTGID] != "42" {
+		t.Fatalf("tgid = %q, want 42", got.Labels[profiler.LabelTGID])
+	}
+	if len(got.Profile.Sample) != 1 ||
+		len(got.Profile.Sample[0].Label) != len(got.Labels) {
+		t.Fatalf("sample labels = %#v, profile labels = %#v", got.Profile.Sample, got.Labels)
+	}
+}
+
+func TestApplyCollectionDimensionLabelsRejectsNonProfileData(t *testing.T) {
+	_, err := applyCollectionDimensionLabels(&profctx.ProfilerContext{}, "not a profile")
+	if err == nil {
+		t.Fatal("applyCollectionDimensionLabels() error = nil")
+	}
+}
+
+func TestApplyCollectionDimensionLabelsAcceptsNilContext(t *testing.T) {
+	data, err := profiler.ParseTree(
+		time.Unix(1, 0),
+		profiler.ProfileTypeCpuSample,
+		[]*profiler.TreeItem{{Stack: [][]byte{[]byte("work")}, Value: 1}},
+		&profiler.ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+
+	got, err := applyCollectionDimensionLabels(nil, data)
+	if err != nil {
+		t.Fatalf("applyCollectionDimensionLabels() error = %v", err)
+	}
+	if got != data {
+		t.Fatalf("profile pointer = %p, want %p", got, data)
+	}
+	if got.Labels != nil || len(got.Profile.Sample[0].Label) != 0 {
+		t.Fatalf("nil context added labels: %#v", got)
+	}
+}

--- a/internal/profiler/context/labels.go
+++ b/internal/profiler/context/labels.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+const (
+	profilingScopeHost        = "host"
+	profilingScopeContainer   = "container"
+	profilingScopePID         = "pid"
+	profilingScopeThreadGroup = "thread_group"
+)
+
+// CollectionDimensionLabels describes the selectors that produced a profile.
+func (pctx *ProfilerContext) CollectionDimensionLabels() map[string]string {
+	if pctx == nil {
+		return nil
+	}
+
+	labels := map[string]string{
+		profiler.LabelProfilingScope: profilingScopeHost,
+	}
+	if pctx.ContainerID != "" {
+		labels[profiler.LabelProfilingScope] = profilingScopeContainer
+		labels[profiler.LabelContainerID] = pctx.ContainerID
+	} else if len(pctx.PIDs) > 0 {
+		label := profiler.LabelPID
+		labels[profiler.LabelProfilingScope] = profilingScopePID
+		if pctx.ThreadGroup {
+			label = profiler.LabelTGID
+			labels[profiler.LabelProfilingScope] = profilingScopeThreadGroup
+		}
+		labels[label] = formatDimensionInts(pctx.PIDs)
+	}
+	if len(pctx.CPUIDs) > 0 {
+		labels[profiler.LabelCPU] = formatDimensionInts(pctx.CPUIDs)
+	}
+
+	return labels
+}
+
+func formatDimensionInts(values []int) string {
+	values = append([]int(nil), values...)
+	sort.Ints(values)
+
+	var result strings.Builder
+	for i, value := range values {
+		if i > 0 {
+			result.WriteByte(',')
+		}
+		result.WriteString(strconv.Itoa(value))
+	}
+	return result.String()
+}

--- a/internal/profiler/context/labels_test.go
+++ b/internal/profiler/context/labels_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"reflect"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+)
+
+func TestCollectionDimensionLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		pctx *ProfilerContext
+		want map[string]string
+	}{
+		{
+			name: "nil context",
+		},
+		{
+			name: "host",
+			pctx: &ProfilerContext{},
+			want: map[string]string{profiler.LabelProfilingScope: profilingScopeHost},
+		},
+		{
+			name: "exact PIDs and CPUs",
+			pctx: &ProfilerContext{
+				PIDs:   []int{99, 42},
+				CPUIDs: []int{3, 1},
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopePID,
+				profiler.LabelPID:            "42,99",
+				profiler.LabelCPU:            "1,3",
+			},
+		},
+		{
+			name: "thread group",
+			pctx: &ProfilerContext{PIDs: []int{42}, ThreadGroup: true},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeThreadGroup,
+				profiler.LabelTGID:           "42",
+			},
+		},
+		{
+			name: "container takes selector precedence",
+			pctx: &ProfilerContext{
+				ContainerID: "containerd://abc",
+				PIDs:        []int{42},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: profilingScopeContainer,
+				profiler.LabelContainerID:    "containerd://abc",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.pctx.CollectionDimensionLabels(); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("CollectionDimensionLabels() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCollectionDimensionLabelsDoesNotSortContextInPlace(t *testing.T) {
+	pctx := &ProfilerContext{
+		PIDs:   []int{99, 42},
+		CPUIDs: []int{3, 1},
+	}
+
+	_ = pctx.CollectionDimensionLabels()
+
+	if got, want := pctx.PIDs, []int{99, 42}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PIDs = %v, want %v", got, want)
+	}
+	if got, want := pctx.CPUIDs, []int{3, 1}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("CPUIDs = %v, want %v", got, want)
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,163 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"sort"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var collectionDimensionLabels = [...]string{
+	LabelProfilingScope,
+	LabelCPU,
+	LabelPID,
+	LabelTGID,
+	LabelContainerID,
+}
+
+// CollectionDimensionLabelNames returns the labels managed by collection.
+func CollectionDimensionLabelNames() []string {
+	names := make([]string, len(collectionDimensionLabels))
+	copy(names, collectionDimensionLabels[:])
+	return names
+}
+
+// IsCollectionDimensionLabel reports whether name is managed by collection.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}
+
+// ApplyCollectionDimensionLabels mirrors managed dimensions into every sample.
+func ApplyCollectionDimensionLabels(data *ProfileData, labels map[string]string) error {
+	if data == nil || len(labels) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		if !IsCollectionDimensionLabel(key) {
+			return fmt.Errorf("unsupported collection dimension label %q", key)
+		}
+		if value != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	if len(data.Profile.StringTable) == 0 {
+		for _, sample := range data.Profile.Sample {
+			if sample != nil && len(sample.Label) > 0 {
+				return fmt.Errorf("invalid pprof label: string table is empty")
+			}
+		}
+	} else if data.Profile.StringTable[0] != "" {
+		return fmt.Errorf("invalid pprof string table: first entry must be empty")
+	}
+	for _, sample := range data.Profile.Sample {
+		if sample == nil {
+			continue
+		}
+		for _, label := range sample.Label {
+			if label == nil {
+				continue
+			}
+			if label.Key < 0 || label.Key >= int64(len(data.Profile.StringTable)) {
+				return fmt.Errorf("invalid pprof label key index %d", label.Key)
+			}
+			if label.Str < 0 || label.Str >= int64(len(data.Profile.StringTable)) {
+				return fmt.Errorf("invalid pprof label string index %d", label.Str)
+			}
+			if label.NumUnit < 0 || label.NumUnit >= int64(len(data.Profile.StringTable)) {
+				return fmt.Errorf("invalid pprof label unit index %d", label.NumUnit)
+			}
+		}
+	}
+	if len(data.Profile.StringTable) == 0 && len(keys) > 0 {
+		data.Profile.StringTable = append(data.Profile.StringTable, "")
+	}
+
+	if data.Labels == nil && len(keys) > 0 {
+		data.Labels = make(map[string]string, len(keys))
+	}
+	for _, key := range collectionDimensionLabels {
+		delete(data.Labels, key)
+	}
+	for _, key := range keys {
+		data.Labels[key] = labels[key]
+	}
+
+	stringIndexes := make(map[string]int64, len(data.Profile.StringTable)+len(keys)*2)
+	for i, value := range data.Profile.StringTable {
+		stringIndexes[value] = int64(i)
+	}
+	stringIndex := func(value string) int64 {
+		if index, ok := stringIndexes[value]; ok {
+			return index
+		}
+		index := int64(len(data.Profile.StringTable))
+		data.Profile.StringTable = append(data.Profile.StringTable, value)
+		stringIndexes[value] = index
+		return index
+	}
+
+	for _, key := range keys {
+		stringIndex(key)
+	}
+
+	for _, sample := range data.Profile.Sample {
+		if sample == nil {
+			continue
+		}
+
+		kept := sample.Label[:0]
+		for _, label := range sample.Label {
+			if label == nil {
+				continue
+			}
+			if !IsCollectionDimensionLabel(data.Profile.StringTable[label.Key]) {
+				kept = append(kept, label)
+			}
+		}
+		sample.Label = kept
+		for _, key := range keys {
+			sample.Label = append(sample.Label, &ptree.Label{
+				Key: stringIndex(key),
+				Str: stringIndex(labels[key]),
+			})
+		}
+	}
+
+	return nil
+}

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestApplyCollectionDimensionLabelsInjectsAndReplaces(t *testing.T) {
+	data := newLabelTestProfile(t)
+	data.Labels = map[string]string{"legacy": "preserved"}
+	customKey := appendProfileString(&data.Profile, "legacy")
+	customValue := appendProfileString(&data.Profile, "value")
+	for _, sample := range data.Profile.Sample {
+		sample.Label = append(sample.Label, &ptree.Label{
+			Key: customKey,
+			Str: customValue,
+		})
+	}
+
+	first := map[string]string{
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "4242",
+	}
+	if err := ApplyCollectionDimensionLabels(data, first); err != nil {
+		t.Fatalf("ApplyCollectionDimensionLabels() error = %v", err)
+	}
+	if err := ApplyCollectionDimensionLabels(data, first); err != nil {
+		t.Fatalf("idempotent ApplyCollectionDimensionLabels() error = %v", err)
+	}
+	if err := ApplyCollectionDimensionLabels(
+		data,
+		map[string]string{
+			LabelProfilingScope: "thread_group",
+			LabelTGID:           "5252",
+		},
+	); err != nil {
+		t.Fatalf("replacement ApplyCollectionDimensionLabels() error = %v", err)
+	}
+
+	wantMetadata := map[string]string{
+		"legacy":            "preserved",
+		LabelProfilingScope: "thread_group",
+		LabelTGID:           "5252",
+	}
+	if !reflect.DeepEqual(data.Labels, wantMetadata) {
+		t.Fatalf("profile labels = %#v, want %#v", data.Labels, wantMetadata)
+	}
+
+	for _, sample := range data.Profile.Sample {
+		got := resolveStringLabels(t, data.Profile.StringTable, sample.Label)
+		want := map[string]string{
+			"legacy":            "value",
+			LabelProfilingScope: "thread_group",
+			LabelTGID:           "5252",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("sample labels = %#v, want %#v", got, want)
+		}
+		if len(sample.Label) != len(got) {
+			t.Fatalf("sample contains duplicate labels: %#v", sample.Label)
+		}
+	}
+}
+
+func TestApplyCollectionDimensionLabelsClearsStaleManagedLabels(t *testing.T) {
+	data := newLabelTestProfile(t)
+
+	if err := ApplyCollectionDimensionLabels(data, map[string]string{
+		LabelProfilingScope: "container",
+		LabelContainerID:    "containerd://abc",
+		LabelCPU:            "1,3",
+	}); err != nil {
+		t.Fatalf("container ApplyCollectionDimensionLabels() error = %v", err)
+	}
+	if err := ApplyCollectionDimensionLabels(data, map[string]string{
+		LabelProfilingScope: "host",
+	}); err != nil {
+		t.Fatalf("host ApplyCollectionDimensionLabels() error = %v", err)
+	}
+
+	want := map[string]string{LabelProfilingScope: "host"}
+	if !reflect.DeepEqual(data.Labels, want) {
+		t.Fatalf("profile labels = %#v, want %#v", data.Labels, want)
+	}
+	for _, sample := range data.Profile.Sample {
+		got := resolveStringLabels(t, data.Profile.StringTable, sample.Label)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("sample labels = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestApplyCollectionDimensionLabelsRejectsUnmanagedLabelBeforeMutation(t *testing.T) {
+	data := newLabelTestProfile(t)
+	beforeStrings := append([]string(nil), data.Profile.StringTable...)
+
+	err := ApplyCollectionDimensionLabels(data, map[string]string{
+		LabelPID: "42",
+		"custom": "not-allowed",
+	})
+	if err == nil {
+		t.Fatal("ApplyCollectionDimensionLabels() error = nil")
+	}
+	if data.Labels != nil || !reflect.DeepEqual(data.Profile.StringTable, beforeStrings) {
+		t.Fatalf("profile mutated after validation error: %#v", data)
+	}
+}
+
+func TestApplyCollectionDimensionLabelsRejectsMalformedProfileBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name string
+		data *ProfileData
+	}{
+		{
+			name: "non-empty first string",
+			data: &ProfileData{Profile: ptree.Profile{
+				StringTable: []string{"invalid"},
+			}},
+		},
+		{
+			name: "label key outside string table",
+			data: &ProfileData{Profile: ptree.Profile{
+				StringTable: []string{""},
+				Sample: []*ptree.Sample{{
+					Label: []*ptree.Label{{Key: 2, Str: 0}},
+				}},
+			}},
+		},
+		{
+			name: "label value outside string table",
+			data: &ProfileData{Profile: ptree.Profile{
+				StringTable: []string{""},
+				Sample: []*ptree.Sample{{
+					Label: []*ptree.Label{{Key: 0, Str: 2}},
+				}},
+			}},
+		},
+		{
+			name: "label unit outside string table",
+			data: &ProfileData{Profile: ptree.Profile{
+				StringTable: []string{""},
+				Sample: []*ptree.Sample{{
+					Label: []*ptree.Label{{Key: 0, Str: 0, NumUnit: 2}},
+				}},
+			}},
+		},
+		{
+			name: "label without string table",
+			data: &ProfileData{Profile: ptree.Profile{
+				Sample: []*ptree.Sample{{
+					Label: []*ptree.Label{{Key: 0, Str: 0}},
+				}},
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			beforeStrings := append([]string(nil), test.data.Profile.StringTable...)
+
+			err := ApplyCollectionDimensionLabels(
+				test.data,
+				map[string]string{LabelPID: "42"},
+			)
+			if err == nil {
+				t.Fatal("ApplyCollectionDimensionLabels() error = nil")
+			}
+			if test.data.Labels != nil ||
+				!reflect.DeepEqual(test.data.Profile.StringTable, beforeStrings) {
+				t.Fatalf("profile mutated after validation error: %#v", test.data)
+			}
+		})
+	}
+}
+
+func TestApplyCollectionDimensionLabelsKeepsLegacyProfileUnchanged(t *testing.T) {
+	data := newLabelTestProfile(t)
+	beforeStrings := append([]string(nil), data.Profile.StringTable...)
+
+	if err := ApplyCollectionDimensionLabels(data, nil); err != nil {
+		t.Fatalf("ApplyCollectionDimensionLabels() error = %v", err)
+	}
+	if data.Labels != nil || !reflect.DeepEqual(data.Profile.StringTable, beforeStrings) {
+		t.Fatalf("legacy profile mutated: %#v", data)
+	}
+}
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	names := CollectionDimensionLabelNames()
+	names[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}
+
+func newLabelTestProfile(t *testing.T) *ProfileData {
+	t.Helper()
+
+	data, err := ParseTree(
+		time.Unix(1, 0),
+		ProfileTypeCpuSample,
+		[]*TreeItem{
+			{Stack: [][]byte{[]byte("process"), []byte("work")}, Value: 1},
+			{Stack: [][]byte{[]byte("process"), []byte("wait")}, Value: 2},
+		},
+		&ParseOption{SampleRate: 99},
+	)
+	if err != nil {
+		t.Fatalf("ParseTree() error = %v", err)
+	}
+	return data
+}
+
+func appendProfileString(profile *ptree.Profile, value string) int64 {
+	index := int64(len(profile.StringTable))
+	profile.StringTable = append(profile.StringTable, value)
+	return index
+}
+
+func resolveStringLabels(
+	t *testing.T,
+	stringTable []string,
+	labels []*ptree.Label,
+) map[string]string {
+	t.Helper()
+
+	result := make(map[string]string, len(labels))
+	for _, label := range labels {
+		if label.Key < 0 || label.Key >= int64(len(stringTable)) ||
+			label.Str < 0 || label.Str >= int64(len(stringTable)) {
+			t.Fatalf("invalid label indexes: %#v", label)
+		}
+		result[stringTable[label.Key]] = stringTable[label.Str]
+	}
+	return result
+}

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels mirror profile-wide dimensions for storage backends.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends


### PR DESCRIPTION
## Summary

- derive a fixed set of managed collection labels from `ProfilerContext`
- persist scope, PID/TGID, container, and CPU dimensions in profile metadata
- inject the same dimensions into standard pprof sample labels for compatible consumers
- clear stale managed labels while preserving unrelated existing labels

## Testing

- `go test ./internal/profiler ./internal/profiler/context ./internal/profiler/aggregator`
- matching race tests and `go vet`
- `git diff --check`

Refs #329