### PR TITLE
feat(bpf): configure kretprobe concurrency

### DIFF
--- a/internal/bpf/bpf_default.go
+++ b/internal/bpf/bpf_default.go
@@ -388,6 +388,16 @@ func (b *defaultBPF) attachWithOptions(opts []AttachOption) error {
 		if !ok {
 			return fmt.Errorf("bpf %s: unknown program %q", b, opt.ProgramName)
 		}
+		isRetprobe := program.programType == ebpf.Kprobe &&
+			program.sectionPrefix == "kretprobe"
+		if err = validateRetprobeMaxActive(opt.RetprobeMaxActive, isRetprobe); err != nil {
+			return fmt.Errorf(
+				"bpf %s: program %q: %w",
+				b,
+				opt.ProgramName,
+				err,
+			)
+		}
 		switch program.programType {
 		case ebpf.TracePoint:
 			// opt.Symbol: <system>/<symbol>
@@ -402,7 +412,12 @@ func (b *defaultBPF) attachWithOptions(opts []AttachOption) error {
 		case ebpf.Kprobe:
 			// opt.Symbol: <symbol>[+<offset>]
 			// opt.Symbol: <symbol>
-			if err = b.attachKprobe(program, opt.Symbol, program.sectionPrefix == "kretprobe"); err != nil {
+			if err = b.attachKprobe(
+				program,
+				opt.Symbol,
+				isRetprobe,
+				opt.RetprobeMaxActive,
+			); err != nil {
 				return fmt.Errorf("attach kprobe: %w", err)
 			}
 		case ebpf.RawTracepoint:
@@ -468,7 +483,12 @@ func (b *defaultBPF) attach() error {
 				return fmt.Errorf("bpf %s: invalid section name: %q", b, program.sectionName)
 			}
 
-			if err = b.attachKprobe(program, symbols[1], symbols[0] == "kretprobe"); err != nil {
+			if err = b.attachKprobe(
+				program,
+				symbols[1],
+				symbols[0] == "kretprobe",
+				0,
+			); err != nil {
 				return fmt.Errorf("attach kprobe: %w", err)
 			}
 		case ebpf.RawTracepoint:
@@ -489,7 +509,38 @@ func (b *defaultBPF) attach() error {
 	return nil
 }
 
-func (b *defaultBPF) attachKprobe(program *loadedProgram, symbol string, isRetprobe bool) error {
+func validateRetprobeMaxActive(value int, isRetprobe bool) error {
+	if value < 0 {
+		return fmt.Errorf("retprobe max active must not be negative: %d", value)
+	}
+	if value != 0 && !isRetprobe {
+		return fmt.Errorf(
+			"retprobe max active is valid only for kretprobe programs",
+		)
+	}
+	return nil
+}
+
+func newKprobeOptions(
+	offset uint64,
+	retprobeMaxActive int,
+	isRetprobe bool,
+) (*link.KprobeOptions, error) {
+	if err := validateRetprobeMaxActive(retprobeMaxActive, isRetprobe); err != nil {
+		return nil, err
+	}
+	return &link.KprobeOptions{
+		Offset:            offset,
+		RetprobeMaxActive: retprobeMaxActive,
+	}, nil
+}
+
+func (b *defaultBPF) attachKprobe(
+	program *loadedProgram,
+	symbol string,
+	isRetprobe bool,
+	retprobeMaxActive int,
+) error {
 	if !isRetprobe { // kprobe
 		// : <symbol>[+<offset>]
 		// : <symbol>
@@ -513,10 +564,11 @@ func (b *defaultBPF) attachKprobe(program *loadedProgram, symbol string, isRetpr
 			return fmt.Errorf("bpf %s: duplicate symbol: %q", b, symbol)
 		}
 
-		opts := link.KprobeOptions{
-			Offset: offset,
+		opts, err := newKprobeOptions(offset, retprobeMaxActive, false)
+		if err != nil {
+			return err
 		}
-		l, err := link.Kprobe(symOffsets[0], program.handle, &opts)
+		l, err := link.Kprobe(symOffsets[0], program.handle, opts)
 		if err != nil {
 			return fmt.Errorf("attach kprobe %q: %w", symbol, err)
 		}
@@ -529,7 +581,11 @@ func (b *defaultBPF) attachKprobe(program *loadedProgram, symbol string, isRetpr
 			return fmt.Errorf("bpf %s: duplicate symbol: %q", b, symbol)
 		}
 
-		l, err := link.Kretprobe(symbol, program.handle, nil)
+		opts, err := newKprobeOptions(0, retprobeMaxActive, true)
+		if err != nil {
+			return err
+		}
+		l, err := link.Kretprobe(symbol, program.handle, opts)
 		if err != nil {
 			return fmt.Errorf("attach kretprobe %q: %w", symbol, err)
 		}

--- a/internal/bpf/bpf_default_test.go
+++ b/internal/bpf/bpf_default_test.go
@@ -33,6 +33,7 @@ import (
 	testutils "huatuo-bamai/internal/testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -416,6 +417,62 @@ func TestDefaultBPF_Attach(t *testing.T) {
 		t.Errorf("Attach() expected error on second call (duplicate attach), got nil")
 	} else {
 		t.Logf("Got expected error on second Attach: %v", err)
+	}
+}
+
+func TestNewKprobeOptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		offset            uint64
+		retprobeMaxActive int
+		isRetprobe        bool
+		wantErr           string
+	}{
+		{
+			name:              "kretprobe max active",
+			retprobeMaxActive: 128,
+			isRetprobe:        true,
+		},
+		{
+			name:       "kprobe offset",
+			offset:     32,
+			isRetprobe: false,
+		},
+		{
+			name:              "ordinary kprobe rejects max active",
+			retprobeMaxActive: 128,
+			wantErr: "retprobe max active is valid only for " +
+				"kretprobe programs",
+		},
+		{
+			name:              "negative max active",
+			retprobeMaxActive: -1,
+			isRetprobe:        true,
+			wantErr:           "retprobe max active must not be negative: -1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newKprobeOptions(
+				tt.offset,
+				tt.retprobeMaxActive,
+				tt.isRetprobe,
+			)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				&link.KprobeOptions{
+					Offset:            tt.offset,
+					RetprobeMaxActive: tt.retprobeMaxActive,
+				},
+				got,
+			)
+		})
 	}
 }
 

--- a/internal/bpf/bpf_types.go
+++ b/internal/bpf/bpf_types.go
@@ -28,9 +28,10 @@ type Option struct {
 
 // AttachOption is an option for attaching a program.
 type AttachOption struct {
-	ProgramName string
-	Symbol      string   // symbol for kprobe/kretprobe/tracepoint/raw_tracepoint
-	PerfEvent   struct { // BPF_PROG_TYPE_PERF_EVENT
+	ProgramName       string
+	Symbol            string   // symbol for kprobe/kretprobe/tracepoint/raw_tracepoint
+	RetprobeMaxActive int      // maximum concurrent kretprobe instances; zero uses the kernel default
+	PerfEvent         struct { // BPF_PROG_TYPE_PERF_EVENT
 		SamplePeriod, SampleFreq uint64
 		CPUIDs                   []int
 	}


### PR DESCRIPTION
## Summary

Conflict-free rebase/port of #475 onto current `main` (`ff543d8940c940d9a1437ecfa2ed15446492e213`).

The behavior is unchanged:

- expose `RetprobeMaxActive` through `internal/bpf.AttachOption`
- reject negative values and use on non-kretprobe programs
- pass the value to `link.Kretprobe`
- retain zero as the kernel-default behavior
- preserve the current `loadedProgram` attachment and link bookkeeping model

This PR exists because the original contributor branch in #475 cannot be updated from this fork. It can replace #475 or be cherry-picked into that branch at maintainer discretion.

## Validation

V100 / Ubuntu 22.04 / kernel 6.8.0-134:

- `make bpf-build`: passed
- `go run ./build/bpfabi-tool`: passed
- focused `TestNewKprobeOptions` and attach-option tests: passed
- `sudo go test ./internal/bpf`: passed

Refs #329
Refs #475
