### PR TITLE
fix(metrics): restore disk IO CI checks

### DIFF
--- a/core/metrics/disk_io.go
+++ b/core/metrics/disk_io.go
@@ -189,7 +189,8 @@ func (c *diskIOCollector) collectDiskstats() ([]*metric.Data, error) {
 	var metrics []*metric.Data
 	now := time.Now()
 
-	for _, ds := range diskstats {
+	for i := range diskstats {
+		ds := &diskstats[i]
 		device := ds.DeviceName
 
 		deviceLabel := map[string]string{"device": device}
@@ -204,10 +205,6 @@ func (c *diskIOCollector) collectDiskstats() ([]*metric.Data, error) {
 				"Total number of bytes read from the device.", deviceLabel),
 			metric.NewCounterData("disk_written_bytes_total", float64(ds.WriteSectors)*sectorSize,
 				"Total number of bytes written to the device.", deviceLabel),
-		)
-
-		// Gauge: current queue depth.
-		metrics = append(metrics,
 			metric.NewGaugeData("disk_io_in_progress", float64(ds.IOsInProgress),
 				"Number of I/O requests currently in flight (queue depth).", deviceLabel),
 		)

--- a/core/metrics/disk_io_test.go
+++ b/core/metrics/disk_io_test.go
@@ -40,8 +40,8 @@ func mockProcFS(t *testing.T, diskstats, stat string) string {
 	sysDir := filepath.Join(tmpDir, "sys")
 	require.NoError(t, os.MkdirAll(sysDir, 0o755))
 
-	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"), []byte(diskstats), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(stat), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"), []byte(diskstats), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(stat), 0o600))
 
 	return tmpDir
 }
@@ -205,7 +205,7 @@ func TestDiskIOCollector_CounterReset(t *testing.T) {
 	sysDir := filepath.Join(tmpDir, "sys")
 	require.NoError(t, os.MkdirAll(procDir, 0o755))
 	require.NoError(t, os.MkdirAll(sysDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(testStat), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(testStat), 0o600))
 
 	originalPrefix := filepath.Dir(procfs.DefaultPath())
 	t.Cleanup(func() { procfs.RootPrefix(originalPrefix) })
@@ -213,7 +213,7 @@ func TestDiskIOCollector_CounterReset(t *testing.T) {
 
 	// First diskstats: high values.
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"),
-		[]byte("   8       0 sda 1000 200 50000 3000 2000 400 80000 6000 50 9000 15000\n"), 0o644))
+		[]byte("   8       0 sda 1000 200 50000 3000 2000 400 80000 6000 50 9000 15000\n"), 0o600))
 
 	devFS, err := blockdevice.NewDefaultFS()
 	require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestDiskIOCollector_CounterReset(t *testing.T) {
 
 	// Second diskstats: counters DECREASED (simulating reset).
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"),
-		[]byte("   8       0 sda 500 100 25000 1500 1000 200 40000 3000 25 4500 7500\n"), 0o644))
+		[]byte("   8       0 sda 500 100 25000 1500 1000 200 40000 3000 25 4500 7500\n"), 0o600))
 
 	// Re-create devFS to pick up new file.
 	devFS, err = blockdevice.NewDefaultFS()
@@ -257,7 +257,7 @@ func TestDiskIOCollector_LatencyComputation(t *testing.T) {
 	sysDir := filepath.Join(tmpDir, "sys")
 	require.NoError(t, os.MkdirAll(procDir, 0o755))
 	require.NoError(t, os.MkdirAll(sysDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(testStat), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(testStat), 0o600))
 
 	originalPrefix := filepath.Dir(procfs.DefaultPath())
 	t.Cleanup(func() { procfs.RootPrefix(originalPrefix) })
@@ -265,7 +265,7 @@ func TestDiskIOCollector_LatencyComputation(t *testing.T) {
 
 	// First diskstats: readIOs=1000, readTicks=3000; writeIOs=2000, writeTicks=6000.
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"),
-		[]byte("   8       0 sda 1000 200 50000 3000 2000 400 80000 6000 50 9000 15000\n"), 0o644))
+		[]byte("   8       0 sda 1000 200 50000 3000 2000 400 80000 6000 50 9000 15000\n"), 0o600))
 
 	devFS, err := blockdevice.NewDefaultFS()
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestDiskIOCollector_LatencyComputation(t *testing.T) {
 	// Second diskstats: readIOs increased by 100, readTicks by 500 → avg latency = 5ms.
 	// writeIOs increased by 200, writeTicks by 1000 → avg latency = 5ms.
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"),
-		[]byte("   8       0 sda 1100 200 55000 3500 2200 400 90000 7000 50 9000 15000\n"), 0o644))
+		[]byte("   8       0 sda 1100 200 55000 3500 2200 400 90000 7000 50 9000 15000\n"), 0o600))
 
 	// Re-create devFS to pick up new file.
 	devFS, err = blockdevice.NewDefaultFS()
@@ -324,7 +324,7 @@ func TestDiskIOCollector_ZeroTicks(t *testing.T) {
 	sysDir := filepath.Join(tmpDir, "sys")
 	require.NoError(t, os.MkdirAll(procDir, 0o755))
 	require.NoError(t, os.MkdirAll(sysDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(testStat), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(procDir, "stat"), []byte(testStat), 0o600))
 
 	originalPrefix := filepath.Dir(procfs.DefaultPath())
 	t.Cleanup(func() { procfs.RootPrefix(originalPrefix) })
@@ -332,7 +332,7 @@ func TestDiskIOCollector_ZeroTicks(t *testing.T) {
 
 	// First diskstats: readIOs=1000, readTicks=0 (no IO accounting).
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"),
-		[]byte("   8       0 sda 1000 200 50000 0 2000 400 80000 0 50 9000 15000\n"), 0o644))
+		[]byte("   8       0 sda 1000 200 50000 0 2000 400 80000 0 50 9000 15000\n"), 0o600))
 
 	devFS, err := blockdevice.NewDefaultFS()
 	require.NoError(t, err)
@@ -351,7 +351,7 @@ func TestDiskIOCollector_ZeroTicks(t *testing.T) {
 
 	// Second diskstats: IOs increased but ticks still 0.
 	require.NoError(t, os.WriteFile(filepath.Join(procDir, "diskstats"),
-		[]byte("   8       0 sda 1100 200 55000 0 2200 400 90000 0 50 9000 15000\n"), 0o644))
+		[]byte("   8       0 sda 1100 200 55000 0 2200 400 90000 0 50 9000 15000\n"), 0o600))
 
 	// Re-create devFS to pick up new file.
 	devFS, err = blockdevice.NewDefaultFS()

--- a/integration/test_autotracing_cpusys.sh
+++ b/integration/test_autotracing_cpusys.sh
@@ -33,7 +33,10 @@ readonly CPUSYS_PROC_STAT="${CPUSYS_FIXTURE_ROOT}/proc/stat"
 readonly CPUSYS_EVENT="${HUATUO_BAMAI_TEST_TMPDIR}/events/cpusys"
 export CPUSYS_PERF_CALLS_FILE="${HUATUO_BAMAI_TEST_TMPDIR}/perf.calls"
 
-mkdir -p "${CPUSYS_FIXTURE_ROOT}/proc" "${CPUSYS_FIXTURE_ROOT}/tools"
+mkdir -p \
+	"${CPUSYS_FIXTURE_ROOT}/proc" \
+	"${CPUSYS_FIXTURE_ROOT}/sys" \
+	"${CPUSYS_FIXTURE_ROOT}/tools"
 # Sample 1: user=100, nice=0, system=100, idle=800, total=1000.
 # The daemon reads this initial value before starting its sampling ticker.
 cp "${HUATUO_BAMAI_TEST_FIXTURES}/proc/stat" "${CPUSYS_PROC_STAT}"


### PR DESCRIPTION
## Summary

- avoid copying large diskstats values and combine adjacent metric appends
- use owner-only permissions for disk IO test fixture files
- provide the sysfs directory required when disk IO initializes in the cpusys integration fixture

## Why

The disk IO collector merged into main left both required CI workflows red. The build lane reported gocritic and gosec violations in core/metrics/disk_io*, while every VM lane failed to start huatuo-bamai because test_autotracing_cpusys.sh supplied a procfs prefix without the sys directory now required by blockdevice.NewDefaultFS.

Failing main workflows:

- https://github.com/ccfos/huatuo/actions/runs/30448126261
- https://github.com/ccfos/huatuo/actions/runs/30448126225

## Testing

- go test ./core/metrics -run TestDiskIOCollector -count=1 -timeout=5m
- make check
- make all
- bash integration/run.sh test_autotracing_cpusys.sh
- make unit (all relevant packages pass; this WSL environment still lacks tracefs for existing BPF attach tests and cgroup v1 cpuacct.stat for internal/cgroups)