### PR TITLE
fix(toolstream): recover stale Unix sockets

### DIFF
--- a/internal/toolstream/transport/uds.go
+++ b/internal/toolstream/transport/uds.go
@@ -15,9 +15,12 @@
 package transport
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"syscall"
+	"time"
 )
 
 type udsListener struct {
@@ -32,12 +35,9 @@ func (l *udsListener) Close() error {
 }
 
 // ListenUDS binds a Unix socket at path.
-// If path already exists it is removed first (leftover from a previous
-// unclean shutdown); an active listener on the same path will cause
-// net.Listen to fail regardless.
 func ListenUDS(path string) (net.Listener, error) {
-	if _, err := os.Stat(path); err == nil {
-		_ = os.Remove(path)
+	if err := prepareSocketPath(path); err != nil {
+		return nil, err
 	}
 
 	l, err := net.Listen("unix", path)
@@ -54,6 +54,36 @@ func ListenUDS(path string) (net.Listener, error) {
 	}
 
 	return &udsListener{Listener: l, path: path}, nil
+}
+
+func prepareSocketPath(path string) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("transport: inspect socket path %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("transport: socket path exists and is not a Unix socket: %s", path)
+	}
+
+	conn, err := net.DialTimeout("unix", path, time.Second)
+	if err == nil {
+		_ = conn.Close()
+		return fmt.Errorf("transport: socket already has an active listener: %s", path)
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		return fmt.Errorf("transport: probe existing socket %s: %w", path, err)
+	}
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("transport: remove stale socket %s: %w", path, err)
+	}
+	return nil
 }
 
 // DialUDS connects to a Unix socket at path.

--- a/internal/toolstream/transport/uds_test.go
+++ b/internal/toolstream/transport/uds_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestListenUDSCreatesMissingSocket(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "toolstream.sock")
+
+	listener, err := ListenUDS(path)
+	if err != nil {
+		t.Fatalf("ListenUDS: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat socket: %v", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("mode = %v, want Unix socket", info.Mode())
+	}
+}
+
+func TestListenUDSReplacesStaleSocket(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "toolstream.sock")
+	stale, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatalf("create stale socket: %v", err)
+	}
+	stale.SetUnlinkOnClose(false)
+	if err := stale.Close(); err != nil {
+		t.Fatalf("close stale socket: %v", err)
+	}
+
+	listener, err := ListenUDS(path)
+	if err != nil {
+		t.Fatalf("ListenUDS with stale socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+}
+
+func TestListenUDSRejectsActiveSocket(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "toolstream.sock")
+	listener, err := ListenUDS(path)
+	if err != nil {
+		t.Fatalf("first ListenUDS: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	if _, err := ListenUDS(path); err == nil {
+		t.Fatal("second ListenUDS error = nil, want active listener error")
+	} else if !strings.Contains(err.Error(), "active listener") {
+		t.Fatalf("second ListenUDS error = %q, want active listener error", err)
+	}
+
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatalf("active listener was disrupted: %v", err)
+	}
+	_ = conn.Close()
+}
+
+func TestListenUDSRejectsNonSocketPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "toolstream.sock")
+	if err := os.WriteFile(path, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("create regular file: %v", err)
+	}
+
+	if _, err := ListenUDS(path); err == nil {
+		t.Fatal("ListenUDS error = nil, want non-socket path error")
+	} else if !strings.Contains(err.Error(), "not a Unix socket") {
+		t.Fatalf("ListenUDS error = %q, want non-socket path error", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read regular file: %v", err)
+	}
+	if string(got) != "keep" {
+		t.Fatalf("regular file content = %q, want keep", got)
+	}
+}


### PR DESCRIPTION
## What changed

- Probe an existing toolstream Unix socket before binding.
- Preserve paths owned by active listeners.
- Remove socket paths only when the probe returns `ECONNREFUSED`.
- Reject non-socket paths and unexpected probe errors.
- Cover missing, stale, active, and non-socket paths with unit tests.

## Why

An unclean `huatuo-bamai` shutdown can leave
`/var/run/huatuo-toolstream.sock` behind. The next start must recover that
stale path without unlinking a socket owned by a running instance or deleting
an unrelated file.

## Impact

`huatuo-bamai` can restart after a stale toolstream socket is left behind.
Concurrent instances fail with an actionable error and do not disrupt the
active listener.

## Validation

- `go test ./internal/toolstream/... -count=10`
- `make check`
