### PR TITLE
fix(profiling): prevent output file overwrite

### DIFF
--- a/internal/profiler/aggregator/export.go
+++ b/internal/profiler/aggregator/export.go
@@ -15,6 +15,7 @@
 package aggregator
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -65,10 +66,14 @@ func createOutputFile(dir, prefix, ext string) (*os.File, error) {
 		return nil, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	fileName := fmt.Sprintf("%s_%d%s", prefix, time.Now().Unix(), ext)
-	filePath := filepath.Join(dir, fileName)
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return nil, fmt.Errorf("failed to generate output filename: %w", err)
+	}
 
-	file, err := os.Create(filePath)
+	fileName := fmt.Sprintf("%s_%d_%x%s", prefix, time.Now().Unix(), suffix, ext)
+	filePath := filepath.Join(dir, fileName)
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create output file: %w", err)
 	}

--- a/internal/profiler/aggregator/export_test.go
+++ b/internal/profiler/aggregator/export_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCreateOutputFileUsesUniqueNames(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := createOutputFile(dir, "perf", ".folded")
+	if err != nil {
+		t.Fatalf("create first output file: %v", err)
+	}
+	firstName := first.Name()
+	if _, err := first.WriteString("first profile"); err != nil {
+		t.Fatalf("write first output file: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first output file: %v", err)
+	}
+
+	second, err := createOutputFile(dir, "perf", ".folded")
+	if err != nil {
+		t.Fatalf("create second output file: %v", err)
+	}
+	secondName := second.Name()
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second output file: %v", err)
+	}
+
+	if firstName == secondName {
+		t.Fatalf("createOutputFile reused %q", firstName)
+	}
+	for _, name := range []string{firstName, secondName} {
+		base := filepath.Base(name)
+		if !strings.HasPrefix(base, "perf_") || !strings.HasSuffix(base, ".folded") {
+			t.Errorf("output filename %q does not preserve prefix and extension", base)
+		}
+	}
+
+	data, err := os.ReadFile(firstName)
+	if err != nil {
+		t.Fatalf("read first output file: %v", err)
+	}
+	if got, want := string(data), "first profile"; got != want {
+		t.Errorf("first output content = %q, want %q", got, want)
+	}
+}
+
+func TestCreateOutputFileCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "profiles")
+
+	file, err := createOutputFile(dir, "flamegraph", ".svg")
+	if err != nil {
+		t.Fatalf("create output file: %v", err)
+	}
+
+	if got := filepath.Dir(file.Name()); got != dir {
+		t.Errorf("output directory = %q, want %q", got, dir)
+	}
+	if base := filepath.Base(file.Name()); !strings.HasPrefix(base, "flamegraph_") || !strings.HasSuffix(base, ".svg") {
+		t.Errorf("output filename %q does not preserve prefix and extension", base)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close output file: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a cryptographically random suffix to timestamped profiling output filenames
- create output files with `O_CREATE|O_EXCL` so an existing profile is never silently truncated
- add focused tests for unique names, preservation of earlier content, and nested output-directory creation

## Root cause and impact

`createOutputFile` used second-resolution `time.Now().Unix()` filenames together with `os.Create`. Two exports with the same prefix and extension in one second selected the same path, and the later export truncated the earlier result.

The change keeps the existing prefix, timestamp, and extension convention while making each output path unique and enforcing exclusive creation.

## Validation

- `go test -count=10 -run '^TestCreateOutputFile' export.go export_test.go` (passed on Windows)
- `git diff --check` (passed)
- package-level `go test -count=1 -run '^TestCreateOutputFile' ./internal/profiler/aggregator` is blocked during package setup because the checkout does not contain generated `internal/bpf/abi`; no test case ran or failed

This is pure Go user-space code. No privileged Docker, eBPF loading, or kernel-specific runtime validation is required.

Closes #485