### PR TITLE
fix(integration): wait for included metrics

### DIFF
--- a/integration/lib.sh
+++ b/integration/lib.sh
@@ -400,11 +400,27 @@ huatuo_bamai_collect_metrics() {
 	huatuo_bamai_metrics > "${HUATUO_BAMAI_TEST_TMPDIR}/metrics.txt"
 }
 
-# huatuo_bamai_await_metrics waits until the metrics endpoint responds, then saves.
+# huatuo_bamai_collect_expected_metrics saves /metrics output and verifies that
+# every expected pattern has appeared. Collectors may populate asynchronously
+# after the endpoint starts responding.
+huatuo_bamai_collect_expected_metrics() {
+	huatuo_bamai_collect_metrics || return 1
+
+	local metrics_file="${HUATUO_BAMAI_TEST_TMPDIR}/metrics.txt"
+	local prefix="huatuo_bamai_"
+	local pattern
+	for pattern in "$@"; do
+		grep -qE "${prefix}(${pattern})" "${metrics_file}" || return 1
+	done
+}
+
+# huatuo_bamai_await_metrics [expected_pattern...]
+# Waits until the metrics endpoint responds and all optional expected patterns
+# have appeared, then saves the successful response.
 huatuo_bamai_await_metrics() {
 	wait_until "${WAIT_HUATUO_BAMAI_TIMEOUT}" \
 		"${WAIT_HUATUO_BAMAI_INTERVAL}" \
-		huatuo_bamai_collect_metrics
+		huatuo_bamai_collect_expected_metrics "$@"
 }
 
 # check_metrics <desc> <present_pattern>... [-- <absent_pattern>...]

--- a/integration/test_metrics_include_filter.sh
+++ b/integration/test_metrics_include_filter.sh
@@ -23,7 +23,11 @@ source "${ROOT_DIR}/integration/config.sh"
 
 integration_huatuo_bamai_start write_include_filter_config
 
-huatuo_bamai_await_metrics
+huatuo_bamai_await_metrics \
+	"memory_vmstat_thp_split_pmd" "memory_vmstat_thp_split_pud" \
+	"netstat_Tcp_RetransSegs" "netstat_TcpExt_TCPLostRetransmit" \
+	'netdev_.*device="eth0"' \
+	'mountpoint_perm_ro{.*mountpoint="/boot"'
 
 check_metrics "include filter" \
 	"memory_vmstat_thp_split_pmd" "memory_vmstat_thp_split_pud" \


### PR DESCRIPTION
## Summary

- allow metric readiness checks to require collector-specific patterns
- retry the include-filter scrape until every required included metric appears
- preserve the existing no-argument readiness behavior for other tests

## Why

The metrics endpoint can respond before asynchronous collectors publish their first samples. In the Ubuntu 22 CI job for #442, readiness succeeded and the first scrape immediately missed netstat_Tcp_RetransSegs, although the tracing-only change did not touch metrics code.

Failed job: https://github.com/ccfos/huatuo/actions/runs/30196913549/job/89779933187

## Testing

- make check
- deterministic helper simulation: first scrape missing a required metric, second scrape contains it
- make unit (all packages pass except internal/cgroups/TestCgroupInterfaces/CpuUsage because this WSL environment does not expose cgroup v1 cpuacct.stat)