### PR TITLE
fix(bpf): use stable TCP retransmit tracepoint context

### DIFF
--- a/bpf/hungtask.c
+++ b/bpf/hungtask.c
@@ -5,8 +5,8 @@
 #include <bpf/bpf_tracing.h>
 
 #include "bpf_common.h"
-#include "bpf_compat_7_0.h"
 #include "bpf_ratelimit.h"
+#include "bpf_tracepoint.h"
 #include "abi/hungtask_types.h"
 
 char __license[] SEC("license") = "Dual MIT/GPL";
@@ -32,8 +32,8 @@ int tracepoint_sched_process_hang(struct trace_event_raw_sched_process_hang *ctx
 	if (bpf_core_field_exists(ctx->comm)) {
 		BPF_CORE_READ_STR_INTO(&info.comm, ctx, comm);
 	} else {
-		struct trace_event_raw_sched_process_hang___7_0 *ctx7 =
-			(struct trace_event_raw_sched_process_hang___7_0 *)ctx;
+		struct trace_event_raw_sched_process_hang___7_0_compat *ctx7 =
+			(struct trace_event_raw_sched_process_hang___7_0_compat *)ctx;
 		u32 dl = BPF_CORE_READ(ctx7, __data_loc_comm);
 
 		bpf_probe_read_str(info.comm, sizeof(info.comm),

--- a/bpf/include/bpf_compat_7_0.h
+++ b/bpf/include/bpf_compat_7_0.h
@@ -40,14 +40,4 @@ struct bio___7_0 {
 	u64 issue_time_ns;
 } __attribute__((preserve_access_index));
 
-/*
- * hungtask: trace_event_raw_sched_process_hang::comm changed from a
- * fixed-size __array to a __data_loc string on 7.0+.
- */
-struct trace_event_raw_sched_process_hang___7_0 {
-	struct trace_entry ent;
-	u32 __data_loc_comm;
-	pid_t pid;
-} __attribute__((preserve_access_index));
-
 #endif /* __BPF_COMPAT_7_0_H__ */

--- a/bpf/include/bpf_tracepoint.h
+++ b/bpf/include/bpf_tracepoint.h
@@ -1,6 +1,26 @@
 #ifndef __BPF_TRACEPOINT_H__
 #define __BPF_TRACEPOINT_H__
 
+/*
+ * Linux 7.0 renamed the tcp_retransmit_skb BTF context type, so CO-RE
+ * cannot resolve the old name. Use a local layout to avoid that relocation.
+ */
+struct trace_event_raw_tcp_event_sk_skb_compat {
+	struct trace_entry ent;
+	const void *skbaddr;
+	const void *skaddr;
+};
+
+/*
+ * hungtask: trace_event_raw_sched_process_hang::comm changed from a
+ * fixed-size __array to a __data_loc string on 7.0+.
+ */
+struct trace_event_raw_sched_process_hang___7_0_compat {
+	struct trace_entry ent;
+	u32 __data_loc_comm;
+	pid_t pid;
+} __attribute__((preserve_access_index));
+
 static __always_inline char *__data_loc_address(char *ctx, u32 __data_loc)
 {
 	return ((char *)ctx + (__data_loc & 0xffff));

--- a/bpf/tcp_retransmit.c
+++ b/bpf/tcp_retransmit.c
@@ -11,6 +11,7 @@
 #include "bpf_pcap_stub.h"
 #include "bpf_ratelimit.h"
 #include "bpf_skbuff.h"
+#include "bpf_tracepoint.h"
 #include "abi/tcp_retransmit_types.h"
 
 struct {
@@ -177,7 +178,7 @@ static __always_inline void read_retransmit_skb_tcp_fields(struct tcp_retransmit
 }
 
 SEC("tracepoint/tcp/tcp_retransmit_skb")
-int retrans_skb(struct trace_event_raw_tcp_event_sk_skb *ctx)
+int retrans_skb(struct trace_event_raw_tcp_event_sk_skb_compat *ctx)
 {
 	struct sk_buff *skb = (struct sk_buff *)ctx->skbaddr;
 


### PR DESCRIPTION
## What

- Add `trace_event_raw_tcp_event_sk_skb_compat` to
  `bpf_tracepoint.h` with the shared `trace_entry` prefix.
- Keep only `skbaddr` and `skaddr` in the local retransmit context.
- Move the existing Linux 7.0 hungtask context compatibility layout into
  `bpf_tracepoint.h` as
  `trace_event_raw_sched_process_hang___7_0_compat`.
- Preserve CO-RE relocation for `sk_buff`, `sock`, and other kernel types.

## Why

Linux 7.0 renamed the generated tracepoint BTF type from
`trace_event_raw_tcp_event_sk_skb` to
`trace_event_raw_tcp_retransmit_skb`. Direct accesses through the generated
local type therefore produce unresolved CO-RE relocations, which Cilium/ebpf
poisons before verifier loading.

The local TCP compatibility context is declared after the generated
`vmlinux.h` pragma has been popped. Its two pointer accesses therefore use
the stable tracepoint offsets without requiring a target BTF type-name match.
The hungtask compatibility type remains explicitly relocatable; the
`___7_0_compat` suffix is a CO-RE flavor and still resolves against
`trace_event_raw_sched_process_hang`.

## Testing

- `make bpf-build`
- `make check`
- Compiled `tcp_retransmit`, `hungtask`, and
  `netdev_txqueue_timeout` directly.
- Confirmed zero TCP context relocations and zero poison relocations against
  the Ubuntu 26.04 Linux 7.0 BTF.
- Confirmed the hungtask compatibility relocation resolves from offset 8 to
  offset 8 on Linux 7.0.
