### PR TITLE
fix(docs): use repository links for docs

### DIFF
--- a/docs/best-practice/storage_en.md
+++ b/docs/best-practice/storage_en.md
@@ -104,7 +104,7 @@ docker logs opensearch
 
 #### 3. Configure huatuo-bamai
 
-Add the following configuration to `huatuo-bamai.conf`. The default username and password for the OpenSearch container image are both `admin`. For a full description of storage configuration options, see the [Configuration Guide](../configuration/huatuo-bamai-configuration_en.md).
+Add the following configuration to `huatuo-bamai.conf`. The default username and password for the OpenSearch container image are both `admin`. For a full description of storage configuration options, see the [Configuration Guide](/docs/configuration/huatuo-bamai-configuration_en.md).
 
 ```toml
 [Storage.Elasticsearch]
@@ -228,7 +228,7 @@ Example response:
 
 #### 3. Configure huatuo-bamai
 
-Add the following configuration to `huatuo-bamai.conf`. The default username for the Elasticsearch container image is `elastic`; the password is set via the `ELASTIC_PASSWORD` environment variable. For a full description of storage configuration options, see the [Configuration Guide](../configuration/huatuo-bamai-configuration_en.md).
+Add the following configuration to `huatuo-bamai.conf`. The default username for the Elasticsearch container image is `elastic`; the password is set via the `ELASTIC_PASSWORD` environment variable. For a full description of storage configuration options, see the [Configuration Guide](/docs/configuration/huatuo-bamai-configuration_en.md).
 
 ```toml
 [Storage.Elasticsearch]

--- a/docs/best-practice/storage_zh.md
+++ b/docs/best-practice/storage_zh.md
@@ -104,7 +104,7 @@ docker logs opensearch
 
 #### 3. 配置 huatuo-bamai
 
-在 `huatuo-bamai.conf` 中添加以下配置。OpenSearch 容器镜像默认用户名和密码均为 `admin`。存储配置的详细说明请参见[配置指南](../configuration/huatuo-bamai-configuration_zh.md)。
+在 `huatuo-bamai.conf` 中添加以下配置。OpenSearch 容器镜像默认用户名和密码均为 `admin`。存储配置的详细说明请参见[配置指南](/docs/configuration/huatuo-bamai-configuration_zh.md)。
 
 ```toml
 [Storage.Elasticsearch]
@@ -227,7 +227,7 @@ curl -k -u elastic:123456 https://localhost:9200
 
 #### 3. 配置 huatuo-bamai
 
-在 `huatuo-bamai.conf` 中添加以下配置。Elasticsearch 容器镜像默认用户名为 `elastic`，密码通过环境变量 `ELASTIC_PASSWORD` 设置。存储配置的详细说明请参见[配置指南](../configuration/huatuo-bamai-configuration_zh.md)。
+在 `huatuo-bamai.conf` 中添加以下配置。Elasticsearch 容器镜像默认用户名为 `elastic`，密码通过环境变量 `ELASTIC_PASSWORD` 设置。存储配置的详细说明请参见[配置指南](/docs/configuration/huatuo-bamai-configuration_zh.md)。
 
 ```toml
 [Storage.Elasticsearch]

--- a/docs/deployment/docker_en.md
+++ b/docs/deployment/docker_en.md
@@ -1,5 +1,5 @@
 ---
-title: Docker Compose
+title: Docker
 type: docs
 description: 
 author: HUATUO Team
@@ -19,12 +19,12 @@ $ docker run --privileged --pid=host --cgroupns=host --network=host -v /sys:/sys
 
 > ⚠️ When this method is used, the container relies on the built-in default configuration file. That configuration does not connect to the kubelet or Elasticsearch.
 
-### Start containers with Docker Compose
+### Start containers with Docker
 
-[Docker Compose](https://docs.docker.com/compose/) allows you to quickly set up a complete local environment where you manage the collector, Elasticsearch, Prometheus, Grafana, and other components yourself.
+The `docker compose` command allows you to quickly set up a complete local environment where you manage the collector, Elasticsearch, Prometheus, Grafana, and other components yourself.
 
 ```bash
 $ docker compose --project-directory ./build/docker up
 ```
 
-For Docker Compose installation instructions, see https://docs.docker.com/compose/install/linux/.
+For installation instructions, see https://docs.docker.com/compose/install/linux/.

--- a/docs/deployment/kubernetes_en.md
+++ b/docs/deployment/kubernetes_en.md
@@ -19,7 +19,7 @@ curl -L -o huatuo-bamai.conf https://github.com/ccfos/huatuo/raw/main/huatuo-bam
 
 ### 1.2 Modify the configuration file
 
-Modify the configuration file for the deployment environment. For example, configure the storage backend and the method used to obtain Pod information. See the [Configuration Guide](../configuration/huatuo-bamai-configuration_en.md) for details.
+Modify the configuration file for the deployment environment. For example, configure the storage backend and the method used to obtain Pod information. See the [Configuration Guide](/docs/configuration/huatuo-bamai-configuration_en.md) for details.
 
 ### 1.3 Create the ConfigMap
 

--- a/docs/deployment/kubernetes_zh.md
+++ b/docs/deployment/kubernetes_zh.md
@@ -19,7 +19,7 @@ curl -L -o huatuo-bamai.conf https://github.com/ccfos/huatuo/raw/main/huatuo-bam
 
 ### 1.2 修改配置文件
 
-根据实际部署环境修改配置文件，例如调整存储后端、Pod 信息获取方式等配置项，详见[配置指南](../configuration/huatuo-bamai-configuration_zh.md)。
+根据实际部署环境修改配置文件，例如调整存储后端、Pod 信息获取方式等配置项，详见[配置指南](/docs/configuration/huatuo-bamai-configuration_zh.md)。
 
 ### 1.3 创建 ConfigMap
 

--- a/docs/deployment/systemd_en.md
+++ b/docs/deployment/systemd_en.md
@@ -64,7 +64,7 @@ sudo wget -O /etc/systemd/system/huatuo-apiserver.service "https://raw.githubuse
 
 ### 4. Modify the configurations
 
-Edit `/opt/huatuo-bamai/conf/huatuo-bamai.conf` and `/opt/huatuo-bamai/conf/huatuo-apiserver.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](../configuration/huatuo-bamai-configuration_en.md) and [`huatuo-apiserver` configuration](../configuration/huatuo-apiserver-configuration_en.md).
+Edit `/opt/huatuo-bamai/conf/huatuo-bamai.conf` and `/opt/huatuo-bamai/conf/huatuo-apiserver.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](/docs/configuration/huatuo-bamai-configuration_en.md) and [`huatuo-apiserver` configuration](/docs/configuration/huatuo-apiserver-configuration_en.md).
 
 ### 5. Register the HUATUO services
 
@@ -118,7 +118,7 @@ sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 
 ### 3. Modify the configuration
 
-Edit `/etc/huatuo-bamai/huatuo-bamai.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](../configuration/huatuo-bamai-configuration_en.md).
+Edit `/etc/huatuo-bamai/huatuo-bamai.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](/docs/configuration/huatuo-bamai-configuration_en.md).
 
 ### 4. Start the HUATUO service
 

--- a/docs/deployment/systemd_zh.md
+++ b/docs/deployment/systemd_zh.md
@@ -64,7 +64,7 @@ sudo wget -O /etc/systemd/system/huatuo-apiserver.service "https://raw.githubuse
 
 ### 4. 修改配置
 
-根据实际部署环境编辑 `/opt/huatuo-bamai/conf/huatuo-bamai.conf` 和 `/opt/huatuo-bamai/conf/huatuo-apiserver.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](../configuration/huatuo-bamai-configuration_zh.md) 和 [`huatuo-apiserver` 配置](../configuration/huatuo-apiserver-configuration_zh.md)。
+根据实际部署环境编辑 `/opt/huatuo-bamai/conf/huatuo-bamai.conf` 和 `/opt/huatuo-bamai/conf/huatuo-apiserver.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](/docs/configuration/huatuo-bamai-configuration_zh.md) 和 [`huatuo-apiserver` 配置](/docs/configuration/huatuo-apiserver-configuration_zh.md)。
 
 ### 5. 注册 HUATUO 服务
 
@@ -118,7 +118,7 @@ sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 
 ### 3. 修改配置
 
-根据实际部署环境编辑 `/etc/huatuo-bamai/huatuo-bamai.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](../configuration/huatuo-bamai-configuration_zh.md)。
+根据实际部署环境编辑 `/etc/huatuo-bamai/huatuo-bamai.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](/docs/configuration/huatuo-bamai-configuration_zh.md)。
 
 ### 4. 启动 HUATUO 服务
 


### PR DESCRIPTION
## Summary

- Keep source documentation links GitHub-readable by using `/docs/...` paths for internal HUATUO docs.
- Update deployment and storage docs to point configuration guide links at `/docs/configuration/*_<lang>.md`.
- Keep the English Docker deployment title and prose simplified from Docker Compose to Docker.

## Related PR

- Requires the companion huatuo-web sync update: https://github.com/hao022/huatuo-web/pull/1

## Validation

- `git diff --check origin/main...HEAD`
- Verified source docs no longer contain published-site configuration URLs or `../configuration` links.
- Synced this branch into huatuo-web with `./sync.sh /private/tmp/huatuo-docs-pr`.
- Started local huatuo-web preview and verified link navigation:
  - `/en/latest/deployment/kubernetes/` -> `/en/latest/configuration/huatuo-bamai-configuration/`
  - `/zh/latest/deployment/kubernetes/` -> `/zh/latest/configuration/huatuo-bamai-configuration/`
  - `/en/latest/deployment/systemd/` -> `/en/latest/configuration/huatuo-apiserver-configuration/`
  - `/zh/latest/deployment/systemd/` -> `/zh/latest/configuration/huatuo-apiserver-configuration/`
