### PR TITLE
test(tracing): cover document subscriptions

### DIFF
--- a/pkg/tracing/watch_test.go
+++ b/pkg/tracing/watch_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSubscribeReceivesDocumentsAndStopsAfterCancel(t *testing.T) {
+	first, cancelFirst := Subscribe()
+	defer cancelFirst()
+	second, cancelSecond := Subscribe()
+	defer cancelSecond()
+
+	firstDocument := &Document{TracerID: "trace-first"}
+	NotifySubscribers(firstDocument)
+	for _, ch := range []<-chan *Document{first, second} {
+		select {
+		case got := <-ch:
+			if got != firstDocument {
+				t.Errorf("received document = %p, want %p", got, firstDocument)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for document notification")
+		}
+	}
+
+	cancelFirst()
+	secondDocument := &Document{TracerID: "trace-second"}
+	NotifySubscribers(secondDocument)
+	select {
+	case got := <-second:
+		if got != secondDocument {
+			t.Errorf("received document = %p, want %p", got, secondDocument)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for active subscriber")
+	}
+	select {
+	case got := <-first:
+		t.Errorf("cancelled subscriber received document = %p", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Summary

- Add coverage for the tracing document subscription wrapper.
- Verify fan-out delivery and cancellation behavior.

## Why

Consumers rely on tracing notifications for live document updates, so the package-level subscription contract needs regression coverage.

## Validation

- `git show --check`
- Go tests not run: this workspace has no Go toolchain.
