### PR TITLE
fix(docs): polish tcpshark doc rendering

### DIFF
--- a/docs/best-practice/tcpshark_en.md
+++ b/docs/best-practice/tcpshark_en.md
@@ -1,7 +1,7 @@
 ---
-title: TCP Retransmission Tracing (tcpshark)
+title: TCP Retransmission Tracing
 type: docs
-description: Observe TCP retransmission-related kernel activity with eBPF, reason classification, and drop correlation
+description: ""
 author: HUATUO Team
 date: 2026-07-20
 weight: 5
@@ -47,7 +47,7 @@ Run dropwatch and tcp_retransmit in the same huatuo-bamai process to correlate p
 
 ### 1. Running tcpshark
 
-```
+```text
 tcpshark --mode retransmit [flags]
 ```
 
@@ -191,13 +191,13 @@ Each event is an NDJSON object (`types.TCPRetransmitTracing`). Fields tagged wit
 
 Text retains its terminal-friendly layout while covering the same event variables as JSON. Variables tagged with `omitempty` appear only when non-zero or non-empty, and string values are not JSON-quoted or escaped. For compatibility with the original text format, `state`, `skb`, `seq`, `end`, `ack`, `flags`, `ca`, and `retrans` correspond to the JSON fields `tcp_state`, `skb_addr`, `tcp_seq`, `tcp_end_seq`, `tcp_ack_seq`, `tcp_flags`, `ca_state`, and `icsk_retransmits`, respectively.
 
-```
+```text
 <timestamp> [<phase>/<tcp_reason>] <saddr>:<sport> > <daddr>:<dport> state=<STATE> event_type=<TYPE> [SYNACK] [skb=<ADDR>] seq=<N> [end=<N>] ack=<N> [flags=<FLAGS>] pid=<N> comm=<COMM> ca=<N> retrans=<N> icsk_pending=<N> [reord_seen=<N>] [dsack_dups=<N>] [container_id=<ID>] [memory_cgroup_css_addr=<ADDR>] [net_namespace_cookie=<N>] [net_namespace_inum=<N>] [drop_location=<LOCATION>] [source=<SOURCE>]
 ```
 
 Example:
 
-```
+```text
 2026-07-23T02:14:40.304775546Z [data/RTO] 127.0.0.1:19996 > 127.0.0.1:42128 state=ESTABLISHED event_type=tcp_retransmit_skb skb=0xffff931c14fdf800 seq=3154974646 end=3154991030 ack=948393597 flags=ACK|PSH pid=1420 comm=kube-apiserver ca=4 retrans=4 icsk_pending=0 net_namespace_inum=4026531992
 ```
 
@@ -291,7 +291,7 @@ When building alerts, aggregate by service or connection and compare against tra
 
 ---
 
-### 5. Correlation with dropwatch (`drop_location`)
+### 5. Correlation with dropwatch
 
 When dropwatch and tcpshark feed the same huatuo-bamai process, dropwatch events are retained in a userspace cache for two seconds from their arrival time. A tcpshark event immediately queries previously received, unexpired drop events using a direction-independent connection key. The implementation does not wait for later drop events and does not revise an event after storage.
 

--- a/docs/best-practice/tcpshark_zh.md
+++ b/docs/best-practice/tcpshark_zh.md
@@ -1,7 +1,7 @@
 ---
-title: TCP 重传追踪（tcpshark）
+title: 重传追踪
 type: docs
-description: 基于 eBPF 观测 TCP 重传相关内核活动、原因分类及丢包关联
+description: ""
 author: HUATUO Team
 date: 2026-07-20
 weight: 5
@@ -47,7 +47,7 @@ HUATUO（华佗）是由滴滴开源并依托 CCF（中国计算机学会）孵�
 
 ### 1. 运行 tcpshark
 
-```
+```text
 tcpshark --mode retransmit [flags]
 ```
 
@@ -191,13 +191,13 @@ tcpshark 使用与 dropwatch 相同的 tcpdump 风格过滤表达式。完整语
 
 文本输出保留面向终端的可读布局，同时覆盖与 JSON 相同的事件变量。带 `omitempty` 的变量仅在非零或非空时显示，字符串值不添加 JSON 引号或转义。为兼容原文本格式，`state`、`skb`、`seq`、`end`、`ack`、`flags`、`ca` 和 `retrans` 分别对应 JSON 中的 `tcp_state`、`skb_addr`、`tcp_seq`、`tcp_end_seq`、`tcp_ack_seq`、`tcp_flags`、`ca_state` 和 `icsk_retransmits`。
 
-```
+```text
 <timestamp> [<phase>/<tcp_reason>] <saddr>:<sport> > <daddr>:<dport> state=<STATE> event_type=<TYPE> [SYNACK] [skb=<ADDR>] seq=<N> [end=<N>] ack=<N> [flags=<FLAGS>] pid=<N> comm=<COMM> ca=<N> retrans=<N> icsk_pending=<N> [reord_seen=<N>] [dsack_dups=<N>] [container_id=<ID>] [memory_cgroup_css_addr=<ADDR>] [net_namespace_cookie=<N>] [net_namespace_inum=<N>] [drop_location=<LOCATION>] [source=<SOURCE>]
 ```
 
 示例：
 
-```
+```text
 2026-07-23T02:14:40.304775546Z [data/RTO] 127.0.0.1:19996 > 127.0.0.1:42128 state=ESTABLISHED event_type=tcp_retransmit_skb skb=0xffff931c14fdf800 seq=3154974646 end=3154991030 ack=948393597 flags=ACK|PSH pid=1420 comm=kube-apiserver ca=4 retrans=4 icsk_pending=0 net_namespace_inum=4026531992
 ```
 
@@ -291,7 +291,7 @@ sequenceDiagram
 
 ---
 
-### 5. 与 dropwatch 关联（`drop_location`）
+### 5. 与 dropwatch 关联
 
 dropwatch 和 tcpshark 向同一个 huatuo-bamai 进程发送事件时，dropwatch 事件会从到达用户态的时刻起在缓存中保留两秒。tcpshark 事件会立即按与方向无关的连接 key 查询此前已收到且尚未过期的 drop 事件。当前实现不会等待之后才到达的 drop 事件，也不会在事件存储后更新关联结果。
 


### PR DESCRIPTION
Remove redundant tool and field labels from the tcpshark page titles.

Mark command and text output examples as plain text so Hugo renders them as literal terminal output.

Change-Id: I140fa290b25c7ea4ee396213f4b98394f3f8c431