### PR TITLE
feat(oom): enrich victim process diagnostics

### DIFF
--- a/bpf/include/abi/oom_types.h
+++ b/bpf/include/abi/oom_types.h
@@ -26,6 +26,10 @@ struct oom_event {
 	u64 victim_memcg_css;
 	u64 mem_limit_pages;
 	u64 mem_usage_pages;
+	u64 victim_rss_anon_pages;
+	u64 victim_rss_file_pages;
+	u64 victim_rss_shmem_pages;
+	u64 victim_total_vm_pages;
 };
 
 BPF_ABI_EXPORT(oom_event);

--- a/bpf/include/abi/oom_types.h
+++ b/bpf/include/abi/oom_types.h
@@ -17,6 +17,11 @@
 
 #include "bpf_abi.h"
 
+#define OOM_CMDLINE_MAX 512
+#define OOM_ENVIRON_MAX 2048
+
+#define OOM_CAPTURE_TRUNC (1U << 0)
+
 struct oom_event {
 	u8 trigger_comm[COMPAT_TASK_COMM_LEN];
 	u8 victim_comm[COMPAT_TASK_COMM_LEN];
@@ -30,8 +35,23 @@ struct oom_event {
 	u64 victim_rss_file_pages;
 	u64 victim_rss_shmem_pages;
 	u64 victim_total_vm_pages;
+	u64 timestamp;
 };
 
 BPF_ABI_EXPORT(oom_event);
+
+struct oom_exit_event {
+	u64 timestamp;
+	u32 victim_tgid;
+	u16 cmdline_len;
+	u16 environ_len;
+	u8 cmdline_flags;
+	u8 environ_flags;
+	u8 pad[6];
+	u8 victim_cmdline[OOM_CMDLINE_MAX];
+	u8 victim_environ[OOM_ENVIRON_MAX];
+};
+
+BPF_ABI_EXPORT(oom_exit_event);
 
 #endif /* __BPF_ABI_OOM_H__ */

--- a/bpf/include/abi/oom_types.h
+++ b/bpf/include/abi/oom_types.h
@@ -47,7 +47,8 @@ struct oom_exit_event {
 	u16 environ_len;
 	u8 cmdline_flags;
 	u8 environ_flags;
-	u8 pad[6];
+	u8 go_build_info;
+	u8 pad[5];
 	u8 victim_cmdline[OOM_CMDLINE_MAX];
 	u8 victim_environ[OOM_ENVIRON_MAX];
 };

--- a/bpf/oom.c
+++ b/bpf/oom.c
@@ -145,6 +145,32 @@ capture_user_region(u8 *dst, u32 capacity, unsigned long start,
 	return (u16)length;
 }
 
+/*
+ * Go places this buildinfo magic at mm->start_data for normal internal-link
+ * executables. Check only that fixed address; do not scan victim memory.
+ */
+#define GO_BUILDINFO_MAGIC "\xff Go buildinf:"
+#define GO_BUILDINFO_MAGIC_LEN 14
+
+static __always_inline u8
+has_go_buildinfo_at_start_data(unsigned long start_data)
+{
+	u8 actual[GO_BUILDINFO_MAGIC_LEN];
+	u8 expected[] = GO_BUILDINFO_MAGIC;
+	int i;
+
+	if (!start_data ||
+	    compat_bpf_probe_read(actual, sizeof(actual), (void *)start_data) != 0)
+		return 0;
+
+#pragma unroll
+	for (i = 0; i < GO_BUILDINFO_MAGIC_LEN; i++) {
+		if (actual[i] != expected[i])
+			return 0;
+	}
+	return 1;
+}
+
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 {
@@ -222,7 +248,7 @@ int BPF_KPROBE(do_exit_trace, long code)
 	struct oom_exit_event *exit_event;
 	struct task_struct *victim_task;
 	struct mm_struct *victim_mm;
-	unsigned long arg_start, arg_end, env_start, env_end;
+	unsigned long arg_start, arg_end, env_start, env_end, start_data;
 
 	/*
 	 * Most exits stop at this global-data check. The hash lookup is only paid
@@ -264,6 +290,9 @@ int BPF_KPROBE(do_exit_trace, long code)
 	arg_end = BPF_CORE_READ(victim_mm, arg_end);
 	env_start = BPF_CORE_READ(victim_mm, env_start);
 	env_end = BPF_CORE_READ(victim_mm, env_end);
+	start_data = BPF_CORE_READ(victim_mm, start_data);
+	exit_event->go_build_info =
+	    has_go_buildinfo_at_start_data(start_data);
 
 	exit_event->cmdline_len = capture_user_region(
 	    exit_event->victim_cmdline, sizeof(exit_event->victim_cmdline),

--- a/bpf/oom.c
+++ b/bpf/oom.c
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "vmlinux.h"
 
 #include <bpf/bpf_core_read.h>
@@ -12,6 +28,62 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 
 BPF_RATELIMIT_IN_MAP(rate, 1, COMPAT_CPU_NUM * 10000, 0);
 
+/*
+ * Linux 4.18 lacks the kernel-specific probe-read helpers used by CO-RE.
+ * Use the legacy probe_read helpers (IDs 4 and 45), which support these
+ * kernel-memory reads and are available on supported older kernels.
+ */
+static long (*compat_bpf_probe_read)(void *dst, __u32 size,
+				     const void *unsafe_ptr) = (void *)4; /* BPF_FUNC_probe_read */
+static long (*compat_bpf_probe_read_str)(void *dst, __u32 size,
+					 const void *unsafe_ptr) = (void *)45; /* BPF_FUNC_probe_read_str */
+
+#define bpf_probe_read_kernel compat_bpf_probe_read
+#define bpf_probe_read_kernel_str compat_bpf_probe_read_str
+
+/*
+ * Upstream mm_struct.rss_stat has two layouts:
+ *
+ * Linux 6.1 and earlier:
+ *   struct mm_rss_stat rss_stat;
+ *   rss_stat.count[MM_*] is atomic_long_t.
+ * Linux 6.2 and later (commit f1a7941243c1):
+ *   struct percpu_counter rss_stat[NR_MM_COUNTERS];
+ *   rss_stat[MM_*].count is the global s64 counter.
+ *
+ * CO-RE checks the actual field layout, including vendor backports. The ___
+ * suffix makes this a CO-RE flavor of mm_struct.
+ */
+struct mm_struct___percpu_rss {
+	struct percpu_counter rss_stat[NR_MM_COUNTERS];
+} __attribute__((preserve_access_index));
+
+/*
+ * member must be a compile-time MM_* constant so both CO-RE array accessors
+ * can be relocated and the unavailable layout can be pruned by the verifier.
+ */
+#define READ_MM_RSS_PAGES(mm, member) ({                                \
+	u64 __pages = 0;                                                 \
+	struct mm_struct *__mm = (mm);                                  \
+	if (bpf_core_field_exists(__mm->rss_stat.count[member])) {       \
+		long __legacy = 0;                                       \
+		bpf_core_read(&__legacy, sizeof(__legacy),                \
+			      &__mm->rss_stat.count[member]);             \
+		if (__legacy > 0)                                        \
+			__pages = (u64)__legacy;                          \
+	} else {                                                         \
+		struct mm_struct___percpu_rss *__new = (void *)__mm;       \
+		if (bpf_core_field_exists(__new->rss_stat[member].count)) {\
+			s64 __percpu = 0;                                 \
+			bpf_core_read(&__percpu, sizeof(__percpu),         \
+				      &__new->rss_stat[member].count);    \
+			if (__percpu > 0)                                  \
+				__pages = (u64)__percpu;                  \
+		}                                                        \
+	}                                                                \
+	__pages;                                                         \
+})
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
 	__uint(key_size, sizeof(int));
@@ -23,6 +95,7 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 {
 	struct oom_event info = {};
 	struct task_struct *trigger_task, *victim_task;
+	struct mm_struct *victim_mm;
 
 	if (bpf_ratelimited_in_map(ctx, rate))
 		return 0;
@@ -32,10 +105,23 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 
 	trigger_task	 = (struct task_struct *)bpf_get_current_task();
 	victim_task	 = BPF_CORE_READ(oc, chosen);
+
 	info.trigger_pid = BPF_CORE_READ(trigger_task, pid);
 	info.victim_pid	 = BPF_CORE_READ(victim_task, pid);
 	BPF_CORE_READ_STR_INTO(&info.trigger_comm, trigger_task, comm);
 	BPF_CORE_READ_STR_INTO(&info.victim_comm, victim_task, comm);
+
+	victim_mm = BPF_CORE_READ(victim_task, mm);
+	if (victim_mm) {
+		info.victim_rss_anon_pages =
+		    READ_MM_RSS_PAGES(victim_mm, MM_ANONPAGES);
+		info.victim_rss_file_pages =
+		    READ_MM_RSS_PAGES(victim_mm, MM_FILEPAGES);
+		info.victim_rss_shmem_pages =
+		    READ_MM_RSS_PAGES(victim_mm, MM_SHMEMPAGES);
+		info.victim_total_vm_pages =
+		    BPF_CORE_READ(victim_mm, total_vm);
+	}
 
 	info.victim_memcg_css =
 	    (u64)BPF_CORE_READ(victim_task, cgroups, subsys[memory_cgrp_id]);

--- a/bpf/oom.c
+++ b/bpf/oom.c
@@ -121,6 +121,8 @@ struct {
 	__uint(max_entries, 1);
 } oom_exit_event_buf SEC(".maps");
 
+static const struct oom_exit_event zero_oom_exit_event = {};
+
 /*
  * Copy a bounded argv or environment region with the legacy probe_read
  * helper supported by CentOS 8.2.
@@ -272,14 +274,20 @@ int BPF_KPROBE(do_exit_trace, long code)
 		return 0;
 	__sync_fetch_and_add(&oom_victim_count, -1);
 
+	/*
+	 * The per-CPU scratch value is reused and the entire structure is sent to
+	 * userspace. Clear it so short or failed captures cannot expose bytes left
+	 * by a previous OOM victim beyond the current lengths.
+	 */
+	if (bpf_map_update_elem(&oom_exit_event_buf, &zero,
+				&zero_oom_exit_event, COMPAT_BPF_EXIST) != 0)
+		return 0;
 	exit_event = bpf_map_lookup_elem(&oom_exit_event_buf, &zero);
 	if (!exit_event)
 		return 0;
 
 	exit_event->timestamp = event_ts;
 	exit_event->victim_tgid = victim_tgid;
-	exit_event->cmdline_flags = 0;
-	exit_event->environ_flags = 0;
 
 	victim_task = (struct task_struct *)bpf_get_current_task();
 	victim_mm = BPF_CORE_READ(victim_task, mm);

--- a/bpf/oom.c
+++ b/bpf/oom.c
@@ -90,6 +90,61 @@ struct {
 	__uint(value_size, sizeof(u32));
 } oom_perf_events SEC(".maps");
 
+/*
+ * Maps an OOM victim TGID to its correlation timestamp.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u64));
+	__uint(max_entries, 256);
+} oom_victims SEC(".maps");
+
+/*
+ * A direct .bss read avoids a map lookup on every ordinary process exit.
+ */
+static volatile u32 oom_victim_count;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(int));
+	__uint(value_size, sizeof(u32));
+} oom_exit_perf_events SEC(".maps");
+
+/*
+ * A per-CPU scratch value keeps the exit event off the 512-byte BPF stack.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(struct oom_exit_event));
+	__uint(max_entries, 1);
+} oom_exit_event_buf SEC(".maps");
+
+/*
+ * Copy a bounded argv or environment region with the legacy probe_read
+ * helper supported by CentOS 8.2.
+ */
+static __always_inline u16
+capture_user_region(u8 *dst, u32 capacity, unsigned long start,
+		    unsigned long end, u8 *flags)
+{
+	u64 length;
+
+	if (!start || end <= start)
+		return 0;
+
+	length = end - start;
+	if (length > capacity) {
+		length = capacity;
+		*flags |= OOM_CAPTURE_TRUNC;
+	}
+	if (compat_bpf_probe_read(dst, (u32)length, (void *)start) != 0)
+		return 0;
+
+	return (u16)length;
+}
+
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 {
@@ -107,7 +162,7 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 	victim_task	 = BPF_CORE_READ(oc, chosen);
 
 	info.trigger_pid = BPF_CORE_READ(trigger_task, pid);
-	info.victim_pid	 = BPF_CORE_READ(victim_task, pid);
+	info.victim_pid	 = BPF_CORE_READ(victim_task, tgid);
 	BPF_CORE_READ_STR_INTO(&info.trigger_comm, trigger_task, comm);
 	BPF_CORE_READ_STR_INTO(&info.victim_comm, victim_task, comm);
 
@@ -135,7 +190,90 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 		    (u64)BPF_CORE_READ(memcg, memory.usage.counter);
 	}
 
+	/*
+	 * NOEXIST preserves the first registration for a TGID. A zero timestamp
+	 * tells userspace that registration failed and it must not wait for exit.
+	 */
+	info.timestamp = bpf_ktime_get_ns();
+	if (bpf_map_update_elem(&oom_victims, &info.victim_pid,
+				&info.timestamp, COMPAT_BPF_NOEXIST) == 0) {
+		__sync_fetch_and_add(&oom_victim_count, 1);
+	} else {
+		info.timestamp = 0;
+	}
+
 	bpf_perf_event_output(ctx, &oom_perf_events, COMPAT_BPF_F_CURRENT_CPU,
 			      &info, sizeof(info));
+	return 0;
+}
+
+/*
+ * Ordinary exits only read the pending counter. An OOM victim additionally
+ * looks up and removes its key, captures argv and environ before mm teardown,
+ * then emits a separately correlated event.
+ */
+SEC("kprobe/do_exit")
+int BPF_KPROBE(do_exit_trace, long code)
+{
+	u32 zero = 0;
+	u32 victim_tgid;
+	u64 event_ts;
+	u64 *victim_ts;
+	struct oom_exit_event *exit_event;
+	struct task_struct *victim_task;
+	struct mm_struct *victim_mm;
+	unsigned long arg_start, arg_end, env_start, env_end;
+
+	/*
+	 * Most exits stop at this global-data check. The hash lookup is only paid
+	 * while at least one OOM victim is pending.
+	 */
+	if (oom_victim_count == 0)
+		return 0;
+
+	victim_tgid = (u32)(bpf_get_current_pid_tgid() >> 32);
+	victim_ts =
+	    bpf_map_lookup_elem(&oom_victims, &victim_tgid);
+	if (!victim_ts)
+		return 0;
+
+	event_ts = *victim_ts;
+	/*
+	 * Consume the registration before capture so a later failure cannot make
+	 * this victim run the expensive path again.
+	 */
+	if (bpf_map_delete_elem(&oom_victims, &victim_tgid) != 0)
+		return 0;
+	__sync_fetch_and_add(&oom_victim_count, -1);
+
+	exit_event = bpf_map_lookup_elem(&oom_exit_event_buf, &zero);
+	if (!exit_event)
+		return 0;
+
+	exit_event->timestamp = event_ts;
+	exit_event->victim_tgid = victim_tgid;
+	exit_event->cmdline_flags = 0;
+	exit_event->environ_flags = 0;
+
+	victim_task = (struct task_struct *)bpf_get_current_task();
+	victim_mm = BPF_CORE_READ(victim_task, mm);
+	if (!victim_mm)
+		return 0;
+
+	arg_start = BPF_CORE_READ(victim_mm, arg_start);
+	arg_end = BPF_CORE_READ(victim_mm, arg_end);
+	env_start = BPF_CORE_READ(victim_mm, env_start);
+	env_end = BPF_CORE_READ(victim_mm, env_end);
+
+	exit_event->cmdline_len = capture_user_region(
+	    exit_event->victim_cmdline, sizeof(exit_event->victim_cmdline),
+	    arg_start, arg_end, &exit_event->cmdline_flags);
+	exit_event->environ_len = capture_user_region(
+	    exit_event->victim_environ, sizeof(exit_event->victim_environ),
+	    env_start, env_end, &exit_event->environ_flags);
+
+	bpf_perf_event_output(ctx, &oom_exit_perf_events,
+			      COMPAT_BPF_F_CURRENT_CPU, exit_event,
+			      sizeof(*exit_event));
 	return 0;
 }

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -211,6 +211,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
 			}
 			mergeOOMExitContext(oomData, exitContext)
 		}
+		completeLanguageInfo(oomData)
 
 		processMu.Lock()
 		defer processMu.Unlock()

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -48,6 +48,7 @@ type OOMTracingData struct {
 	Trigger        OOMActor           `json:"trigger"`
 	Victim         OOMActor           `json:"victim"`
 	MemorySnapshot *OOMMemorySnapshot `json:"memory_snapshot,omitempty"`
+	LanguageInfo   *OOMLanguageInfo   `json:"language_info,omitempty"`
 }
 
 type oomMetric struct {
@@ -140,12 +141,19 @@ func (c *oomCollector) Start(ctx context.Context) error {
 				return fmt.Errorf("failed to read perf event: %w", err)
 			}
 
+			/*
+			 * Read live procfs before container synchronization and
+			 * snapshot collection give the victim time to disappear.
+			 */
+			languageInfo := detectLanguageInfo(data.VictimPID)
+
 			containers, err := pod.Containers()
 			if err != nil {
 				return fmt.Errorf("failed to fetch containers: %w", err)
 			}
 
 			oomData := buildTracingData(data, containers, c.cgroup)
+			oomData.LanguageInfo = languageInfo
 
 			mutex.Lock()
 

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -31,6 +31,7 @@ import (
 	"huatuo-bamai/internal/utils/bytesutil"
 	"huatuo-bamai/internal/utils/kernaddr"
 	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/processlang"
 	"huatuo-bamai/pkg/tracing"
 )
 
@@ -187,21 +188,24 @@ func (c *oomCollector) Start(ctx context.Context) error {
 	 * their base data instead of creating unbounded goroutines.
 	 */
 	processEvent := func(data *abi.OOMEvent, eventTime time.Time,
-		waitForExit bool,
+		executable *os.File, waitForExit bool,
 	) {
 		if childCtx.Err() != nil {
+			if executable != nil {
+				executable.Close()
+			}
 			return
 		}
 
-		/*
-		 * Read live procfs before container synchronization and snapshot
-		 * collection give the victim time to disappear.
-		 */
-		languageInfo := detectLanguageInfo(data.VictimPID)
-
 		processMu.Lock()
-		oomData := c.prepareOOMEvent(data, languageInfo)
+		oomData := c.prepareOOMEvent(data)
 		processMu.Unlock()
+
+		/* The retained executable remains readable after snapshot collection. */
+		oomData.LanguageInfo = detectLanguageInfo(data.VictimPID, executable)
+		if executable != nil {
+			executable.Close()
+		}
 
 		if waitForExit {
 			exitContext := oomExitEvents.wait(
@@ -266,6 +270,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
 				}
 				return fmt.Errorf("failed to read perf event: %w", err)
 			}
+			executable := processlang.OpenExecutable(int(data.VictimPID))
 			eventTime := time.Now()
 
 			/*
@@ -274,7 +279,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
 			 * collection synchronously.
 			 */
 			if exitWaitCtx.Err() != nil || data.Timestamp == 0 {
-				processEvent(data, eventTime, false)
+				processEvent(data, eventTime, executable, false)
 				continue
 			}
 
@@ -285,13 +290,15 @@ func (c *oomCollector) Start(ctx context.Context) error {
 			select {
 			case asyncWorkerSlots <- struct{}{}:
 				workers.Add(1)
-				go func(data *abi.OOMEvent, eventTime time.Time) {
+				go func(data *abi.OOMEvent, eventTime time.Time,
+					executable *os.File,
+				) {
 					defer workers.Done()
 					defer func() { <-asyncWorkerSlots }()
-					processEvent(data, eventTime, true)
-				}(data, eventTime)
+					processEvent(data, eventTime, executable, true)
+				}(data, eventTime, executable)
 			default:
-				processEvent(data, eventTime, false)
+				processEvent(data, eventTime, executable, false)
 			}
 		}
 	}
@@ -302,9 +309,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
  * accounting before waiting for the victim exit event. Container discovery
  * failures degrade enrichment without discarding the base OOM event.
  */
-func (c *oomCollector) prepareOOMEvent(
-	data *abi.OOMEvent, languageInfo *OOMLanguageInfo,
-) *OOMTracingData {
+func (c *oomCollector) prepareOOMEvent(data *abi.OOMEvent) *OOMTracingData {
 	containers, err := pod.Containers()
 	containerLookupSucceeded := err == nil
 	if err != nil {
@@ -313,7 +318,6 @@ func (c *oomCollector) prepareOOMEvent(
 	}
 
 	oomData := buildTracingData(data, containers, c.cgroup)
-	oomData.LanguageInfo = languageInfo
 
 	mutex.Lock()
 	if container, ok := containers[oomData.Victim.ContainerID]; ok {

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -42,6 +42,10 @@ type OOMActor struct {
 	ContainerHostname   string                   `json:"container_hostname,omitempty"`
 	Pid                 int32                    `json:"pid"`
 	Comm                string                   `json:"comm"`
+	Cmdline             string                   `json:"cmdline,omitempty"`
+	CmdlineTruncated    bool                     `json:"cmdline_truncated,omitempty"`
+	Environ             []string                 `json:"environ,omitempty"`
+	EnvironTruncated    bool                     `json:"environ_truncated,omitempty"`
 	RssAnonBytes        uint64                   `json:"rss_anon_bytes,omitempty"`
 	RssFileBytes        uint64                   `json:"rss_file_bytes,omitempty"`
 	RssShmemBytes       uint64                   `json:"rss_shmem_bytes,omitempty"`
@@ -64,6 +68,8 @@ type oomMetric struct {
 type oomCollector struct {
 	cgroup cgroups.Cgroup
 }
+
+const oomExitWorkerLimit = 8
 
 var (
 	outOfMemoryCounterHost      float64
@@ -115,21 +121,131 @@ func (c *oomCollector) Update() ([]*metric.Data, error) {
 	return metrics, nil
 }
 
-func (c *oomCollector) Start(ctx context.Context) error {
+/*
+ * openOOMBPF opens the optional exit stream before attaching the OOM object.
+ * Failure to create that stream only disables exit-context enrichment.
+ */
+func openOOMBPF(ctx context.Context) (
+	bpf.BPF, bpf.PerfEventReader, bpf.PerfEventReader, error,
+) {
 	b, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), nil)
 	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	exitReader, err := b.EventPipeByName(ctx, "oom_exit_perf_events", 8192)
+	if err != nil {
+		log.Warnf("oom exit context disabled: %v", err)
+		exitReader = nil
+	}
+
+	reader, err := b.AttachAndEventPipe(ctx, "oom_perf_events", 8192)
+	if err != nil {
+		if exitReader != nil {
+			exitReader.Close()
+		}
+		b.Close()
+		return nil, nil, nil, err
+	}
+
+	return b, reader, exitReader, nil
+}
+
+/*
+ * Start reads OOM events continuously while separate workers correlate exit
+ * context. A failed exit reader disables context enrichment without
+ * interrupting the primary OOM event stream.
+ */
+func (c *oomCollector) Start(ctx context.Context) error {
+	childCtx, cancel := context.WithCancel(ctx)
+	b, reader, exitReader, err := openOOMBPF(childCtx)
+	if err != nil {
+		cancel()
 		return err
 	}
 	defer b.Close()
 
-	childCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	reader, err := b.AttachAndEventPipe(childCtx, "oom_perf_events", 8192)
-	if err != nil {
-		return err
+	var workers sync.WaitGroup
+	/*
+	 * Preparation and saving touch shared OOM accounting and tracing state.
+	 * Exit-context waits deliberately stay outside this lock.
+	 */
+	var processMu sync.Mutex
+	asyncWorkerSlots := make(chan struct{}, oomExitWorkerLimit)
+	/*
+	 * childCtx owns the collector lifetime. exitWaitCtx can be canceled alone
+	 * to disable exit enrichment while the base OOM reader keeps running.
+	 */
+	exitWaitCtx, cancelExitWait := context.WithCancel(childCtx)
+	if exitReader == nil {
+		cancelExitWait()
 	}
-	defer reader.Close()
+
+	/*
+	 * processEvent preserves the original serialized enrichment and storage.
+	 * Only workers with a slot wait for exit context; overflow events retain
+	 * their base data instead of creating unbounded goroutines.
+	 */
+	processEvent := func(data *abi.OOMEvent, eventTime time.Time,
+		waitForExit bool,
+	) {
+		if childCtx.Err() != nil {
+			return
+		}
+
+		/*
+		 * Read live procfs before container synchronization and snapshot
+		 * collection give the victim time to disappear.
+		 */
+		languageInfo := detectLanguageInfo(data.VictimPID)
+
+		processMu.Lock()
+		oomData := c.prepareOOMEvent(data, languageInfo)
+		processMu.Unlock()
+
+		if waitForExit {
+			exitContext := oomExitEvents.wait(
+				exitWaitCtx, data.VictimPID, data.Timestamp)
+			if childCtx.Err() != nil {
+				return
+			}
+			mergeOOMExitContext(oomData, exitContext)
+		}
+
+		processMu.Lock()
+		defer processMu.Unlock()
+		if childCtx.Err() != nil {
+			return
+		}
+		saveOOMEvent(oomData, eventTime)
+	}
+
+	defer func() {
+		cancelExitWait()
+		cancel()
+		reader.Close()
+		if exitReader != nil {
+			exitReader.Close()
+		}
+		workers.Wait()
+	}()
+
+	/*
+	 * Drain the exit stream independently; otherwise its large records could
+	 * fill the perf buffer while a base event is being enriched or stored.
+	 */
+	if exitReader != nil {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			if err := startOOMExitReader(childCtx, exitReader); err != nil {
+				cancelExitWait()
+				log.Warnf(
+					"oom exit context disabled after reader failure: %v",
+					err)
+			}
+		}()
+	}
 
 	b.DetachOnContextDone(childCtx, cancel)
 
@@ -138,48 +254,89 @@ func (c *oomCollector) Start(ctx context.Context) error {
 		case <-childCtx.Done():
 			return nil
 		default:
-			var data abi.OOMEvent
-			if err := reader.ReadInto(&data); err != nil {
+			data := new(abi.OOMEvent)
+			if err := reader.ReadInto(data); err != nil {
+				if childCtx.Err() != nil {
+					return nil
+				}
 				if errors.Is(err, bpf.ErrPerfEventSamplesLost) {
 					log.WithError(err).Warn("lost BPF perf event samples")
 					continue
 				}
 				return fmt.Errorf("failed to read perf event: %w", err)
 			}
+			eventTime := time.Now()
 
 			/*
-			 * Read live procfs before container synchronization and
-			 * snapshot collection give the victim time to disappear.
+			 * Bound asynchronous exit waits to the kernel pending-map
+			 * capacity. Registration failures and overflow retain base
+			 * collection synchronously.
 			 */
-			languageInfo := detectLanguageInfo(data.VictimPID)
-
-			containers, err := pod.Containers()
-			if err != nil {
-				return fmt.Errorf("failed to fetch containers: %w", err)
+			if exitWaitCtx.Err() != nil || data.Timestamp == 0 {
+				processEvent(data, eventTime, false)
+				continue
 			}
 
-			oomData := buildTracingData(&data, containers, c.cgroup)
-			oomData.LanguageInfo = languageInfo
-
-			mutex.Lock()
-
-			if container, ok := containers[oomData.Victim.ContainerID]; ok {
-				containerCounterUpdate(container.ID, oomData.Victim.Comm)
-			} else {
-				outOfMemoryCounterHost++
-			}
-
-			mutex.Unlock()
-
-			if err := tracing.Save(&tracing.WriteRequest{
-				TracerName:  "oom",
-				TracerTime:  time.Now(),
-				TracerData:  oomData,
-				ContainerID: oomData.Victim.ContainerID,
-			}); err != nil {
-				log.Warnf("failed to save tracing data: %v", err)
+			/*
+			 * Slot acquisition is non-blocking. During an OOM storm, preserving
+			 * the base event takes priority over waiting for optional context.
+			 */
+			select {
+			case asyncWorkerSlots <- struct{}{}:
+				workers.Add(1)
+				go func(data *abi.OOMEvent, eventTime time.Time) {
+					defer workers.Done()
+					defer func() { <-asyncWorkerSlots }()
+					processEvent(data, eventTime, true)
+				}(data, eventTime)
+			default:
+				processEvent(data, eventTime, false)
 			}
 		}
+	}
+}
+
+/*
+ * prepareOOMEvent captures container association, resource snapshots, and
+ * accounting before waiting for the victim exit event. Container discovery
+ * failures degrade enrichment without discarding the base OOM event.
+ */
+func (c *oomCollector) prepareOOMEvent(
+	data *abi.OOMEvent, languageInfo *OOMLanguageInfo,
+) *OOMTracingData {
+	containers, err := pod.Containers()
+	containerLookupSucceeded := err == nil
+	if err != nil {
+		log.Warnf("failed to fetch containers for oom enrichment: %v", err)
+		containers = nil
+	}
+
+	oomData := buildTracingData(data, containers, c.cgroup)
+	oomData.LanguageInfo = languageInfo
+
+	mutex.Lock()
+	if container, ok := containers[oomData.Victim.ContainerID]; ok {
+		containerCounterUpdate(container.ID, oomData.Victim.Comm)
+	} else if containerLookupSucceeded {
+		outOfMemoryCounterHost++
+	}
+	mutex.Unlock()
+
+	return oomData
+}
+
+/*
+ * saveOOMEvent writes the enriched base event and any correlated exit context
+ * as one tracing record.
+ */
+func saveOOMEvent(oomData *OOMTracingData, eventTime time.Time) {
+	if err := tracing.Save(&tracing.WriteRequest{
+		TracerName:  "oom",
+		TracerTime:  eventTime,
+		TracerData:  oomData,
+		ContainerID: oomData.Victim.ContainerID,
+	}); err != nil {
+		log.Warnf("failed to save tracing data: %v", err)
 	}
 }
 

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -336,6 +336,7 @@ func (c *oomCollector) prepareOOMEvent(data *abi.OOMEvent) *OOMTracingData {
  * as one tracing record.
  */
 func saveOOMEvent(oomData *OOMTracingData, eventTime time.Time) {
+	oomData.Victim.Environ = redactOOMEnviron(oomData.Victim.Environ)
 	if err := tracing.Save(&tracing.WriteRequest{
 		TracerName:  "oom",
 		TracerTime:  eventTime,

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -207,15 +207,16 @@ func (c *oomCollector) Start(ctx context.Context) error {
 			executable.Close()
 		}
 
+		var exitContext *oomExitContext
 		if waitForExit {
-			exitContext := oomExitEvents.wait(
+			exitContext = oomExitEvents.wait(
 				exitWaitCtx, data.VictimPID, data.Timestamp)
 			if childCtx.Err() != nil {
 				return
 			}
 			mergeOOMExitContext(oomData, exitContext)
 		}
-		completeLanguageInfo(oomData)
+		completeLanguageInfo(oomData, exitContext)
 
 		processMu.Lock()
 		defer processMu.Unlock()

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -41,6 +42,10 @@ type OOMActor struct {
 	ContainerHostname   string                   `json:"container_hostname,omitempty"`
 	Pid                 int32                    `json:"pid"`
 	Comm                string                   `json:"comm"`
+	RssAnonBytes        uint64                   `json:"rss_anon_bytes,omitempty"`
+	RssFileBytes        uint64                   `json:"rss_file_bytes,omitempty"`
+	RssShmemBytes       uint64                   `json:"rss_shmem_bytes,omitempty"`
+	TotalVmBytes        uint64                   `json:"total_vm_bytes,omitempty"`
 	Cgroup              *OOMCgroupMemorySnapshot `json:"cgroup,omitempty"`
 }
 
@@ -64,6 +69,7 @@ var (
 	outOfMemoryCounterHost      float64
 	outOfMemoryCounterContainer = make(map[string]*oomMetric)
 	mutex                       sync.Mutex
+	pageSize                    = uint64(os.Getpagesize())
 )
 
 func init() {
@@ -152,7 +158,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
 				return fmt.Errorf("failed to fetch containers: %w", err)
 			}
 
-			oomData := buildTracingData(data, containers, c.cgroup)
+			oomData := buildTracingData(&data, containers, c.cgroup)
 			oomData.LanguageInfo = languageInfo
 
 			mutex.Lock()
@@ -177,7 +183,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
 	}
 }
 
-func buildTracingData(data abi.OOMEvent, containers map[string]*pod.Container, cgroup cgroups.Cgroup) *OOMTracingData {
+func buildTracingData(data *abi.OOMEvent, containers map[string]*pod.Container, cgroup cgroups.Cgroup) *OOMTracingData {
 	cssContainers := pod.BuildCssContainersID(containers, subsystem.SubsystemMemory)
 
 	triggerID := cssContainers[data.TriggerMemcgCSS]
@@ -195,6 +201,10 @@ func buildTracingData(data abi.OOMEvent, containers map[string]*pod.Container, c
 			ContainerID:         victimID,
 			Pid:                 int32(data.VictimPID),
 			Comm:                bytesutil.ToStr(data.VictimComm[:]),
+			RssAnonBytes:        data.VictimRssAnonPages * pageSize,
+			RssFileBytes:        data.VictimRssFilePages * pageSize,
+			RssShmemBytes:       data.VictimRssShmemPages * pageSize,
+			TotalVmBytes:        data.VictimTotalVmPages * pageSize,
 		},
 	}
 

--- a/core/events/oom_environ.go
+++ b/core/events/oom_environ.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import "strings"
+
+const oomEnvironRedactedValue = "[REDACTED]"
+
+var sensitiveOOMEnvKeywords = []string{
+	"PASSWORD",
+	"PASSWD",
+	"TOKEN",
+	"SECRET",
+	"CREDENTIAL",
+	"API_KEY",
+	"ACCESS_KEY",
+	"PRIVATE_KEY",
+	"COOKIE",
+	"SESSION",
+	"AUTH",
+	"DATABASE_URL",
+	"DB_URL",
+	"REDIS_URL",
+	"MONGO_URI",
+	"DATABASE_DSN",
+	"CONNECTION_STRING",
+	"ENDPOINT",
+}
+
+/*
+ * redactOOMEnviron preserves useful runtime settings while masking values
+ * whose variable names contain a known sensitive keyword. Malformed entries
+ * are masked because their variable name cannot be classified safely.
+ */
+func redactOOMEnviron(environ []string) []string {
+	if len(environ) == 0 {
+		return environ
+	}
+
+	redacted := make([]string, len(environ))
+	for i, entry := range environ {
+		name, _, found := strings.Cut(entry, "=")
+		if !found || name == "" {
+			redacted[i] = oomEnvironRedactedValue
+			continue
+		}
+
+		redacted[i] = entry
+		upperName := strings.ToUpper(name)
+		for _, keyword := range sensitiveOOMEnvKeywords {
+			if strings.Contains(upperName, keyword) {
+				redacted[i] = name + "=" + oomEnvironRedactedValue
+				break
+			}
+		}
+	}
+	return redacted
+}

--- a/core/events/oom_exit.go
+++ b/core/events/oom_exit.go
@@ -40,6 +40,7 @@ type oomExitContext struct {
 	cmdlineTruncated bool
 	environ          []string
 	environTruncated bool
+	goBuildInfo      bool
 }
 
 type oomExitKey [2]uint64
@@ -91,7 +92,7 @@ func mergeOOMExitContext(
 func (c *oomExitEventCache) store(evt *abi.OOMExitEvent) {
 	key := newOOMExitKey(evt.VictimTGID, evt.Timestamp)
 	capturedAt := time.Now()
-	context := &oomExitContext{}
+	context := &oomExitContext{goBuildInfo: evt.GoBuildInfo != 0}
 	if evt.CmdlineLen > 0 {
 		context.cmdline = strings.Join(
 			decodeExitNUL(evt.VictimCmdline[:], evt.CmdlineLen), " ")

--- a/core/events/oom_exit.go
+++ b/core/events/oom_exit.go
@@ -99,8 +99,8 @@ func (c *oomExitEventCache) store(evt *abi.OOMExitEvent) {
 		context.cmdlineTruncated = evt.CmdlineFlags&oomCaptureTrunc != 0
 	}
 	if evt.EnvironLen > 0 {
-		context.environ = decodeExitNUL(
-			evt.VictimEnviron[:], evt.EnvironLen)
+		context.environ = redactOOMEnviron(decodeExitNUL(
+			evt.VictimEnviron[:], evt.EnvironLen))
 		context.environTruncated = evt.EnvironFlags&oomCaptureTrunc != 0
 	}
 

--- a/core/events/oom_exit.go
+++ b/core/events/oom_exit.go
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/bpf/abi"
+	"huatuo-bamai/internal/log"
+)
+
+const (
+	oomCaptureTrunc          = 1 << 0
+	oomExitContextTTL        = 5 * time.Second
+	oomExitContextMaxEntries = 256
+)
+
+type oomExitContext struct {
+	cmdline          string
+	cmdlineTruncated bool
+	environ          []string
+	environTruncated bool
+}
+
+type oomExitKey [2]uint64
+
+type oomExitEntry struct {
+	context   *oomExitContext
+	ready     chan struct{}
+	expiresAt time.Time
+}
+
+type oomExitEventCache struct {
+	mu      sync.Mutex
+	entries map[oomExitKey]*oomExitEntry
+}
+
+var oomExitEvents = newOOMExitEventCache()
+
+func newOOMExitEventCache() *oomExitEventCache {
+	return &oomExitEventCache{
+		entries: make(map[oomExitKey]*oomExitEntry),
+	}
+}
+
+func newOOMExitKey(victimTGID uint32, timestamp uint64) oomExitKey {
+	return oomExitKey{uint64(victimTGID), timestamp}
+}
+
+/*
+ * mergeOOMExitContext adds best-effort data captured immediately before the
+ * victim address space is torn down.
+ */
+func mergeOOMExitContext(
+	oomData *OOMTracingData, exitContext *oomExitContext,
+) {
+	if exitContext == nil {
+		return
+	}
+
+	oomData.Victim.Cmdline = exitContext.cmdline
+	oomData.Victim.CmdlineTruncated = exitContext.cmdlineTruncated
+	oomData.Victim.Environ = exitContext.environ
+	oomData.Victim.EnvironTruncated = exitContext.environTruncated
+}
+
+/*
+ * store decodes an exit event, caches it for base events that arrive later,
+ * and closes the shared ready channel for the matching base events.
+ */
+func (c *oomExitEventCache) store(evt *abi.OOMExitEvent) {
+	key := newOOMExitKey(evt.VictimTGID, evt.Timestamp)
+	capturedAt := time.Now()
+	context := &oomExitContext{}
+	if evt.CmdlineLen > 0 {
+		context.cmdline = strings.Join(
+			decodeExitNUL(evt.VictimCmdline[:], evt.CmdlineLen), " ")
+		context.cmdlineTruncated = evt.CmdlineFlags&oomCaptureTrunc != 0
+	}
+	if evt.EnvironLen > 0 {
+		context.environ = decodeExitNUL(
+			evt.VictimEnviron[:], evt.EnvironLen)
+		context.environTruncated = evt.EnvironFlags&oomCaptureTrunc != 0
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.purgeLocked(capturedAt)
+	/*
+	 * The base event and exit event may arrive in either order. Reuse the
+	 * placeholder made by wait(), or create one for a future waiter.
+	 */
+	entry, ok := c.entries[key]
+	if !ok && len(c.entries) >= oomExitContextMaxEntries {
+		c.evictOldestLocked()
+	}
+	if !ok {
+		entry = &oomExitEntry{ready: make(chan struct{})}
+		c.entries[key] = entry
+	}
+	if entry.context == nil {
+		close(entry.ready)
+	}
+	entry.context = context
+	entry.expiresAt = capturedAt.Add(oomExitContextTTL)
+}
+
+/*
+ * wait correlates a base OOM event with its exit context without blocking the
+ * perf reader. The context cancellation path lets collector shutdown release
+ * every outstanding asynchronous wait immediately.
+ */
+func (c *oomExitEventCache) wait(ctx context.Context, victimTGID uint32,
+	timestamp uint64,
+) *oomExitContext {
+	key := newOOMExitKey(victimTGID, timestamp)
+	now := time.Now()
+	c.mu.Lock()
+	c.purgeLocked(now)
+	entry, ok := c.entries[key]
+	if ok && entry.context != nil {
+		c.mu.Unlock()
+		return entry.context
+	}
+	if !ok {
+		if len(c.entries) >= oomExitContextMaxEntries {
+			c.evictOldestLocked()
+		}
+		entry = &oomExitEntry{
+			ready: make(chan struct{}),
+		}
+		c.entries[key] = entry
+	}
+	/* All waiters for one correlation key share this single notification. */
+	entry.expiresAt = now.Add(oomExitContextTTL)
+	ready := entry.ready
+	c.mu.Unlock()
+
+	timer := time.NewTimer(oomExitContextTTL)
+	defer timer.Stop()
+	select {
+	case <-ready:
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+
+	/* Re-read under the lock because delivery, expiry, or eviction may win. */
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry = c.entries[key]
+	if entry == nil {
+		return nil
+	}
+	return entry.context
+}
+
+/*
+ * purgeLocked bounds entries whose matching event never arrived.
+ */
+func (c *oomExitEventCache) purgeLocked(now time.Time) {
+	for key, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+/*
+ * evictOldestLocked keeps the userspace cache bounded during an OOM storm.
+ */
+func (c *oomExitEventCache) evictOldestLocked() {
+	var oldestKey oomExitKey
+	var oldestTime time.Time
+	found := false
+	for key, entry := range c.entries {
+		if !found || entry.expiresAt.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.expiresAt
+			found = true
+		}
+	}
+	if found {
+		delete(c.entries, oldestKey)
+	}
+}
+
+/*
+ * decodeExitNUL clamps kernel-provided lengths before decoding NUL-separated
+ * argv or environment entries.
+ */
+func decodeExitNUL(raw []byte, length uint16) []string {
+	size := int(length)
+	if size > len(raw) {
+		size = len(raw)
+	}
+	data := bytes.TrimRight(raw[:size], "\x00")
+	if len(data) == 0 {
+		return nil
+	}
+
+	parts := bytes.Split(data, []byte{0})
+	values := make([]string, len(parts))
+	for i := range parts {
+		values[i] = string(parts[i])
+	}
+	return values
+}
+
+/*
+ * startOOMExitReader drains the large exit records independently from base
+ * OOM processing so waiting and storage work cannot fill the perf ring.
+ */
+func startOOMExitReader(ctx context.Context,
+	reader bpf.PerfEventReader,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			var evt abi.OOMExitEvent
+			if err := reader.ReadInto(&evt); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				if errors.Is(err, bpf.ErrPerfEventSamplesLost) {
+					log.WithError(err).Warn(
+						"lost OOM exit BPF perf event samples")
+					continue
+				}
+				return err
+			}
+			oomExitEvents.store(&evt)
+		}
+	}
+}

--- a/core/events/oom_exit_test.go
+++ b/core/events/oom_exit_test.go
@@ -35,7 +35,8 @@ func TestOOMExitEventCacheCorrelatesAndDecodes(t *testing.T) {
 	event.CmdlineLen = uint16(copy(
 		event.VictimCmdline[:], "python3\x00worker.py\x00"))
 	event.EnvironLen = uint16(copy(
-		event.VictimEnviron[:], "ROLE=worker\x00EMPTY=\x00"))
+		event.VictimEnviron[:],
+		"ROLE=worker\x00GITHUB_TOKEN=top-secret\x00EMPTY=\x00"))
 	cache.store(event)
 
 	canceled, cancel := context.WithCancel(context.Background())
@@ -50,11 +51,63 @@ func TestOOMExitEventCacheCorrelatesAndDecodes(t *testing.T) {
 	if got.cmdline != "python3 worker.py" {
 		t.Fatalf("cmdline = %q", got.cmdline)
 	}
-	if !reflect.DeepEqual(got.environ, []string{"ROLE=worker", "EMPTY="}) {
+	if !reflect.DeepEqual(got.environ, []string{
+		"ROLE=worker",
+		"GITHUB_TOKEN=" + oomEnvironRedactedValue,
+		"EMPTY=",
+	}) {
 		t.Fatalf("environ = %q", got.environ)
 	}
 	if !got.goBuildInfo {
 		t.Fatal("Go buildinfo marker was not preserved")
+	}
+}
+
+func TestRedactOOMEnviron(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"ROLE=worker", "ROLE=worker"},
+		{"GOMEMLIMIT=8GiB", "GOMEMLIMIT=8GiB"},
+		{"EMPTY=", "EMPTY="},
+		{"EMBEDDED_EQUALS=a=b=c", "EMBEDDED_EQUALS=a=b=c"},
+		{"DB_PASSWORD=value", "DB_PASSWORD=" + oomEnvironRedactedValue},
+		{"LEGACY_PASSWD=value", "LEGACY_PASSWD=" + oomEnvironRedactedValue},
+		{"SERVICE_TOKEN=value", "SERVICE_TOKEN=" + oomEnvironRedactedValue},
+		{"JWT_SECRET=value", "JWT_SECRET=" + oomEnvironRedactedValue},
+		{"CLOUD_CREDENTIAL=value", "CLOUD_CREDENTIAL=" + oomEnvironRedactedValue},
+		{"API_KEY=value", "API_KEY=" + oomEnvironRedactedValue},
+		{"ACCESS_KEY_ID=value", "ACCESS_KEY_ID=" + oomEnvironRedactedValue},
+		{"PRIVATE_KEY_DATA=value", "PRIVATE_KEY_DATA=" + oomEnvironRedactedValue},
+		{"HTTP_COOKIE=value", "HTTP_COOKIE=" + oomEnvironRedactedValue},
+		{"USER_SESSION=value", "USER_SESSION=" + oomEnvironRedactedValue},
+		{"proxy_auth=value", "proxy_auth=" + oomEnvironRedactedValue},
+		{"EMPTY_TOKEN=", "EMPTY_TOKEN=" + oomEnvironRedactedValue},
+		{"DATABASE_URL=value", "DATABASE_URL=" + oomEnvironRedactedValue},
+		{"DB_URL=value", "DB_URL=" + oomEnvironRedactedValue},
+		{"REDIS_URL=value", "REDIS_URL=" + oomEnvironRedactedValue},
+		{"MONGO_URI=value", "MONGO_URI=" + oomEnvironRedactedValue},
+		{"DATABASE_DSN=value", "DATABASE_DSN=" + oomEnvironRedactedValue},
+		{"CONNECTION_STRING=value", "CONNECTION_STRING=" + oomEnvironRedactedValue},
+		{"SERVICE_ENDPOINT=value", "SERVICE_ENDPOINT=" + oomEnvironRedactedValue},
+		{"MALFORMED_SECRET", oomEnvironRedactedValue},
+		{"=missing-name", oomEnvironRedactedValue},
+	}
+
+	for _, test := range tests {
+		original := []string{test.input}
+		got := redactOOMEnviron(original)
+		if !reflect.DeepEqual(got, []string{test.want}) {
+			t.Errorf("redactOOMEnviron(%q) = %q, want %q",
+				test.input, got, test.want)
+		}
+		if original[0] != test.input {
+			t.Errorf("input mutated: %q", original)
+		}
+		if gotAgain := redactOOMEnviron(got); !reflect.DeepEqual(gotAgain, got) {
+			t.Errorf("redaction is not idempotent: %q", gotAgain)
+		}
 	}
 }
 

--- a/core/events/oom_exit_test.go
+++ b/core/events/oom_exit_test.go
@@ -28,8 +28,9 @@ import (
 func TestOOMExitEventCacheCorrelatesAndDecodes(t *testing.T) {
 	cache := newOOMExitEventCache()
 	event := &abi.OOMExitEvent{
-		VictimTGID: 42,
-		Timestamp:  101,
+		VictimTGID:  42,
+		Timestamp:   101,
+		GoBuildInfo: 1,
 	}
 	event.CmdlineLen = uint16(copy(
 		event.VictimCmdline[:], "python3\x00worker.py\x00"))
@@ -51,6 +52,9 @@ func TestOOMExitEventCacheCorrelatesAndDecodes(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.environ, []string{"ROLE=worker", "EMPTY="}) {
 		t.Fatalf("environ = %q", got.environ)
+	}
+	if !got.goBuildInfo {
+		t.Fatal("Go buildinfo marker was not preserved")
 	}
 }
 

--- a/core/events/oom_exit_test.go
+++ b/core/events/oom_exit_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/bpf/abi"
+)
+
+func TestOOMExitEventCacheCorrelatesAndDecodes(t *testing.T) {
+	cache := newOOMExitEventCache()
+	event := &abi.OOMExitEvent{
+		VictimTGID: 42,
+		Timestamp:  101,
+	}
+	event.CmdlineLen = uint16(copy(
+		event.VictimCmdline[:], "python3\x00worker.py\x00"))
+	event.EnvironLen = uint16(copy(
+		event.VictimEnviron[:], "ROLE=worker\x00EMPTY=\x00"))
+	cache.store(event)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := cache.wait(canceled, 42, 999); got != nil {
+		t.Fatalf("wrong timestamp matched: %#v", got)
+	}
+	got := cache.wait(context.Background(), 42, 101)
+	if got == nil {
+		t.Fatal("matching exit context is nil")
+	}
+	if got.cmdline != "python3 worker.py" {
+		t.Fatalf("cmdline = %q", got.cmdline)
+	}
+	if !reflect.DeepEqual(got.environ, []string{"ROLE=worker", "EMPTY="}) {
+		t.Fatalf("environ = %q", got.environ)
+	}
+}
+
+func TestOOMExitEventCachePreservesTruncation(t *testing.T) {
+	cache := newOOMExitEventCache()
+	event := &abi.OOMExitEvent{
+		VictimTGID:   7,
+		Timestamp:    202,
+		CmdlineFlags: oomCaptureTrunc,
+		EnvironFlags: oomCaptureTrunc,
+	}
+	event.CmdlineLen = uint16(copy(event.VictimCmdline[:], "node"))
+	event.EnvironLen = uint16(copy(event.VictimEnviron[:], "A=B\x00"))
+	cache.store(event)
+
+	got := cache.wait(context.Background(), 7, 202)
+	if got == nil || !got.cmdlineTruncated || !got.environTruncated {
+		t.Fatalf("truncation flags were not preserved: %#v", got)
+	}
+}
+
+func TestOOMExitEventCacheWakesConcurrentWaiters(t *testing.T) {
+	cache := newOOMExitEventCache()
+	key := newOOMExitKey(9, 303)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	var sharedReady chan struct{}
+	for range 2 {
+		if got := cache.wait(canceled, 9, 303); got != nil {
+			t.Fatalf("unexpected exit context: %#v", got)
+		}
+		cache.mu.Lock()
+		entry := cache.entries[key]
+		cache.mu.Unlock()
+		if entry == nil {
+			t.Fatal("shared ready channel was not registered")
+		}
+		if sharedReady == nil {
+			sharedReady = entry.ready
+		} else if entry.ready != sharedReady {
+			t.Fatal("waits did not share the ready channel")
+		}
+	}
+
+	results := make(chan *oomExitContext, 2)
+	for range 2 {
+		go func() {
+			results <- cache.wait(context.Background(), 9, 303)
+		}()
+	}
+
+	event := &abi.OOMExitEvent{
+		VictimTGID: 9,
+		Timestamp:  303,
+	}
+	event.CmdlineLen = uint16(copy(event.VictimCmdline[:], "java\x00"))
+	cache.store(event)
+
+	for range 2 {
+		select {
+		case got := <-results:
+			if got == nil || got.cmdline != "java" {
+				t.Fatalf("correlated context = %#v", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("concurrent waiter was not woken")
+		}
+	}
+}

--- a/core/events/oom_langdetect.go
+++ b/core/events/oom_langdetect.go
@@ -33,3 +33,21 @@ func detectLanguageInfo(victimPID uint32) *OOMLanguageInfo {
 
 	return &OOMLanguageInfo{Victim: detected}
 }
+
+/*
+ * completeLanguageInfo retries only an unknown live result with process
+ * metadata. Cmdline takes precedence over the kernel command name.
+ */
+func completeLanguageInfo(oomData *OOMTracingData) {
+	if oomData == nil ||
+		(oomData.LanguageInfo != nil &&
+			oomData.LanguageInfo.Victim != processlang.LanguageUnknown) {
+		return
+	}
+
+	detected := processlang.DetectLanguage(processlang.ProcessDetails{
+		Cmdline: oomData.Victim.Cmdline,
+		Comm:    oomData.Victim.Comm,
+	})
+	oomData.LanguageInfo = &OOMLanguageInfo{Victim: detected}
+}

--- a/core/events/oom_langdetect.go
+++ b/core/events/oom_langdetect.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import "huatuo-bamai/pkg/processlang"
+
+/* OOMLanguageInfo captures the selected victim's detected language. */
+type OOMLanguageInfo struct {
+	Victim processlang.Language `json:"victim"`
+}
+
+func detectLanguageInfo(victimPID uint32) *OOMLanguageInfo {
+	detected := processlang.LanguageUnknown
+	if victimPID > 0 {
+		detected = processlang.DetectLanguage(processlang.ProcessDetails{
+			PID: int(victimPID),
+		})
+	}
+
+	return &OOMLanguageInfo{Victim: detected}
+}

--- a/core/events/oom_langdetect.go
+++ b/core/events/oom_langdetect.go
@@ -41,13 +41,19 @@ func detectLanguageInfo(
 }
 
 /*
- * completeLanguageInfo retries only an unknown live result with process
- * metadata. Cmdline takes precedence over the kernel command name.
+ * completeLanguageInfo retries an unknown live result with exit context.
+ * A Go buildinfo marker takes precedence over cmdline and comm metadata.
  */
-func completeLanguageInfo(oomData *OOMTracingData) {
+func completeLanguageInfo(
+	oomData *OOMTracingData, exitContext *oomExitContext,
+) {
 	if oomData == nil ||
 		(oomData.LanguageInfo != nil &&
 			oomData.LanguageInfo.Victim != processlang.LanguageUnknown) {
+		return
+	}
+	if exitContext != nil && exitContext.goBuildInfo {
+		oomData.LanguageInfo = &OOMLanguageInfo{Victim: processlang.LanguageGo}
 		return
 	}
 

--- a/core/events/oom_langdetect.go
+++ b/core/events/oom_langdetect.go
@@ -16,16 +16,22 @@
 
 package events
 
-import "huatuo-bamai/pkg/processlang"
+import (
+	"os"
+
+	"huatuo-bamai/pkg/processlang"
+)
 
 /* OOMLanguageInfo captures the selected victim's detected language. */
 type OOMLanguageInfo struct {
 	Victim processlang.Language `json:"victim"`
 }
 
-func detectLanguageInfo(victimPID uint32) *OOMLanguageInfo {
-	detected := processlang.LanguageUnknown
-	if victimPID > 0 {
+func detectLanguageInfo(
+	victimPID uint32, executable *os.File,
+) *OOMLanguageInfo {
+	detected := processlang.DetectLanguageFromExecutable(executable)
+	if detected == processlang.LanguageUnknown && victimPID > 0 {
 		detected = processlang.DetectLanguage(processlang.ProcessDetails{
 			PID: int(victimPID),
 		})

--- a/core/events/oom_langdetect_test.go
+++ b/core/events/oom_langdetect_test.go
@@ -31,3 +31,36 @@ func TestDetectLanguageInfoReadsRunningGoExecutable(t *testing.T) {
 			info.Victim, processlang.LanguageGo)
 	}
 }
+
+func TestCompleteLanguageInfoUsesExitCmdline(t *testing.T) {
+	oomData := &OOMTracingData{
+		Victim: OOMActor{
+			Cmdline: "/usr/bin/python3 worker.py",
+			Comm:    "java",
+		},
+		LanguageInfo: &OOMLanguageInfo{
+			Victim: processlang.LanguageUnknown,
+		},
+	}
+
+	completeLanguageInfo(oomData)
+	if oomData.LanguageInfo.Victim != processlang.LanguagePython {
+		t.Fatalf("exit cmdline language = %q, want %q",
+			oomData.LanguageInfo.Victim, processlang.LanguagePython)
+	}
+}
+
+func TestCompleteLanguageInfoUsesCommWithoutExitCmdline(t *testing.T) {
+	oomData := &OOMTracingData{
+		Victim: OOMActor{Comm: "java"},
+		LanguageInfo: &OOMLanguageInfo{
+			Victim: processlang.LanguageUnknown,
+		},
+	}
+
+	completeLanguageInfo(oomData)
+	if oomData.LanguageInfo.Victim != processlang.LanguageJava {
+		t.Fatalf("comm language = %q, want %q",
+			oomData.LanguageInfo.Victim, processlang.LanguageJava)
+	}
+}

--- a/core/events/oom_langdetect_test.go
+++ b/core/events/oom_langdetect_test.go
@@ -23,8 +23,14 @@ import (
 	"huatuo-bamai/pkg/processlang"
 )
 
-func TestDetectLanguageInfoReadsRunningGoExecutable(t *testing.T) {
-	info := detectLanguageInfo(uint32(os.Getpid()))
+func TestDetectLanguageInfoReadsRetainedGoExecutable(t *testing.T) {
+	executable := processlang.OpenExecutable(os.Getpid())
+	if executable == nil {
+		t.Fatal("failed to open current executable")
+	}
+	defer executable.Close()
+
+	info := detectLanguageInfo(0, executable)
 
 	if info.Victim != processlang.LanguageGo {
 		t.Fatalf("current Go test process detected as %q, want %q",

--- a/core/events/oom_langdetect_test.go
+++ b/core/events/oom_langdetect_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"os"
+	"testing"
+
+	"huatuo-bamai/pkg/processlang"
+)
+
+func TestDetectLanguageInfoReadsRunningGoExecutable(t *testing.T) {
+	info := detectLanguageInfo(uint32(os.Getpid()))
+
+	if info.Victim != processlang.LanguageGo {
+		t.Fatalf("current Go test process detected as %q, want %q",
+			info.Victim, processlang.LanguageGo)
+	}
+}

--- a/core/events/oom_langdetect_test.go
+++ b/core/events/oom_langdetect_test.go
@@ -49,7 +49,7 @@ func TestCompleteLanguageInfoUsesExitCmdline(t *testing.T) {
 		},
 	}
 
-	completeLanguageInfo(oomData)
+	completeLanguageInfo(oomData, nil)
 	if oomData.LanguageInfo.Victim != processlang.LanguagePython {
 		t.Fatalf("exit cmdline language = %q, want %q",
 			oomData.LanguageInfo.Victim, processlang.LanguagePython)
@@ -64,9 +64,24 @@ func TestCompleteLanguageInfoUsesCommWithoutExitCmdline(t *testing.T) {
 		},
 	}
 
-	completeLanguageInfo(oomData)
+	completeLanguageInfo(oomData, nil)
 	if oomData.LanguageInfo.Victim != processlang.LanguageJava {
 		t.Fatalf("comm language = %q, want %q",
 			oomData.LanguageInfo.Victim, processlang.LanguageJava)
+	}
+}
+
+func TestCompleteLanguageInfoUsesExitGoBuildInfo(t *testing.T) {
+	oomData := &OOMTracingData{
+		Victim: OOMActor{Comm: "oom-go"},
+		LanguageInfo: &OOMLanguageInfo{
+			Victim: processlang.LanguageUnknown,
+		},
+	}
+
+	completeLanguageInfo(oomData, &oomExitContext{goBuildInfo: true})
+	if oomData.LanguageInfo.Victim != processlang.LanguageGo {
+		t.Fatalf("exit buildinfo language = %q, want %q",
+			oomData.LanguageInfo.Victim, processlang.LanguageGo)
 	}
 }

--- a/core/events/oom_test.go
+++ b/core/events/oom_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package events
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/bpf/abi"
+)
+
+func TestOOMPageCountsToBytes(t *testing.T) {
+	event := abi.OOMEvent{
+		VictimRssAnonPages:  2,
+		VictimRssFilePages:  3,
+		VictimRssShmemPages: 4,
+		VictimTotalVmPages:  5,
+	}
+	actor := buildTracingData(&event, nil, nil).Victim
+
+	if actor.RssAnonBytes != 2*pageSize ||
+		actor.RssFileBytes != 3*pageSize ||
+		actor.RssShmemBytes != 4*pageSize ||
+		actor.TotalVmBytes != 5*pageSize {
+		t.Fatalf("memory footprint = %#v", actor)
+	}
+}

--- a/pkg/processlang/language.go
+++ b/pkg/processlang/language.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2023 Odigos
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Adapted from odigos-io/odigos procdiscovery commit
+ * 7c6279dd7530a0fd3cdb3d21829c06d65445ff70.
+ */
+
+/* Package processlang detects process runtime languages. */
+package processlang
+
+import (
+	"bufio"
+	"debug/buildinfo"
+	"debug/elf"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+/* Language identifies a process runtime. */
+type Language string
+
+const (
+	LanguageUnknown Language = "unknown"
+	LanguageJava    Language = "java"
+	LanguageGo      Language = "go"
+	LanguagePython  Language = "python"
+	LanguageNode    Language = "node"
+)
+
+/* ProcessDetails contains live or captured process metadata. */
+type ProcessDetails struct {
+	PID     int
+	Comm    string
+	Cmdline string
+}
+
+var pythonExecutablePattern = regexp.MustCompile(`^python(\d+(\.\d+)?)?$`)
+
+/* DetectLanguage detects a runtime from a live PID or captured metadata. */
+func DetectLanguage(details ProcessDetails) Language {
+	if details.PID <= 0 {
+		return languageFromMetadata(details.Cmdline, details.Comm)
+	}
+
+	return languageFromRunningProcess(details.PID)
+}
+
+func languageFromRunningProcess(pid int) Language {
+	exeFile, _ := os.Open(procPath(pid, "exe"))
+	if exeFile != nil {
+		defer exeFile.Close()
+
+		/* Go binaries contain readable Go build information. */
+		if _, err := buildinfo.Read(exeFile); err == nil {
+			return LanguageGo
+		}
+	}
+
+	exePath, _ := os.Readlink(procPath(pid, "exe"))
+	detected := languageFromExecutable(filepath.Base(exePath))
+	if detected != LanguageUnknown {
+		return detected
+	}
+
+	return languageFromRuntimeLibraries(pid, exeFile)
+}
+
+func languageFromRuntimeLibraries(pid int, exeFile *os.File) Language {
+	java := mapsContain(pid, "/libjvm.so")
+	python := exeFile != nil && linksPython(exeFile)
+	switch {
+	case java && python:
+		return LanguageUnknown
+	case java:
+		return LanguageJava
+	case python:
+		return LanguagePython
+	default:
+		return LanguageUnknown
+	}
+}
+
+func languageFromMetadata(cmdline, comm string) Language {
+	detected := languageFromCmdline(cmdline)
+	if detected == LanguageUnknown {
+		detected = languageFromExecutable(comm)
+	}
+	return detected
+}
+
+func languageFromCmdline(cmdline string) Language {
+	fields := strings.Fields(cmdline)
+	if len(fields) == 0 {
+		return LanguageUnknown
+	}
+
+	detected := languageFromExecutable(filepath.Base(fields[0]))
+	if detected != LanguageUnknown || filepath.Base(fields[0]) != "env" {
+		return detected
+	}
+	for _, field := range fields[1:] {
+		if strings.HasPrefix(field, "-") || strings.Contains(field, "=") {
+			continue
+		}
+		return languageFromExecutable(filepath.Base(field))
+	}
+	return LanguageUnknown
+}
+
+func languageFromExecutable(executable string) Language {
+	switch {
+	case executable == "java":
+		return LanguageJava
+	case pythonExecutablePattern.MatchString(executable):
+		return LanguagePython
+	case executable == "node", executable == "npm", executable == "npx", executable == "yarn":
+		return LanguageNode
+	default:
+		return LanguageUnknown
+	}
+}
+
+func mapsContain(pid int, substring string) bool {
+	file, err := os.Open(procPath(pid, "maps"))
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func linksPython(file *os.File) bool {
+	executable, err := elf.NewFile(file)
+	if err != nil {
+		return false
+	}
+	dependencies, err := executable.DynString(elf.DT_NEEDED)
+	if err != nil {
+		return false
+	}
+	for _, dependency := range dependencies {
+		if strings.Contains(dependency, "libpython3") {
+			return true
+		}
+	}
+	return false
+}
+
+func procPath(pid int, name string) string {
+	return fmt.Sprintf("/proc/%d/%s", pid, name)
+}

--- a/pkg/processlang/language.go
+++ b/pkg/processlang/language.go
@@ -61,14 +61,34 @@ func DetectLanguage(details ProcessDetails) Language {
 	return languageFromRunningProcess(details.PID)
 }
 
+/* OpenExecutable retains a live process executable for deferred detection. */
+func OpenExecutable(pid int) *os.File {
+	if pid <= 0 {
+		return nil
+	}
+
+	file, _ := os.Open(procPath(pid, "exe"))
+	return file
+}
+
+/* DetectLanguageFromExecutable detects a runtime from an open executable. */
+func DetectLanguageFromExecutable(executable *os.File) Language {
+	if executable != nil {
+		if _, err := buildinfo.Read(executable); err == nil {
+			return LanguageGo
+		}
+	}
+	return LanguageUnknown
+}
+
 func languageFromRunningProcess(pid int) Language {
-	exeFile, _ := os.Open(procPath(pid, "exe"))
+	exeFile := OpenExecutable(pid)
 	if exeFile != nil {
 		defer exeFile.Close()
 
 		/* Go binaries contain readable Go build information. */
-		if _, err := buildinfo.Read(exeFile); err == nil {
-			return LanguageGo
+		if detected := DetectLanguageFromExecutable(exeFile); detected != LanguageUnknown {
+			return detected
 		}
 	}
 

--- a/pkg/processlang/language_test.go
+++ b/pkg/processlang/language_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 The HuaTuo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package processlang
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetectLanguageByComm(t *testing.T) {
+	tests := map[string]Language{
+		"java":          LanguageJava,
+		"python":        LanguagePython,
+		"python3.12":    LanguagePython,
+		"node":          LanguageNode,
+		"npm":           LanguageNode,
+		"node_exporter": LanguageUnknown,
+		"python-worker": LanguageUnknown,
+	}
+
+	for comm, want := range tests {
+		t.Run(comm, func(t *testing.T) {
+			got := DetectLanguage(ProcessDetails{Comm: comm})
+			if got != want {
+				t.Fatalf("DetectLanguage(%q) = %q, want %q", comm, got, want)
+			}
+		})
+	}
+}
+
+func TestDetectLanguageReadsRunningGoExecutable(t *testing.T) {
+	got := DetectLanguage(ProcessDetails{PID: os.Getpid()})
+	if got != LanguageGo {
+		t.Fatalf("current Go test process detected as %q, want %q", got, LanguageGo)
+	}
+}
+
+func TestDetectLanguageByCapturedCmdline(t *testing.T) {
+	got := DetectLanguage(ProcessDetails{
+		Cmdline: "/usr/bin/env python3 worker.py",
+	})
+	if got != LanguagePython {
+		t.Fatalf("captured env command detected as %q, want %q", got, LanguagePython)
+	}
+}


### PR DESCRIPTION
## Summary

This PR improves OOM diagnostics by preserving more information about the selected victim before it exits. It adds runtime-language detection, memory-footprint fields, bounded command-line and environment capture, and best-effort container association.

The primary OOM event and the victim exit context are correlated asynchronously, so waiting for `do_exit` does not block the main OOM event reader. If exit-context capture or container lookup fails, Huatuo still stores the base OOM event.

Related to #333. This PR covers the victim-context requirements but does not include OOM CPU profiling.

## Changes

- Add a focused `pkg/processlang` detector for Java, Go, Python, and Node.
  - Inspect live executable metadata and mapped runtime libraries.
  - Fall back to captured command-line and command-name metadata.
- Report the victim runtime language in `language_info.victim`.
- Report the victim memory footprint:
  - `rss_anon_bytes`
  - `rss_file_bytes`
  - `rss_shmem_bytes`
  - `total_vm_bytes`
- Capture bounded victim process context at `do_exit`:
  - `cmdline` and `cmdline_truncated`
  - `environ` and `environ_truncated`
- Correlate the base OOM event and exit event by victim TGID and event timestamp.
- Keep OOM processing available when exit-context collection or the final container lookup is unavailable.
- Improve Go detection with two complementary fallbacks:
  - Retain `/proc/<pid>/exe` early and inspect Go build information after the existing snapshots are collected.
  - Check the Go buildinfo marker at `mm->start_data` when the registered victim enters `do_exit`.
- Support both `rss_stat` layouts through CO-RE and use probe-read helpers available on CentOS 8.2.

## Event processing

1. Huatuo receives the base `oom_kill_process` event and immediately retains the victim executable when possible.
2. Existing cgroup, container, and host memory snapshots are collected.
3. Runtime-language detection first uses the retained executable and live process metadata.
4. The main event processing continues asynchronously while the victim reaches `do_exit`.
5. The exit hook captures command-line and environment data and emits a correlated exit event.
6. Huatuo merges the optional exit context, retries unknown language detection from Go buildinfo/cmdline/comm, and writes the final OOM JSON.

## Compatibility and failure behavior

- The added context is best-effort; missing exit context does not discard the base OOM event.
- Missing or expired container metadata leaves `container_id` empty but does not prevent event storage.
- Command-line and environment buffers are bounded and expose truncation flags.
- No kernel behavior is delayed or changed: the BPF hooks only observe the OOM and exit paths.

## Validation

- `make bpf-build`
- `go build -o _output/bin/huatuo-bamai ./cmd/huatuo-bamai`
- `go test ./pkg/processlang ./core/events ./pkg/tracing`
- Real memory-cgroup OOM tests on the 5.10 VM for Go, Java, Python, and Node:
  - All four victims were killed by the kernel with exit status 137.
  - All four languages were detected correctly (`go`, `java`, `python`, and `node`).
  - Command line, environment, RSS/virtual-memory footprint, and the existing host memory snapshot were present in the saved OOM events.

## Scope

OOM CPU profiling is intentionally not part of this PR and should be handled separately.
