### PR TITLE
fix(profiler,dashboards): enable region filtering and simplify dashboards

### DIFF
--- a/build/docker/grafana/dashboards/autotracing-event.json
+++ b/build/docker/grafana/dashboards/autotracing-event.json
@@ -72,7 +72,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "Shows the percentage breakdown of each event type relative to the total number of captured events.  \nProvides a quick overview of dominant event categories and their proportional impact.",
+      "description": "Event type distribution by percentage.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -607,7 +607,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "Displays the temporal distribution of captured events along the timeline.  \nHelps analyze event occurrence patterns, bursts, and correlations over time.",
+      "description": "Event occurrence over time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -726,7 +726,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## cpusys(Autotracing)\n\nDetects abnormal spikes in system CPU usage (`sys`, kernel space) on physical hosts.  \nWhen triggered, it automatically generates flame graphs and provides process-level context for root cause analysis.\n\nHelps identify and resolve application jitter and latency issues caused by abnormal system load.\n\n### Threshold Definition\n\n**Trigger conditions (ANY of the following):**\n- `sys` CPU usage > 50%\n- `sys` CPU usage fluctuation > 30% within 1 second",
+      "description": "Detects abnormal system CPU (sys) spikes. Triggers automatic call stack capture.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -846,7 +846,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## softirq(Event)\n\nDetects excessively long softirq disabled duration in the kernel.  \nOutputs kernel call stack and process context information for analysis.\n\nHelps identify and resolve system stalls, network latency, and scheduling delays.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Softirq disabled duration > 100 ms",
+      "description": "Detects excessive softirq-disabled durations. Outputs kernel call stack.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -966,7 +966,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## netdev down (Event)\n\nDetects network device link status changes.\n\nIdentifies both physical link failures and administrative (software-triggered) link-down events on network interfaces.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Network interface down event detected (physical layer down or administrative down)",
+      "description": "Detects network device link state changes (physical or administrative).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1046,7 +1046,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## cpuidle (Autotracing)\n\nDetects abnormal decreases in container CPU idle rate, automatically generates flame graphs and provides process context information.\n\nAddresses abnormal container CPU usage and helps analyze process hotspots.\n\n### Threshold Definition\n\n**Trigger conditions (ANY of the following):**\n- `sys` CPU usage > 45%  \n- `user` CPU usage > 75% AND fluctuation > 30% within 10 seconds  \n- `usage` CPU usage > 90% AND fluctuation > 30% within 10 seconds  ",
+      "description": "Detects abnormal container CPU idle rate drops. Generates flame graphs.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1166,7 +1166,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## container loadavg (Autotracing)\n\nDetects sudden increases in container load average.  \nAutomatically captures call stack information of D-state processes within the container.\n\nHelps identify and resolve issues caused by spikes in D-state processes, resource contention, or long-held locks.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- D-state process detected in container",
+      "description": "Detects sudden container load average increases. Captures call stacks.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1286,7 +1286,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## net rx latency (Event)\n\nDetects latency events along the network receive path (driver → protocol stack → user space).\n\nHelps identify and resolve application timeouts and jitter caused by receive-side latency.\n\n### Threshold Definition\n\n**Trigger conditions (ANY of the following):**\n- NIC → driver receive latency > 5 ms  \n- NIC → protocol stack receive latency > 10 ms  \n- NIC → user-space copy latency > 115 ms  \n\n**Latency location filters (`where`):**\n- `TO_NETIF_RCV`  \n- `TO_TCPV4_RCV`  \n- `TO_USER_COPY`  \n\n> Note: Most events are attributed to `TO_USER_COPY`, indicating delays caused by user-space read operations exceeding the threshold.",
+      "description": "Detects latency along the network receive path (driver -> stack -> userspace).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1406,7 +1406,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## softlockup (Event)\n\nDetects softlockup events and provides target process and kernel stack information.\n\nHelps locate and resolve system softlockup issues.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Softlockup event detected",
+      "description": "Detects softlockup events. Provides target process and kernel stack info.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1526,7 +1526,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## ras (Event)\n\nDetects hardware faults across CPU, memory, PCIe, and other subsystems.\n\nEnables timely detection of hardware failures to minimize impact on applications.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Hardware error event detected",
+      "description": "Detects hardware faults (CPU, memory, PCIe).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1646,7 +1646,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## iotracing (Autotracing)\n\nDetects abnormal disk I/O latency on physical hosts.  \nAutomatically captures related process, container, disk, and file-level context.\n\nHelps identify and resolve application latency and system performance jitter caused by I/O saturation or sudden spikes in disk access.\n\n### Threshold Definition\n\n**Trigger conditions (ANY of the following):**\n\n**1. HDD / SATA SSD:**\n- `io.util` > 90% sustained for > 2 seconds  \n- 2-second average I/O latency > 100 ms  \n\n**2. NVMe SSD:**\n- `io.util` > 90% AND I/O bandwidth exceeds:\n  - Read > 2000 MB/s **OR**\n  - Write > 1500 MB/s  \n- 2-second average I/O latency > 100 ms",
+      "description": "Detects abnormal disk I/O latency. Captures related process stacks.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1766,7 +1766,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## oom (Event)\n\nDetects Out-Of-Memory (OOM) events on the host or within containers.\n\nFocuses on memory exhaustion issues and provides detailed fault snapshots for analysis.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- OOM event detected on host or container",
+      "description": "Detects OOM events on host or containers. Records OOM score and victim process.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1886,7 +1886,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## waitrate (Autotracing)\n\nDetects abnormal increases in container wait rate based on statistical anomaly detection.  \nContinuously analyzes historical wait rate behavior and identifies significant deviations.\n\nHelps identify performance degradation caused by resource contention, scheduling delays, or blocking operations.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- For each container, compute `mean` and `std` of wait rate over the past 30 minutes  \n- Alert is triggered when:\n  - `waitrate > mean + std × factor`\n\n**Service levels:**\n- Level 0: factor = 30  \n- Level 1: factor = 40  \n- Level 2: factor = 60  ",
+      "description": "Detects abnormal container wait rate increases via statistical anomaly detection.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2006,7 +2006,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "pad...",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2126,7 +2126,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## hungtask (Event)\n\nDetects hung task events and outputs all processes in D-state along with their stack traces.\n\nCaptures transient scenarios with large numbers of D-state processes and preserves the fault context for analysis.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Hung task event detected",
+      "description": "Detects hung tasks. Outputs D-state processes and their stack traces.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2246,7 +2246,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## reclaim (Event)\n\nDetects direct memory reclaim events, recording reclaim duration along with process and container context.\n\nHelps identify and resolve application stalls caused by memory pressure.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Within a 1-second sampling window, cumulative time a process spends in `sys` state > 900 ms  \n  *(Note: due to non-preemptible kernel execution, observed duration may exceed 1 second)*",
+      "description": "Detects direct memory reclaim events. Records duration and process/container context.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2366,7 +2366,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## dropwatch (Event)\n\nDetects packet drops within the kernel network protocol stack.  \nOutputs kernel call stack and network context for analysis.\n\nHelps identify and resolve application jitter and latency caused by packet drops in the protocol stack.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- TCP request traffic AND TCP state != `CLOSED`\n\n**Excluded scenarios:**\n- Out-of-order (OOO) packets in `CLOSE_WAIT` state\n\n```\n// state: CLOSE_WAIT\n// stack:\n//  1. kfree_skb/ffffffff963047b0\n//  2. kfree_skb/ffffffff963047b0\n//  3. skb_rbtree_purge/ffffffff963089e0\n//  4. tcp_fin/ffffffff963ac200\n//  5. ...\n```",
+      "description": "Detects packet drops in the kernel network stack. Outputs call stack and interface.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2486,7 +2486,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## memburst (Autotracing)\n\nDetects sudden bursts in memory allocation on physical hosts.  \nAutomatically captures process-level memory usage context.\n\nHelps identify scenarios with rapid memory growth that may trigger direct reclaim or OOM conditions.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Memory usage doubles within the last 5 minutes AND current anonymous memory usage on the host ≥ 70%",
+      "description": "Detects sudden memory allocation bursts. Captures process allocation stacks.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2606,7 +2606,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "## TX queue timeout (Event)\n\nDetects network interface transmit queue timeout events.\n\nHelps identify and locate hardware or driver issues in the NIC transmit queue.\n\n### Threshold Definition\n\n**Trigger conditions:**\n- Transmit queue timeout event detected",
+      "description": "Detects NIC transmit queue timeout events. Identifies hardware/driver failures.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2726,7 +2726,7 @@
         "type": "elasticsearch",
         "uid": "huatuo-bamai-es"
       },
-      "description": "pad...",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/build/docker/grafana/dashboards/autotracing-event.json
+++ b/build/docker/grafana/dashboards/autotracing-event.json
@@ -148,7 +148,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:cpusys AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:cpusys AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         },
@@ -175,7 +175,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:cpuidle AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:cpuidle AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "B",
           "timeField": "uploaded_time"
         },
@@ -202,7 +202,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:dload AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:dload AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "C",
           "timeField": "uploaded_time"
         },
@@ -229,7 +229,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:memory_reclaim_events AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:memory_reclaim_events AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "D",
           "timeField": "uploaded_time"
         },
@@ -256,7 +256,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:oom AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:oom AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "E",
           "timeField": "uploaded_time"
         },
@@ -283,7 +283,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:memburst AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:memburst AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "F",
           "timeField": "uploaded_time"
         },
@@ -310,7 +310,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:iotracing AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:iotracing AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "G",
           "timeField": "uploaded_time"
         },
@@ -337,7 +337,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:dropwatch AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:dropwatch AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "H",
           "timeField": "uploaded_time"
         },
@@ -364,7 +364,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:net_rx_latency AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:net_rx_latency AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "I",
           "timeField": "uploaded_time"
         },
@@ -391,7 +391,7 @@
               "type": "count"
             }
           ],
-          "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*down*",
+          "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*down*",
           "refId": "J",
           "timeField": "uploaded_time"
         },
@@ -418,7 +418,7 @@
               "type": "count"
             }
           ],
-          "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev_bonding_lacp",
+          "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev_bonding_lacp",
           "refId": "K",
           "timeField": "uploaded_time"
         },
@@ -445,7 +445,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:softirq_tracing AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:softirq_tracing AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "L",
           "timeField": "uploaded_time"
         },
@@ -472,7 +472,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:softlockup AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:softlockup AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "M",
           "timeField": "uploaded_time"
         },
@@ -499,7 +499,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:hungtask AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:hungtask AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "N",
           "timeField": "uploaded_time"
         },
@@ -526,7 +526,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:ras AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:ras AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "O",
           "timeField": "uploaded_time"
         },
@@ -553,7 +553,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "P",
           "timeField": "uploaded_time"
         }
@@ -672,7 +672,7 @@
               "type": "count"
             }
           ],
-          "query": "region:$region AND hostname:$hostname \nAND (\ntracer_name:cpusys \nOR tracer_name:cpuidle \nOR tracer_name:dload \nOR tracer_name:waitrate \nOR tracer_name:memory_reclaim_events \nOR tracer_name:oom \nOR tracer_name:memburst \nOR tracer_name:iotracing \nOR tracer_name:dropwatch \nOR tracer_name:net_rx_latency \nOR (tracer_name:netdev AND tracer_data.linkstatus:*down*) \nOR tracer_name:netdev_bonding_lacp \nOR tracer_name:softirq_tracing \nOR tracer_name:softlockup \nOR tracer_name:hungtask \nOR tracer_name:ras\nOR tracer_name:netdev_txqueue_timeout\n)",
+          "query": "region.keyword:$region AND hostname.keyword:$hostname \nAND (\ntracer_name:cpusys \nOR tracer_name:cpuidle \nOR tracer_name:dload \nOR tracer_name:waitrate \nOR tracer_name:memory_reclaim_events \nOR tracer_name:oom \nOR tracer_name:memburst \nOR tracer_name:iotracing \nOR tracer_name:dropwatch \nOR tracer_name:net_rx_latency \nOR (tracer_name:netdev AND tracer_data.linkstatus:*down*) \nOR tracer_name:netdev_bonding_lacp \nOR tracer_name:softirq_tracing \nOR tracer_name:softlockup \nOR tracer_name:hungtask \nOR tracer_name:ras\nOR tracer_name:netdev_txqueue_timeout\n)",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -793,7 +793,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:cpusys AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:cpusys AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -913,7 +913,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:softirq_tracing AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:softirq_tracing AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1033,7 +1033,7 @@
               "type": "count"
             }
           ],
-          "query": "region:$region \nAND hostname:$hostname \nAND (\n  (tracer_name:netdev AND tracer_data.linkstatus:*down*)\n  OR tracer_name:netdev_bonding_lacp\n)",
+          "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND (\n  (tracer_name:netdev AND tracer_data.linkstatus:*down*)\n  OR tracer_name:netdev_bonding_lacp\n)",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1113,7 +1113,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:cpuidle AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:cpuidle AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1233,7 +1233,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:dload AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:dload AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1353,7 +1353,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:net_rx_latency AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:net_rx_latency AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1473,7 +1473,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:softlockup AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:softlockup AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1593,7 +1593,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:ras AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:ras AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1713,7 +1713,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:iotracing AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:iotracing AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1833,7 +1833,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:oom AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:oom AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -1953,7 +1953,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2073,7 +2073,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:null AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:null AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2193,7 +2193,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:hungtask AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:hungtask AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2313,7 +2313,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:memory_reclaim_events AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:memory_reclaim_events AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2433,7 +2433,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:dropwatch AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:dropwatch AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2553,7 +2553,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:memburst AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:memburst AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2673,7 +2673,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:netdev_txqueue_timeout AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:netdev_txqueue_timeout AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2793,7 +2793,7 @@
               "type": "count"
             }
           ],
-          "query": "tracer_name:null AND region:$region AND hostname:$hostname",
+          "query": "tracer_name:null AND region.keyword:$region AND hostname.keyword:$hostname",
           "refId": "A",
           "timeField": "uploaded_time"
         }
@@ -2988,7 +2988,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:cpusys AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:cpusys AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -3136,7 +3136,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:cpusys AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:cpusys AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -3291,7 +3291,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:cpusys AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:cpusys AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -3523,7 +3523,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:cpuidle AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:cpuidle AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -3674,7 +3674,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:cpuidle AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:cpuidle AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -3853,7 +3853,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:cpuidle AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:cpuidle AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -4132,7 +4132,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:dload AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:dload AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -4280,7 +4280,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:dload AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:dload AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -4450,7 +4450,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:dload AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:dload AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -4635,7 +4635,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -4783,7 +4783,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -4910,7 +4910,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -5117,7 +5117,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:memory_reclaim_events AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:memory_reclaim_events AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -5265,7 +5265,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:memory_reclaim_events AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:memory_reclaim_events AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -5427,7 +5427,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:memory_reclaim_events AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:memory_reclaim_events AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -5599,7 +5599,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:oom AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:oom AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -5747,7 +5747,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:oom AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:oom AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -5881,7 +5881,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:oom AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:oom AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -6063,7 +6063,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:memburst AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:memburst AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -6211,7 +6211,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:memburst AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:memburst AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -6352,7 +6352,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:memburst AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:memburst AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -6540,7 +6540,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:iotracing AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:iotracing AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -6688,7 +6688,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:iotracing AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:iotracing AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -6857,7 +6857,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:iotracing AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:iotracing AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -7066,7 +7066,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:dropwatch AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:dropwatch AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -7217,7 +7217,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:dropwatch AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:dropwatch AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -7359,7 +7359,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:dropwatch AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:dropwatch AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -7553,7 +7553,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:net_rx_latency AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:net_rx_latency AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -7702,7 +7702,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:net_rx_latency AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:net_rx_latency AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -7836,7 +7836,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:net_rx_latency AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:net_rx_latency AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8030,7 +8030,7 @@
                   "type": "count"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*carrierdown*",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*carrierdown*",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8142,7 +8142,7 @@
                   "type": "count"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*carrierdown*",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*carrierdown*",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8235,7 +8235,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*carrierdown*",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*carrierdown*",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8404,7 +8404,7 @@
                   "type": "count"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*admindown*",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*admindown*",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8516,7 +8516,7 @@
                   "type": "count"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*admindown*",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*admindown*",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8603,7 +8603,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*admindown*",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev \nAND tracer_data.linkstatus:*admindown*",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8770,7 +8770,7 @@
                   "type": "count"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev_bonding_lacp",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev_bonding_lacp",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8882,7 +8882,7 @@
                   "type": "count"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev_bonding_lacp",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev_bonding_lacp",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -8987,7 +8987,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "region:$region \nAND hostname:$hostname \nAND tracer_name:netdev_bonding_lacp",
+              "query": "region.keyword:$region \nAND hostname.keyword:$hostname \nAND tracer_name:netdev_bonding_lacp",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -9174,7 +9174,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:softirq_tracing AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:softirq_tracing AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -9322,7 +9322,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:softirq_tracing AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:softirq_tracing AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -9516,7 +9516,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:softirq_tracing AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:softirq_tracing AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -9689,7 +9689,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:softlockup AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:softlockup AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -9837,7 +9837,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:softlockup AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:softlockup AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -9983,7 +9983,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:softlockup AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:softlockup AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -10149,7 +10149,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:hungtask AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:hungtask AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -10297,7 +10297,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:hungtask AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:hungtask AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -10443,7 +10443,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:hungtask AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:hungtask AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -10609,7 +10609,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:ras AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:ras AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -10757,7 +10757,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:ras AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:ras AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -10904,7 +10904,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:ras AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:ras AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -11076,7 +11076,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -11224,7 +11224,7 @@
                   "type": "count"
                 }
               ],
-              "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -11371,7 +11371,7 @@
                   "type": "logs"
                 }
               ],
-              "query": "tracer_name:waitrate AND region:$region AND hostname:$hostname",
+              "query": "tracer_name:waitrate AND region.keyword:$region AND hostname.keyword:$hostname",
               "refId": "A",
               "timeField": "uploaded_time"
             }
@@ -11476,13 +11476,13 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\"find\": \"terms\", \"field\": \"region\", \"size\": 100}",
+        "definition": "{\"find\": \"terms\", \"field\": \"region.keyword\", \"size\": 100}",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "region",
         "options": [],
-        "query": "{\"find\": \"terms\", \"field\": \"region\", \"size\": 100}",
+        "query": "{\"find\": \"terms\", \"field\": \"region.keyword\", \"size\": 100}",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -11499,13 +11499,13 @@
           "type": "elasticsearch",
           "uid": "huatuo-bamai-es"
         },
-        "definition": "{\"find\": \"terms\", \"field\": \"hostname\", \"query\": \"region:$region\", \"size\":20000}",
+        "definition": "{\"find\": \"terms\", \"field\": \"hostname.keyword\", \"query\": \"region.keyword:$region\", \"size\":20000}",
         "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "hostname",
         "options": [],
-        "query": "{\"find\": \"terms\", \"field\": \"hostname\", \"query\": \"region:$region\", \"size\":20000}",
+        "query": "{\"find\": \"terms\", \"field\": \"hostname.keyword\", \"query\": \"region.keyword:$region\", \"size\":20000}",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/build/docker/grafana/dashboards/metrics-container.json
+++ b/build/docker/grafana/dashboards/metrics-container.json
@@ -46,7 +46,7 @@
         "type": "prometheus",
         "uid": "huatuo-bamai-prom"
       },
-      "description": "Arbitrary metric selected from the $metric variable, filtered by container host and region.",
+      "description": "Selected metric filtered by container host and region.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -163,7 +163,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Per-container user-space CPU utilization.",
+          "description": "Per-container user CPU utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -265,7 +265,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Per-container kernel-space CPU utilization.",
+          "description": "Per-container kernel CPU utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -367,7 +367,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Wait time caused by cgroup quota limits within the container.",
+          "description": "Wait time from cgroup CPU quota limits.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -469,7 +469,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Wait time caused by host-level resource contention outside the container's cgroup.",
+          "description": "Wait time from host-level resource contention.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -571,7 +571,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "CPU throttling events when container exceeds its cgroup CPU quota.",
+          "description": "CPU throttle events when cgroup quota exceeded.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -700,7 +700,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Asynchronous memory reclaim latency for all the container (ms).",
+          "description": "Async memory reclaim latency (ms).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -802,7 +802,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Direct memory reclaim latency triggered by try_charge for all the containers.",
+          "description": "Direct reclaim latency from try_charge (ms).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -904,7 +904,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Cumulative count of pages reclaimed asynchronously for the container.",
+          "description": "Pages reclaimed asynchronously (cumulative).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1005,7 +1005,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Cumulative total of host direct reclaim and try_charge direct reclaim pages for the container.",
+          "description": "Host + try_charge direct reclaim pages (cumulative).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1106,7 +1106,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Cumulative total of host kswapd and container cswapd async reclaim pages for all the containers.",
+          "description": "Host kswapd + container cswapd reclaim pages (cumulative).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1207,7 +1207,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Cumulative count of pages reclaimed by host direct reclaim path for all the containers.",
+          "description": "Pages reclaimed by host direct reclaim (cumulative).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1435,7 +1435,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total received bytes per second across all network interfaces.",
+          "description": "Rx bytes/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1536,7 +1536,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total received packets per second across all network interfaces.",
+          "description": "Rx packets/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1637,7 +1637,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total transmitted bytes per second across all network interfaces.",
+          "description": "Tx bytes/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1738,7 +1738,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total transmitted packets per second across all network interfaces.",
+          "description": "Tx packets/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1839,7 +1839,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Receive-side anomaly stats: drops, errors, FIFO overruns, frame errors (packets/s).",
+          "description": "Rx anomalies: drops, errors, overruns, frame errors (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1952,7 +1952,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Transmit-side anomaly stats: drops, errors, FIFO overruns, carrier errors (packets/s).",
+          "description": "Tx anomalies: drops, errors, overruns, carrier errors (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2089,7 +2089,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total ARP request and reply packets on all interfaces.",
+          "description": "ARP packets/s on all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2214,7 +2214,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Number of TCP sockets currently in use.",
+          "description": "TCP sockets in use.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2339,7 +2339,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Number of TCP sockets in TIME_WAIT state.",
+          "description": "TCP sockets in TIME_WAIT.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2464,7 +2464,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total socket count across all protocols (TCP, UDP, RAW, etc.).",
+          "description": "Total sockets across all protocols.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2589,7 +2589,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Aggregated kernel netstat counters (SNMP/netstat).",
+          "description": "Kernel netstat counters (SNMP).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2784,7 +2784,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Packet loss rate derived from netstat counters.",
+          "description": "Packet loss rate from netstat.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3069,7 +3069,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Network error counters: InErrors, OutErrors, InCsumErrors, etc.",
+          "description": "Network errors: InErrors, OutErrors, InCsumErrors.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3309,7 +3309,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "TCP segment retransmission rate and count.",
+          "description": "TCP retransmission rate and count.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3489,7 +3489,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Packets dropped due to socket receive buffer exhaustion (RcvbufErrors, SndbufErrors).",
+          "description": "Packets dropped from buffer exhaustion (RcvbufErrors, SndbufErrors).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3609,7 +3609,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "TCP SYN packet statistics: SYN received, SYN sent, SYN retransmissions.",
+          "description": "TCP SYN stats: received, sent, retransmissions.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3741,7 +3741,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Disk IO count where queue-to-completion (q2c) latency exceeds 20ms, 5-minute incremental.",
+          "description": "Disk IO with q2c latency >20ms (5-min incremental).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3843,7 +3843,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Disk IO count where device-to-completion (d2c) latency exceeds 20ms, 5-minute incremental.",
+          "description": "Disk IO with d2c latency >20ms (5-min incremental).",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/build/docker/grafana/dashboards/metrics-container.json
+++ b/build/docker/grafana/dashboards/metrics-container.json
@@ -134,7 +134,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "$metric{container_host=~\"$container_host\",region=\"$region\",container_type!=\"Sidecar\"}",
+          "expr": "$metric{container_host=~\"$container_host\",region=~\"$region\",container_type!=\"Sidecar\"}",
           "interval": "",
           "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
           "range": true,
@@ -251,7 +251,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_util_container_usr{container_host=~\"$container_host\",region=\"$region\", container_type != \"sidecar\"}",
+              "expr": "huatuo_bamai_cpu_util_container_usr{container_host=~\"$container_host\",region=~\"$region\", container_type != \"sidecar\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}: {{container_type}}",
               "refId": "A"
@@ -353,7 +353,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_util_container_sys{container_host=~\"$container_host\",region=\"$region\", container_type != \"sidecar\"}",
+              "expr": "huatuo_bamai_cpu_util_container_sys{container_host=~\"$container_host\",region=~\"$region\", container_type != \"sidecar\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}: {{container_type}}",
               "refId": "A"
@@ -455,7 +455,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_stat_container_inner_wait_rate{container_host=~\"$container_host\",region=\"$region\", container_type != \"sidecar\"}",
+              "expr": "huatuo_bamai_cpu_stat_container_inner_wait_rate{container_host=~\"$container_host\",region=~\"$region\", container_type != \"sidecar\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}: {{container_type}}",
               "refId": "A"
@@ -557,7 +557,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_stat_container_exter_wait_rate{container_host=~\"$container_host\",region=\"$region\", container_type != \"sidecar\"}",
+              "expr": "huatuo_bamai_cpu_stat_container_exter_wait_rate{container_host=~\"$container_host\",region=~\"$region\", container_type != \"sidecar\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}: {{container_type}}",
               "refId": "A"
@@ -659,7 +659,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_stat_container_throttle_wait_rate{container_host=~\"$container_host\",region=\"$region\", container_type != \"sidecar\"}",
+              "expr": "huatuo_bamai_cpu_stat_container_throttle_wait_rate{container_host=~\"$container_host\",region=~\"$region\", container_type != \"sidecar\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}: {{container_type}}",
               "refId": "A"
@@ -788,7 +788,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_others_container_asyncreclaim_time{container_host=~\"$container_host\",region=\"$region\"}/1000000",
+              "expr": "huatuo_bamai_memory_others_container_asyncreclaim_time{container_host=~\"$container_host\",region=~\"$region\"}/1000000",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -890,7 +890,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_others_container_directstall_time{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_memory_others_container_directstall_time{container_host=~\"$container_host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -991,7 +991,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_cswapd{container_host=~\"$container_host\",region=\"$region\"}/1024/1024",
+              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_cswapd{container_host=~\"$container_host\",region=~\"$region\"}/1024/1024",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1092,7 +1092,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_direct{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_direct{container_host=~\"$container_host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1193,7 +1193,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_kswapd{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_kswapd{container_host=~\"$container_host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1294,7 +1294,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_globaldirect{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_globaldirect{container_host=~\"$container_host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1394,7 +1394,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_globalkswapd{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_memory_vmstat_container_pgsteal_globalkswapd{container_host=~\"$container_host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1521,7 +1521,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_receive_bytes_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_receive_bytes_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -1622,7 +1622,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_receive_packets_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_receive_packets_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -1723,7 +1723,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_bytes_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_bytes_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -1824,7 +1824,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_packets_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_packets_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -1926,7 +1926,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_receive_dropped_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_receive_dropped_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "dropped: {{container_host}}",
               "refId": "A"
@@ -1937,7 +1937,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_receive_errors_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_receive_errors_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "errors: {{container_host}}",
@@ -2039,7 +2039,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_dropped_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_dropped_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "dropped: {{container_host}}",
               "refId": "A"
@@ -2050,7 +2050,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_errors_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_errors_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "errors: {{container_host}}",
@@ -2062,7 +2062,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_carrier_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_carrier_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "carrier: {{container_host}}",
@@ -2074,7 +2074,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_colls_total{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_colls_total{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "colls: {{container_host}}",
@@ -2196,7 +2196,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_arp_container_entries{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_arp_container_entries{container_host=~\"$container_host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2321,7 +2321,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_TCP_inuse{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_TCP_inuse{container_host=~\"$container_host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2446,7 +2446,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_TCP_tw{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_TCP_tw{container_host=~\"$container_host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2571,7 +2571,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_sockets_used{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_sockets_used{container_host=~\"$container_host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2676,7 +2676,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_InSegs{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_InSegs{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2691,7 +2691,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_OutSegs{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_OutSegs{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2706,7 +2706,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPDelivered{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPDelivered{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2721,7 +2721,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPOrigDataSent{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPOrigDataSent{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2736,7 +2736,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_ActiveOpens{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_ActiveOpens{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2751,7 +2751,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_netstat_container_Tcp_CurrEstab{container_host=~\"$container_host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_netstat_container_Tcp_CurrEstab{container_host=~\"$container_host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2766,7 +2766,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_PassiveOpens{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_PassiveOpens{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2871,7 +2871,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_ListenDrops{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_ListenDrops{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2886,7 +2886,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_ListenOverflows{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_ListenOverflows{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2901,7 +2901,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPReqQFullDoCookies{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPReqQFullDoCookies{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2916,7 +2916,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_PFMemallocDrop{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_PFMemallocDrop{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2931,7 +2931,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPBacklogDrop{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPBacklogDrop{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2946,7 +2946,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPRcvQDrop{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPRcvQDrop{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2961,7 +2961,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPTimeouts{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPTimeouts{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2976,7 +2976,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPLossFailures{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPLossFailures{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -2991,7 +2991,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSACKDiscard{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSACKDiscard{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3006,7 +3006,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPMemoryPressures{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPMemoryPressures{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3021,7 +3021,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPMinTTLDrop{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPMinTTLDrop{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3036,7 +3036,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPMinTTLDrop{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPMinTTLDrop{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3051,7 +3051,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPTimeWaitOverflow{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPTimeWaitOverflow{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3156,7 +3156,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_InErrs{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_InErrs{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3171,7 +3171,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_InCsumErrors{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_InCsumErrors{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3186,7 +3186,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPAbortOnMemory{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPAbortOnMemory{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3201,7 +3201,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPAbortOnTimeout{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPAbortOnTimeout{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3216,7 +3216,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPRetransFail{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPRetransFail{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3231,7 +3231,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSackFailures{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSackFailures{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3246,7 +3246,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSackFailures{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSackFailures{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3261,7 +3261,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_SyncookiesFailed{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_SyncookiesFailed{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3276,7 +3276,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPWqueueTooBig{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPWqueueTooBig{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3291,7 +3291,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_AttemptFails{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_AttemptFails{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3396,7 +3396,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_RetransSegs{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_RetransSegs{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3411,7 +3411,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSynRetrans{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSynRetrans{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3426,7 +3426,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPFastRetrans{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPFastRetrans{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3441,7 +3441,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSlowStartRetrans{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSlowStartRetrans{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3456,7 +3456,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSpuriousRTOs{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSpuriousRTOs{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3471,7 +3471,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSpuriousRtxHostQueues{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_TCPSpuriousRtxHostQueues{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3576,7 +3576,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_PruneCalled{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_PruneCalled{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3591,7 +3591,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_RcvPruned{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_TcpExt_RcvPruned{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3696,7 +3696,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_container_Tcp_ActiveOpens{container_host=~\"$container_host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_container_Tcp_PassiveOpens{container_host=~\"$container_host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_container_TcpExt_ListenDrops{container_host=~\"$container_host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_container_TcpExt_TCPSynRetrans{container_host=~\"$container_host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_container_Tcp_ActiveOpens{container_host=~\"$container_host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_container_Tcp_PassiveOpens{container_host=~\"$container_host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_container_TcpExt_ListenDrops{container_host=~\"$container_host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_container_TcpExt_TCPSynRetrans{container_host=~\"$container_host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3829,7 +3829,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "increase(huatuo_bamai_iolatency_container_blkdisk_q2c{container_host=~\"$container_host\",region=\"$region\"}[5m])",
+              "expr": "increase(huatuo_bamai_iolatency_container_blkdisk_q2c{container_host=~\"$container_host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{container_host}} [{{latency}}]",
               "refId": "A"
@@ -3932,7 +3932,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "increase(huatuo_bamai_iolatency_container_blkdisk_d2c{container_host=~\"$container_host\",region=\"$region\"}[5m])",
+              "expr": "increase(huatuo_bamai_iolatency_container_blkdisk_d2c{container_host=~\"$container_host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{container_host}} [{{latency}}]",
               "range": true,
@@ -3977,7 +3977,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "region",
-        "multi": false,
+        "multi": true,
         "name": "region",
         "options": [],
         "query": {
@@ -3988,7 +3988,8 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 2,
-        "type": "query"
+        "type": "query",
+        "allValue": ".*"
       },
       {
         "current": {
@@ -4025,17 +4026,14 @@
           "type": "prometheus",
           "uid": "huatuo-bamai-prom"
         },
-        "definition": "label_values(huatuo_bamai_cpu_util_container_usr{container_hostnamespace =~\"$ns\"}, container_host)",
+        "definition": "label_values(huatuo_bamai_cpu_util_container_usr{container_hostnamespace =~\"$ns\",region=~\"$region\"}, container_host)",
         "hide": 0,
         "includeAll": true,
         "label": "container_host",
         "multi": true,
         "name": "container_host",
         "options": [],
-        "query": {
-          "query": "label_values(huatuo_bamai_cpu_util_container_usr{container_hostnamespace =~\"$ns\"}, container_host)",
-          "refId": "StandardVariableQuery"
-        },
+        "query": "label_values(huatuo_bamai_cpu_util_container_usr{container_hostnamespace =~\"$ns\",region=~\"$region\"}, container_host)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/build/docker/grafana/dashboards/metrics-disk-io.json
+++ b/build/docker/grafana/dashboards/metrics-disk-io.json
@@ -120,7 +120,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "rate(huatuo_bamai_diskio_read_requests_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m])",
+          "expr": "rate(huatuo_bamai_diskio_read_requests_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m])",
           "legendFormat": "Read IOPS - {{device}}",
           "refId": "A"
         },
@@ -129,7 +129,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "rate(huatuo_bamai_diskio_write_requests_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m])",
+          "expr": "rate(huatuo_bamai_diskio_write_requests_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m])",
           "legendFormat": "Write IOPS - {{device}}",
           "refId": "B"
         }
@@ -225,7 +225,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "rate(huatuo_bamai_diskio_read_bytes_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m])",
+          "expr": "rate(huatuo_bamai_diskio_read_bytes_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m])",
           "legendFormat": "Read BPS - {{device}}",
           "refId": "A"
         },
@@ -234,7 +234,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "rate(huatuo_bamai_diskio_written_bytes_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m])",
+          "expr": "rate(huatuo_bamai_diskio_written_bytes_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m])",
           "legendFormat": "Write BPS - {{device}}",
           "refId": "B"
         }
@@ -330,7 +330,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "rate(huatuo_bamai_diskio_read_time_seconds_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m]) / clamp_min(rate(huatuo_bamai_diskio_read_requests_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m]), 1e-9) * 1000",
+          "expr": "rate(huatuo_bamai_diskio_read_time_seconds_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m]) / clamp_min(rate(huatuo_bamai_diskio_read_requests_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m]), 1e-9) * 1000",
           "legendFormat": "Read Latency - {{device}}",
           "refId": "A"
         },
@@ -339,7 +339,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "rate(huatuo_bamai_diskio_write_time_seconds_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m]) / clamp_min(rate(huatuo_bamai_diskio_write_requests_total{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}[5m]), 1e-9) * 1000",
+          "expr": "rate(huatuo_bamai_diskio_write_time_seconds_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m]) / clamp_min(rate(huatuo_bamai_diskio_write_requests_total{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}[5m]), 1e-9) * 1000",
           "legendFormat": "Write Latency - {{device}}",
           "refId": "B"
         }
@@ -435,7 +435,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "huatuo_bamai_diskio_io_in_progress{host=~\"$host\",region=\"$region\",device!~\"loop.*\"}",
+          "expr": "huatuo_bamai_diskio_io_in_progress{host=~\"$host\",region=~\"$region\",device!~\"loop.*\"}",
           "legendFormat": "Queue Depth - {{device}}",
           "refId": "A"
         }
@@ -510,7 +510,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "expr": "huatuo_bamai_diskio_disk_iowait_percent{host=~\"$host\",region=\"$region\"}",
+          "expr": "huatuo_bamai_diskio_disk_iowait_percent{host=~\"$host\",region=~\"$region\"}",
           "refId": "A",
           "legendFormat": "IO Wait %"
         }
@@ -536,8 +536,9 @@
         },
         "query": "label_values(huatuo_bamai_diskio_disk_iowait_percent, region)",
         "refresh": 2,
-        "includeAll": false,
-        "multi": false
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*"
       },
       {
         "name": "host",

--- a/build/docker/grafana/dashboards/metrics-host.json
+++ b/build/docker/grafana/dashboards/metrics-host.json
@@ -143,7 +143,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "huatuo_bamai_arp_container_entries{host=~\"$host\",region=\"$region\"}",
+          "expr": "huatuo_bamai_arp_container_entries{host=~\"$host\",region=~\"$region\"}",
           "format": "table",
           "interval": "",
           "legendFormat": "",
@@ -303,7 +303,7 @@
             "uid": "huatuo-bamai-prom"
           },
           "exemplar": true,
-          "expr": "$metric{host=~\"$host\",region=\"$region\"}",
+          "expr": "$metric{host=~\"$host\",region=~\"$region\"}",
           "interval": "",
           "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
           "refId": "A"
@@ -420,7 +420,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_util_usr{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_util_usr{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}",
               "range": true,
@@ -521,7 +521,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_util_sys{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_util_sys{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}",
               "refId": "A"
@@ -623,7 +623,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_util_container_usr{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_util_container_usr{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}/{{container_name}}:{{container_type}}",
               "refId": "A"
@@ -722,7 +722,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_util_container_sys{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_util_container_sys{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -821,7 +821,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_stat_container_exter_wait_rate{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_stat_container_exter_wait_rate{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -920,7 +920,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_stat_container_inner_wait_rate{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_stat_container_inner_wait_rate{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1020,7 +1020,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_cpu_stat_container_throttle_wait_rate{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_cpu_stat_container_throttle_wait_rate{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}:{{container_type}}",
               "refId": "A"
@@ -1122,7 +1122,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_runqlat_latency{host=~\"$host\",region=\"$region\"}[5m])",
+              "expr": "rate(huatuo_bamai_runqlat_latency{host=~\"$host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{host}} zone={{zone}}",
               "range": true,
@@ -1225,7 +1225,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_softirq_latency{host=~\"$host\",region=\"$region\"}[5m])",
+              "expr": "rate(huatuo_bamai_softirq_latency{host=~\"$host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{host}} {{type}} zone={{zone}}",
               "range": true,
@@ -1353,7 +1353,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_pgsteal_direct{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_pgsteal_direct{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "refId": "A"
@@ -1453,7 +1453,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_pgsteal_kswapd{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_pgsteal_kswapd{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "refId": "A"
@@ -1553,7 +1553,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_nr_dirty{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_nr_dirty{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "refId": "A"
@@ -1652,7 +1652,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_nr_writeback{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_nr_writeback{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "refId": "A"
@@ -1751,7 +1751,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_nr_free_pages{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_nr_free_pages{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "refId": "A"
@@ -1850,7 +1850,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_nr_inactive_file{host=~\"$host\",region=\"$region\"}/256 + huatuo_bamai_memory_vmstat_nr_active_file{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_nr_inactive_file{host=~\"$host\",region=~\"$region\"}/256 + huatuo_bamai_memory_vmstat_nr_active_file{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "refId": "A"
@@ -1950,7 +1950,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "huatuo_bamai_memory_vmstat_nr_inactive_anon{host=~\"$host\",region=\"$region\"}/256 + huatuo_bamai_memory_vmstat_nr_active_anon{host=~\"$host\",region=\"$region\"}/256",
+              "expr": "huatuo_bamai_memory_vmstat_nr_inactive_anon{host=~\"$host\",region=~\"$region\"}/256 + huatuo_bamai_memory_vmstat_nr_active_anon{host=~\"$host\",region=~\"$region\"}/256",
               "interval": "",
               "legendFormat": "{{host}}/{{container_host}}",
               "range": true,
@@ -2078,7 +2078,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_receive_bytes_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_receive_bytes_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "{{host}}/{{device}}",
               "range": true,
@@ -2090,7 +2090,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_receive_bytes_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_receive_bytes_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -2190,7 +2190,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_receive_packets_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_receive_packets_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{host}}/{{device}}",
@@ -2202,7 +2202,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_receive_packets_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_receive_packets_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -2302,7 +2302,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_transmit_bytes_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_transmit_bytes_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "{{host}}/{{device}}",
               "refId": "A"
@@ -2313,7 +2313,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_bytes_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_bytes_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -2413,7 +2413,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_transmit_packets_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_transmit_packets_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "{{host}}/{{device}}",
               "refId": "A"
@@ -2424,7 +2424,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_container_transmit_packets_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_container_transmit_packets_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{container_host}}",
@@ -2525,7 +2525,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_receive_dropped_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_receive_dropped_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "dropped: {{device}}",
               "refId": "A"
@@ -2536,7 +2536,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_receive_errors_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_receive_errors_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "errors: {{device}}",
@@ -2637,7 +2637,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_transmit_dropped_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_transmit_dropped_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "interval": "",
               "legendFormat": "dropped: {{device}}",
               "refId": "A"
@@ -2648,7 +2648,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_transmit_errors_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_transmit_errors_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "errors: {{device}}",
@@ -2660,7 +2660,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_transmit_carrier_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_transmit_carrier_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "carrier: {{device}}",
@@ -2672,7 +2672,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_transmit_colls_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_transmit_colls_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "colls: {{device}}",
@@ -2793,7 +2793,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_qdisc_bytes_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_qdisc_bytes_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -2916,7 +2916,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_qdisc_packets_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_qdisc_packets_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -3043,7 +3043,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_qdisc_drops_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_qdisc_drops_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -3057,7 +3057,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_qdisc_overlimits_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_qdisc_overlimits_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3072,7 +3072,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_qdisc_requeues_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_qdisc_requeues_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3087,7 +3087,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_netdev_qdisc_backlog{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_netdev_qdisc_backlog{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3211,7 +3211,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_arp_total{host=~\"$host\",region=\"$region\"}[5m])",
+              "expr": "rate(huatuo_bamai_arp_total{host=~\"$host\",region=~\"$region\"}[5m])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3226,7 +3226,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_arp_entries{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_arp_entries{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -3240,7 +3240,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_arp_container_entries{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_arp_container_entries{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3364,7 +3364,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_TCP_inuse{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_TCP_inuse{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3379,7 +3379,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_TCP_inuse{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_TCP_inuse{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3503,7 +3503,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_TCP_tw{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_TCP_tw{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3518,7 +3518,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_TCP_tw{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_TCP_tw{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3642,7 +3642,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_sockets_used{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_sockets_used{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3657,7 +3657,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_sockets_used{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_sockets_used{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3781,7 +3781,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_TCP_mem_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_TCP_mem_bytes{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3796,7 +3796,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_TCP_mem_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_TCP_mem_bytes{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3920,7 +3920,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_UDP_mem_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_UDP_mem_bytes{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -3935,7 +3935,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_UDP_mem_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_UDP_mem_bytes{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4059,7 +4059,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_UDP_inuse{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_UDP_inuse{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4074,7 +4074,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_sockstat_container_UDP_inuse{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_sockstat_container_UDP_inuse{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4178,7 +4178,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_InSegs{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_InSegs{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4193,7 +4193,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_OutSegs{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_OutSegs{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4208,7 +4208,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPDelivered{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPDelivered{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4223,7 +4223,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPOrigDataSent{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPOrigDataSent{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4238,7 +4238,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_ActiveOpens{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_ActiveOpens{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4253,7 +4253,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_netstat_Tcp_CurrEstab{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_netstat_Tcp_CurrEstab{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4268,7 +4268,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_PassiveOpens{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_PassiveOpens{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4372,7 +4372,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_ListenDrops{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_ListenDrops{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4387,7 +4387,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_ListenOverflows{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_ListenOverflows{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4402,7 +4402,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPReqQFullDoCookies{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPReqQFullDoCookies{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4417,7 +4417,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_PFMemallocDrop{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_PFMemallocDrop{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4432,7 +4432,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPBacklogDrop{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPBacklogDrop{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4447,7 +4447,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPRcvQDrop{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPRcvQDrop{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4462,7 +4462,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPTimeouts{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPTimeouts{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4477,7 +4477,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPLossFailures{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPLossFailures{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4492,7 +4492,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSACKDiscard{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSACKDiscard{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4507,7 +4507,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPMemoryPressures{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPMemoryPressures{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4522,7 +4522,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPMinTTLDrop{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPMinTTLDrop{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4537,7 +4537,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPMinTTLDrop{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPMinTTLDrop{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4552,7 +4552,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPTimeWaitOverflow{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPTimeWaitOverflow{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4656,7 +4656,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_InErrs{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_InErrs{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4671,7 +4671,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_InCsumErrors{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_InCsumErrors{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4686,7 +4686,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPAbortOnMemory{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPAbortOnMemory{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4701,7 +4701,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPAbortOnTimeout{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPAbortOnTimeout{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4716,7 +4716,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPRetransFail{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPRetransFail{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4731,7 +4731,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSackFailures{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSackFailures{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4746,7 +4746,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSackFailures{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSackFailures{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4761,7 +4761,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_SyncookiesFailed{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_SyncookiesFailed{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4776,7 +4776,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPWqueueTooBig{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPWqueueTooBig{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4791,7 +4791,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_AttemptFails{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_AttemptFails{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4895,7 +4895,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_RetransSegs{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_RetransSegs{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4910,7 +4910,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSynRetrans{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSynRetrans{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4925,7 +4925,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPFastRetrans{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPFastRetrans{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4940,7 +4940,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSlowStartRetrans{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSlowStartRetrans{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4955,7 +4955,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSpuriousRTOs{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSpuriousRTOs{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -4970,7 +4970,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSpuriousRtxHostQueues{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSpuriousRtxHostQueues{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5074,7 +5074,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_PruneCalled{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_PruneCalled{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5089,7 +5089,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_RcvPruned{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_RcvPruned{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5194,7 +5194,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_ActiveOpens{host=~\"$host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_TcpExt_TCPSynRetrans{host=~\"$host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_Tcp_PassiveOpens{host=~\"$host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_TcpExt_ListenDrops{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_ActiveOpens{host=~\"$host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_TcpExt_TCPSynRetrans{host=~\"$host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_Tcp_PassiveOpens{host=~\"$host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_TcpExt_ListenDrops{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5210,7 +5210,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_ActiveOpens{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_ActiveOpens{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5226,7 +5226,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_Tcp_PassiveOpens{host=~\"$host\",region=\"$region\"}[30s])+rate(huatuo_bamai_netstat_TcpExt_ListenDrops{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_Tcp_PassiveOpens{host=~\"$host\",region=~\"$region\"}[30s])+rate(huatuo_bamai_netstat_TcpExt_ListenDrops{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "Receiver: {{host}}",
@@ -5240,7 +5240,7 @@
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSynRetrans{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netstat_TcpExt_TCPSynRetrans{host=~\"$host\",region=~\"$region\"}[30s])",
               "hide": false,
               "interval": "",
               "legendFormat": "Retransmission count（Sender+Reciever）: {{host}}",
@@ -5342,7 +5342,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_netdev_hw_rx_dropped_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_netdev_hw_rx_dropped_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5474,7 +5474,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "increase(huatuo_bamai_iolatency_blkdisk_q2c{host=~\"$host\",region=\"$region\"}[5m])",
+              "expr": "increase(huatuo_bamai_iolatency_blkdisk_q2c{host=~\"$host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{host}},disk={{disk}} [{{latency}}]",
               "refId": "A"
@@ -5600,7 +5600,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "increase(huatuo_bamai_iolatency_blkdisk_d2c{host=~\"$host\",region=\"$region\"}[5m])",
+              "expr": "increase(huatuo_bamai_iolatency_blkdisk_d2c{host=~\"$host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{host}},disk={{disk}} [{{latency}}]",
               "refId": "A"
@@ -5701,7 +5701,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "increase(huatuo_bamai_iolatency_blkdisk_freeze{host=~\"$host\",region=\"$region\"}[5m])",
+              "expr": "increase(huatuo_bamai_iolatency_blkdisk_freeze{host=~\"$host\",region=~\"$region\"}[5m])",
               "interval": "",
               "legendFormat": "{{host}},disk={{disk}} [{{latency}}]",
               "refId": "A"
@@ -5828,7 +5828,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "increase(huatuo_bamai_xfs_alloc_blocks_total{host=~\"$host\",region=\"$region\"}[5m]) / clamp_min(increase(huatuo_bamai_xfs_alloc_extents_total{host=~\"$host\",region=\"$region\"}[5m]), 1e-6)",
+              "expr": "increase(huatuo_bamai_xfs_alloc_blocks_total{host=~\"$host\",region=~\"$region\"}[5m]) / clamp_min(increase(huatuo_bamai_xfs_alloc_extents_total{host=~\"$host\",region=~\"$region\"}[5m]), 1e-6)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -5932,7 +5932,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "clamp_min((increase(huatuo_bamai_xfs_inode_attempts_total{host=~\"$host\",region=\"$region\"}[5m]) - increase(huatuo_bamai_xfs_inode_missed_total{host=~\"$host\",region=\"$region\"}[5m]))/clamp_min(increase(huatuo_bamai_xfs_inode_attempts_total{host=~\"$host\",region=\"$region\"}[5m]), 1e-6),0)",
+              "expr": "clamp_min((increase(huatuo_bamai_xfs_inode_attempts_total{host=~\"$host\",region=~\"$region\"}[5m]) - increase(huatuo_bamai_xfs_inode_missed_total{host=~\"$host\",region=~\"$region\"}[5m]))/clamp_min(increase(huatuo_bamai_xfs_inode_attempts_total{host=~\"$host\",region=~\"$region\"}[5m]), 1e-6),0)",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6036,7 +6036,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_xfs_buf_locked_waited_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_xfs_buf_locked_waited_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6140,7 +6140,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_xfs_buf_busy_locked_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_xfs_buf_busy_locked_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6244,7 +6244,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "huatuo_bamai_xfs_log_free_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_xfs_log_free_bytes{host=~\"$host\",region=~\"$region\"}",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6348,7 +6348,7 @@
                 "uid": "huatuo-bamai-prom"
               },
               "exemplar": true,
-              "expr": "rate(huatuo_bamai_xfs_log_space_sleep_total{host=~\"$host\",region=\"$region\"}[30s])",
+              "expr": "rate(huatuo_bamai_xfs_log_space_sleep_total{host=~\"$host\",region=~\"$region\"}[30s])",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -6480,7 +6480,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "rate(huatuo_bamai_process_cpu_seconds_total{host=~\"$host\",region=\"$region\"}[1m]) * 100",
+              "expr": "rate(huatuo_bamai_process_cpu_seconds_total{host=~\"$host\",region=~\"$region\"}[1m]) * 100",
               "interval": "",
               "legendFormat": "{{host}}",
               "refId": "A"
@@ -6581,7 +6581,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_process_resident_memory_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_process_resident_memory_bytes{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "Process RSS",
               "refId": "A"
@@ -6594,7 +6594,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_memstats_sys_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_memstats_sys_bytes{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "Go Runtime Total",
               "refId": "B"
@@ -6607,7 +6607,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_memstats_heap_inuse_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_memstats_heap_inuse_bytes{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "Go Heap In-Use",
               "refId": "C"
@@ -6620,7 +6620,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_memstats_stack_inuse_bytes{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_memstats_stack_inuse_bytes{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "Go Stack",
               "refId": "D"
@@ -6721,7 +6721,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_process_open_fds{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_process_open_fds{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "Open FDs",
               "refId": "A"
@@ -6822,7 +6822,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_goroutines{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_goroutines{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "Goroutines",
               "refId": "A"
@@ -6835,7 +6835,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_threads{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_threads{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "OS Threads",
               "refId": "B"
@@ -6936,7 +6936,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_memstats_heap_objects{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_memstats_heap_objects{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}",
               "refId": "A"
@@ -7037,7 +7037,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "(rate(huatuo_bamai_go_gc_duration_seconds_sum{host=~\"$host\",region=\"$region\"}[5m]) / rate(huatuo_bamai_go_gc_duration_seconds_count{host=~\"$host\",region=\"$region\"}[5m])) * 1000",
+              "expr": "(rate(huatuo_bamai_go_gc_duration_seconds_sum{host=~\"$host\",region=~\"$region\"}[5m]) / rate(huatuo_bamai_go_gc_duration_seconds_count{host=~\"$host\",region=~\"$region\"}[5m])) * 1000",
               "interval": "",
               "legendFormat": "{{host}}",
               "refId": "A"
@@ -7138,7 +7138,7 @@
               "editorMode": "code",
               "exemplar": true,
               "range": true,
-              "expr": "huatuo_bamai_go_gc_gogc_percent{host=~\"$host\",region=\"$region\"}",
+              "expr": "huatuo_bamai_go_gc_gogc_percent{host=~\"$host\",region=~\"$region\"}",
               "interval": "",
               "legendFormat": "{{host}}",
               "refId": "A"
@@ -7182,7 +7182,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "region",
-        "multi": false,
+        "multi": true,
         "name": "region",
         "options": [],
         "query": {
@@ -7193,7 +7193,8 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 2,
-        "type": "query"
+        "type": "query",
+        "allValue": ".*"
       },
       {
         "current": {

--- a/build/docker/grafana/dashboards/metrics-host.json
+++ b/build/docker/grafana/dashboards/metrics-host.json
@@ -72,7 +72,7 @@
         "type": "prometheus",
         "uid": "huatuo-bamai-prom"
       },
-      "description": "List of all containers running on this host.",
+      "description": "Containers on this host.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -311,7 +311,7 @@
       ],
       "title": "Selected Metric: $metric",
       "type": "timeseries",
-      "description": "Arbitrary metric selected from the $metric variable, filtered by host and region."
+      "description": "Selected metric filtered by host and region."
     },
     {
       "collapsed": true,
@@ -332,7 +332,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Host-level user-space CPU utilization",
+          "description": "Host user CPU utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -435,7 +435,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Host-level kernel-space CPU utilization",
+          "description": "Host kernel CPU utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -535,7 +535,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Per-container user-space CPU utilization on host.",
+          "description": "Per-container user CPU utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -637,7 +637,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Per-container kernel-space CPU utilization on host.",
+          "description": "Per-container kernel CPU utilization.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -736,7 +736,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Wait time caused by host-level resource contention outside the container's cgroup.",
+          "description": "Wait time from host-level resource contention.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -835,7 +835,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Wait time caused by cgroup quota limits within the\ncontainer.",
+          "description": "Wait time from cgroup CPU quota limits.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -934,7 +934,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "CPU throttling events when container exceeds its cgroup CPU quota.",
+          "description": "CPU throttle events when cgroup quota exceeded.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1034,7 +1034,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "CPU run queue latency distribution by zone (rate)",
+          "description": "Run queue latency distribution by zone (rate).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1137,7 +1137,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Softirq latency distribution by type and zone (rate)",
+          "description": "Softirq latency distribution by type and zone (rate).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1267,7 +1267,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Cumulative count of pages reclaimed synchronously by the  process itself (direct reclaim path)",
+          "description": "Pages reclaimed via direct reclaim path (cumulative).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1367,7 +1367,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Cumulative count of pages reclaimed asynchronously by the kswapd background daemon.",
+          "description": "Pages reclaimed by kswapd daemon (cumulative).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1467,7 +1467,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Real-time count of memory pages modified but not yet written to disk.",
+          "description": "Dirty pages not yet written to disk.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1567,7 +1567,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Real-time count of memory pages currently being flushed to disk.",
+          "description": "Pages being flushed to disk.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1666,7 +1666,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Real-time count of unallocated memory pages available on the host.",
+          "description": "Free memory pages available.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1765,7 +1765,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Real-time size of file-backed page cache in memory.",
+          "description": "File-backed page cache size.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1864,7 +1864,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Real-time anonymous memory usage including shared memory (shmem/tmpfs).",
+          "description": "Anonymous memory including shmem/tmpfs.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1992,7 +1992,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total received bytes per second across all network interfaces.",
+          "description": "Rx bytes/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2105,7 +2105,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total received packets per second across all network interfaces.",
+          "description": "Rx packets/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2217,7 +2217,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total transmitted bytes per second across all network interfaces.",
+          "description": "Tx bytes/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2328,7 +2328,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total transmitted packets per second across all network interfaces.",
+          "description": "Tx packets/s across all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2439,7 +2439,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Receive-side anomaly stats: drops, errors, FIFO overruns, frame errors (packets/s).",
+          "description": "Rx anomalies: drops, errors, overruns, frame errors (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2551,7 +2551,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Transmit-side anomaly stats: drops, errors, FIFO overruns, carrier errors (packets/s).",
+          "description": "Tx anomalies: drops, errors, overruns, carrier errors (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2687,7 +2687,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Queueing discipline total throughput (MiB/s).",
+          "description": "Qdisc throughput (MiB/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2810,7 +2810,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Queueing discipline total packet rate (packets/s).",
+          "description": "Qdisc packet rate (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2933,7 +2933,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Qdisc-level anomaly stats: drops, backlog, overlimits, requeues (packets/s).",
+          "description": "Qdisc anomalies: drops, backlog, overlimits, requeues (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3105,7 +3105,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total ARP request and reply packets on all interfaces.",
+          "description": "ARP packets/s on all interfaces.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3258,7 +3258,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Number of TCP sockets currently in use.",
+          "description": "TCP sockets in use.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3397,7 +3397,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Number of TCP sockets in TIME_WAIT state.",
+          "description": "TCP sockets in TIME_WAIT.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3536,7 +3536,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total socket count across all protocols (TCP, UDP, RAW, etc.).",
+          "description": "Total sockets across all protocols.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3675,7 +3675,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total memory consumed by TCP socket buffers (bytes).",
+          "description": "TCP socket buffer memory (bytes).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3814,7 +3814,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Total memory consumed by UDP socket buffers (bytes).",
+          "description": "UDP socket buffer memory (bytes).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3953,7 +3953,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Number of UDP sockets currently in use.",
+          "description": "UDP sockets in use.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4092,7 +4092,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Aggregated kernel netstat counters (SNMP/netstat).",
+          "description": "Kernel netstat counters (SNMP).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4286,7 +4286,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Packet loss rate derived from netstat counters.",
+          "description": "Packet loss rate from netstat.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4570,7 +4570,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Network error counters: InErrors, OutErrors, InCsumErrors, etc.",
+          "description": "Network errors: InErrors, OutErrors, InCsumErrors.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4809,7 +4809,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "TCP segment retransmission rate and count.",
+          "description": "TCP retransmission rate and count.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -4988,7 +4988,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Packets dropped due to socket receive buffer exhaustion (RcvbufErrors, SndbufErrors).",
+          "description": "Packets dropped from buffer exhaustion (RcvbufErrors, SndbufErrors).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5107,7 +5107,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "TCP SYN packet statistics: SYN received, SYN sent, SYN retransmissions.",
+          "description": "TCP SYN stats: received, sent, retransmissions.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5256,7 +5256,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Packets dropped at the NIC hardware/driver level (packets/s).",
+          "description": "NIC hardware/driver drops (pkt/s).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5387,7 +5387,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Disk IO count where queue-to-completion (q2c) latency exceeds 20ms, 5-minute incremental.",
+          "description": "Disk IO with q2c latency >20ms (5-min incremental).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5488,7 +5488,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Disk IO count where device-to-completion (d2c) latency exceeds 20ms, 5-minute incremental.",
+          "description": "Disk IO with d2c latency >20ms (5-min incremental).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5614,7 +5614,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Disk IO count where RAID flush latency exceeds 20ms, 5-minute incremental.",
+          "description": "Disk IO with RAID flush latency >20ms (5-min incremental).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5742,7 +5742,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "XFS fragmentation level measured as average blocks per extent per second.",
+          "description": "XFS fragmentation: avg blocks per extent.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5846,7 +5846,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "XFS inode cache hit rate, 5-minute rolling average per second.",
+          "description": "XFS inode cache hit rate (5-min avg).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5950,7 +5950,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "XFS buffer lock contention: number of waits for locked buffers per second.",
+          "description": "XFS buffer lock contention waits/s.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6054,7 +6054,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "XFS buffer busy acquisition: number of retries on busy buffers per second.",
+          "description": "XFS buffer busy retries/s.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6158,7 +6158,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Remaining free space in the XFS journal/write-ahead log (bytes).",
+          "description": "XFS journal free space (bytes).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6262,7 +6262,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Count of sleeps per second due to XFS journal space exhaustion.",
+          "description": "XFS journal exhaustion sleeps/s.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6393,7 +6393,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Process CPU usage as percentage of one core, derived from process_cpu_seconds_total rate.",
+          "description": "Process CPU usage (% of one core).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6494,7 +6494,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Process RSS: total physical memory held by the OS. Go Runtime Total: all memory obtained from the OS by the Go runtime. Go Heap In-Use: live objects on the Go heap. Go Stack: goroutine stack memory.",
+          "description": "Process RSS and Go runtime memory breakdown. Go Heap In-Use: live objects on the Go heap. Go Stack: goroutine stack memory.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6634,7 +6634,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Current number of open file descriptors of the huatuo-bamai process.",
+          "description": "Open file descriptors.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6735,7 +6735,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Goroutines: number of Go goroutines. OS Threads: number of OS-level threads created by the Go runtime. A growing thread count may indicate a thread leak.",
+          "description": "Goroutine and OS thread count. count may indicate a thread leak.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6849,7 +6849,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Number of live objects allocated on the Go heap. A sustained upward trend may indicate an object leak.",
+          "description": "Live heap objects; sustained growth may indicate a leak.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -6950,7 +6950,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Average Go GC stop-the-world pause time per collection cycle. High values cause request latency spikes.",
+          "description": "Avg GC stop-the-world pause per cycle.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -7051,7 +7051,7 @@
             "type": "prometheus",
             "uid": "huatuo-bamai-prom"
           },
-          "description": "Current GOGC setting controlling GC frequency. 100 means GC triggers when heap doubles. Lower values increase GC frequency and reduce memory usage.",
+          "description": "GOGC setting controlling GC trigger threshold.cy and reduce memory usage.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -233,6 +233,8 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 	switch matcher.Name {
 	case "id":
 		filter.ID = matcher.Value
+	case "region":
+		filter.Region = matcher.Value
 	case "hostname":
 		filter.Hostname = matcher.Value
 	case "container_id":

--- a/internal/profiler/service/flamegraph_test.go
+++ b/internal/profiler/service/flamegraph_test.go
@@ -17,12 +17,35 @@ package service
 import (
 	"strings"
 	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 func TestServiceReadyRejectsUninitializedStorage(t *testing.T) {
 	err := (*Service)(nil).Ready(t.Context())
 	if err == nil || !strings.Contains(err.Error(), "not initialized") {
 		t.Fatalf("Ready() error = %v, want initialization error", err)
+	}
+}
+
+func TestApplyProfileMatcherRegion(t *testing.T) {
+	filter := &SearchFilter{}
+	matcher := &labels.Matcher{Name: "region", Value: "cn-beijing", Type: labels.MatchEqual}
+
+	if err := applyProfileMatcher(filter, matcher); err != nil {
+		t.Fatalf("applyProfileMatcher() error = %v", err)
+	}
+	if filter.Region != "cn-beijing" {
+		t.Errorf("filter.Region = %q, want %q", filter.Region, "cn-beijing")
+	}
+}
+
+func TestApplyProfileMatcherRejectsUnknownLabel(t *testing.T) {
+	filter := &SearchFilter{}
+	matcher := &labels.Matcher{Name: "unknown", Value: "x", Type: labels.MatchEqual}
+
+	if err := applyProfileMatcher(filter, matcher); err == nil {
+		t.Fatal("applyProfileMatcher() error = nil, want error for unknown label")
 	}
 }
 

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -88,6 +88,7 @@ func (d *ProfileDocument) CapturedAt() time.Time {
 // SearchFilter defines the search filter.
 type SearchFilter struct {
 	ID                string
+	Region            string
 	Hostname          string
 	ContainerID       string
 	ContainerHostname string
@@ -301,6 +302,13 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Field: profileFieldTracerID + ".keyword",
 			Op:    driver.OpEq,
 			Value: id,
+		})
+	}
+	if filter.Region != "" {
+		query.Filters = append(query.Filters, driver.Filter{
+			Field: profileFieldRegion + ".keyword",
+			Op:    driver.OpEq,
+			Value: filter.Region,
 		})
 	}
 	if filter.Hostname != "" {

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -58,3 +58,21 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
 	}
 }
+
+func TestBuildProfileAggregationQueryFiltersByRegion(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		Region:   "cn-beijing",
+		Hostname: "node-1",
+	})
+
+	found := false
+	for _, f := range query.Filters {
+		if f.Field == profileFieldRegion+".keyword" && f.Value == "cn-beijing" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("query filters = %#v, want region filter present", query.Filters)
+	}
+}


### PR DESCRIPTION
## Summary

Three issues around the `region` tag in profiler queries and Grafana dashboards, plus a dashboard description cleanup.

## Changes

### fix(profiler): enable region label filtering

`LabelNames` advertised `region` but `applyProfileMatcher` rejected it with `ErrInvalidQuery`. Add `Region` to `SearchFilter`, handle `region` in `applyProfileMatcher`, and apply a `region.keyword` filter in `buildProfileAggregationQuery`. The filter is optional — queries without `region` are unaffected.

### fix(dashboards): fix region/hostname variables and ES keyword fields

- **Metrics dashboards** (`metrics-host`, `metrics-container`, `metrics-disk-io`): region var used exact match `region="$region"` with `includeAll:true` but no `allValue`. Selecting "All" expanded `$region` to `.*` and matched zero series. Switch to `multi:true` + `allValue:".*"` and `region=~"$region"` (regex).
- **autotracing-event**: queried ES text fields (`region`, `hostname`) instead of `.keyword`, causing tokenizer splits on values like `cn-beijing`. Switch variable definitions, panel Lucene queries, and the hostname cascade inner query to `.keyword`. Sync `definition` with `query`.
- **metrics-container**: `container_host` cascade variable dropped the region filter. Add `region=~"$region"`.

### refactor(dashboards): simplify panel descriptions

Replace verbose multi-sentence descriptions with concise one-liners across 105 panels in `metrics-host`, `metrics-container`, and `autotracing-event`. No query or layout changes.

## Test

- Unit tests: `TestApplyProfileMatcherRegion`, `TestApplyProfileMatcherRejectsUnknownLabel`, `TestBuildProfileAggregationQueryFiltersByRegion` — all pass.
- Dashboard JSON validated; automated checks confirm no residual `region="$region"`, no unqualified `region:`/`hostname:` in autotracing, region vars have `multi:true`+`allValue:".*"`, container_host cascade includes region filter.