### PR TITLE
fix(bpf): disable perf events until BPF attachment

### DIFF
--- a/internal/bpf/perf_event_pmu.go
+++ b/internal/bpf/perf_event_pmu.go
@@ -104,12 +104,12 @@ func attachPerfEvent(opt *perfEventOption) (*perfEventAttach, error) {
 		Type:   unix.PERF_TYPE_SOFTWARE,
 		Size:   unix.PERF_ATTR_SIZE_VER0,
 		Config: unix.PERF_COUNT_SW_CPU_CLOCK,
-		Bits:   unix.PerfBitFreq,
+		Bits:   unix.PerfBitFreq | unix.PerfBitDisabled,
 		Sample: opt.sample,
 	}
 
 	if opt.sampleMode == perfEventSamplePeriod {
-		attr.Bits = 0
+		attr.Bits = unix.PerfBitDisabled
 	}
 
 	cpuIDs := opt.cpuIDs

--- a/internal/bpf/perf_event_pmu_test.go
+++ b/internal/bpf/perf_event_pmu_test.go
@@ -44,7 +44,7 @@ func TestAttachPerfEvent(t *testing.T) {
 		{
 			name: "ok period sampling",
 			opt: &perfEventOption{
-				sample:     1,
+				sample:     1_000_000,
 				sampleMode: perfEventSamplePeriod,
 				program:    prog,
 			},


### PR DESCRIPTION
## What changed

- Set PerfBitDisabled when constructing frequency and period perf event attrs.
- Keep the existing SET_BPF then ENABLE ordering.
- Raise the period sampling test value from 1 to 1,000,000.

## Root cause

Period mode cleared attr.Bits, so CPU clock sampling with period 1 could start
inside perf_event_open. In a KVM guest this generated enough sampling pressure
to block the syscall before the BPF program could be attached. The unit test
then hit its five-minute timeout.

## Validation

- make check
- go test ./internal/bpf -run Test(AttachPerfEvent|OpenPerfEvent) -count=1 -timeout=2m

The original period test completed locally before the fix, so the VM-specific
hang was confirmed from Actions run 30790326587, job 91665106516.