### PR TITLE
fix: repair container cpuset count error

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -19,9 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"os"
-	"runtime"
 	"time"
 
 	"huatuo-bamai/internal/cgroups"
@@ -30,6 +28,7 @@ import (
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/matcher"
 	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/internal/utils/cpuutil"
 	"huatuo-bamai/pkg/tracing"
 	"huatuo-bamai/pkg/types"
 )
@@ -77,6 +76,7 @@ type cpuIdleTracing struct {
 	threshold        cpuIdleThreshold
 	filter           *matcher.ContainerMatcher
 	containers       map[string]*containerCPUState
+	hostCPUCount     uint64
 }
 
 type containerCPUState struct {
@@ -139,6 +139,10 @@ func newCPUIdleTracing(
 	if err != nil {
 		return nil, fmt.Errorf("build container filter: %w", err)
 	}
+	hostCPUCount, err := cpuutil.HostOnlineCPUCount()
+	if err != nil {
+		return nil, fmt.Errorf("read online CPUs: %w", err)
+	}
 
 	return &cpuIdleTracing{
 		cgroupReader:     cgroupReader,
@@ -148,6 +152,7 @@ func newCPUIdleTracing(
 		threshold:        threshold,
 		filter:           filter,
 		containers:       make(map[string]*containerCPUState),
+		hostCPUCount:     hostCPUCount,
 	}, nil
 }
 
@@ -218,20 +223,6 @@ func cpuUsageDelta(
 		system: current.system - previous.system,
 		total:  current.total - previous.total,
 	}, true
-}
-
-func containerCPUCapacity(quota *stats.CpuQuota) (float64, error) {
-	if quota.Quota == math.MaxUint64 {
-		return float64(runtime.NumCPU()), nil
-	}
-	if quota.Quota == 0 {
-		return 0, fmt.Errorf("container cpu quota must be positive")
-	}
-	if quota.Period == 0 {
-		return 0, fmt.Errorf("container cpu period must be positive")
-	}
-
-	return float64(quota.Quota) / float64(quota.Period), nil
 }
 
 func (s *containerCPUState) update(
@@ -333,7 +324,10 @@ func (c *cpuIdleTracing) readContainerCPUSample(
 		return cpuUsageBreakdown[uint64]{}, 0,
 			fmt.Errorf("read cpu quota for %q: %w", state.containerID, err)
 	}
-	capacity, err := containerCPUCapacity(quota)
+	capacity, err := cpuutil.CPUCapacity(
+		quota.Quota, quota.Period,
+		quota.EffectiveCPUCount, c.hostCPUCount,
+	)
 	if err != nil {
 		return cpuUsageBreakdown[uint64]{}, 0,
 			fmt.Errorf("calculate cpu capacity for %q: %w", state.containerID, err)

--- a/core/autotracing/cpuidle_test.go
+++ b/core/autotracing/cpuidle_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"math"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"huatuo-bamai/internal/cgroups"
 	"huatuo-bamai/internal/cgroups/stats"
 	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/internal/utils/cpuutil"
 )
 
 type stubContainerCPUReader struct {
@@ -177,29 +177,34 @@ func TestContainerCPUCapacity(t *testing.T) {
 		wantError string
 	}{
 		{
-			name:  "half cpu",
-			quota: stats.CpuQuota{Quota: 50_000, Period: 100_000},
+			name:  "quota below cpuset",
+			quota: stats.CpuQuota{Quota: 50_000, Period: 100_000, EffectiveCPUCount: 4},
 			want:  0.5,
 		},
 		{
-			name:  "one and a half cpus",
-			quota: stats.CpuQuota{Quota: 150_000, Period: 100_000},
-			want:  1.5,
+			name:  "quota above cpuset",
+			quota: stats.CpuQuota{Quota: 150_000, Period: 100_000, EffectiveCPUCount: 1},
+			want:  1,
 		},
 		{
 			name:  "unlimited",
-			quota: stats.CpuQuota{Quota: math.MaxUint64},
-			want:  float64(runtime.NumCPU()),
+			quota: stats.CpuQuota{Quota: math.MaxUint64, EffectiveCPUCount: 4},
+			want:  4,
 		},
 		{
 			name:      "zero quota",
-			quota:     stats.CpuQuota{Period: 100_000},
+			quota:     stats.CpuQuota{Period: 100_000, EffectiveCPUCount: 1},
 			wantError: "quota must be positive",
 		},
 		{
 			name:      "zero period",
-			quota:     stats.CpuQuota{Quota: 100_000},
+			quota:     stats.CpuQuota{Quota: 100_000, EffectiveCPUCount: 1},
 			wantError: "period must be positive",
+		},
+		{
+			name:      "zero effective CPU count",
+			quota:     stats.CpuQuota{Quota: math.MaxUint64},
+			wantError: "effective CPU count must be positive",
 		},
 	}
 
@@ -207,18 +212,21 @@ func TestContainerCPUCapacity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual, err := containerCPUCapacity(&tt.quota)
+			actual, err := cpuutil.CPUCapacity(
+				tt.quota.Quota, tt.quota.Period,
+				tt.quota.EffectiveCPUCount, 0,
+			)
 			if tt.wantError != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
-					t.Fatalf("containerCPUCapacity() error = %v, want contain %q", err, tt.wantError)
+					t.Fatalf("cpuutil.CPUCapacity() error = %v, want contain %q", err, tt.wantError)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("containerCPUCapacity() error = %v", err)
+				t.Fatalf("cpuutil.CPUCapacity() error = %v", err)
 			}
 			if actual != tt.want {
-				t.Errorf("containerCPUCapacity() = %v, want %v", actual, tt.want)
+				t.Errorf("cpuutil.CPUCapacity() = %v, want %v", actual, tt.want)
 			}
 		})
 	}
@@ -395,8 +403,8 @@ func TestCPUIdleTracingSelectTraceTarget(t *testing.T) {
 			"b": {},
 		},
 		quota: map[string]stats.CpuQuota{
-			"a": {Quota: 100_000, Period: 100_000},
-			"b": {Quota: 100_000, Period: 100_000},
+			"a": {Quota: 100_000, Period: 100_000, EffectiveCPUCount: 1},
+			"b": {Quota: 100_000, Period: 100_000, EffectiveCPUCount: 1},
 		},
 	}
 	tracer := &cpuIdleTracing{

--- a/core/metrics/cpu_util.go
+++ b/core/metrics/cpu_util.go
@@ -15,9 +15,8 @@
 package collector
 
 import (
-	"math"
+	"fmt"
 	"reflect"
-	"runtime"
 	"sync"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"huatuo-bamai/internal/cgroups/stats"
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/internal/utils/cpuutil"
 	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 )
@@ -55,9 +55,14 @@ func newCpuCollector() (*tracing.EventTracingAttr, error) {
 		return nil, err
 	}
 
+	numCores, err := cpuutil.HostOnlineCPUCount()
+	if err != nil {
+		return nil, fmt.Errorf("read online CPUs: %w", err)
+	}
+
 	return &tracing.EventTracingAttr{
 		TracingData: &cpuUtilCollector{
-			numCores: float64(runtime.NumCPU()),
+			numCores: float64(numCores),
 			cgroup:   cgroup,
 		},
 		Flag: tracing.FlagMetric,
@@ -140,14 +145,12 @@ func (c *cpuUtilCollector) Update() ([]*metric.Data, error) {
 			continue
 		}
 
-		var numCores float64
-		if cpuQuota.Quota == math.MaxUint64 {
-			numCores = float64(runtime.NumCPU())
-		} else {
-			numCores = float64(cpuQuota.Quota) / float64(cpuQuota.Period)
-		}
-
-		if numCores <= 0 {
+		numCores, err := cpuutil.CPUCapacity(
+			cpuQuota.Quota, cpuQuota.Period,
+			cpuQuota.EffectiveCPUCount, uint64(c.numCores),
+		)
+		if err != nil {
+			log.Infof("calculate cpu capacity for container [%s]: %v", container, err)
 			continue
 		}
 
@@ -156,16 +159,17 @@ func (c *cpuUtilCollector) Update() ([]*metric.Data, error) {
 			log.Warnf("cpu_util: LifeResources for container %s returned unexpected type or nil", container)
 			continue
 		}
-		containerDataCache := dataCache
-		if err := c.updateDataCache(containerDataCache, container, numCores); err != nil {
+		if err := c.updateDataCache(dataCache, container, numCores); err != nil {
 			log.Infof("failed to update cpu info of %s, %v", container, err)
 			continue
 		}
 
-		metrics = append(metrics, metric.NewContainerGaugeData(container, "cores", numCores, "cpu core number for the containers", nil),
-			metric.NewContainerGaugeData(container, "usr", containerDataCache.usrUtil, "cpu usr for the containers", nil),
-			metric.NewContainerGaugeData(container, "sys", containerDataCache.sysUtil, "cpu sys for the containers", nil),
-			metric.NewContainerGaugeData(container, "total", containerDataCache.totalUtil, "cpu total for the containers", nil))
+		metrics = append(metrics,
+			metric.NewContainerGaugeData(container, "cores", numCores, "cpu core number for the containers", nil),
+			metric.NewContainerGaugeData(container, "usr", dataCache.usrUtil, "cpu usr for the containers", nil),
+			metric.NewContainerGaugeData(container, "sys", dataCache.sysUtil, "cpu sys for the containers", nil),
+			metric.NewContainerGaugeData(container, "total", dataCache.totalUtil, "cpu total for the containers", nil),
+		)
 	}
 
 	more, err := c.updateHostDataCache()

--- a/internal/cgroups/stats/stats.go
+++ b/internal/cgroups/stats/stats.go
@@ -22,8 +22,9 @@ type CpuUsage struct {
 }
 
 type CpuQuota struct {
-	Quota  uint64
-	Period uint64
+	Quota             uint64
+	Period            uint64
+	EffectiveCPUCount uint64
 }
 
 type MemoryUsage struct {

--- a/internal/cgroups/v1/cgroups.go
+++ b/internal/cgroups/v1/cgroups.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"errors"
+	"io/fs"
 	"math"
 	"syscall"
 
@@ -23,6 +24,7 @@ import (
 	"huatuo-bamai/internal/cgroups/pids"
 	"huatuo-bamai/internal/cgroups/stats"
 	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/utils/cpuutil"
 	"huatuo-bamai/internal/utils/parseutil"
 
 	extv1 "github.com/containerd/cgroups/v3/cgroup1"
@@ -127,17 +129,28 @@ func (c *CgroupV1) CpuQuotaAndPeriod(path string) (*stats.CpuQuota, error) {
 		return nil, err
 	}
 
+	effectiveCPUCount, err := readEffectiveCPUCount(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
 	if quota == -1 {
 		return &stats.CpuQuota{
-			Quota:  math.MaxUint64,
-			Period: period,
+			Quota:             math.MaxUint64,
+			Period:            period,
+			EffectiveCPUCount: effectiveCPUCount,
 		}, nil
 	}
 
 	return &stats.CpuQuota{
-		Quota:  uint64(quota),
-		Period: period,
+		Quota:             uint64(quota),
+		Period:            period,
+		EffectiveCPUCount: effectiveCPUCount,
 	}, nil
+}
+
+func readEffectiveCPUCount(path string) (uint64, error) {
+	return cpuutil.CPUSetCount(paths.Path(subsystem.SubsystemCPUSet, path, "cpuset.cpus"))
 }
 
 func (c *CgroupV1) MemoryStatRaw(path string) (map[string]uint64, error) {

--- a/internal/cgroups/v1/cgroups_test.go
+++ b/internal/cgroups/v1/cgroups_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/cgroups/paths"
+	"huatuo-bamai/internal/cgroups/subsystem"
+)
+
+func TestCpuQuotaAndPeriodEffectiveCPUCount(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := paths.RootfsDefaultPath
+	paths.RootfsDefaultPath = root
+	t.Cleanup(func() { paths.RootfsDefaultPath = oldRoot })
+
+	tests := []struct {
+		name   string
+		cpuset string
+		want   uint64
+	}{
+		{name: "cpuset", cpuset: "0-3", want: 4},
+		{name: "missing", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join("test", tt.name)
+			writeCgroupFile(t, paths.Path(subsystem.SubsystemCPU, path, "cpu.cfs_period_us"), "100000\n")
+			writeCgroupFile(t, paths.Path(subsystem.SubsystemCPU, path, "cpu.cfs_quota_us"), "-1\n")
+			if tt.cpuset != "" {
+				writeCgroupFile(t, paths.Path(subsystem.SubsystemCPUSet, path, "cpuset.cpus"), tt.cpuset+"\n")
+			}
+
+			quota, err := (&CgroupV1{}).CpuQuotaAndPeriod(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if quota.EffectiveCPUCount != tt.want {
+				t.Errorf("EffectiveCPUCount = %d, want %d", quota.EffectiveCPUCount, tt.want)
+			}
+		})
+	}
+}
+
+func writeCgroupFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cgroups/v2/cgroups.go
+++ b/internal/cgroups/v2/cgroups.go
@@ -16,7 +16,9 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"strconv"
 
@@ -24,6 +26,7 @@ import (
 	"huatuo-bamai/internal/cgroups/pids"
 	"huatuo-bamai/internal/cgroups/stats"
 	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/utils/cpuutil"
 	"huatuo-bamai/internal/utils/parseutil"
 
 	extv2 "github.com/containerd/cgroups/v3/cgroup2"
@@ -169,8 +172,17 @@ func (c *CgroupV2) CpuQuotaAndPeriod(path string) (*stats.CpuQuota, error) {
 		return nil, err
 	}
 
+	effectiveCPUCount, err := readEffectiveCPUCount(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
 	if maxQuota == "max" {
-		return &stats.CpuQuota{Quota: math.MaxUint64, Period: period}, nil
+		return &stats.CpuQuota{
+			Quota:             math.MaxUint64,
+			Period:            period,
+			EffectiveCPUCount: effectiveCPUCount,
+		}, nil
 	}
 
 	quota, err := strconv.ParseUint(maxQuota, 10, 64)
@@ -178,7 +190,15 @@ func (c *CgroupV2) CpuQuotaAndPeriod(path string) (*stats.CpuQuota, error) {
 		return nil, err
 	}
 
-	return &stats.CpuQuota{Quota: quota, Period: period}, nil
+	return &stats.CpuQuota{
+		Quota:             quota,
+		Period:            period,
+		EffectiveCPUCount: effectiveCPUCount,
+	}, nil
+}
+
+func readEffectiveCPUCount(path string) (uint64, error) {
+	return cpuutil.CPUSetCount(paths.Path(path, "cpuset.cpus.effective"))
 }
 
 func (c *CgroupV2) MemoryStatRaw(path string) (map[string]uint64, error) {

--- a/internal/cgroups/v2/cgroups_test.go
+++ b/internal/cgroups/v2/cgroups_test.go
@@ -15,7 +15,11 @@
 package v2
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"huatuo-bamai/internal/cgroups/paths"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -298,5 +302,54 @@ func TestUpdateRuntimeEmptySpecNoDbusCall(t *testing.T) {
 func TestPostfixConstant(t *testing.T) {
 	if Postfix != ".slice" {
 		t.Errorf("Postfix: got %q, want %q", Postfix, ".slice")
+	}
+}
+
+func TestCpuQuotaAndPeriodEffectiveCPUCount(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := paths.RootfsDefaultPath
+	paths.RootfsDefaultPath = root
+	t.Cleanup(func() { paths.RootfsDefaultPath = oldRoot })
+
+	tests := []struct {
+		name      string
+		effective string
+		requested string
+		want      uint64
+	}{
+		{name: "effective", effective: "0-3", requested: "0-7", want: 4},
+		{name: "requested ignored", requested: "0-1", want: 0},
+		{name: "missing", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join("test", tt.name)
+			writeCgroupFile(t, paths.Path(path, "cpu.max"), "max 100000\n")
+			if tt.effective != "" {
+				writeCgroupFile(t, paths.Path(path, "cpuset.cpus.effective"), tt.effective+"\n")
+			}
+			if tt.requested != "" {
+				writeCgroupFile(t, paths.Path(path, "cpuset.cpus"), tt.requested+"\n")
+			}
+
+			quota, err := (&CgroupV2{}).CpuQuotaAndPeriod(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if quota.EffectiveCPUCount != tt.want {
+				t.Errorf("EffectiveCPUCount = %d, want %d", quota.EffectiveCPUCount, tt.want)
+			}
+		})
+	}
+}
+
+func writeCgroupFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/utils/cpuutil/cpuset.go
+++ b/internal/utils/cpuutil/cpuset.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpuutil
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const hostOnlineCPUPath = "/sys/devices/system/cpu/online"
+
+// HostOnlineCPUCount returns the number of online logical CPUs on the host.
+func HostOnlineCPUCount() (uint64, error) {
+	return CPUSetCount(hostOnlineCPUPath)
+}
+
+// CPUSetCount returns the number of CPUs described by a Linux CPU list file.
+func CPUSetCount(path string) (uint64, error) {
+	v, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	var count uint64
+	for _, item := range strings.Split(strings.TrimSpace(string(v)), ",") {
+		if item == "" {
+			return 0, fmt.Errorf("invalid CPU list %q", string(v))
+		}
+
+		bounds := strings.Split(item, "-")
+		switch len(bounds) {
+		case 1:
+			if _, err := strconv.ParseUint(bounds[0], 10, 64); err != nil {
+				return 0, fmt.Errorf("parse CPU %q: %w", item, err)
+			}
+			count++
+		case 2:
+			first, err := strconv.ParseUint(bounds[0], 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("parse CPU range %q: %w", item, err)
+			}
+			last, err := strconv.ParseUint(bounds[1], 10, 64)
+			if err != nil || last < first {
+				return 0, fmt.Errorf("invalid CPU range %q", item)
+			}
+			width := last - first
+			if count > math.MaxUint64-width-1 {
+				return 0, fmt.Errorf("CPU list count overflow")
+			}
+			count += width + 1
+		default:
+			return 0, fmt.Errorf("invalid CPU range %q", item)
+		}
+	}
+
+	if count == 0 {
+		return 0, fmt.Errorf("empty CPU list")
+	}
+	return count, nil
+}
+
+// CPUCapacity returns the effective CPU capacity after applying quota and cpuset.
+func CPUCapacity(quota, period, effective, fallback uint64) (float64, error) {
+	if effective == 0 {
+		effective = fallback
+	}
+	if effective == 0 {
+		return 0, fmt.Errorf("container effective CPU count must be positive")
+	}
+	if quota == 0 {
+		return 0, fmt.Errorf("container cpu quota must be positive")
+	}
+	if quota == math.MaxUint64 {
+		return float64(effective), nil
+	}
+	if period == 0 {
+		return 0, fmt.Errorf("container cpu period must be positive")
+	}
+	return min(float64(effective), float64(quota)/float64(period)), nil
+}

--- a/internal/utils/cpuutil/cpuset_test.go
+++ b/internal/utils/cpuutil/cpuset_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpuutil
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCPUSetCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "ranges", content: "0-3,8,10-11\n", want: 7},
+		{name: "single", content: "7\n", want: 1},
+		{name: "invalid range", content: "3-1\n", wantErr: true},
+		{name: "empty", content: "\n", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "cpuset")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := CPUSetCount(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("CPUSetCount() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CPUSetCount() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("CPUSetCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCPUCapacityFallback(t *testing.T) {
+	got, err := CPUCapacity(math.MaxUint64, 0, 0, 4)
+	if err != nil {
+		t.Fatalf("CPUCapacity() error = %v", err)
+	}
+	if got != 4 {
+		t.Errorf("CPUCapacity() = %v, want 4", got)
+	}
+}


### PR DESCRIPTION
该指标 huatuo_bamai_cpu_util_container_cores 实际测试含义不对，测试环境如下：

- 内核：6.8.0-106-generic
- cgroup：v2
- 在线逻辑 CPU：0-127，即 128
- Huatuo affinity：0,30-65,94-127，即 71，由 k8s 的 cpu 亲和性决定

当前 Huatuo Pod 的实际 cgroup：

- cpuset.cpus.effective = 0,30-65,94-127   # 71
- cpu.max               = 200000 100000    # 2 CPU，通过 k8s 的 cpu qouta 决定

指标拿到为：

```
huatuo_bamai_cpu_util_container_cores{container_name="compute"} 71
huatuo_bamai_cpu_util_container_cores{container_name="nginx-proxy"} 71
```

且原代码存在问题，当读取不到 qouta 或者 max 的时候，就使用 runtime.NumCPU() 来获取，导致拿到的是 huatuo 本身的 cpu core，即 71。应改为 cores = min(容器 cgroup quota / period, 容器 effective cpuset 数)
