### PR TITLE
feat(docs): add deployment guides

### DIFF
--- a/build/charts/Chart.yaml
+++ b/build/charts/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: huatuo
+description: Helm chart for deploying the HUATUO collector as a Kubernetes DaemonSet
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/build/charts/templates/_helpers.tpl
+++ b/build/charts/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "huatuo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "huatuo.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "huatuo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "huatuo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "huatuo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app: huatuo
+{{- end -}}
+
+{{- define "huatuo.labels" -}}
+helm.sh/chart: {{ include "huatuo.chart" . }}
+{{ include "huatuo.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "huatuo.configName" -}}
+{{- default (printf "%s-config" (include "huatuo.fullname" .)) .Values.config.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/build/charts/templates/configmap.yaml
+++ b/build/charts/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "huatuo.configName" . }}
+  labels:
+{{ include "huatuo.labels" . | nindent 4 }}
+data:
+  {{ .Values.config.fileName }}: |-
+{{ .Values.config.content | nindent 4 }}

--- a/build/charts/templates/daemonset.yaml
+++ b/build/charts/templates/daemonset.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "huatuo.fullname" . }}
+  labels:
+{{ include "huatuo.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+{{ include "huatuo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "huatuo.selectorLabels" . | nindent 8 }}
+{{- with .Values.podLabels }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
+    spec:
+      hostNetwork: {{ .Values.hostNetwork }}
+      hostPID: {{ .Values.hostPID }}
+{{- if .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+{{- else }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+{{- end }}
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      containers:
+        - name: huatuo
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.resources | nindent 12 }}
+          securityContext:
+{{ toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: proc
+              mountPath: /proc
+            - name: sys
+              mountPath: /sys
+            - name: run
+              mountPath: /run
+            - name: var
+              mountPath: /var
+            - name: etc
+              mountPath: /etc
+            - name: huatuo-local
+              mountPath: {{ .Values.localStorage.mountPath }}
+            - name: huatuo-bamai-config-volume
+              mountPath: {{ .Values.config.mountPath }}
+              subPath: {{ .Values.config.fileName }}
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: {{ .Values.hostPaths.proc }}
+            type: Directory
+        - name: sys
+          hostPath:
+            path: {{ .Values.hostPaths.sys }}
+            type: Directory
+        - name: run
+          hostPath:
+            path: {{ .Values.hostPaths.run }}
+            type: Directory
+        - name: var
+          hostPath:
+            path: {{ .Values.hostPaths.var }}
+            type: Directory
+        - name: etc
+          hostPath:
+            path: {{ .Values.hostPaths.etc }}
+            type: Directory
+        - name: huatuo-local
+          hostPath:
+            path: {{ .Values.hostPaths.data }}
+            type: DirectoryOrCreate
+        - name: huatuo-bamai-config-volume
+          configMap:
+            name: {{ include "huatuo.configName" . }}

--- a/build/charts/values.yaml
+++ b/build/charts/values.yaml
@@ -1,0 +1,54 @@
+image:
+  repository: docker.io/huatuo/huatuo-bamai
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+config:
+  name: huatuo-bamai-config
+  fileName: huatuo-bamai.conf
+  mountPath: /home/huatuo-bamai/conf/huatuo-bamai.conf
+  content: ""
+
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "19704"
+  prometheus.io/path: /metrics
+
+podLabels: {}
+
+hostNetwork: true
+hostPID: true
+dnsPolicy: ClusterFirst
+
+securityContext:
+  privileged: true
+
+resources:
+  limits:
+    cpu: "1"
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+nodeSelector: {}
+
+tolerations:
+  - operator: Exists
+
+affinity: {}
+
+hostPaths:
+  proc: /proc
+  sys: /sys
+  run: /run
+  var: /var
+  etc: /etc
+  data: /var/log/huatuo/huatuo-local
+
+localStorage:
+  mountPath: /home/huatuo-bamai/huatuo-local

--- a/docs/best-practice/datasource_ch.md
+++ b/docs/best-practice/datasource_ch.md
@@ -2,49 +2,118 @@
 title: 数据源配置
 type: docs
 description:
-author: admin-dong
+author: HUATUO Team
 date: 2026-05-05
 weight: 2
 ---
 
-HUATUO 支持与 Prometheus 集成进行指标采集，并使用 Elasticsearch 存储日志。本文档介绍如何在 Grafana 中配置数据源和导入仪表盘。
+HUATUO 通过 Prometheus 采集指标，并将事件数据写入 Elasticsearch。本文介绍 Docker Compose 和 Kubernetes 环境下的数据源与仪表盘配置方法。
 
-### 指标采集
+> 不要在同一节点同时运行 Docker Compose、systemd 和 Kubernetes 版本的
+> huatuo-bamai。它们会争用 `19704` 端口和
+> `/var/run/huatuo-toolstream.sock`。
 
-#### 1. 端口转发测试
+## Docker Compose
+
+`build/docker/` 提供已配置完成的 Prometheus、Elasticsearch、Grafana 和 HUATUO 组件。
 
 ```bash
-$ kubectl port-forward -n default --address=0.0.0.0 pod/huatuo-XXXX 19704:19704
+export ELASTIC_PASSWORD=huatuo-bamai
+docker compose --project-directory ./build/docker up -d
 ```
 
-#### 2. 验证指标端点
+服务使用宿主机网络：
 
-访问指标端点以验证服务是否正常运行：
+| 服务 | 地址 | 用途 |
+|---|---|---|
+| Elasticsearch | `http://localhost:9200` | 事件存储 |
+| Prometheus | `http://localhost:9090` | 指标采集 |
+| Grafana | `http://localhost:3000` | 可视化 |
+| huatuo-bamai | `http://localhost:19704` | 指标和事件采集 |
 
-```
-http://172.16.20.113:19704/metrics
-```
+Grafana 默认账号为 `admin/admin`。首次登录后应立即修改密码。
 
-如果显示指标数据，说明服务运行正常。
+### 已预配置的数据源
 
-#### 3. 配置 Prometheus 采集
+数据源由 `build/docker/grafana/datasources/` 自动加载：
 
-有两种方式配置 Prometheus 采集 HUATUO 指标：
+| 名称 | 类型 | UID |
+|---|---|---|
+| `huatuo-bamai-prom` | Prometheus | `huatuo-bamai-prom` |
+| `huatuo-bamai-es` | Elasticsearch | `huatuo-bamai-es` |
+| `huatuo-bamai-infinity` | Infinity | `huatuo-bamai-infinity-auto-flamegraph` |
 
-**方案一：使用注解**
+### 已预配置的仪表盘
 
-在 Pod 模板元数据中添加注解：
+仪表盘由 `build/docker/grafana/dashboards/` 自动加载：
+
+- Metric 大盘（宿主机）
+- Metric 大盘（容器）
+- HuaTuo 根因定位 AutoTracing
+- Continuous Profiling（宿主机）
+- Continuous Profiling（容器）
+- AutoTracing Flame Redirect
+
+使用 Docker Compose 时不需要手动配置数据源或导入仪表盘。
+
+## Kubernetes
+
+Prometheus 可以通过 Pod 注解或 ServiceMonitor 采集 HUATUO 指标。两种方式选择一种即可，避免重复采集。
+
+### Pod 注解
+
+`build/huatuo-daemonset.minimal.yaml` 默认包含以下注解：
 
 ```yaml
 template:
-    metadata:
-      annotations:                     
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "19704"
-        prometheus.io/path: "/metrics"
+  metadata:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "19704"
+      prometheus.io/path: "/metrics"
 ```
 
-**方案二：使用 ServiceMonitor**
+Helm Chart 根据 `charts/huatuo/values.yaml` 中的以下配置生成注解：
+
+```yaml
+metrics:
+  enabled: true
+  port: 19704
+  path: /metrics
+```
+
+Prometheus 需要启用 Kubernetes Pod 服务发现，并通过 relabel 读取注解：
+
+```yaml
+scrape_configs:
+  - job_name: k8s-pods
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: "true"
+      - source_labels:
+          [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        regex: (.+)
+        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+```
+
+### ServiceMonitor
+
+ServiceMonitor 仅适用于安装了 Prometheus Operator 和 ServiceMonitor CRD 的集群。以下示例假设 Helm release 名和命名空间均为 `huatuo`。如果实际名称不同，需要同步修改命名空间和 `app.kubernetes.io/instance` 标签。
 
 创建 `huatuo-service.yaml`：
 
@@ -53,17 +122,20 @@ apiVersion: v1
 kind: Service
 metadata:
   name: huatuo
+  namespace: huatuo
   labels:
-    app: huatuo
+    app.kubernetes.io/name: huatuo
+    app.kubernetes.io/instance: huatuo
 spec:
   clusterIP: None
+  selector:
+    app.kubernetes.io/name: huatuo
+    app.kubernetes.io/instance: huatuo
   ports:
     - name: metrics
       port: 19704
       targetPort: 19704
       protocol: TCP
-  selector:
-    app: huatuo
 ```
 
 创建 `huatuo-servicemonitor.yaml`：
@@ -73,16 +145,17 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: huatuo
-  namespace: default
+  namespace: huatuo
   labels:
     release: prometheus
 spec:
   namespaceSelector:
     matchNames:
-      - default
+      - huatuo
   selector:
     matchLabels:
-      app: huatuo
+      app.kubernetes.io/name: huatuo
+      app.kubernetes.io/instance: huatuo
   endpoints:
     - port: metrics
       path: /metrics
@@ -90,64 +163,62 @@ spec:
       scrapeTimeout: 10s
 ```
 
-#### 4. 在 Prometheus 中查询指标
+`release: prometheus` 必须匹配 Prometheus 实例的 `spec.serviceMonitorSelector`。不同 Prometheus Operator 安装方式可能使用不同标签。
 
-使用以下模式查询 HUATUO 指标：
+如果使用 `build/huatuo-daemonset.minimal.yaml`，Pod 标签是 `app: huatuo`，需要将 Service 的 `spec.selector` 改为：
 
-```bash
-huatuo_*
+```yaml
+selector:
+  app: huatuo
 ```
 
-如果返回结果，说明指标采集配置成功。
+ServiceMonitor 选择的是 Service 的 `metadata.labels`，不是 Pod 标签。
 
-### 日志采集
-
-从 Elasticsearch 查询日志：
+应用配置：
 
 ```bash
-$ curl -u elastic:123456 "http://172.16.15.118:9200/huatuo_bamai/_search?pretty"
+kubectl apply -f huatuo-service.yaml
+kubectl apply -f huatuo-servicemonitor.yaml
 ```
 
-### Grafana 数据源配置
+## Grafana 数据源
 
-#### 1. 配置 Prometheus 数据源
+不使用 Docker Compose 时，在 Grafana 中手动添加数据源。
 
-详细配置文件请参考 `build/docker/datasource/` 目录。
+### Prometheus
 
-#### 2. 配置 Elasticsearch 数据源
+- URL：`http://<prometheus-host>:9090`
+- Access：Server (proxy)
+- UID：`huatuo-bamai-prom`
 
-在 Grafana 中添加新的 Elasticsearch 数据源，配置如下：
+### Elasticsearch
 
-- **URL**：`http://172.16.15.118:9200`
-- **认证方式**：Basic Authentication
-- **用户名**：`elastic`
-- **密码**：`123456`
-- **索引名称**：`huatuo_bamai`
-- **时间字段名**：`uploaded_time`
+- URL：`http://<elasticsearch-host>:9200`
+- Authentication：Basic Authentication
+- Username：`elastic`
+- Password：`<password>`
+- Index name：`huatuo_bamai*`
+- Time field name：`uploaded_time`
+- UID：`huatuo-bamai-es`
 
-### 仪表盘导入
+Provisioning 配置示例见 `build/docker/grafana/datasources/`。
 
-#### 1. 从控制台导出仪表盘
+## 导入仪表盘
 
-1. 访问 `http://console.huatuo.tech/dashboards`（用户名：`huatuo`，密码：`huatuo1024`）
-2. 选择所需的仪表盘
+Docker Compose 会自动加载仓库内置仪表盘。外部 Grafana 按以下步骤导入：
+
+1. 打开 Grafana 的 **Dashboards** -> **Import**
+2. 上传或粘贴 `build/docker/grafana/dashboards/*.json`
+3. 点击 **Load**
+4. 选择 `huatuo-bamai-prom` 和 `huatuo-bamai-es` 数据源
+5. 点击 **Import**
+
+也可以从 HUATUO 控制台导出仪表盘：
+
+1. 访问 `http://console.huatuo.tech/dashboards`
+2. 登录并选择仪表盘
 3. 点击 **Export** -> **Export as JSON**
 4. 勾选 "Export the dashboard to use in another instance"
-5. 点击 **Copy to clipboard**
+5. 复制 JSON 并导入目标 Grafana
 
-#### 2. 导入仪表盘到本地 Grafana
-
-1. 在本地 Grafana 中，导航到 **Dashboards** -> **Import**
-2. 粘贴复制的 JSON 内容
-3. 点击 **Load**
-4. 配置数据源并点击 **Import**
-
-### 故障排除
-
-**问题**：导入 "HuaTuo 根因定位 AutoTracing" 仪表盘时出现 "datasource not found" 错误。
-
-**解决方案**：
-1. 手动替换仪表盘 JSON 中的数据源 UID
-2. 从 URL 中查找 Elasticsearch 数据源 UID（例如从 `http://172.16.15.118:3000/connections/datasources/edit/dflcs0w2ghybka` 中获取 `dflcs0w2ghybka`）
-3. 将所有 `"uid": "${DS_HUATUO-BAMAI-ES}"` 替换为实际的数据源 UID
-4. 重新导入仪表盘
+控制台登录凭证由部署管理员提供，不应保存在公开文档中。

--- a/docs/best-practice/datasource_en.md
+++ b/docs/best-practice/datasource_en.md
@@ -1,5 +1,5 @@
 ---
-title: Data Source Configuration
+title: Data Source
 type: docs
 description:
 author: HUATUO Team
@@ -7,46 +7,117 @@ date: 2026-05-05
 weight: 2
 ---
 
-HUATUO supports integrating with Prometheus for metrics collection and Elasticsearch for log storage. This document describes how to configure data sources and import dashboards in Grafana.
+HUATUO integrates with Prometheus for metrics collection and Elasticsearch for log storage. This document covers data source configuration and dashboard provisioning in Grafana.
 
-### Metrics Collection
+Two deployment paths are supported:
 
-#### 1. Port Forwarding for Testing
+- **Docker Compose** — recommended for development and testing; all components are pre-configured.
+- **Kubernetes** — for production clusters; requires manual data source configuration.
+
+## Quick Start (Docker Compose)
+
+The `build/docker/` directory contains a complete stack. All default credentials and ports listed below match this setup.
 
 ```bash
-$ kubectl port-forward -n default --address=0.0.0.0 pod/huatuo-XXXX 19704:19704
+cd build/docker
+docker compose up -d
 ```
 
-#### 2. Verify Metrics Endpoint
+This starts four services on the host network:
 
-Access the metrics endpoint to verify it's working:
+| Service | Port | Purpose |
+|---|---|---|
+| Elasticsearch | 9200 | Log storage |
+| Prometheus | 9090 | Metrics collection |
+| Grafana | 3000 | Visualization |
+| huatuo-bamai | 19704 | Agent (metrics + tracing) |
 
+**Default credentials:**
+
+| Service | Username | Password |
+|---|---|---|
+| Elasticsearch | `elastic` | `huatuo-bamai` |
+| Grafana | `admin` | `admin` |
+
+Data sources and dashboards are auto-provisioned. Access Grafana at `http://<host>:3000`.
+
+### Verify the Stack
+
+```bash
+# Elasticsearch
+curl -s -u elastic:huatuo-bamai http://localhost:9200/_cluster/health?pretty
+
+# Prometheus — should show huatuo target as "up"
+curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, health: .health}'
+
+# Grafana
+curl -s http://localhost:3000/api/health | jq .version
+
+# HuaTuo metrics
+curl -s http://localhost:19704/metrics | head -5
 ```
-http://172.16.20.113:19704/metrics
+
+### Provisioned Data Sources
+
+The following data sources are created automatically via `build/docker/grafana/datasources/`:
+
+| Name | Type | UID |
+|---|---|---|
+| huatuo-bamai-prom | Prometheus | `huatuo-bamai-prom` |
+| huatuo-bamai-es | Elasticsearch | `huatuo-bamai-es` |
+| huatuo-bamai-infinity | Infinity | `huatuo-bamai-infinity-auto-flamegraph` |
+
+### Provisioned Dashboards
+
+Six dashboards are loaded from `build/docker/grafana/dashboards/`:
+
+- Metric Dashboard — Host View
+- Metric Dashboard — Container View
+- HuaTuo Root Cause Analysis AutoTracing
+- Continuous Profiling (Host)
+- Continuous Profiling (Container)
+- AutoTracing Flame Redirect
+
+No manual import is needed when using Docker Compose.
+
+## Metrics Collection (Kubernetes)
+
+### 1. Verify Metrics Endpoint
+
+After deploying huatuo-bamai to Kubernetes, expose the metrics endpoint:
+
+```bash
+kubectl port-forward -n default --address=0.0.0.0 pod/huatuo-XXXX 19704:19704
 ```
 
-If metrics are displayed, the service is running correctly.
+Verify:
 
-#### 3. Configure Prometheus Scraping
+```bash
+curl http://localhost:19704/metrics
+```
 
-There are two approaches to configure Prometheus for scraping HUATUO metrics:
+Metrics output confirms the agent is running correctly.
 
-**Option 1: Using Annotations**
+### 2. Configure Prometheus Scraping
 
-Add annotations to the Pod template metadata:
+**Option A: Pod Annotations**
+
+Add annotations to the Pod template metadata. This requires a Prometheus setup with Kubernetes pod service discovery enabled (e.g., `kubernetes_sd_configs` with `role: pod`).
 
 ```yaml
 template:
     metadata:
-      annotations:                     
+      annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "19704"
         prometheus.io/path: "/metrics"
 ```
 
-**Option 2: Using ServiceMonitor**
+**Option B: ServiceMonitor**
 
-Create `huatuo-service.yaml`:
+Requires [Prometheus Operator](https://prometheus-operator.dev/). Create two resources:
+
+`huatuo-service.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -66,7 +137,7 @@ spec:
     app: huatuo
 ```
 
-Create `huatuo-servicemonitor.yaml`:
+`huatuo-servicemonitor.yaml`:
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -90,44 +161,49 @@ spec:
       scrapeTimeout: 10s
 ```
 
-#### 4. Query Metrics in Prometheus
+### 3. Query Metrics in Prometheus
 
-Use the following pattern to query HUATUO metrics:
-
-```bash
+```promql
 huatuo_*
 ```
 
 If results are returned, metrics collection is working properly.
 
-### Log Collection
+## Log Collection (Kubernetes)
 
 Query logs from Elasticsearch:
 
 ```bash
-$ curl -u elastic:123456 "http://172.16.15.118:9200/huatuo_bamai/_search?pretty"
+curl -u elastic:<password> "http://<es-host>:9200/huatuo_bamai/_search?pretty"
 ```
 
-### Grafana Data Source Configuration
+Replace `<password>` and `<es-host>` with your Elasticsearch credentials and address.
 
-#### 1. Configure Prometheus Data Source
+## Manual Grafana Data Source Configuration
 
-Refer to `build/docker/datasource/` for detailed configuration files.
+When not using Docker Compose (e.g., external Grafana), configure data sources manually.
 
-#### 2. Configure Elasticsearch Data Source
+### Prometheus Data Source
 
-In Grafana, add a new Elasticsearch data source with the following settings:
+Refer to `build/docker/grafana/datasources/prometheus.yaml` for the provisioning file, or configure via Grafana UI:
 
-- **URL**: `http://172.16.15.118:9200`
+- **URL**: `http://<prometheus-host>:9090`
+- **Access**: Server (proxy)
+
+### Elasticsearch Data Source
+
+Configure via Grafana UI or provisioning:
+
+- **URL**: `http://<es-host>:9200`
 - **Authentication**: Basic Authentication
 - **Username**: `elastic`
-- **Password**: `123456`
+- **Password**: `<your-elasticsearch-password>`
 - **Index name**: `huatuo_bamai`
 - **Time field name**: `uploaded_time`
 
-### Dashboard Import
+## Dashboard Import
 
-#### 1. Export Dashboard from Console
+When using Docker Compose, dashboards are provisioned automatically. To import additional dashboards from the HUAUO console:
 
 1. Access `http://console.huatuo.tech/dashboards` (Username: `huatuo`, Password: `huatuo1024`)
 2. Select the desired dashboard
@@ -135,19 +211,43 @@ In Grafana, add a new Elasticsearch data source with the following settings:
 4. Check "Export the dashboard to use in another instance"
 5. Click **Copy to clipboard**
 
-#### 2. Import Dashboard to Local Grafana
+Then in your Grafana instance:
 
-1. In your local Grafana, navigate to **Dashboards** -> **Import**
-2. Paste the copied JSON content
+1. Navigate to **Dashboards** -> **Import**
+2. Paste the JSON content
 3. Click **Load**
-4. Configure data sources and click **Import**
+4. Select the correct data sources and click **Import**
 
-### Troubleshooting
+## Troubleshooting
 
-**Issue**: "datasource not found" error when importing the "HuaTuo Root Cause Analysis AutoTracing" dashboard.
+### "datasource not found" when importing dashboard
 
-**Solution**: 
-1. Manually replace the datasource UID in the dashboard JSON
-2. Find your Elasticsearch datasource UID from the URL (e.g., `dflcs0w2ghybka` from `http://172.16.15.118:3000/connections/datasources/edit/dflcs0w2ghybka`)
-3. Replace all occurrences of `"uid": "${DS_HUATUO-BAMAI-ES}"` with your actual datasource UID
-4. Re-import the dashboard
+This occurs when the dashboard JSON references a datasource UID that does not exist in your Grafana instance.
+
+**Solution:**
+
+1. Find your Elasticsearch datasource UID from the Grafana UI URL: `http://<grafana-host>:3000/connections/datasources/edit/<uid>`
+2. In the dashboard JSON, replace all occurrences of `"uid": "${DS_HUATUO-BAMAI-ES}"` with your actual UID
+3. Re-import the dashboard
+
+### Prometheus target shows "down"
+
+- Verify huatuo-bamai is running: `curl http://<host>:19704/metrics`
+- Check Prometheus configuration matches the agent's address and port
+- For Kubernetes: ensure pod annotations are correct or ServiceMonitor selector matches
+
+### Elasticsearch index is empty
+
+- Verify Elasticsearch is reachable: `curl -u elastic:<password> http://<host>:9200/_cat/indices`
+- Check huatuo-bamai config `[Storage.ES]` section has correct `Address`, `Username`, `Password`
+- Default index name is `huatuo_bamai`
+
+### "socket path already exists" on startup
+
+This occurs when a previous huatuo-bamai process was not cleanly stopped.
+
+**Solution:**
+
+```bash
+rm -f /var/run/huatuo-toolstream.sock
+```

--- a/docs/best-practice/dropwatch_en.md
+++ b/docs/best-practice/dropwatch_en.md
@@ -1,5 +1,5 @@
 ---
-title: Network Drop Monitoring (dropwatch)
+title: Network Drop Monitoring
 type: docs
 description: ""
 author: HUATUO Team

--- a/docs/best-practice/storage_en.md
+++ b/docs/best-practice/storage_en.md
@@ -1,5 +1,5 @@
 ---
-title: Storage
+title: Storage Service
 type: docs
 description: ""
 author: HUATUO Team
@@ -104,7 +104,7 @@ docker logs opensearch
 
 #### 3. Configure huatuo-bamai
 
-Add the following configuration to `huatuo-bamai.conf`. The default username and password for the OpenSearch container image are both `admin`. For a full description of storage configuration options, refer to the Configuration Guide.
+Add the following configuration to `huatuo-bamai.conf`. The default username and password for the OpenSearch container image are both `admin`. For a full description of storage configuration options, see the [Configuration Guide](../configuration/huatuo-bamai-configuration_en.md).
 
 ```toml
 [Storage.Elasticsearch]
@@ -228,7 +228,7 @@ Example response:
 
 #### 3. Configure huatuo-bamai
 
-Add the following configuration to `huatuo-bamai.conf`. The default username for the Elasticsearch container image is `elastic`; the password is set via the `ELASTIC_PASSWORD` environment variable. For a full description of storage configuration options, refer to the Configuration Guide.
+Add the following configuration to `huatuo-bamai.conf`. The default username for the Elasticsearch container image is `elastic`; the password is set via the `ELASTIC_PASSWORD` environment variable. For a full description of storage configuration options, see the [Configuration Guide](../configuration/huatuo-bamai-configuration_en.md).
 
 ```toml
 [Storage.Elasticsearch]
@@ -389,10 +389,7 @@ curl -k -u elastic:123456 -X GET "http://localhost:9200/huatuo_bamai/_count?pret
 
 ### System Architecture
 
-The HUATUO Storage module runs on each node. It writes kernel events captured
-by the Tracer to the local directory and to Elasticsearch or OpenSearch. Both
-backends share the same `[Storage.Elasticsearch]` configuration interface and
-are differentiated by address.
+The HUATUO Storage module runs on each node. It writes kernel events captured by the Tracer to the local directory and to Elasticsearch or OpenSearch. Both backends share the same `[Storage.Elasticsearch]` configuration interface and are differentiated by address.
 
 The remote write path uses the ES/OpenSearch **Bulk API** (`_bulk`): events are queued in an in-memory buffer and submitted in batches by background workers based on size and time thresholds, with transport-layer retries on transient failures.
 

--- a/docs/best-practice/storage_zh.md
+++ b/docs/best-practice/storage_zh.md
@@ -104,7 +104,7 @@ docker logs opensearch
 
 #### 3. 配置 huatuo-bamai
 
-在 `huatuo-bamai.conf` 中添加以下配置。OpenSearch 容器镜像默认用户名和密码均为 `admin`。存储配置的详细说明请参见《配置指南》章节。
+在 `huatuo-bamai.conf` 中添加以下配置。OpenSearch 容器镜像默认用户名和密码均为 `admin`。存储配置的详细说明请参见[配置指南](../configuration/huatuo-bamai-configuration_zh.md)。
 
 ```toml
 [Storage.Elasticsearch]
@@ -227,7 +227,7 @@ curl -k -u elastic:123456 https://localhost:9200
 
 #### 3. 配置 huatuo-bamai
 
-在 `huatuo-bamai.conf` 中添加以下配置。Elasticsearch 容器镜像默认用户名为 `elastic`，密码通过环境变量 `ELASTIC_PASSWORD` 设置。存储配置的详细说明请参见《配置指南》章节。
+在 `huatuo-bamai.conf` 中添加以下配置。Elasticsearch 容器镜像默认用户名为 `elastic`，密码通过环境变量 `ELASTIC_PASSWORD` 设置。存储配置的详细说明请参见[配置指南](../configuration/huatuo-bamai-configuration_zh.md)。
 
 ```toml
 [Storage.Elasticsearch]
@@ -385,9 +385,7 @@ curl -k -u elastic:123456 \
 
 ### 系统架构
 
-HUATUO Storage 模块部署在节点上，将采集到的内核事件同时写入本地目录和
-Elasticsearch 或 OpenSearch。两种存储后端共用同一套
-`[Storage.Elasticsearch]` 配置接口，通过地址区分。
+HUATUO Storage 模块部署在节点上，将采集到的内核事件同时写入本地目录和 Elasticsearch 或 OpenSearch。两种存储后端共用同一套 `[Storage.Elasticsearch]` 配置接口，通过地址区分。
 
 写入远端时使用 ES/OpenSearch 的 **Bulk API**（`_bulk`）：事件先进入节点内的批量缓冲，由后台 worker 按"大小或时间"的阈值聚合后一次提交多条记录，并在传输层失败时按策略自动重试。
 

--- a/docs/deployment/daemonset_en.md
+++ b/docs/deployment/daemonset_en.md
@@ -1,38 +1,185 @@
 ---
-title: Kubernetes Daemonset
+title: Kubernetes
 type: docs
-description: 
+description:
 author: HUATUO Team
 date: 2026-01-11
 weight: 2
 ---
 
-This document describes how to deploy the Huatuo collector to a cloud-native cluster using a Kubernetes DaemonSet.
+This document describes how to deploy the Huatuo collector to a Kubernetes cluster using a DaemonSet.
 
-### 1. Download the configuration file
+## 1. Kubernetes Manifest Deployment
 
-```bash
-$ curl -L -o huatuo-bamai.conf https://github.com/ccfos/huatuo/raw/main/huatuo-bamai.conf
-```
-
-### 2. Modify the configuration file
-
-Modify the configuration file according to your actual deployment environment. For example, adjust settings such as the storage backend and the method for obtaining Pod information. For details, see the *Configuration Guide*.
-
-### 3. Create a ConfigMap
+### 1.1 Download the configuration file
 
 ```bash
-$ kubectl delete configmap huatuo-bamai-config
-$ kubectl create configmap huatuo-bamai-config --from-file=./huatuo-bamai.conf
+curl -L -o huatuo-bamai.conf https://github.com/ccfos/huatuo/raw/main/huatuo-bamai.conf
 ```
 
-### 3. Deploy the Collector
+### 1.2 Modify the configuration file
+
+Modify the configuration file for the deployment environment. For example, configure the storage backend and the method used to obtain Pod information. See the [Configuration Guide](../configuration/huatuo-bamai-configuration_en.md) for details.
+
+### 1.3 Create the ConfigMap
 
 ```bash
-$ kubectl apply -f https://github.com/ccfos/huatuo/blob/main/build/huatuo-daemonset.minimal.yaml
+kubectl create configmap huatuo-bamai-config \
+  --namespace default \
+  --from-file=./huatuo-bamai.conf \
+  --dry-run=client -o yaml |
+kubectl apply -f -
 ```
 
-**Notes:**
+### 1.4 Deploy the collector
 
-- In `huatuo-daemonset.minimal.yaml`, the container image uses the `huatuo-bamai:latest` tag by default. For production deployments, replace it with a specific release version image.
-- When using `huatuo-bamai:latest` for testing, verify that the tag points to the latest image. You can remove the old image and pull it again by running `docker image rm huatuo/huatuo-bamai:latest`.
+```bash
+kubectl apply -f \
+  https://raw.githubusercontent.com/ccfos/huatuo/main/build/huatuo-daemonset.minimal.yaml
+```
+
+### 1.5 Verify the deployment
+
+```bash
+kubectl rollout status daemonset/huatuo \
+  --namespace default \
+  --timeout=10m
+
+kubectl get pods \
+  --namespace default \
+  --selector app=huatuo \
+  --output wide
+```
+
+After updating `huatuo-bamai.conf`, rerun section 1.3 to update the ConfigMap, then manually restart the DaemonSet:
+
+```bash
+kubectl rollout restart daemonset/huatuo --namespace default
+```
+
+## 2. Helm Deployment
+
+The Helm Chart is located at `build/charts/`.
+
+### 2.1 Check the deployment environment
+
+Helm and kubectl must be installed on the management host, which must be able to access the target Kubernetes cluster.
+
+```bash
+(command -v helm || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash) && helm version
+
+TARGET_CONTEXT="$(kubectl config get-contexts -o name | sed -n '1p')"
+kubectl --context "${TARGET_CONTEXT}" get nodes
+```
+
+Verify that the target Nodes are `Ready`.
+
+### 2.2 Prepare the configuration file
+
+Download and modify `huatuo-bamai.conf` as described in sections 1.1 and 1.2.
+
+### 2.3 Configure deployment values
+
+Create `values-production.yaml`:
+
+```yaml
+image:
+  repository: <registry-accessible-to-all-nodes>/huatuo-bamai
+  tag: "<release-version>"
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: "1"
+    memory: 1Gi
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations:
+  - operator: Exists
+
+hostPaths:
+  proc: /proc
+  sys: /sys
+  run: /run
+  var: /var
+  etc: /etc
+  data: /var/log/huatuo/huatuo-local
+```
+
+### 2.4 Validate the Helm Chart
+
+```bash
+helm lint ./build/charts \
+  -f ./values-production.yaml \
+  --set-file config.content=./huatuo-bamai.conf
+
+helm template huatuo ./build/charts \
+  --namespace huatuo \
+  -f ./values-production.yaml \
+  --set-file config.content=./huatuo-bamai.conf \
+  >/dev/null
+```
+
+### 2.5 Deploy the collector
+
+```bash
+helm upgrade --install huatuo ./build/charts \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  --create-namespace \
+  -f ./values-production.yaml \
+  --set-file config.content=./huatuo-bamai.conf \
+  --atomic \
+  --timeout 10m
+```
+
+### 2.6 Verify the deployment
+
+```bash
+helm status huatuo \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo
+
+kubectl --context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  get daemonset,configmap,pod --output wide
+
+kubectl --context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  rollout status daemonset/huatuo \
+  --timeout=10m
+```
+
+Inspect the collector logs:
+
+```bash
+kubectl --context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  logs \
+  --selector app.kubernetes.io/name=huatuo \
+  --prefix \
+  --tail=100
+```
+
+### 2.7 Upgrade and roll back
+
+After changing the image version or `huatuo-bamai.conf`, rerun the command in section 2.5.
+
+List the release history and roll back to a selected revision:
+
+```bash
+helm history huatuo \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo
+
+helm rollback huatuo <revision> \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  --wait \
+  --timeout 10m
+```

--- a/docs/deployment/daemonset_zh.md
+++ b/docs/deployment/daemonset_zh.md
@@ -1,36 +1,185 @@
 ---
-title: DaemonSet 云原生集群部署
+title: 集群部署
 type: docs
-description: 
+description:
 author: HUATUO Team, hao022
 date: 2026-01-11
 weight: 2
 ---
 
-本文介绍如何通过 Kubernetes DaemonSet 将华佗采集器部署到云原生集群。
+本文介绍如何通过 Kubernetes DaemonSet 将华佗采集器部署到集群。
 
-### 1. 获取配置文件
+## 1. Kubernetes 清单部署
+
+### 1.1 获取配置文件
 
 ```bash
-$ curl -L -o huatuo-bamai.conf https://github.com/ccfos/huatuo/raw/main/huatuo-bamai.conf
+curl -L -o huatuo-bamai.conf https://github.com/ccfos/huatuo/raw/main/huatuo-bamai.conf
 ```
 
-### 2. 修改配置文件
+### 1.2 修改配置文件
 
-根据实际部署环境修改配置文件，例如调整存储后端、Pod 信息获取方式等配置项，详见《配置指南》。
+根据实际部署环境修改配置文件，例如调整存储后端、Pod 信息获取方式等配置项，详见[配置指南](../configuration/huatuo-bamai-configuration_zh.md)。
 
-### 3. 创建 ConfigMap
+### 1.3 创建 ConfigMap
+
 ```bash
-$ kubectl delete configmap huatuo-bamai-config
-$ kubectl create configmap huatuo-bamai-config --from-file=./huatuo-bamai.conf
+kubectl create configmap huatuo-bamai-config \
+  --namespace default \
+  --from-file=./huatuo-bamai.conf \
+  --dry-run=client -o yaml |
+kubectl apply -f -
 ```
 
+### 1.4 部署采集器
 
-### 4. 部署采集器
 ```bash
-$ kubectl apply -f https://github.com/ccfos/huatuo/blob/main/build/huatuo-daemonset.minimal.yaml
+kubectl apply -f \
+  https://raw.githubusercontent.com/ccfos/huatuo/main/build/huatuo-daemonset.minimal.yaml
 ```
 
-注意事项：
-- huatuo-daemonset.minimal.yaml 中容器镜像默认使用 huatuo-bamai:latest 标签。若需用于生产环境，请将其替换为指定的发行版本镜像。
-- 若使用 huatuo-bamai:latest 进行测试，请确保该标签指向最新镜像（可通过 docker image rm huatuo/huatuo-bamai:latest 删除旧镜像后重新拉取）。
+### 1.5 验证部署
+
+```bash
+kubectl rollout status daemonset/huatuo \
+  --namespace default \
+  --timeout=10m
+
+kubectl get pods \
+  --namespace default \
+  --selector app=huatuo \
+  --output wide
+```
+
+更新 `huatuo-bamai.conf` 后，重新执行 1.3 节更新 ConfigMap，并手工触发滚动更新：
+
+```bash
+kubectl rollout restart daemonset/huatuo --namespace default
+```
+
+## 2. Helm 部署
+
+Helm Chart 位于 `build/charts/`。
+
+### 2.1 检查部署环境
+
+管理机需要安装 Helm 和 kubectl，并能够访问目标 Kubernetes 集群。
+
+```bash
+(command -v helm || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash) && helm version
+
+TARGET_CONTEXT="$(kubectl config get-contexts -o name | sed -n '1p')"
+kubectl --context "${TARGET_CONTEXT}" get nodes
+```
+
+确认目标 Node 状态为 `Ready`。
+
+### 2.2 准备配置文件
+
+按照 1.1 和 1.2 节获取并修改 `huatuo-bamai.conf`。
+
+### 2.3 配置部署参数
+
+创建 `values-production.yaml`：
+
+```yaml
+image:
+  repository: <所有Node均可访问的镜像仓库>/huatuo-bamai
+  tag: "<固定发行版本>"
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: "1"
+    memory: 1Gi
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations:
+  - operator: Exists
+
+hostPaths:
+  proc: /proc
+  sys: /sys
+  run: /run
+  var: /var
+  etc: /etc
+  data: /var/log/huatuo/huatuo-local
+```
+
+### 2.4 检查 Helm Chart
+
+```bash
+helm lint ./build/charts \
+  -f ./values-production.yaml \
+  --set-file config.content=./huatuo-bamai.conf
+
+helm template huatuo ./build/charts \
+  --namespace huatuo \
+  -f ./values-production.yaml \
+  --set-file config.content=./huatuo-bamai.conf \
+  >/dev/null
+```
+
+### 2.5 部署采集器
+
+```bash
+helm upgrade --install huatuo ./build/charts \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  --create-namespace \
+  -f ./values-production.yaml \
+  --set-file config.content=./huatuo-bamai.conf \
+  --atomic \
+  --timeout 10m
+```
+
+### 2.6 验证部署
+
+```bash
+helm status huatuo \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo
+
+kubectl --context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  get daemonset,configmap,pod --output wide
+
+kubectl --context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  rollout status daemonset/huatuo \
+  --timeout=10m
+```
+
+查看采集器日志：
+
+```bash
+kubectl --context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  logs \
+  --selector app.kubernetes.io/name=huatuo \
+  --prefix \
+  --tail=100
+```
+
+### 2.7 更新和回滚
+
+修改镜像版本或 `huatuo-bamai.conf` 后，重新执行 2.5 节的命令。
+
+查看发布历史并回滚到指定版本：
+
+```bash
+helm history huatuo \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo
+
+helm rollback huatuo <Revision> \
+  --kube-context "${TARGET_CONTEXT}" \
+  --namespace huatuo \
+  --wait \
+  --timeout 10m
+```

--- a/docs/deployment/systemd_en.md
+++ b/docs/deployment/systemd_en.md
@@ -1,38 +1,131 @@
 ---
-title: Systemd Bare-Metal
+title: Bare-Metal
 type: docs
-description: 
+description:
 author: HUATUO Team, HAO022
 date: 2026-01-11
 weight: 3
 ---
 
-The RPM release of HUATUO is available from the OpenCloudOS repository. Only version 2.1.0 is currently supported.
+## Binary
+
+The HUATUO release provides static Linux tar packages for amd64 and arm64. The tar package contains the `huatuo-bamai` and `huatuo-apiserver` binaries, configuration files, and BPF objects.
+
+This section applies to releases that provide assets named `huatuo-bamai-<version>-static-linux-<arch>.tar.gz`. This naming starts with `v2.2.0` in the current releases. The `v2.0.0` and `v2.1.0` tar packages use different names, so the commands below do not apply to them directly.
+
+The commands below use `HUATUO_VERSION` for the target version. Change it to the release version you want to install, for example `v2.2.0`:
+
+```bash
+HUATUO_VERSION="<release-version>"
+```
+
+### 1. Download the tar package
+
+For x86_64 hosts, download the amd64 package:
+
+```bash
+wget "https://github.com/ccfos/huatuo/releases/download/${HUATUO_VERSION}/huatuo-bamai-${HUATUO_VERSION}-static-linux-amd64.tar.gz"
+```
+
+For aarch64 hosts, download the arm64 package:
+
+```bash
+wget "https://github.com/ccfos/huatuo/releases/download/${HUATUO_VERSION}/huatuo-bamai-${HUATUO_VERSION}-static-linux-arm64.tar.gz"
+```
+
+### 2. Install the tar package
+
+Create the installation, log, and data directories:
+
+```bash
+sudo install -d -m 0755 /opt/huatuo-bamai /var/log/huatuo-bamai /var/lib/huatuo-bamai
+```
+
+For amd64:
+
+```bash
+sudo tar -xzf "huatuo-bamai-${HUATUO_VERSION}-static-linux-amd64.tar.gz" --strip-components=1 --no-same-owner -C /opt/huatuo-bamai
+```
+
+For arm64:
+
+```bash
+sudo tar -xzf "huatuo-bamai-${HUATUO_VERSION}-static-linux-arm64.tar.gz" --strip-components=1 --no-same-owner -C /opt/huatuo-bamai
+```
+
+### 3. Install the service unit files
+
+Download the service unit files from the matching source version:
+
+```bash
+sudo wget -O /etc/systemd/system/huatuo-bamai.service "https://raw.githubusercontent.com/ccfos/huatuo/${HUATUO_VERSION}/build/rpm/huatuo-bamai.service"
+sudo wget -O /etc/systemd/system/huatuo-apiserver.service "https://raw.githubusercontent.com/ccfos/huatuo/${HUATUO_VERSION}/build/rpm/huatuo-apiserver.service"
+```
+
+### 4. Modify the configurations
+
+Edit `/opt/huatuo-bamai/conf/huatuo-bamai.conf` and `/opt/huatuo-bamai/conf/huatuo-apiserver.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](../configuration/huatuo-bamai-configuration_en.md) and [`huatuo-apiserver` configuration](../configuration/huatuo-apiserver-configuration_en.md).
+
+### 5. Register the HUATUO services
+
+Reload the systemd configuration:
+
+```bash
+sudo systemctl daemon-reload
+```
+
+### 6. Start the HUATUO services
+
+Start the services and enable them at system startup:
+
+```bash
+sudo systemctl enable --now huatuo-bamai huatuo-apiserver
+```
+
+## RPM Package
+
+The OpenCloudOS repository provides HUATUO v2.1.0 RPM packages for x86_64 and aarch64. The RPM package installs the HUATUO files and systemd service unit file.
 
 ### 1. Download the RPM package
 
-The OpenCloudOS mirror provides the HUATUO RPM package. Download the appropriate package for your architecture:
+Download the package for the host architecture:
+
+For x86_64:
 
 ```bash
-wget https://mirrors.opencloudos.tech/epol/9/Everything/x86_64/os/Packages/huatuo-bamai-2.1.0-2.oc9.x86_64.rpm  
-wget https://mirrors.opencloudos.tech/epol/9/Everything/aarch64/os/Packages/huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
+wget https://mirrors.opencloudos.tech/epol/9/Everything/x86_64/os/Packages/huatuo-bamai-2.1.0-2.oc9.x86_64.rpm
+```
+
+For aarch64:
+
+```bash
+wget https://mirrors.opencloudos.tech/epol/9/Everything/aarch64/os/Packages/huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 ```
 
 ### 2. Install the RPM package
 
+For x86_64:
+
 ```bash
-sudo rpm -ivh huatuo-bamai*.rpm
+sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.x86_64.rpm
+```
+
+For aarch64:
+
+```bash
+sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 ```
 
 ### 3. Modify the configuration
 
-Edit the configuration file `/etc/huatuo-bamai/huatuo-bamai.conf` to match your deployment environment. For detailed configuration options, refer to the *Configuration Guide*.
+Edit `/etc/huatuo-bamai/huatuo-bamai.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](../configuration/huatuo-bamai-configuration_en.md).
 
 ### 4. Start the HUATUO service
 
+The RPM package installs the `huatuo-bamai.service` service unit file. Start the service and enable it at system startup:
+
 ```bash
-sudo systemctl start huatuo-bamai
-sudo systemctl enable huatuo-bamai
+sudo systemctl enable --now huatuo-bamai
 ```
 
-> For complete installation instructions, see [https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ](https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ)
+> For complete RPM installation instructions, see [https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ](https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ).

--- a/docs/deployment/systemd_zh.md
+++ b/docs/deployment/systemd_zh.md
@@ -1,38 +1,131 @@
 ---
-title: Systemd 物理机部署
+title: 物理机部署
 type: docs
-description: 
+description:
 author: HUATUO Team, HAO022
 date: 2026-01-11
 weight: 3
 ---
 
-HUATUO（华佗）的 RPM 发行版可通过 OpenCloudOS 镜像仓库获取，当前仅支持 v2.1.0 版本。
+## 二进制
+
+HUATUO Release 提供 amd64 和 arm64 的 Linux 静态 tar 包。tar 包包含 `huatuo-bamai` 和 `huatuo-apiserver` 二进制文件、配置文件和 BPF 对象。
+
+本节命令适用于发布资产名为 `huatuo-bamai-<version>-static-linux-<arch>.tar.gz` 的版本。当前该命名从 `v2.2.0` 开始提供；`v2.0.0` 和 `v2.1.0` 的 tar 包名不同，不能直接套用以下命令。
+
+以下命令使用 `HUATUO_VERSION` 表示目标版本，可按实际发行版本调整，例如 `v2.2.0`：
+
+```bash
+HUATUO_VERSION="<release-version>"
+```
+
+### 1. 下载 tar 包
+
+x86_64 主机下载 amd64 包：
+
+```bash
+wget "https://github.com/ccfos/huatuo/releases/download/${HUATUO_VERSION}/huatuo-bamai-${HUATUO_VERSION}-static-linux-amd64.tar.gz"
+```
+
+aarch64 主机下载 arm64 包：
+
+```bash
+wget "https://github.com/ccfos/huatuo/releases/download/${HUATUO_VERSION}/huatuo-bamai-${HUATUO_VERSION}-static-linux-arm64.tar.gz"
+```
+
+### 2. 安装 tar 包
+
+创建安装、日志和数据目录：
+
+```bash
+sudo install -d -m 0755 /opt/huatuo-bamai /var/log/huatuo-bamai /var/lib/huatuo-bamai
+```
+
+amd64：
+
+```bash
+sudo tar -xzf "huatuo-bamai-${HUATUO_VERSION}-static-linux-amd64.tar.gz" --strip-components=1 --no-same-owner -C /opt/huatuo-bamai
+```
+
+arm64：
+
+```bash
+sudo tar -xzf "huatuo-bamai-${HUATUO_VERSION}-static-linux-arm64.tar.gz" --strip-components=1 --no-same-owner -C /opt/huatuo-bamai
+```
+
+### 3. 安装服务单元文件
+
+从对应版本源码下载服务单元文件：
+
+```bash
+sudo wget -O /etc/systemd/system/huatuo-bamai.service "https://raw.githubusercontent.com/ccfos/huatuo/${HUATUO_VERSION}/build/rpm/huatuo-bamai.service"
+sudo wget -O /etc/systemd/system/huatuo-apiserver.service "https://raw.githubusercontent.com/ccfos/huatuo/${HUATUO_VERSION}/build/rpm/huatuo-apiserver.service"
+```
+
+### 4. 修改配置
+
+根据实际部署环境编辑 `/opt/huatuo-bamai/conf/huatuo-bamai.conf` 和 `/opt/huatuo-bamai/conf/huatuo-apiserver.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](../configuration/huatuo-bamai-configuration_zh.md) 和 [`huatuo-apiserver` 配置](../configuration/huatuo-apiserver-configuration_zh.md)。
+
+### 5. 注册 HUATUO 服务
+
+重新加载 systemd 配置：
+
+```bash
+sudo systemctl daemon-reload
+```
+
+### 6. 启动 HUATUO 服务
+
+启动服务并设置开机启动：
+
+```bash
+sudo systemctl enable --now huatuo-bamai huatuo-apiserver
+```
+
+## RPM 包
+
+OpenCloudOS 镜像仓库提供 HUATUO v2.1.0 的 x86_64 和 aarch64 RPM 包。RPM 包会安装 HUATUO 文件和 systemd 服务单元文件。
 
 ### 1. 下载 RPM 包
 
-OpenCloudOS 镜像站提供了 HUATUO 的 RPM 安装包，可按需选择对应架构下载：
+根据主机架构下载对应的 RPM 包：
+
+x86_64：
 
 ```bash
-wget https://mirrors.opencloudos.tech/epol/9/Everything/x86_64/os/Packages/huatuo-bamai-2.1.0-2.oc9.x86_64.rpm  
-wget https://mirrors.opencloudos.tech/epol/9/Everything/aarch64/os/Packages/huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
+wget https://mirrors.opencloudos.tech/epol/9/Everything/x86_64/os/Packages/huatuo-bamai-2.1.0-2.oc9.x86_64.rpm
+```
+
+aarch64：
+
+```bash
+wget https://mirrors.opencloudos.tech/epol/9/Everything/aarch64/os/Packages/huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 ```
 
 ### 2. 安装 RPM 包
 
+x86_64：
+
 ```bash
-sudo rpm -ivh huatuo-bamai*.rpm
+sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.x86_64.rpm
+```
+
+aarch64：
+
+```bash
+sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 ```
 
 ### 3. 修改配置
 
-根据实际部署环境编辑配置文件 /etc/huatuo-bamai/huatuo-bamai.conf，详细配置项说明请参见《配置指南》。
+根据实际部署环境编辑 `/etc/huatuo-bamai/huatuo-bamai.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](../configuration/huatuo-bamai-configuration_zh.md)。
 
 ### 4. 启动 HUATUO 服务
 
+RPM 包会安装 `huatuo-bamai.service` 服务单元文件。启动服务并设置开机启动：
+
 ```bash
-sudo systemctl start huatuo-bamai
-sudo systemctl enable huatuo-bamai
+sudo systemctl enable --now huatuo-bamai
 ```
 
-> 完整的安装指引请参阅 [https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ](https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ)
+> 完整的 RPM 安装指引请参阅 [https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ](https://mp.weixin.qq.com/s/Gmst4_FsbXUIhuJw1BXNnQ)。


### PR DESCRIPTION
## Summary

- Add a minimal Helm chart under `build/charts` for the Kubernetes collector.
- Refresh Kubernetes DaemonSet and Helm deployment documentation.
- Refresh bare-metal deployment and data source documentation with reusable commands.
