### PR TITLE
fix(ci): repair lint and distro integration failures

### DIFF
--- a/integration/lib_namespace.sh
+++ b/integration/lib_namespace.sh
@@ -49,6 +49,6 @@ tcp_namespace_setup() {
 }
 
 tcp_namespace_cleanup() {
-	[[ -z "${TCP_NS_SERVER}" ]] || ip netns del "${TCP_NS_SERVER}" 2>/dev/null || true
-	[[ -z "${TCP_NS_CLIENT}" ]] || ip netns del "${TCP_NS_CLIENT}" 2>/dev/null || true
+	[[ -z "${TCP_NS_SERVER}" ]] || ip netns del "${TCP_NS_SERVER}" 2> /dev/null || true
+	[[ -z "${TCP_NS_CLIENT}" ]] || ip netns del "${TCP_NS_CLIENT}" 2> /dev/null || true
 }

--- a/integration/test_net_rx_latency.sh
+++ b/integration/test_net_rx_latency.sh
@@ -56,7 +56,7 @@ compile_user_fixture \
 	"${SLOW_TCP_SERVER}"
 
 ip netns exec "${TCP_NS_SERVER}" "${SLOW_TCP_SERVER}" \
-	>"${WORK_DIR}/testserver.log" 2>&1 &
+	> "${WORK_DIR}/testserver.log" 2>&1 &
 server_pid=$!
 _server_pid="${server_pid}"
 sleep 0.5
@@ -65,7 +65,7 @@ for i in $(seq 1 5); do
 	log_info "curl request #${i} to ${TCP_NS_SERVER_ADDR}:${TEST_PORT}"
 	ip netns exec "${TCP_NS_CLIENT}" curl -s --connect-timeout 1 --max-time 2 \
 		http://${TCP_NS_SERVER_ADDR}:${TEST_PORT}/ \
-		>>"${WORK_DIR}/curl.log" 2>&1 || true
+		>> "${WORK_DIR}/curl.log" 2>&1 || true
 done
 
 sleep 5
@@ -76,9 +76,9 @@ EVENTS_FILE="${HUATUO_BAMAI_TEST_TMPDIR}/events/net_rx_latency"
 # Filter events matching our veth IP pair, then validate.
 MATCHED=$(jq -s --arg saddr "${TCP_NS_CLIENT_ADDR}" --arg daddr "${TCP_NS_SERVER_ADDR}" \
 	'[.[] | select(.tracer_data.tcp_saddr == $saddr and .tracer_data.tcp_daddr == $daddr)]' \
-	"${EVENTS_FILE}" 2>/dev/null)
+	"${EVENTS_FILE}" 2> /dev/null)
 
-event_count=$(echo "${MATCHED}" | jq 'length' 2>/dev/null || echo 0)
+event_count=$(echo "${MATCHED}" | jq 'length' 2> /dev/null || echo 0)
 event_count=$(echo "${event_count}" | tr -d '[:space:]')
 log_info "net_rx_latency events (${TCP_NS_CLIENT_ADDR} -> ${TCP_NS_SERVER_ADDR}): ${event_count}"
 
@@ -88,4 +88,4 @@ fi
 
 log_info "net_rx_latency integration test passed: ${event_count} events"
 log_info "event details:"
-echo "${MATCHED}" | jq '.' 2>/dev/null || echo "${MATCHED}"
+echo "${MATCHED}" | jq '.' 2> /dev/null || echo "${MATCHED}"

--- a/integration/test_profiler_native_cpu_offcpu.sh
+++ b/integration/test_profiler_native_cpu_offcpu.sh
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Verify the native off-CPU profiler attributes blocked time to the CPU from
-# which the task switched out. The assertion anchors on wait_loop because user
-# stack depth varies by kernel and glibc build.
+# which the task switched out. The assertion anchors on the process and blocked
+# category because older kernels may truncate the userspace call chain.
 
 set -euo pipefail
 
@@ -45,14 +45,12 @@ readonly EXCLUDED_CPU=${CPU_IDS[1]}
 
 readonly PROFILER_DURATION=10
 readonly PROFILER_AGGR_INTERVAL=5
-readonly BLOCKED_PATTERN='off-CPU blocked;.*;wait_loop'
-
 WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/profiler-offcpu.XXXXXX")
 FIXTURE_BIN="${WORK_DIR}/offcpu-fixture"
 TARGET_PID=""
 
 cleanup() {
-	[[ -n "${TARGET_PID}" ]] || return
+	[[ -n "${TARGET_PID}" ]] || return 0
 	stop_by_pid "${TARGET_PID}" 1 || true
 	wait "${TARGET_PID}" 2> /dev/null || true
 }
@@ -65,6 +63,7 @@ verify_offcpu_cpuid() {
 	local output_dir="${WORK_DIR}/cpu-${cpuid}"
 	local tool_out="${output_dir}/profiler.out"
 	local tool_err="${output_dir}/profiler.err"
+	local blocked_prefix
 	local match_count=0
 
 	case "${expected}" in
@@ -75,9 +74,10 @@ verify_offcpu_cpuid() {
 	mkdir -p "${output_dir}"
 	taskset -c "${SELECTED_CPU}" "${FIXTURE_BIN}" > /dev/null 2>&1 &
 	TARGET_PID=$!
+	blocked_prefix="process ${TARGET_PID}:offcpu-fixture;off-CPU blocked;"
 	kill -0 "${TARGET_PID}" 2> /dev/null || fatal "fixture exited immediately (pid=${TARGET_PID})"
 
-	log_info "fixture on CPU ${SELECTED_CPU}; profiler --cpuid ${cpuid}; expect ${expected} stack"
+	log_info "fixture on CPU ${SELECTED_CPU}; profiler --cpuid ${cpuid}; expect ${expected} event"
 	if ! "${TOOL_BIN}" \
 		--type cpu \
 		--language c \
@@ -101,14 +101,14 @@ verify_offcpu_cpuid() {
 	TARGET_PID=""
 
 	if compgen -G "${output_dir}/perf_*.folded" > /dev/null; then
-		match_count=$(grep -hE "${BLOCKED_PATTERN}" "${output_dir}"/perf_*.folded | wc -l) || true
+		match_count=$(grep -hF "${blocked_prefix}" "${output_dir}"/perf_*.folded | wc -l) || true
 	fi
 	case "${expected}" in
 	present)
-		[[ "${match_count}" -gt 0 ]] || fatal "blocking wait stack not found for CPU ${cpuid}"
+		[[ "${match_count}" -gt 0 ]] || fatal "blocked event not found for CPU ${cpuid}"
 		;;
 	absent)
-		[[ "${match_count}" -eq 0 ]] || fatal "blocking wait stack unexpectedly found for CPU ${cpuid}"
+		[[ "${match_count}" -eq 0 ]] || fatal "blocked event unexpectedly found for CPU ${cpuid}"
 		;;
 	esac
 }

--- a/integration/test_tcp_retransmit_fast.sh
+++ b/integration/test_tcp_retransmit_fast.sh
@@ -41,9 +41,9 @@ fi
 require_python3
 
 cleanup() {
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2>/dev/null || true
-	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2>/dev/null || true
-	[[ -n "${CLI_PID:-}" ]] && kill "${CLI_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2> /dev/null || true
+	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2> /dev/null || true
+	[[ -n "${CLI_PID:-}" ]] && kill "${CLI_PID}" 2> /dev/null || true
 	tcp_namespace_cleanup
 }
 trap cleanup EXIT
@@ -69,10 +69,10 @@ ip netns exec "${TCP_NS_CLIENT}" iptables -I INPUT 1 -p tcp --sport "${TEST_PORT
 log_info "connbytes rule: drop reply packet #30 in client netns"
 
 # 3. Start tcpshark in retransmit mode in the root netns (sees all netns traffic via BPF).
-"${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" --duration 15 --output json >"${OUTPUT_DIR}/events.json" 2>"${OUTPUT_DIR}/stderr.log" &
+"${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" --duration 15 --output json > "${OUTPUT_DIR}/events.json" 2> "${OUTPUT_DIR}/stderr.log" &
 TCPSHARK_PID=$!
 sleep 1
-if ! kill -0 "${TCPSHARK_PID}" 2>/dev/null; then
+if ! kill -0 "${TCPSHARK_PID}" 2> /dev/null; then
 	TCPSHARK_STATUS=0
 	wait "${TCPSHARK_PID}" || TCPSHARK_STATUS=$?
 	TCPSHARK_PID=""
@@ -82,18 +82,18 @@ fi
 # 4. Server: listen and send 2 MB of data.
 ip netns exec "${TCP_NS_SERVER}" timeout 10 python3 "${ROOT_DIR}/integration/testdata/tcp_server.py" \
 	--listen-address "${TCP_NS_SERVER_ADDR}" --port "${TEST_PORT}" \
-	--payload-bytes "${PAYLOAD_SIZE}" >/dev/null 2>&1 &
+	--payload-bytes "${PAYLOAD_SIZE}" > /dev/null 2>&1 &
 SRV_PID=$!
 sleep 0.5
 
 # 5. Client: connect and receive data to /dev/null.
-ip netns exec "${TCP_NS_CLIENT}" timeout 8 bash -c "exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}; cat <&3 >/dev/null" 2>/dev/null &
+ip netns exec "${TCP_NS_CLIENT}" timeout 8 bash -c "exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}; cat <&3 >/dev/null" 2> /dev/null &
 CLI_PID=$!
 
 # 6. Wait for data transfer + fast retransmit (3 dup ACKs are fast on veth).
 sleep 10
 
-if ! kill -0 "${TCPSHARK_PID}" 2>/dev/null; then
+if ! kill -0 "${TCPSHARK_PID}" 2> /dev/null; then
 	TCPSHARK_STATUS=0
 	wait "${TCPSHARK_PID}" || TCPSHARK_STATUS=$?
 	TCPSHARK_PID=""
@@ -104,20 +104,20 @@ wait "${TCPSHARK_PID}" || true
 TCPSHARK_PID=""
 
 # Filter events for our test port (server-side tcp_sport).
-grep "\"tcp_sport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" >"${OUTPUT_DIR}/filtered.json" 2>/dev/null || true
+grep "\"tcp_sport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" > "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true
 
-RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2>/dev/null || true)
+RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2> /dev/null || true)
 RAW_COUNT=${RAW_COUNT:-0}
-PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 PORT_COUNT=${PORT_COUNT:-0}
 
-FAST_COUNT=$(grep -c '"tcp_reason":"fast_retransmit"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+FAST_COUNT=$(grep -c '"tcp_reason":"fast_retransmit"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 FAST_COUNT=${FAST_COUNT:-0}
-REORDER_FAST=$(grep -c '"tcp_reason":"reorder_prone_fast"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+REORDER_FAST=$(grep -c '"tcp_reason":"reorder_prone_fast"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 REORDER_FAST=${REORDER_FAST:-0}
-RECOVERY=$(grep -c '"ca_state":3' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+RECOVERY=$(grep -c '"ca_state":3' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 RECOVERY=${RECOVERY:-0}
-RTO_COUNT=$(grep -c '"tcp_reason":"RTO"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+RTO_COUNT=$(grep -c '"tcp_reason":"RTO"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 RTO_COUNT=${RTO_COUNT:-0}
 
 log_info "captured retransmit events: raw=${RAW_COUNT}, tcp_sport=${TEST_PORT}: ${PORT_COUNT}"

--- a/integration/test_tcp_retransmit_ratelimit.sh
+++ b/integration/test_tcp_retransmit_ratelimit.sh
@@ -43,11 +43,11 @@ fi
 require_python3
 
 cleanup() {
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2>/dev/null || true
-	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2>/dev/null || true
-	[[ -n "${CLI_PID:-}" ]] && kill "${CLI_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2> /dev/null || true
+	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2> /dev/null || true
+	[[ -n "${CLI_PID:-}" ]] && kill "${CLI_PID}" 2> /dev/null || true
 	sleep 0.2
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2> /dev/null || true
 	tcp_namespace_cleanup
 	rm -rf "${OUTPUT_DIR}"
 }
@@ -64,18 +64,18 @@ ip netns exec "${TCP_NS_CLIENT}" iptables -I INPUT 1 -p tcp --sport "${TEST_PORT
 "${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" \
 	--max-events-per-second "${RATE}" \
 	--duration "${DURATION}" --output json \
-	>"${OUTPUT_DIR}/events.json" 2>"${OUTPUT_DIR}/stderr.log" &
+	> "${OUTPUT_DIR}/events.json" 2> "${OUTPUT_DIR}/stderr.log" &
 TCPSHARK_PID=$!
 sleep 1
 
 ip netns exec "${TCP_NS_SERVER}" timeout 10 python3 "${ROOT_DIR}/integration/testdata/tcp_server.py" \
 	--listen-address "${TCP_NS_SERVER_ADDR}" --port "${TEST_PORT}" \
-	--payload-bytes "${PAYLOAD_SIZE}" >/dev/null 2>&1 &
+	--payload-bytes "${PAYLOAD_SIZE}" > /dev/null 2>&1 &
 SRV_PID=$!
 sleep 0.5
 
 ip netns exec "${TCP_NS_CLIENT}" timeout 8 bash -c \
-	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}; cat <&3 >/dev/null" 2>/dev/null &
+	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}; cat <&3 >/dev/null" 2> /dev/null &
 CLI_PID=$!
 
 sleep 6
@@ -83,11 +83,11 @@ sleep 6
 wait "${TCPSHARK_PID}" || true
 TCPSHARK_PID=""
 
-events=$(grep -c '"event_type":"tcp_retransmit_' "${OUTPUT_DIR}/events.json" 2>/dev/null || true)
+events=$(grep -c '"event_type":"tcp_retransmit_' "${OUTPUT_DIR}/events.json" 2> /dev/null || true)
 events=${events:-0}
 warns=$(grep -h "rate limit hit" \
-	"${OUTPUT_DIR}/events.json" "${OUTPUT_DIR}/stderr.log" 2>/dev/null |
-	wc -l || true)
+	"${OUTPUT_DIR}/events.json" "${OUTPUT_DIR}/stderr.log" 2> /dev/null \
+	| wc -l || true)
 warns=${warns:-0}
 
 log_info "events=${events} (cap=${EXPECTED_MAX}), rate-limit warnings=${warns}"

--- a/integration/test_tcp_retransmit_syn.sh
+++ b/integration/test_tcp_retransmit_syn.sh
@@ -31,9 +31,9 @@ C_ADDR="10.99.2.2"
 [[ -f "${BPF_OBJ}" ]] || fatal "BPF object not found: ${BPF_OBJ}"
 
 cleanup() {
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2> /dev/null || true
 	sleep 0.2
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2> /dev/null || true
 	tcp_namespace_cleanup
 	rm -rf "${OUTPUT_DIR}"
 }
@@ -46,29 +46,29 @@ tcp_namespace_setup syn "${S_ADDR}" "${C_ADDR}"
 # Drop SYN packets in the peer namespace so the client enters TCP RTO retry.
 ip netns exec "${TCP_NS_SERVER}" iptables -I INPUT 1 -p tcp --dport "${TEST_PORT}" -j DROP
 
-"${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" --duration 6 --output json >"${OUTPUT_DIR}/events.json" 2>"${OUTPUT_DIR}/stderr.log" &
+"${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" --duration 6 --output json > "${OUTPUT_DIR}/events.json" 2> "${OUTPUT_DIR}/stderr.log" &
 TCPSHARK_PID=$!
 sleep 1
 
 timeout 7 ip netns exec "${TCP_NS_CLIENT}" bash -c \
-	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}" 2>/dev/null || true
+	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}" 2> /dev/null || true
 sleep 1
 
-kill "${TCPSHARK_PID}" 2>/dev/null || true
+kill "${TCPSHARK_PID}" 2> /dev/null || true
 sleep 0.3
 TCPSHARK_PID=""
 
 # Filter events for our test port (active-open destination tcp_dport).
-grep "\"tcp_dport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" >"${OUTPUT_DIR}/filtered.json" 2>/dev/null || true
+grep "\"tcp_dport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" > "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true
 
-RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2>/dev/null || true)
+RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2> /dev/null || true)
 RAW_COUNT=${RAW_COUNT:-0}
-PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 PORT_COUNT=${PORT_COUNT:-0}
 
-SYN_COUNT=$(grep '"phase":"connect"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null |
-	grep '"tcp_reason":"RTO"' |
-	grep -c '"event_type":"tcp_retransmit_skb"' || true)
+SYN_COUNT=$(grep '"phase":"connect"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null \
+	| grep '"tcp_reason":"RTO"' \
+	| grep -c '"event_type":"tcp_retransmit_skb"' || true)
 SYN_COUNT=${SYN_COUNT:-0}
 
 log_info "captured retransmit events: raw=${RAW_COUNT}, tcp_dport=${TEST_PORT}: ${PORT_COUNT}"
@@ -85,7 +85,7 @@ else
 fi
 
 if ((SYN_COUNT == 0)); then
-	cat "${OUTPUT_DIR}/events.json" 2>/dev/null || true
-	cat "${OUTPUT_DIR}/stderr.log" 2>/dev/null || true
+	cat "${OUTPUT_DIR}/events.json" 2> /dev/null || true
+	cat "${OUTPUT_DIR}/stderr.log" 2> /dev/null || true
 	fatal "EXP1 failed"
 fi

--- a/integration/test_tcp_retransmit_synack.sh
+++ b/integration/test_tcp_retransmit_synack.sh
@@ -32,10 +32,10 @@ C_ADDR="10.99.3.2"
 require_python3
 
 cleanup() {
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2>/dev/null || true
-	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2> /dev/null || true
+	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2> /dev/null || true
 	sleep 0.2
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2> /dev/null || true
 	tcp_namespace_cleanup
 	rm -rf "${OUTPUT_DIR}"
 }
@@ -47,7 +47,7 @@ tcp_namespace_setup synack "${S_ADDR}" "${C_ADDR}"
 
 # 1. Hold a listening socket while the kernel handles the 3-way handshake.
 ip netns exec "${TCP_NS_SERVER}" timeout 8 python3 "${ROOT_DIR}/integration/testdata/tcp_server.py" \
-	--listen-address "${TCP_NS_SERVER_ADDR}" --port "${TEST_PORT}" >/dev/null 2>&1 &
+	--listen-address "${TCP_NS_SERVER_ADDR}" --port "${TEST_PORT}" > /dev/null 2>&1 &
 SRV_PID=$!
 sleep 0.5
 
@@ -59,30 +59,30 @@ ip netns exec "${TCP_NS_CLIENT}" iptables -I OUTPUT 1 -p tcp --dport "${TEST_POR
 log_info "iptables: DROP pure ACK (dport=${TEST_PORT})"
 
 # 3. Start tcpshark in retransmit mode.
-"${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" --duration 8 --output json >"${OUTPUT_DIR}/events.json" 2>"${OUTPUT_DIR}/stderr.log" &
+"${TCPSHARK_BIN}" --mode retransmit --bpf-path "${BPF_OBJ}" --duration 8 --output json > "${OUTPUT_DIR}/events.json" 2> "${OUTPUT_DIR}/stderr.log" &
 TCPSHARK_PID=$!
 sleep 1
 
 # 4. Client connects: SYN → server, SYNACK → client, ACK → dropped.
 timeout 3 ip netns exec "${TCP_NS_CLIENT}" bash -c \
-	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}" 2>/dev/null || true
+	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}" 2> /dev/null || true
 
 # 5. Wait for SYNACK retransmissions (initial RTO ~1s, exponential backoff).
 sleep 5
 
-kill "${TCPSHARK_PID}" 2>/dev/null || true
+kill "${TCPSHARK_PID}" 2> /dev/null || true
 sleep 0.3
 TCPSHARK_PID=""
 
 # Filter events for our test port (server-side tcp_sport).
-grep "\"tcp_sport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" >"${OUTPUT_DIR}/filtered.json" 2>/dev/null || true
+grep "\"tcp_sport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" > "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true
 
-RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2>/dev/null || true)
+RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2> /dev/null || true)
 RAW_COUNT=${RAW_COUNT:-0}
-PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 PORT_COUNT=${PORT_COUNT:-0}
 
-SYNACK_COUNT=$(grep -c '"event_type":"tcp_retransmit_synack"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+SYNACK_COUNT=$(grep -c '"event_type":"tcp_retransmit_synack"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 SYNACK_COUNT=${SYNACK_COUNT:-0}
 
 log_info "captured retransmit events: raw=${RAW_COUNT}, tcp_sport=${TEST_PORT}: ${PORT_COUNT}"
@@ -99,7 +99,7 @@ else
 fi
 
 if ((SYNACK_COUNT == 0)); then
-	cat "${OUTPUT_DIR}/events.json" 2>/dev/null || true
-	cat "${OUTPUT_DIR}/stderr.log" 2>/dev/null || true
+	cat "${OUTPUT_DIR}/events.json" 2> /dev/null || true
+	cat "${OUTPUT_DIR}/stderr.log" 2> /dev/null || true
 	fatal "synack test failed"
 fi

--- a/integration/test_tcp_retransmit_tlp.sh
+++ b/integration/test_tcp_retransmit_tlp.sh
@@ -33,11 +33,11 @@ C_ADDR="10.99.4.2"
 require_python3
 
 cleanup() {
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2>/dev/null || true
-	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2>/dev/null || true
-	[[ -n "${CLI_PID:-}" ]] && kill "${CLI_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill "${TCPSHARK_PID}" 2> /dev/null || true
+	[[ -n "${SRV_PID:-}" ]] && kill "${SRV_PID}" 2> /dev/null || true
+	[[ -n "${CLI_PID:-}" ]] && kill "${CLI_PID}" 2> /dev/null || true
 	sleep 0.2
-	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2>/dev/null || true
+	[[ -n "${TCPSHARK_PID:-}" ]] && kill -9 "${TCPSHARK_PID}" 2> /dev/null || true
 	tcp_namespace_cleanup
 }
 trap cleanup EXIT
@@ -50,16 +50,16 @@ tcp_namespace_setup tlp "${S_ADDR}" "${C_ADDR}"
 #    iptables rule is installed. This leaves unacknowledged data for TLP.
 ip netns exec "${TCP_NS_SERVER}" timeout 14 python3 "${ROOT_DIR}/integration/testdata/tcp_server.py" \
 	--listen-address "${TCP_NS_SERVER_ADDR}" --port "${TEST_PORT}" \
-	--payload-bytes "${PAYLOAD_SIZE}" --send-delay 3 >/dev/null 2>&1 &
+	--payload-bytes "${PAYLOAD_SIZE}" --send-delay 3 > /dev/null 2>&1 &
 SRV_PID=$!
 sleep 0.5
 
 # 2. Start tcpshark with TLP collection explicitly enabled.
 "${TCPSHARK_BIN}" --mode retransmit --enable-tlp --bpf-path "${BPF_OBJ}" \
-	--duration 14 --output json >"${OUTPUT_DIR}/events.json" 2>"${OUTPUT_DIR}/stderr.log" &
+	--duration 14 --output json > "${OUTPUT_DIR}/events.json" 2> "${OUTPUT_DIR}/stderr.log" &
 TCPSHARK_PID=$!
 sleep 0.5
-if ! kill -0 "${TCPSHARK_PID}" 2>/dev/null; then
+if ! kill -0 "${TCPSHARK_PID}" 2> /dev/null; then
 	TCPSHARK_STATUS=0
 	wait "${TCPSHARK_PID}" || TCPSHARK_STATUS=$?
 	TCPSHARK_PID=""
@@ -68,7 +68,7 @@ fi
 
 # 3. Client connects via bash /dev/tcp and reads data to /dev/null.
 ip netns exec "${TCP_NS_CLIENT}" timeout 12 bash -c \
-	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}; cat <&3 >/dev/null" 2>/dev/null &
+	"exec 3<>/dev/tcp/${TCP_NS_SERVER_ADDR}/${TEST_PORT}; cat <&3 >/dev/null" 2> /dev/null &
 CLI_PID=$!
 
 # 4. Wait for handshake to complete, then drop ACKs to the server.
@@ -80,7 +80,7 @@ log_info "iptables: DROP ACK (dport=${TEST_PORT}) — client ACKs will be droppe
 # 5. Wait for data send + TLP (PTO ~10ms on loopback; generous window).
 sleep 10
 
-if ! kill -0 "${TCPSHARK_PID}" 2>/dev/null; then
+if ! kill -0 "${TCPSHARK_PID}" 2> /dev/null; then
 	TCPSHARK_STATUS=0
 	wait "${TCPSHARK_PID}" || TCPSHARK_STATUS=$?
 	TCPSHARK_PID=""
@@ -91,16 +91,16 @@ wait "${TCPSHARK_PID}" || true
 TCPSHARK_PID=""
 
 # Filter events for our test port (server-side tcp_sport).
-grep "\"tcp_sport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" >"${OUTPUT_DIR}/filtered.json" 2>/dev/null || true
+grep "\"tcp_sport\":${TEST_PORT}" "${OUTPUT_DIR}/events.json" > "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true
 
-RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2>/dev/null || true)
+RAW_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/events.json" 2> /dev/null || true)
 RAW_COUNT=${RAW_COUNT:-0}
-PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+PORT_COUNT=$(grep -c '"event_type":' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 PORT_COUNT=${PORT_COUNT:-0}
 
-TLP_COUNT=$(grep -c '"event_type":"tcp_send_loss_probe"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true)
+TLP_COUNT=$(grep -c '"event_type":"tcp_send_loss_probe"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true)
 TLP_COUNT=${TLP_COUNT:-0}
-TLP_REASON=$(grep '"event_type":"tcp_send_loss_probe"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null | grep -c '"tcp_reason":"TLP"' || true)
+TLP_REASON=$(grep '"event_type":"tcp_send_loss_probe"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null | grep -c '"tcp_reason":"TLP"' || true)
 TLP_REASON=${TLP_REASON:-0}
 
 log_info "captured retransmit events: raw=${RAW_COUNT}, tcp_sport=${TEST_PORT}: ${PORT_COUNT}"
@@ -112,6 +112,6 @@ elif ((TLP_COUNT == 0)); then
 	log_info "SKIP: no TLP events for tcp_sport=${TEST_PORT} (kernel may not have sent loss probe in this scenario)"
 else
 	log_error "FAIL: TLP events found but reason mismatch"
-	grep '"event_type":"tcp_send_loss_probe"' "${OUTPUT_DIR}/filtered.json" 2>/dev/null || true
+	grep '"event_type":"tcp_send_loss_probe"' "${OUTPUT_DIR}/filtered.json" 2> /dev/null || true
 	fatal "TLP test failed"
 fi


### PR DESCRIPTION
## What

- Format the seven integration shell scripts rewritten by the repository shfmt
  configuration.
- Stabilize the native off-CPU CPU-filter integration check across Ubuntu 20.04
  and Ubuntu 26.04.

## Why

The main-branch lint workflow failed because `make check` reformatted recently
added integration scripts and then detected the resulting diff.

The OS distro workflow had two separate compatibility failures:

- Ubuntu 20.04 captured the target blocked event, but its older kernel and
  userspace stack unwinding omitted the deep `wait_loop` frame required by the
  test.
- Ubuntu 26.04 uses Bash 5.3, which propagates the non-zero status from the
  cleanup trap's implicit `return` and turns an otherwise passing test into an
  exit status of 1.

The updated check matches the target PID, command, and blocked category, which
is the behavior needed to verify the CPU filter without depending on deep stack
shape. The cleanup path now returns success explicitly when no fixture remains.

Failed runs:

- https://github.com/ccfos/huatuo/actions/runs/31065274619
- https://github.com/ccfos/huatuo/actions/runs/31065274638

## Impact

This restores the lint job and removes distro-specific false failures while
preserving the selected-CPU and excluded-CPU assertions.

## Testing

- `make check` (`golangci-lint`: 0 issues)
- `shfmt -i 0 -bn -sr -d` on all changed shell scripts
- `bash -n` on all changed shell scripts
- Ubuntu 26.04/Bash 5.3 cleanup regression reproduction
- Ubuntu 20.04 and 26.04 folded-stack sample matching

The full QEMU matrix was not run locally.
