### PR TITLE
fix(config): preserve numeric update types

### DIFF
--- a/cmd/huatuo-bamai/handlers/config.go
+++ b/cmd/huatuo-bamai/handlers/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
 package handlers
 
 import (
-	"math"
 	"net/http"
-	"reflect"
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
 	"huatuo-bamai/internal/log"
@@ -48,13 +46,6 @@ func (h *ConfigHandler) update(ctx *server.Context) error {
 	}
 
 	for k, v := range req.Config {
-		if reflect.ValueOf(v).Kind() == reflect.Float64 {
-			f := v.(float64)
-			if f > math.MaxInt64 || f < math.MinInt64 {
-				return response.ErrInvalidRequest.WithMessage("integer value out of range")
-			}
-			v = int64(f)
-		}
 		if err := config.Set(k, v); err != nil {
 			return response.ErrInvalidRequest.WithMessage(err.Error())
 		}

--- a/cmd/huatuo-bamai/handlers/config_test.go
+++ b/cmd/huatuo-bamai/handlers/config_test.go
@@ -54,6 +54,87 @@ Log = { Level = "Info" }
 	}
 }
 
+func TestConfigHandlerUpdatesNumericConfig(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	if err := config.Load(writeConfig(t, `
+[Runtime]
+StartupCPULimitCores = 0.5
+CPULimitCores = 2.0
+MemoryLimitMiB = 2048
+
+[Pod]
+KubeletReadOnlyPort = 10255
+`)); err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	engine := httpGin.New()
+	server.NewRoot(engine, "").PUT("/config", NewConfigHandler().update)
+
+	body := `{"config":{
+		"Runtime.StartupCPULimitCores":0.75,
+		"Runtime.CPULimitCores":1.5,
+		"Runtime.MemoryLimitMiB":1024,
+		"Pod.KubeletReadOnlyPort":10250
+	}}`
+	req := httptest.NewRequest(http.MethodPut, "/config", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	cfg := config.Get()
+	if cfg.Runtime.StartupCPULimitCores != 0.75 {
+		t.Errorf("StartupCPULimitCores = %v, want 0.75", cfg.Runtime.StartupCPULimitCores)
+	}
+	if cfg.Runtime.CPULimitCores != 1.5 {
+		t.Errorf("CPULimitCores = %v, want 1.5", cfg.Runtime.CPULimitCores)
+	}
+	if cfg.Runtime.MemoryLimitMiB != 1024 {
+		t.Errorf("MemoryLimitMiB = %d, want 1024", cfg.Runtime.MemoryLimitMiB)
+	}
+	if cfg.Pod.KubeletReadOnlyPort != 10250 {
+		t.Errorf("KubeletReadOnlyPort = %d, want 10250", cfg.Pod.KubeletReadOnlyPort)
+	}
+}
+
+func TestConfigHandlerRejectsFractionalInteger(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	if err := config.Load(writeConfig(t, `
+[Runtime]
+StartupCPULimitCores = 0.5
+CPULimitCores = 2.0
+MemoryLimitMiB = 2048
+`)); err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	engine := httpGin.New()
+	server.NewRoot(engine, "").PUT("/config", NewConfigHandler().update)
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/config",
+		bytes.NewBufferString(`{"config":{"Runtime.MemoryLimitMiB":1024.5}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if config.Get().Runtime.MemoryLimitMiB != 2048 {
+		t.Errorf("MemoryLimitMiB changed to %d after rejected update", config.Get().Runtime.MemoryLimitMiB)
+	}
+}
+
 func writeConfig(t *testing.T, content string) string {
 	t.Helper()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -83,9 +84,55 @@ func Set(cfg any, key string, val any) error {
 	rc := reflect.Indirect(c)
 	rval := reflect.ValueOf(val)
 	if rc.Kind() != rval.Kind() {
-		return fmt.Errorf("%s type %s is not assignable to type %s", key, rc.Kind(), rval.Kind())
+		converted, ok := convertJSONNumber(rc, rval)
+		if !ok {
+			return fmt.Errorf("%s type %s is not assignable to type %s", key, rval.Kind(), rc.Kind())
+		}
+		rval = converted
 	}
 
 	rc.Set(rval)
 	return nil
+}
+
+// convertJSONNumber converts the float64 representation produced by encoding/json
+// to the destination's numeric type without truncation or overflow.
+func convertJSONNumber(dst, src reflect.Value) (reflect.Value, bool) {
+	if src.Kind() != reflect.Float64 {
+		return reflect.Value{}, false
+	}
+
+	f := src.Float()
+	converted := reflect.New(dst.Type()).Elem()
+	switch dst.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if math.Trunc(f) != f ||
+			f < float64(math.MinInt64) ||
+			f >= -float64(math.MinInt64) {
+			return reflect.Value{}, false
+		}
+		value := int64(f)
+		if dst.OverflowInt(value) {
+			return reflect.Value{}, false
+		}
+		converted.SetInt(value)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if math.Trunc(f) != f || f < 0 || f >= math.Ldexp(1, 64) {
+			return reflect.Value{}, false
+		}
+		value := uint64(f)
+		if dst.OverflowUint(value) {
+			return reflect.Value{}, false
+		}
+		converted.SetUint(value)
+	case reflect.Float32, reflect.Float64:
+		if dst.OverflowFloat(f) {
+			return reflect.Value{}, false
+		}
+		converted.SetFloat(f)
+	default:
+		return reflect.Value{}, false
+	}
+
+	return converted, true
 }


### PR DESCRIPTION
## Summary

- preserve floating-point config values submitted through PUT /config
- convert JSON numbers to signed and unsigned integer fields only when exact and in range
- reject fractional integer updates instead of truncating them
- add HTTP regression coverage for float, signed integer, and unsigned integer fields

## Why

JSON numbers in ConfigRequest.Config arrive as float64. The handler previously converted every numeric value to int64, so documented settings such as Runtime.StartupCPULimitCores = 0.5 could not be updated through the API, while fractional integer values were silently truncated.

## Testing

- make check
- go test ./internal/config ./cmd/huatuo-bamai/handlers -run ConfigHandler -count=1
- make unit (all packages pass except internal/cgroups/TestCgroupInterfaces/CpuUsage because this WSL environment does not expose cgroup v1 cpuacct.stat)