### PR TITLE
Iotracing相关功能 - part 1

### DIFF
--- a/bpf/io_health.c
+++ b/bpf/io_health.c
@@ -1,0 +1,205 @@
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+
+#include "bpf_common.h"
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+#define BPF_DEV_MINOR_BITS 20
+#define BPF_DEV_MINOR_MASK ((1U << BPF_DEV_MINOR_BITS) - 1)
+
+#define REQ_OP_BITS 8
+#define REQ_OP_MASK ((1 << REQ_OP_BITS) - 1)
+
+/*
+ * Linux 4.18-5.15 use bit 11 for RQF_QUIET. The completion fallback is
+ * attached only when block_rq_error is absent, so this compatibility value
+ * is deliberately limited to those kernels.
+ */
+#define RQF_QUIET_BEFORE_5_16 (1U << 11)
+
+enum health_event_type {
+	HEALTH_EVENT_BLOCK_ERROR = 1,
+};
+
+struct health_event {
+	u64 sector;
+	u32 dev;
+	s32 status;
+	u8 type;
+	u8 operation;
+	u8 pad[6];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, sizeof(u32));
+} health_events SEC(".maps");
+
+struct request_queue___5_14 {
+	struct gendisk *disk;
+} __attribute__((preserve_access_index));
+
+/* block_rq_error uses this event class from Linux 5.18 onward. */
+struct trace_event_raw_block_rq_completion___io_health {
+	struct trace_entry ent;
+	dev_t dev;
+	sector_t sector;
+	unsigned int nr_sector;
+	int error;
+	char rwbs[2];
+} __attribute__((preserve_access_index));
+
+static __always_inline u32 encode_dev(u32 major, u32 minor)
+{
+	return (major & 0xfff) << BPF_DEV_MINOR_BITS |
+	       (minor & BPF_DEV_MINOR_MASK);
+}
+
+static __always_inline struct gendisk *request_disk(struct request *req)
+{
+	struct request_queue___5_14 *q = NULL;
+
+	if (bpf_core_field_exists(req->rq_disk))
+		return BPF_CORE_READ(req, rq_disk);
+
+	if (bpf_core_field_exists(q->disk)) {
+		q = (struct request_queue___5_14 *)BPF_CORE_READ(req, q);
+		return BPF_CORE_READ(q, disk);
+	}
+	return NULL;
+}
+
+static __always_inline u32 request_dev(struct request *req)
+{
+	struct gendisk *disk;
+	u32 major, minor;
+
+	disk = request_disk(req);
+	if (!disk)
+		return 0;
+	/*
+	 * A partition dev_t may come from the extended-device IDR, so it cannot
+	 * be derived from first_minor + partno. Health events are attributed to
+	 * the containing disk, whose dev_t is major:first_minor.
+	 */
+	major = BPF_CORE_READ(disk, major);
+	minor = BPF_CORE_READ(disk, first_minor);
+	return encode_dev(major, minor);
+}
+
+static __always_inline u8 request_operation(struct request *req)
+{
+	return BPF_CORE_READ(req, cmd_flags) & REQ_OP_MASK;
+}
+
+static __always_inline u8 block_tracepoint_operation(
+	struct trace_event_raw_block_rq_completion___io_health *ctx)
+{
+	char operation = BPF_CORE_READ(ctx, rwbs[0]);
+
+	/* REQ_PREFLUSH precedes the request operation, for example "FW". */
+	if (operation == 'F') {
+		char next = BPF_CORE_READ(ctx, rwbs[1]);
+
+		if (next == 'R' || next == 'W' || next == 'D' || next == 'F')
+			operation = next;
+	}
+
+	switch (operation) {
+	case 'R':
+		return REQ_OP_READ;
+	case 'W':
+		return REQ_OP_WRITE;
+	case 'F':
+		return REQ_OP_FLUSH;
+	case 'D':
+		return REQ_OP_DISCARD;
+	default:
+		return REQ_OP_MASK;
+	}
+}
+
+static __always_inline void submit_event(void *ctx, struct health_event *event)
+{
+	bpf_perf_event_output(ctx, &health_events, COMPAT_BPF_F_CURRENT_CPU,
+				      event, sizeof(*event));
+}
+
+static __always_inline int submit_block_error(void *ctx, struct request *req,
+					      s32 status)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_BLOCK_ERROR,
+		.status = status,
+	};
+
+	if (!req)
+		return 0;
+	event.dev = request_dev(req);
+	event.sector = BPF_CORE_READ(req, __sector);
+	event.operation = request_operation(req);
+	submit_event(ctx, &event);
+	return 0;
+}
+
+SEC("tracepoint/block/block_rq_error")
+int trace_block_rq_error(
+	struct trace_event_raw_block_rq_completion___io_health *ctx)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_BLOCK_ERROR,
+	};
+
+	if (!bpf_core_type_exists(
+		    struct trace_event_raw_block_rq_completion___io_health))
+		return 0;
+
+	event.dev = BPF_CORE_READ(ctx, dev);
+	event.sector = BPF_CORE_READ(ctx, sector);
+	event.status = BPF_CORE_READ(ctx, error);
+	event.operation = block_tracepoint_operation(ctx);
+	submit_event(ctx, &event);
+	return 0;
+}
+
+/*
+ * block_rq_error was added in Linux 5.18. Go attaches this completion
+ * program only on Linux 5.15 and earlier, where args[1] is a negative errno.
+ * Non-negative values are still rejected defensively.
+ *
+ * Match the dedicated error tracepoint's old-kernel emission rules closely
+ * so passthrough health commands and quiet requests do not recursively
+ * trigger another health collection.
+ */
+SEC("raw_tracepoint/block_rq_complete")
+int trace_block_rq_complete_error(struct bpf_raw_tracepoint_args *ctx)
+{
+	struct request *req = (struct request *)ctx->args[0];
+	s32 status = (s32)ctx->args[1];
+	u32 operation;
+	u32 rq_flags;
+
+	if (status >= 0 || !req)
+		return 0;
+
+	/* blk_update_request() returns before reporting errors without a bio. */
+	if (!BPF_CORE_READ(req, bio))
+		return 0;
+
+	/* Match blk_rq_is_passthrough(), which print_req_error() excludes. */
+	operation = BPF_CORE_READ(req, cmd_flags) & REQ_OP_MASK;
+	if (operation == REQ_OP_SCSI_IN || operation == REQ_OP_SCSI_OUT ||
+	    operation == REQ_OP_DRV_IN || operation == REQ_OP_DRV_OUT)
+		return 0;
+
+	/* Match print_req_error(), which suppresses requests marked RQF_QUIET. */
+	rq_flags = BPF_CORE_READ(req, rq_flags);
+	if (rq_flags & RQF_QUIET_BEFORE_5_16)
+		return 0;
+
+	return submit_block_error(ctx, req, status);
+}

--- a/bpf/io_health.c
+++ b/bpf/io_health.c
@@ -2,6 +2,7 @@
 
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
 
 #include "bpf_common.h"
 
@@ -12,6 +13,11 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 
 #define REQ_OP_BITS 8
 #define REQ_OP_MASK ((1 << REQ_OP_BITS) - 1)
+
+#define NVME_CTRL_NAME_LEN 16
+#define NVME_CTRL_NAME_ENTRIES 256
+#define NVME_CDEV_CALL_ENTRIES 256
+#define NVME_STATE_CALL_ENTRIES 1024
 
 /*
  * Linux 4.18-5.15 use bit 11 for RQF_QUIET. The completion fallback is
@@ -24,6 +30,24 @@ enum health_event_type {
 	HEALTH_EVENT_BLOCK_ERROR = 1,
 	HEALTH_EVENT_SCSI_TIMEOUT,
 	HEALTH_EVENT_SCSI_DISPATCH_ERROR,
+	HEALTH_EVENT_NVME_TIMEOUT,
+	HEALTH_EVENT_NVME_RESET,
+	HEALTH_EVENT_NVME_STATE_CHANGE,
+};
+
+struct nvme_ctrl_name {
+	char name[NVME_CTRL_NAME_LEN];
+};
+
+struct nvme_state_call {
+	u64 ctrl;
+	u32 new_state_raw;
+	u32 pad;
+};
+
+struct nvme_cdev_call {
+	u64 ctrl;
+	struct nvme_ctrl_name name;
 };
 
 struct health_event {
@@ -34,9 +58,11 @@ struct health_event {
 	u32 channel;
 	u32 target;
 	u32 lun;
+	char controller[NVME_CTRL_NAME_LEN];
+	u32 new_state_raw;
 	u8 type;
 	u8 operation;
-	u8 pad[6];
+	u8 pad[2];
 };
 
 struct {
@@ -44,6 +70,30 @@ struct {
 	__uint(key_size, sizeof(u32));
 	__uint(value_size, sizeof(u32));
 } health_events SEC(".maps");
+
+/* The key is an opaque struct nvme_ctrl pointer learned through sysfs. */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, NVME_CTRL_NAME_ENTRIES);
+	__type(key, u64);
+	__type(value, struct nvme_ctrl_name);
+} nvme_ctrl_names SEC(".maps");
+
+/* Pair cdev_device_add entry and return so failed additions are ignored. */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, NVME_CDEV_CALL_ENTRIES);
+	__type(key, u64);
+	__type(value, struct nvme_cdev_call);
+} nvme_cdev_calls SEC(".maps");
+
+/* Pair nvme_change_ctrl_state entry and return without reading private BTF. */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, NVME_STATE_CALL_ENTRIES);
+	__type(key, u64);
+	__type(value, struct nvme_state_call);
+} nvme_state_calls SEC(".maps");
 
 struct request_queue___5_14 {
 	struct gendisk *disk;
@@ -156,6 +206,49 @@ static __always_inline void submit_event(void *ctx, struct health_event *event)
 				      event, sizeof(*event));
 }
 
+static __always_inline void set_nvme_controller(struct health_event *event,
+						u64 ctrl)
+{
+	struct nvme_ctrl_name *name;
+
+	name = bpf_map_lookup_elem(&nvme_ctrl_names, &ctrl);
+	if (name)
+		__builtin_memcpy(event->controller, name->name,
+				 sizeof(event->controller));
+}
+
+static __always_inline bool read_nvme_controller(struct device *dev,
+						  u64 *ctrl,
+						  struct nvme_ctrl_name *name)
+{
+	char class_name[5] = {};
+	struct class *class;
+	const char *name_ptr;
+	const char *class_name_ptr;
+
+	if (!dev)
+		return false;
+	class = BPF_CORE_READ(dev, class);
+	if (!class)
+		return false;
+	class_name_ptr = BPF_CORE_READ(class, name);
+	if (!class_name_ptr)
+		return false;
+	/* Linux 4.18 exposes only the compatible kernel string helper. */
+	if (bpf_probe_read_str(class_name, sizeof(class_name),
+			       class_name_ptr) != sizeof(class_name))
+		return false;
+	if (class_name[0] != 'n' || class_name[1] != 'v' ||
+	    class_name[2] != 'm' || class_name[3] != 'e' || class_name[4])
+		return false;
+
+	*ctrl = (u64)BPF_CORE_READ(dev, driver_data);
+	name_ptr = BPF_CORE_READ(dev, kobj.name);
+	if (!*ctrl || !name_ptr)
+		return false;
+	return bpf_probe_read_str(name->name, sizeof(name->name), name_ptr) > 1;
+}
+
 static __always_inline int submit_block_error(void *ctx, struct request *req,
 					      s32 status)
 {
@@ -259,5 +352,132 @@ int trace_scsi_dispatch_error(struct io_health_scsi_dispatch_error_ctx *ctx)
 	};
 
 	submit_event(ctx, &event);
+	return 0;
+}
+
+/*
+ * nvme_sysfs_show_state() obtains its controller with dev_get_drvdata(). Go
+ * reads each existing controller state file once during startup, then detaches
+ * this bootstrap hook. cdev_device_add/delete maintain subsequent hotplug
+ * changes without NVMe module BTF.
+ */
+SEC("kprobe/nvme_sysfs_show_state")
+int BPF_KPROBE(kprobe_nvme_sysfs_show_state, struct device *dev)
+{
+	struct nvme_ctrl_name name = {};
+	u64 ctrl;
+
+	if (!read_nvme_controller(dev, &ctrl, &name))
+		return 0;
+	bpf_map_update_elem(&nvme_ctrl_names, &ctrl, &name, COMPAT_BPF_ANY);
+	return 0;
+}
+
+SEC("kprobe/cdev_device_add")
+int BPF_KPROBE(kprobe_nvme_cdev_add, struct cdev *cdev, struct device *dev)
+{
+	struct nvme_cdev_call call = {};
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+
+	(void)cdev;
+	if (read_nvme_controller(dev, &call.ctrl, &call.name))
+		bpf_map_update_elem(&nvme_cdev_calls, &pid_tgid, &call,
+				    COMPAT_BPF_ANY);
+	return 0;
+}
+
+SEC("kretprobe/cdev_device_add")
+int BPF_KRETPROBE(kretprobe_nvme_cdev_add)
+{
+	struct nvme_ctrl_name name = {};
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct nvme_cdev_call *call;
+	u64 ctrl;
+
+	call = bpf_map_lookup_elem(&nvme_cdev_calls, &pid_tgid);
+	if (!call)
+		return 0;
+	if (!PT_REGS_RC(ctx)) {
+		ctrl = call->ctrl;
+		__builtin_memcpy(name.name, call->name.name, sizeof(name.name));
+		bpf_map_update_elem(&nvme_ctrl_names, &ctrl, &name,
+				    COMPAT_BPF_ANY);
+	}
+	bpf_map_delete_elem(&nvme_cdev_calls, &pid_tgid);
+	return 0;
+}
+
+SEC("kprobe/cdev_device_del")
+int BPF_KPROBE(kprobe_nvme_cdev_del, struct cdev *cdev, struct device *dev)
+{
+	struct nvme_ctrl_name name = {};
+	u64 ctrl;
+
+	(void)cdev;
+	if (read_nvme_controller(dev, &ctrl, &name))
+		bpf_map_delete_elem(&nvme_ctrl_names, &ctrl);
+	return 0;
+}
+
+SEC("kprobe/nvme_timeout")
+int BPF_KPROBE(kprobe_nvme_timeout, struct request *req)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_NVME_TIMEOUT,
+	};
+
+	if (!req)
+		return 0;
+	event.dev = request_dev(req);
+	submit_event(ctx, &event);
+	return 0;
+}
+
+SEC("kprobe/nvme_reset_ctrl")
+int BPF_KPROBE(kprobe_nvme_reset, void *raw_ctrl)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_NVME_RESET,
+	};
+
+	if (raw_ctrl)
+		set_nvme_controller(&event, (u64)raw_ctrl);
+	submit_event(ctx, &event);
+	return 0;
+}
+
+SEC("kprobe/nvme_change_ctrl_state")
+int BPF_KPROBE(kprobe_nvme_change_state, void *raw_ctrl, u32 new_state)
+{
+	struct nvme_state_call call = {
+		.ctrl = (u64)raw_ctrl,
+		.new_state_raw = new_state,
+	};
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+
+	if (call.ctrl)
+		bpf_map_update_elem(&nvme_state_calls, &pid_tgid, &call,
+				    COMPAT_BPF_ANY);
+	return 0;
+}
+
+SEC("kretprobe/nvme_change_ctrl_state")
+int BPF_KRETPROBE(kretprobe_nvme_change_state)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_NVME_STATE_CHANGE,
+	};
+	u64 pid_tgid = bpf_get_current_pid_tgid();
+	struct nvme_state_call *call;
+
+	call = bpf_map_lookup_elem(&nvme_state_calls, &pid_tgid);
+	if (!call)
+		return 0;
+	if (PT_REGS_RC(ctx)) {
+		set_nvme_controller(&event, call->ctrl);
+		event.new_state_raw = call->new_state_raw;
+		submit_event(ctx, &event);
+	}
+	bpf_map_delete_elem(&nvme_state_calls, &pid_tgid);
 	return 0;
 }

--- a/bpf/io_health.c
+++ b/bpf/io_health.c
@@ -22,12 +22,18 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 
 enum health_event_type {
 	HEALTH_EVENT_BLOCK_ERROR = 1,
+	HEALTH_EVENT_SCSI_TIMEOUT,
+	HEALTH_EVENT_SCSI_DISPATCH_ERROR,
 };
 
 struct health_event {
 	u64 sector;
 	u32 dev;
 	s32 status;
+	u32 host;
+	u32 channel;
+	u32 target;
+	u32 lun;
 	u8 type;
 	u8 operation;
 	u8 pad[6];
@@ -52,6 +58,27 @@ struct trace_event_raw_block_rq_completion___io_health {
 	int error;
 	char rwbs[2];
 } __attribute__((preserve_access_index));
+
+/*
+ * SCSI trace-event types may live in module BTF. Mirror the stable prefix
+ * from include/trace/events/scsi.h instead of depending on those types.
+ */
+struct io_health_scsi_timeout_ctx {
+	u64 trace_entry;
+	u32 host_no;
+	u32 channel;
+	u32 id;
+	u32 lun;
+};
+
+struct io_health_scsi_dispatch_error_ctx {
+	u64 trace_entry;
+	u32 host_no;
+	u32 channel;
+	u32 id;
+	u32 lun;
+	s32 rtn;
+};
 
 static __always_inline u32 encode_dev(u32 major, u32 minor)
 {
@@ -202,4 +229,35 @@ int trace_block_rq_complete_error(struct bpf_raw_tracepoint_args *ctx)
 		return 0;
 
 	return submit_block_error(ctx, req, status);
+}
+
+SEC("tracepoint/scsi/scsi_dispatch_cmd_timeout")
+int trace_scsi_timeout(struct io_health_scsi_timeout_ctx *ctx)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_SCSI_TIMEOUT,
+		.host = ctx->host_no,
+		.channel = ctx->channel,
+		.target = ctx->id,
+		.lun = ctx->lun,
+	};
+
+	submit_event(ctx, &event);
+	return 0;
+}
+
+SEC("tracepoint/scsi/scsi_dispatch_cmd_error")
+int trace_scsi_dispatch_error(struct io_health_scsi_dispatch_error_ctx *ctx)
+{
+	struct health_event event = {
+		.type = HEALTH_EVENT_SCSI_DISPATCH_ERROR,
+		.status = ctx->rtn,
+		.host = ctx->host_no,
+		.channel = ctx->channel,
+		.target = ctx->id,
+		.lun = ctx->lun,
+	};
+
+	submit_event(ctx, &event);
+	return 0;
 }

--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -97,7 +97,9 @@ var (
 
 // Load loads the config file and updates module level configs.
 func Load(path string) error {
-	loaded := &BamaiConfig{}
+	loaded := &BamaiConfig{
+		MetricCollector: collector.DefaultConfig(),
+	}
 	if err := internalconfig.Load(path, loaded); err != nil {
 		return err
 	}

--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	"huatuo-bamai/core/autotracing"
 	"huatuo-bamai/core/events"
@@ -93,11 +94,13 @@ var (
 	configFile = ""
 	cfg        = &BamaiConfig{}
 	Region     string
+	configMu   sync.Mutex
 )
 
 // Load loads the config file and updates module level configs.
 func Load(path string) error {
 	loaded := &BamaiConfig{
+		AutoTracing:     autotracing.DefaultConfig(),
 		MetricCollector: collector.DefaultConfig(),
 	}
 	if err := internalconfig.Load(path, loaded); err != nil {
@@ -132,6 +135,9 @@ func (c *BamaiConfig) Validate() error {
 	}
 	if err := c.Pod.Validate(); err != nil {
 		return fmt.Errorf("validating pod config: %w", err)
+	}
+	if err := c.AutoTracing.Validate(); err != nil {
+		return fmt.Errorf("validating autotracing config: %w", err)
 	}
 	return nil
 }
@@ -214,8 +220,16 @@ func Get() *BamaiConfig {
 
 // Set updates a config field by dot-separated key.
 func Set(key string, val any) error {
+	configMu.Lock()
+	defer configMu.Unlock()
+
+	previous := *cfg
 	if err := internalconfig.Set(cfg, key, val); err != nil {
 		return err
+	}
+	if err := cfg.AutoTracing.Validate(); err != nil {
+		*cfg = previous
+		return fmt.Errorf("validate config after setting %s: %w", key, err)
 	}
 	setCoreModuleConfig()
 	return nil
@@ -223,6 +237,9 @@ func Set(key string, val any) error {
 
 // Sync writes the config back to the current config file.
 func Sync() error {
+	configMu.Lock()
+	defer configMu.Unlock()
+
 	return internalconfig.Sync(configFile, cfg)
 }
 

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -132,6 +132,9 @@ ExcludedOnContainer = "writeback"
 	if Get().MetricCollector.Vmstat.IncludedOnContainer != "inactive_file" {
 		t.Errorf("unexpected Vmstat.IncludedOnContainer: %q", Get().MetricCollector.Vmstat.IncludedOnContainer)
 	}
+	if !Get().MetricCollector.IOHealth.Enabled {
+		t.Error("IOHealth must remain enabled when its section is omitted")
+	}
 	if len(Get().EventTracing.NetRxLatency.ExcludedContainerQos) != 1 {
 		t.Errorf("unexpected ExcludedContainerQos length: %d", len(Get().EventTracing.NetRxLatency.ExcludedContainerQos))
 	}
@@ -329,6 +332,7 @@ ExcludedOnContainer = "writeback"
 		{"EventTracing.IssuesList", [][]string{{"dropwatch", "kfree_skb"}}},
 		{"MetricCollector.Vmstat.IncludedOnHost", "pgsteal_direct"},
 		{"MetricCollector.Vmstat.IncludedOnContainer", "workingset_refault_file"},
+		{"MetricCollector.IOHealth.Enabled", false},
 	} {
 		if err := Set(kv.key, kv.val); err != nil {
 			t.Fatalf("Set %s returned error: %v", kv.key, err)
@@ -351,6 +355,9 @@ ExcludedOnContainer = "writeback"
 	}
 	if Get().MetricCollector.Vmstat.IncludedOnContainer != "workingset_refault_file" {
 		t.Errorf("unexpected Vmstat.IncludedOnContainer after reload: %q", Get().MetricCollector.Vmstat.IncludedOnContainer)
+	}
+	if Get().MetricCollector.IOHealth.Enabled {
+		t.Error("IOHealth runtime update was not persisted")
 	}
 	if len(Get().AutoTracing.IssuesList) != 1 || len(Get().AutoTracing.IssuesList[0]) != 2 || Get().AutoTracing.IssuesList[0][0] != "cpuidle" {
 		t.Errorf("unexpected AutoTracing.IssuesList after reload: %#v", Get().AutoTracing.IssuesList)

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -15,9 +15,11 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -149,6 +151,12 @@ ExcludedOnContainer = "writeback"
 	}
 	if Get().Storage.Elasticsearch.Enabled() {
 		t.Error("Elasticsearch is enabled without connection settings")
+	}
+	if Get().AutoTracing.IOTracing.Interval != 5 {
+		t.Errorf(
+			"default AutoTracing.IOTracing.Interval = %d, want 5",
+			Get().AutoTracing.IOTracing.Interval,
+		)
 	}
 }
 
@@ -381,5 +389,119 @@ ExcludedOnContainer = "writeback"
 	}
 	if !strings.Contains(string(raw), "MemoryLimitMiB = 2048") {
 		t.Errorf("synced config should preserve the public memory unit, got %s", string(raw))
+	}
+}
+func TestLoadRejectsInvalidIOTracingInterval(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "invalid-io.conf", `
+[AutoTracing.IOTracing]
+Interval = 0
+`)
+	err := Load(path)
+	if err == nil ||
+		!strings.Contains(err.Error(), "AutoTracing.IOTracing.Interval") {
+		t.Fatalf("Load() error = %v, want startup validation key", err)
+	}
+}
+
+func TestLoadAcceptsCustomIOTracingInterval(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "iotracing.conf", `
+[AutoTracing.IOTracing]
+Interval = 17
+`)
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() rejected custom IOTracing interval: %v", err)
+	}
+	if Get().AutoTracing.IOTracing.Interval != 17 {
+		t.Fatalf(
+			"AutoTracing.IOTracing.Interval = %d, want 17",
+			Get().AutoTracing.IOTracing.Interval,
+		)
+	}
+}
+
+func TestSetRejectsInvalidIOTracingIntervalWithoutChangingConfig(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "iotracing.conf", "")
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	err := Set("AutoTracing.IOTracing.Interval", int64(0))
+	if err == nil ||
+		!strings.Contains(err.Error(), "AutoTracing.IOTracing.Interval") {
+		t.Fatalf("Set() error = %v, want interval validation error", err)
+	}
+	if Get().AutoTracing.IOTracing.Interval != 5 {
+		t.Fatalf(
+			"interval after rejected Set = %d, want 5",
+			Get().AutoTracing.IOTracing.Interval,
+		)
+	}
+}
+
+func TestSetAndSyncSerializeConcurrentValidation(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "iotracing.conf", "")
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	const iterations = 64
+	start := make(chan struct{})
+	errs := make(chan error, iterations*3)
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			if err := Set("AutoTracing.IOTracing.Interval", int64(17)); err != nil {
+				errs <- fmt.Errorf("Set(valid): %w", err)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			err := Set("AutoTracing.IOTracing.Interval", int64(0))
+			if err == nil ||
+				!strings.Contains(err.Error(), "AutoTracing.IOTracing.Interval") {
+				errs <- fmt.Errorf("Set(invalid) error = %v", err)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			if err := Sync(); err != nil {
+				errs <- fmt.Errorf("Sync(): %w", err)
+			}
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+
+	if err := Set("AutoTracing.IOTracing.Interval", int64(17)); err != nil {
+		t.Fatalf("final Set() error = %v", err)
+	}
+	if err := Sync(); err != nil {
+		t.Fatalf("final Sync() error = %v", err)
+	}
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() after concurrent updates error = %v", err)
+	}
+	if Get().AutoTracing.IOTracing.Interval != 17 {
+		t.Fatalf(
+			"persisted interval = %d, want 17",
+			Get().AutoTracing.IOTracing.Interval,
+		)
 	}
 }

--- a/cmd/huatuo-bamai/handlers/config_test.go
+++ b/cmd/huatuo-bamai/handlers/config_test.go
@@ -54,6 +54,43 @@ Log = { Level = "Info" }
 	}
 }
 
+func TestConfigHandlerUpdatesIOTracingInterval(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	if err := config.Load(writeConfig(t, `
+Log = { Level = "Info" }
+`)); err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	engine := httpGin.New()
+	server.NewRoot(engine, "").PUT("/config", NewConfigHandler().update)
+
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/config",
+		bytes.NewBufferString(
+			`{"config":{"AutoTracing.IOTracing.Interval":17}}`,
+		),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	engine.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf(
+			"status = %d, want %d, body: %s",
+			rec.Code,
+			http.StatusNoContent,
+			rec.Body.String(),
+		)
+	}
+	if got := config.Get().AutoTracing.IOTracing.Interval; got != 17 {
+		t.Fatalf("IOTracing interval = %d, want 17", got)
+	}
+}
+
 func writeConfig(t *testing.T, content string) string {
 	t.Helper()
 

--- a/cmd/iotracing/main.go
+++ b/cmd/iotracing/main.go
@@ -115,16 +115,17 @@ func mainAction(c *cli.Context) (returnErr error) {
 	defer bpf.Shutdown()
 
 	result, err := runTrace(c.Context, c.String(cliFlagBpfPath), cfg, filters)
-	if err != nil {
+	if result == nil {
 		return err
 	}
 
 	sink := newWriter(c.String(cliFlagOutput), client)
-	if err := sink.Write(result); err != nil {
-		return fmt.Errorf("write output: %w", err)
+	writeErr := sink.Write(result)
+	if writeErr != nil {
+		writeErr = fmt.Errorf("write output: %w", writeErr)
 	}
 
-	return nil
+	return errors.Join(err, writeErr)
 }
 
 // openToolstream returns a connected toolstream client when

--- a/cmd/iotracing/trace.go
+++ b/cmd/iotracing/trace.go
@@ -62,10 +62,7 @@ func runTrace(ctx context.Context, bpfPath string, cfg ioConfig, filters map[str
 	}
 	defer reader.Close()
 
-	stalls, err := collectStalls(reader, cfg.maxStack)
-	if err != nil {
-		return nil, err
-	}
+	stalls, collectErr := collectStalls(reader, cfg.maxStack)
 
 	if err := b.Detach(); err != nil {
 		return nil, fmt.Errorf("detach bpf: %w", err)
@@ -76,7 +73,14 @@ func runTrace(ctx context.Context, bpfPath string, cfg ioConfig, filters map[str
 		return nil, err
 	}
 
-	return &types.IOTracingSnapshot{Processes: processes, StallStacks: stalls}, nil
+	snapshot := &types.IOTracingSnapshot{
+		Processes:   processes,
+		StallStacks: stalls,
+	}
+	if collectErr != nil {
+		snapshot.FailureReason = types.IOTracingFailureReader
+	}
+	return snapshot, collectErr
 }
 
 // collectStalls drains the iodelay perf reader until ctx cancellation
@@ -86,10 +90,11 @@ func runTrace(ctx context.Context, bpfPath string, cfg ioConfig, filters map[str
 // of the window.
 func collectStalls(reader bpf.PerfEventReader, maxStack uint64) ([]types.IOScheduleEvent, error) {
 	var (
-		event bpfScheduleDelay
-		ring  []types.IOScheduleEvent
-		head  uint64
-		count uint64
+		event   bpfScheduleDelay
+		ring    []types.IOScheduleEvent
+		readErr error
+		head    uint64
+		count   uint64
 	)
 
 	if maxStack > 0 {
@@ -102,11 +107,10 @@ func collectStalls(reader bpf.PerfEventReader, maxStack uint64) ([]types.IOSched
 				log.WithError(err).Warn("lost BPF perf event samples")
 				continue
 			}
-			if errors.Is(err, types.ErrExitByCancelCtx) {
-				break
+			if !errors.Is(err, types.ErrExitByCancelCtx) {
+				readErr = fmt.Errorf("read event: %w", err)
 			}
-
-			return nil, fmt.Errorf("read event: %w", err)
+			break
 		}
 
 		if maxStack == 0 {
@@ -130,7 +134,7 @@ func collectStalls(reader bpf.PerfEventReader, maxStack uint64) ([]types.IOSched
 	}
 
 	if count < maxStack {
-		return ring[:count], nil
+		return ring[:count], readErr
 	}
 
 	// Buffer wrapped: head points to the oldest entry. Stitch
@@ -139,7 +143,7 @@ func collectStalls(reader bpf.PerfEventReader, maxStack uint64) ([]types.IOSched
 	out = append(out, ring[head:]...)
 	out = append(out, ring[:head]...)
 
-	return out, nil
+	return out, readErr
 }
 
 // dumpAndAggregate reads io_source_map after detach and reduces it into

--- a/cmd/iotracing/trace_test.go
+++ b/cmd/iotracing/trace_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+)
+
+var _ bpf.PerfEventReader = (*readerErrorAfterEvent)(nil)
+
+type readerErrorAfterEvent struct {
+	readErr error
+	read    bool
+}
+
+func (r *readerErrorAfterEvent) ReadInto(data any) error {
+	if r.read {
+		return r.readErr
+	}
+
+	r.read = true
+	event := data.(*bpfScheduleDelay)
+	event.PID = 1
+	event.Cost = 2500
+	copy(event.Comm[:], "init")
+	return nil
+}
+
+func (*readerErrorAfterEvent) ReadBatch(func() any) ([]any, error) {
+	return nil, nil
+}
+
+func (*readerErrorAfterEvent) Close() error {
+	return nil
+}
+
+func TestCollectStallsReturnsEventsBeforeReaderError(t *testing.T) {
+	readerErr := errors.New("reader failed")
+	stalls, err := collectStalls(
+		&readerErrorAfterEvent{readErr: readerErr},
+		1,
+	)
+
+	if !errors.Is(err, readerErr) {
+		t.Fatalf("collectStalls() error = %v, want %v", err, readerErr)
+	}
+	if len(stalls) != 1 {
+		t.Fatalf("collectStalls() returned %d stalls, want 1", len(stalls))
+	}
+	if stalls[0].Pid != 1 || stalls[0].Comm != "init" ||
+		stalls[0].LatencyUs != 2 {
+		t.Fatalf("collectStalls() stall = %+v", stalls[0])
+	}
+}

--- a/core/autotracing/config.go
+++ b/core/autotracing/config.go
@@ -14,7 +14,15 @@
 
 package autotracing
 
-import "huatuo-bamai/internal/matcher"
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"huatuo-bamai/internal/matcher"
+)
+
+const defaultIOTracingIntervalSeconds int64 = 5
 
 // ContainerFilterConfig is the serializable form of a container filter.
 // It is converted to a *matcher.ContainerMatcher at runtime.
@@ -73,6 +81,7 @@ type Config struct {
 	}
 
 	IOTracing struct {
+		Interval              int64  `default:"5"`
 		RbpsThreshold         uint64 `default:"2000"`
 		WbpsThreshold         uint64 `default:"1500"`
 		UtilThreshold         uint64 `default:"90"`
@@ -88,14 +97,64 @@ type Config struct {
 	IssuesList [][]string
 }
 
-var cfg = &Config{}
+// DefaultConfig also makes the IO sampling default available to callers that
+// construct Config without going through the TOML decoder.
+func DefaultConfig() Config {
+	var c Config
+	c.IOTracing.Interval = defaultIOTracingIntervalSeconds
+	return c
+}
 
-// Set sets the autotracing config. A nil argument resets to the zero value so
-// callers never need to nil-check cfg.
+var cfg = func() *Config {
+	c := DefaultConfig()
+	return &c
+}()
+
+var (
+	ioTracingIntervalSeconds atomic.Int64
+	ioTracingIntervalChanged = make(chan struct{}, 1)
+)
+
+func init() {
+	ioTracingIntervalSeconds.Store(defaultIOTracingIntervalSeconds)
+}
+
+// Set sets the autotracing config. A nil argument restores package defaults.
 func Set(c *Config) {
 	if c == nil {
-		cfg = &Config{}
-		return
+		defaults := DefaultConfig()
+		c = &defaults
 	}
 	cfg = c
+	if ioTracingIntervalSeconds.Swap(c.IOTracing.Interval) == c.IOTracing.Interval {
+		return
+	}
+	select {
+	case ioTracingIntervalChanged <- struct{}{}:
+	default:
+	}
+}
+
+// Validate rejects an unusable or overflowing diskstats sampling interval.
+func (c *Config) Validate() error {
+	if c == nil {
+		return nil
+	}
+
+	if _, err := ioTracingInterval(c.IOTracing.Interval); err != nil {
+		return fmt.Errorf("AutoTracing.IOTracing.Interval: %w", err)
+	}
+	return nil
+}
+
+func ioTracingInterval(seconds int64) (time.Duration, error) {
+	if seconds <= 0 {
+		return 0, fmt.Errorf("must be greater than 0")
+	}
+	const maxDuration = time.Duration(1<<63 - 1)
+	maxSeconds := int64(maxDuration / time.Second)
+	if seconds > maxSeconds {
+		return 0, fmt.Errorf("%d seconds overflows time.Duration", seconds)
+	}
+	return time.Duration(seconds) * time.Second, nil
 }

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -33,6 +34,7 @@ import (
 	"huatuo-bamai/internal/procfs"
 	"huatuo-bamai/internal/procfs/blockdevice"
 	"huatuo-bamai/internal/toolstream"
+	"huatuo-bamai/pkg/metric"
 	"huatuo-bamai/pkg/tracing"
 	"huatuo-bamai/pkg/types"
 )
@@ -102,11 +104,12 @@ func newIOTracing() (*tracing.EventTracingAttr, error) {
 	return &tracing.EventTracingAttr{
 		TracingData: tracer,
 		Interval:    5,
-		Flag:        tracing.FlagTracing,
+		Flag:        tracing.FlagTracing | tracing.FlagMetric,
 	}, nil
 }
 
 type ioTracing struct {
+	latest       atomic.Pointer[diskStatusSnapshot]
 	childRunning atomic.Bool
 
 	thresholds              ioThresholds
@@ -633,6 +636,8 @@ func (i *ioTracing) Start(ctx context.Context) error {
 			}
 
 			snapshot := buildDiskStatusSnapshot(previous, current)
+			// Neither this map nor its values are mutated after publication.
+			i.latest.Store(snapshot)
 			reason, nextMetrics := evaluateThresholds(
 				current,
 				snapshot,
@@ -752,6 +757,84 @@ func killIOTracingProcessAndWait(
 	case <-timer.C:
 		return errors.New("timed out waiting for iotracing to stop")
 	}
+}
+
+// round2 rounds v to two decimal places. All iotracing gauge values are
+// exported at this precision so scrapes stay free of floating point noise.
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+// Update exports the immutable diskstats snapshot produced by Start. It does
+// not read /proc/diskstats or recompute a delta.
+func (i *ioTracing) Update() ([]*metric.Data, error) {
+	snapshot := i.latest.Load()
+	if snapshot == nil || len(snapshot.devices) == 0 {
+		return nil, metric.ErrNoData
+	}
+
+	metrics := make([]*metric.Data, 0, len(snapshot.devices)*8)
+	for _, device := range snapshot.order {
+		status, ok := snapshot.devices[device]
+		if !ok {
+			continue
+		}
+		labels := map[string]string{"device": device}
+		metrics = append(metrics,
+			metric.NewGaugeData(
+				"read_bytes_per_second",
+				round2(status.ReadBPS),
+				"Disk read throughput over the latest sampling window in bytes per second.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"write_bytes_per_second",
+				round2(status.WriteBPS),
+				"Disk write throughput over the latest sampling window in bytes per second.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"read_iops",
+				round2(status.ReadIOPS),
+				"Disk read operations per second over the latest sampling window.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"write_iops",
+				round2(status.WriteIOPS),
+				"Disk write operations per second over the latest sampling window.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"read_await_seconds",
+				round2(status.ReadAwait/1000),
+				"Average read completion time over the latest sampling window in seconds.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"write_await_seconds",
+				round2(status.WriteAwait/1000),
+				"Average write completion time over the latest sampling window in seconds.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"io_utilization_percent",
+				round2(status.IOUtil),
+				"Percentage of the latest sampling window spent doing I/O.",
+				labels,
+			),
+			metric.NewGaugeData(
+				"average_queue_size",
+				round2(status.QueueSize),
+				"Average disk I/O queue size over the latest sampling window.",
+				labels,
+			),
+		)
+	}
+	if len(metrics) == 0 {
+		return nil, metric.ErrNoData
+	}
+	return metrics, nil
 }
 
 func iotracingSummary(

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -73,9 +73,10 @@ func handleIotracingEvent(sess *toolstream.Session, ev *types.IOTracingSnapshot)
 		TracerName: iotracingToolName,
 		TracerTime: time.Now(),
 		TracerData: &ioStatusData{
-			Reason:      reason,
-			Processes:   ev.Processes,
-			StallStacks: ev.StallStacks,
+			Reason:        reason,
+			FailureReason: ev.FailureReason,
+			Processes:     ev.Processes,
+			StallStacks:   ev.StallStacks,
 		},
 		TracerRunType: tracing.TracerRunTypeAutotracing,
 	})
@@ -113,9 +114,10 @@ type ioTracing struct {
 //go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/iotracing.c -o $BPF_DIR/iotracing.o
 
 type ioStatusData struct {
-	Reason      *reasonSnapshot            `json:"reason_snapshot"`
-	Processes   []types.ProcessFileIOStats `json:"process_file_io_stats"`
-	StallStacks []types.IOScheduleEvent    `json:"io_schedule_timeout_stacks"`
+	Reason        *reasonSnapshot            `json:"reason_snapshot"`
+	FailureReason string                     `json:"failure_reason,omitempty"`
+	Processes     []types.ProcessFileIOStats `json:"process_file_io_stats"`
+	StallStacks   []types.IOScheduleEvent    `json:"io_schedule_timeout_stacks"`
 }
 
 type diskStatus struct {
@@ -457,6 +459,7 @@ func (i *ioTracing) Start(ctx context.Context) error {
 		done <- cmd.Wait()
 	}()
 
+	var exitErr error
 	select {
 	case <-ctx.Done():
 		pendingReasons.Delete(taskID)
@@ -475,19 +478,29 @@ func (i *ioTracing) Start(ctx context.Context) error {
 			log.Info("iotracing stopped")
 			return nil
 		}
-		if werr != nil {
-			pendingReasons.Delete(taskID)
-			return fmt.Errorf("iotracing exited: %w", werr)
-		}
+		exitErr = werr
 	}
 
-	return waitForSnapshot(
+	return waitForSnapshotAfterExit(ctx, taskID, pending, exitErr)
+}
+
+func waitForSnapshotAfterExit(
+	ctx context.Context,
+	taskID string,
+	pending *pendingIOTracingReason,
+	exitErr error,
+) error {
+	snapshotErr := waitForSnapshot(
 		ctx,
 		taskID,
 		pending,
 		iotracingSnapshotTimeout,
 		iotracingSnapshotSaveTimeout,
 	)
+	if exitErr == nil {
+		return snapshotErr
+	}
+	return errors.Join(fmt.Errorf("iotracing exited: %w", exitErr), snapshotErr)
 }
 
 func waitForSnapshot(

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -111,6 +111,17 @@ type ioTracing struct {
 	maxFilesPerProcess      int
 }
 
+type diskStatusSnapshot struct {
+	devices map[string]diskStatus
+	order   []string
+}
+
+type rawDiskstatsSnapshot struct {
+	timestamp time.Time
+	devices   map[string]blockdevice.Diskstats
+	order     []string
+}
+
 //go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/iotracing.c -o $BPF_DIR/iotracing.o
 
 type ioStatusData struct {
@@ -121,14 +132,14 @@ type ioStatusData struct {
 }
 
 type diskStatus struct {
-	ReadBPS    uint64 `json:"read_bps"`
-	ReadIOPS   uint64 `json:"read_iops"`
-	ReadAwait  uint64 `json:"read_await"`
-	WriteBPS   uint64 `json:"write_bps"`
-	WriteIOPS  uint64 `json:"write_iops"`
-	WriteAwait uint64 `json:"write_await"`
-	IOUtil     uint64 `json:"io_util"`
-	QueueSize  uint64 `json:"queue_size"`
+	ReadBPS    float64 `json:"read_bps"`
+	ReadIOPS   float64 `json:"read_iops"`
+	ReadAwait  float64 `json:"read_await"`
+	WriteBPS   float64 `json:"write_bps"`
+	WriteIOPS  float64 `json:"write_iops"`
+	WriteAwait float64 `json:"write_await"`
+	IOUtil     float64 `json:"io_util"`
+	QueueSize  float64 `json:"queue_size"`
 }
 
 type reasonSnapshot struct {
@@ -164,16 +175,16 @@ func thresholdReasonFor(
 	thresholds ioThresholds,
 	isNVMe bool,
 ) thresholdReason {
-	if previous.IOUtil > thresholds.UtilThreshold &&
-		current.IOUtil > thresholds.UtilThreshold {
+	if previous.IOUtil > float64(thresholds.UtilThreshold) &&
+		current.IOUtil > float64(thresholds.UtilThreshold) {
 		if isNVMe {
 			// https://man7.org/linux/man-pages/man1/iostat.1.html
-			if previous.ReadBPS > thresholds.RBPSThreshold*1024*1024 &&
-				current.ReadBPS > thresholds.RBPSThreshold*1024*1024 {
+			if previous.ReadBPS > float64(thresholds.RBPSThreshold)*1024*1024 &&
+				current.ReadBPS > float64(thresholds.RBPSThreshold)*1024*1024 {
 				return ioReasonReadBPS
 			}
-			if previous.WriteBPS > thresholds.WBPSThreshold*1024*1024 &&
-				current.WriteBPS > thresholds.WBPSThreshold*1024*1024 {
+			if previous.WriteBPS > float64(thresholds.WBPSThreshold)*1024*1024 &&
+				current.WriteBPS > float64(thresholds.WBPSThreshold)*1024*1024 {
 				return ioReasonWriteBPS
 			}
 		} else {
@@ -181,13 +192,13 @@ func thresholdReasonFor(
 		}
 	}
 
-	if previous.ReadAwait > thresholds.AwaitThreshold &&
-		current.ReadAwait > thresholds.AwaitThreshold {
+	if previous.ReadAwait > float64(thresholds.AwaitThreshold) &&
+		current.ReadAwait > float64(thresholds.AwaitThreshold) {
 		return ioReasonReadAwait
 	}
 
-	if previous.WriteAwait > thresholds.AwaitThreshold &&
-		current.WriteAwait > thresholds.AwaitThreshold {
+	if previous.WriteAwait > float64(thresholds.AwaitThreshold) &&
+		current.WriteAwait > float64(thresholds.AwaitThreshold) {
 		return ioReasonWriteAwait
 	}
 
@@ -231,6 +242,25 @@ func readDiskStats() ([]blockdevice.Diskstats, error) {
 	return fs.ProcDiskstats()
 }
 
+func readRawDiskstatsSnapshot() (*rawDiskstatsSnapshot, error) {
+	stats, err := readDiskStats()
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot := &rawDiskstatsSnapshot{
+		timestamp: time.Now(),
+		devices:   make(map[string]blockdevice.Diskstats, len(stats)),
+		order:     make([]string, 0, len(stats)),
+	}
+	for i := range stats {
+		current := stats[i]
+		snapshot.devices[current.DeviceName] = current
+		snapshot.order = append(snapshot.order, current.DeviceName)
+	}
+	return snapshot, nil
+}
+
 func validDiskstatsWindow(
 	previous *blockdevice.Diskstats,
 	current *blockdevice.Diskstats,
@@ -258,114 +288,130 @@ func validDiskstatsWindow(
 func buildDiskMetric(
 	previous *blockdevice.Diskstats,
 	current *blockdevice.Diskstats,
-	intervalSeconds uint64,
+	elapsed time.Duration,
 ) (diskStatus, bool) {
-	if intervalSeconds == 0 || !validDiskstatsWindow(previous, current) {
+	if elapsed <= 0 || !validDiskstatsWindow(previous, current) {
 		return diskStatus{}, false
 	}
 
-	deltaReadIOs := current.ReadIOs - previous.ReadIOs
-	deltaWriteIOs := current.WriteIOs - previous.WriteIOs
-
-	metrics := diskStatus{
-		IOUtil:    (current.IOsTotalTicks - previous.IOsTotalTicks) / (intervalSeconds * 10),
-		QueueSize: (current.WeightedIOTicks - previous.WeightedIOTicks) / (intervalSeconds * 1000),
-		ReadBPS:   ((current.ReadSectors - previous.ReadSectors) * 512) / intervalSeconds,
-		WriteBPS:  ((current.WriteSectors - previous.WriteSectors) * 512) / intervalSeconds,
-		ReadIOPS:  deltaReadIOs / intervalSeconds,
-		WriteIOPS: deltaWriteIOs / intervalSeconds,
+	elapsedSeconds := elapsed.Seconds()
+	readIOs := current.ReadIOs - previous.ReadIOs
+	writeIOs := current.WriteIOs - previous.WriteIOs
+	status := diskStatus{
+		ReadBPS:   float64(current.ReadSectors-previous.ReadSectors) * 512 / elapsedSeconds,
+		ReadIOPS:  float64(readIOs) / elapsedSeconds,
+		WriteBPS:  float64(current.WriteSectors-previous.WriteSectors) * 512 / elapsedSeconds,
+		WriteIOPS: float64(writeIOs) / elapsedSeconds,
+		IOUtil:    float64(current.IOsTotalTicks-previous.IOsTotalTicks) / (elapsedSeconds * 1000) * 100,
+		QueueSize: float64(current.WeightedIOTicks-previous.WeightedIOTicks) / (elapsedSeconds * 1000),
 	}
 
-	if deltaReadIOs > 0 {
-		metrics.ReadAwait = (current.ReadTicks - previous.ReadTicks) / deltaReadIOs
+	if readIOs > 0 {
+		status.ReadAwait = float64(current.ReadTicks-previous.ReadTicks) / float64(readIOs)
 	}
-	if deltaWriteIOs > 0 {
-		metrics.WriteAwait = (current.WriteTicks - previous.WriteTicks) / deltaWriteIOs
+	if writeIOs > 0 {
+		status.WriteAwait = float64(current.WriteTicks-previous.WriteTicks) / float64(writeIOs)
 	}
 
-	return metrics, true
+	return status, true
+}
+
+func buildDiskStatusSnapshot(
+	previous *rawDiskstatsSnapshot,
+	current *rawDiskstatsSnapshot,
+) *diskStatusSnapshot {
+	snapshot := &diskStatusSnapshot{
+		devices: make(map[string]diskStatus, len(current.devices)),
+		order:   make([]string, 0, len(current.order)),
+	}
+	elapsed := current.timestamp.Sub(previous.timestamp)
+	for _, name := range current.order {
+		currentDisk := current.devices[name]
+		previousDisk, ok := previous.devices[name]
+		if !ok {
+			continue
+		}
+		status, ok := buildDiskMetric(&previousDisk, &currentDisk, elapsed)
+		if !ok {
+			continue
+		}
+		snapshot.devices[name] = status
+		snapshot.order = append(snapshot.order, name)
+	}
+	return snapshot
 }
 
 func evaluateThresholds(
-	currentRawStats []blockdevice.Diskstats,
-	lastRawStats map[string]*blockdevice.Diskstats,
+	raw *rawDiskstatsSnapshot,
+	snapshot *diskStatusSnapshot,
 	lastMetrics map[string]diskStatus,
 	thresholds ioThresholds,
-	intervalSeconds uint64,
 ) *reasonSnapshot {
-	currentDevices := make(map[string]struct{}, len(currentRawStats))
-	for i := range currentRawStats {
-		current := &currentRawStats[i]
+	for name := range lastMetrics {
+		if _, valid := snapshot.devices[name]; !valid {
+			delete(lastMetrics, name)
+		}
+	}
 
-		if strings.HasPrefix(current.DeviceName, "md") {
+	for _, name := range snapshot.order {
+		if strings.HasPrefix(name, "md") {
 			continue
 		}
-		currentDevices[current.DeviceName] = struct{}{}
 
-		if previous, ok := lastRawStats[current.DeviceName]; ok {
-			metric, valid := buildDiskMetric(previous, current, intervalSeconds)
-			if !valid {
-				delete(lastMetrics, current.DeviceName)
-				lastRawStats[current.DeviceName] = current
-				continue
-			}
+		status := snapshot.devices[name]
+		log.WithField("device", name).
+			WithField("io_util_percent", status.IOUtil).
+			WithField("queue_size", status.QueueSize).
+			WithField("read_kbps", status.ReadBPS/1024).
+			WithField("write_kbps", status.WriteBPS/1024).
+			WithField("read_iops", status.ReadIOPS).
+			WithField("write_iops", status.WriteIOPS).
+			WithField("read_await_ms", status.ReadAwait).
+			WithField("write_await_ms", status.WriteAwait).
+			Debug("sampled disk io metrics")
 
-			log.WithField("device", current.DeviceName).
-				WithField("io_util_percent", metric.IOUtil).
-				WithField("queue_size", metric.QueueSize).
-				WithField("read_kbps", metric.ReadBPS/1024).
-				WithField("write_kbps", metric.WriteBPS/1024).
-				WithField("read_iops", metric.ReadIOPS).
-				WithField("write_iops", metric.WriteIOPS).
-				WithField("read_await_ms", metric.ReadAwait).
-				WithField("write_await_ms", metric.WriteAwait).
-				Debug("sampled disk io metrics")
-
-			reasonType := thresholdReasonFor(
-				lastMetrics[current.DeviceName],
-				metric,
-				thresholds,
-				strings.HasPrefix(current.DeviceName, "nvme"),
+		reasonType := thresholdReasonFor(
+			lastMetrics[name],
+			status,
+			thresholds,
+			strings.HasPrefix(name, "nvme"),
+		)
+		if reasonType != ioReasonNone {
+			device := raw.devices[name]
+			deviceLabel := fmt.Sprintf(
+				"%s(%d:%d)",
+				name,
+				device.MajorNumber,
+				device.MinorNumber,
 			)
-			if reasonType != ioReasonNone {
-				device := fmt.Sprintf(
-					"%s(%d:%d)",
-					current.DeviceName,
-					current.MajorNumber,
-					current.MinorNumber,
-				)
-				return &reasonSnapshot{
-					Type:        string(reasonType),
-					Device:      current.DeviceName,
-					MajorNumber: current.MajorNumber,
-					MinorNumber: current.MinorNumber,
-					IOStatus:    metric,
-					Summary: iotracingSummary(
-						reasonType,
-						device,
-						metric,
-						thresholds,
-					),
-				}
+			return &reasonSnapshot{
+				Type:        string(reasonType),
+				Device:      name,
+				MajorNumber: device.MajorNumber,
+				MinorNumber: device.MinorNumber,
+				IOStatus:    status,
+				Summary: iotracingSummary(
+					reasonType,
+					deviceLabel,
+					status,
+					thresholds,
+				),
 			}
-
-			lastMetrics[current.DeviceName] = metric
 		}
 
-		lastRawStats[current.DeviceName] = current
+		lastMetrics[name] = status
 	}
-	deleteMissingDiskState(lastRawStats, lastMetrics, currentDevices)
 	return nil
 }
 
 func waitForDiskEvent(
 	ctx context.Context,
-	intervalSeconds uint64,
+	interval time.Duration,
 	thresholds ioThresholds,
 ) (*reasonSnapshot, error) {
-	lastRawStats := make(map[string]*blockdevice.Diskstats)
+	var previous *rawDiskstatsSnapshot
 	lastMetrics := make(map[string]diskStatus)
-	ticker := time.NewTicker(time.Duration(int64(intervalSeconds)) * time.Second)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -373,20 +419,26 @@ func waitForDiskEvent(
 		case <-ctx.Done():
 			return nil, types.ErrExitByCancelCtx
 		case <-ticker.C:
-			currentRawStats, err := readDiskStats()
+			current, err := readRawDiskstatsSnapshot()
 			if err != nil {
 				return nil, err
 			}
+			if previous == nil {
+				previous = current
+				continue
+			}
 
-			if reason := evaluateThresholds(
-				currentRawStats,
-				lastRawStats,
+			snapshot := buildDiskStatusSnapshot(previous, current)
+			reason := evaluateThresholds(
+				current,
+				snapshot,
 				lastMetrics,
 				thresholds,
-				intervalSeconds,
-			); reason != nil {
+			)
+			if reason != nil {
 				return reason, nil
 			}
+			previous = current
 		}
 	}
 }
@@ -446,7 +498,7 @@ func newIOTracer(config *Config) (*ioTracing, error) {
 func (i *ioTracing) Start(ctx context.Context) error {
 	reasonSnapshot, err := waitForDiskEvent(
 		ctx,
-		i.samplingIntervalSeconds,
+		time.Duration(i.samplingIntervalSeconds)*time.Second,
 		i.thresholds,
 	)
 	if err != nil {
@@ -622,22 +674,22 @@ func iotracingSummary(
 ) string {
 	switch reasonType {
 	case ioReasonUtil:
-		return fmt.Sprintf("ioutil=%d%% (threshold=%d%%) on %s, aqu-sz=%d, r_await=%dms w_await=%dms",
+		return fmt.Sprintf("ioutil=%.2f%% (threshold=%d%%) on %s, aqu-sz=%.2f, r_await=%.2fms w_await=%.2fms",
 			ioStatus.IOUtil, thresholds.UtilThreshold, device, ioStatus.QueueSize,
 			ioStatus.ReadAwait, ioStatus.WriteAwait)
 	case ioReasonReadBPS:
-		return fmt.Sprintf("read_bps=%dMB/s (threshold=%dMB/s) on %s, aqu-sz=%d, r_await=%dms w_await=%dms",
+		return fmt.Sprintf("read_bps=%.2fMB/s (threshold=%dMB/s) on %s, aqu-sz=%.2f, r_await=%.2fms w_await=%.2fms",
 			ioStatus.ReadBPS/1024/1024, thresholds.RBPSThreshold, device, ioStatus.QueueSize,
 			ioStatus.ReadAwait, ioStatus.WriteAwait)
 	case ioReasonWriteBPS:
-		return fmt.Sprintf("write_bps=%dMB/s (threshold=%dMB/s) on %s, aqu-sz=%d, r_await=%dms w_await=%dms",
+		return fmt.Sprintf("write_bps=%.2fMB/s (threshold=%dMB/s) on %s, aqu-sz=%.2f, r_await=%.2fms w_await=%.2fms",
 			ioStatus.WriteBPS/1024/1024, thresholds.WBPSThreshold, device, ioStatus.QueueSize,
 			ioStatus.ReadAwait, ioStatus.WriteAwait)
 	case ioReasonReadAwait:
-		return fmt.Sprintf("r_await=%dms (threshold=%dms) on %s, aqu-sz=%d",
+		return fmt.Sprintf("r_await=%.2fms (threshold=%dms) on %s, aqu-sz=%.2f",
 			ioStatus.ReadAwait, thresholds.AwaitThreshold, device, ioStatus.QueueSize)
 	case ioReasonWriteAwait:
-		return fmt.Sprintf("w_await=%dms (threshold=%dms) on %s, aqu-sz=%d",
+		return fmt.Sprintf("w_await=%.2fms (threshold=%dms) on %s, aqu-sz=%.2f",
 			ioStatus.WriteAwait, thresholds.AwaitThreshold, device, ioStatus.QueueSize)
 	default:
 		return fmt.Sprintf("%s on %s", reasonType, device)

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -535,29 +535,20 @@ func newIOTracer(config *Config) (*ioTracing, error) {
 	}, nil
 }
 
-// Start waits for a disk-burst trigger then runs the iotracing tool as a
-// subprocess; results stream back via toolstream. The trigger reason is
-// stashed under a generated task ID so handleIotracingEvent can attach it.
-func (i *ioTracing) Start(ctx context.Context) error {
-	reasonSnapshot, err := waitForDiskEvent(
-		ctx,
-		time.Duration(i.samplingIntervalSeconds)*time.Second,
-		i.thresholds,
-	)
-	if err != nil {
-		return err
-	}
-
-	log.WithField("reason_snapshot", reasonSnapshot).
-		Debug("detected disk io event")
-
+func runIOTracingChild(
+	ctx context.Context,
+	reason *reasonSnapshot,
+	duration uint64,
+	maxProcesses int,
+	maxFilesPerProcess int,
+) error {
 	taskID, err := tracing.AllocTaskID()
 	if err != nil {
 		return fmt.Errorf("allocate iotracing task id: %w", err)
 	}
 
 	pending := &pendingIOTracingReason{
-		reason:   reasonSnapshot,
+		reason:   reason,
 		received: make(chan struct{}),
 		result:   make(chan error, 1),
 	}
@@ -567,9 +558,9 @@ func (i *ioTracing) Start(ctx context.Context) error {
 		"--bpf-path", path.Join(internalconfig.CoreBpfDir, "iotracing.o"),
 		"--output-storage", toolstream.DefaultSockPath,
 		"--task-id", taskID,
-		"--duration", strconv.FormatUint(i.runDurationSeconds, 10),
-		"--max-process", strconv.Itoa(i.maxProcesses),
-		"--max-files-per-process", strconv.Itoa(i.maxFilesPerProcess),
+		"--duration", strconv.FormatUint(duration, 10),
+		"--max-process", strconv.Itoa(maxProcesses),
+		"--max-files-per-process", strconv.Itoa(maxFilesPerProcess),
 	}
 
 	cmd := exec.CommandContext(
@@ -631,6 +622,31 @@ func waitForSnapshotAfterExit(
 		return snapshotErr
 	}
 	return errors.Join(fmt.Errorf("iotracing exited: %w", exitErr), snapshotErr)
+}
+
+// Start waits for a disk-burst trigger then runs the iotracing tool as a
+// subprocess; results stream back via toolstream. The trigger reason is
+// stashed under a generated task ID so handleIotracingEvent can attach it.
+func (i *ioTracing) Start(ctx context.Context) error {
+	reasonSnapshot, err := waitForDiskEvent(
+		ctx,
+		time.Duration(i.samplingIntervalSeconds)*time.Second,
+		i.thresholds,
+	)
+	if err != nil {
+		return err
+	}
+
+	log.WithField("reason_snapshot", reasonSnapshot).
+		Debug("detected disk io event")
+
+	return runIOTracingChild(
+		ctx,
+		reasonSnapshot,
+		i.runDurationSeconds,
+		i.maxProcesses,
+		i.maxFilesPerProcess,
+	)
 }
 
 func waitForSnapshot(

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,6 +29,7 @@ import (
 
 	internalconfig "huatuo-bamai/internal/config"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/procfs"
 	"huatuo-bamai/internal/procfs/blockdevice"
 	"huatuo-bamai/internal/toolstream"
 	"huatuo-bamai/pkg/tracing"
@@ -255,10 +257,51 @@ func readRawDiskstatsSnapshot() (*rawDiskstatsSnapshot, error) {
 	}
 	for i := range stats {
 		current := stats[i]
+		if !isMonitoredDisk(&current) {
+			continue
+		}
 		snapshot.devices[current.DeviceName] = current
 		snapshot.order = append(snapshot.order, current.DeviceName)
 	}
 	return snapshot, nil
+}
+
+func isMonitoredDisk(stat *blockdevice.Diskstats) bool {
+	if stat == nil || stat.DeviceName == "" || isPseudoDisk(stat.DeviceName) {
+		return false
+	}
+
+	devicePath := filepath.Join(
+		procfs.DefaultPathByType("sys"),
+		"dev",
+		"block",
+		fmt.Sprintf("%d:%d", stat.MajorNumber, stat.MinorNumber),
+	)
+	if _, err := os.Stat(devicePath); err != nil {
+		return false
+	}
+
+	_, err := os.Stat(filepath.Join(devicePath, "partition"))
+	if err == nil {
+		return false
+	}
+	if !os.IsNotExist(err) {
+		return false
+	}
+
+	// Confirm that a concurrent removal did not make the partition file
+	// disappear before treating the entry as a whole device.
+	_, err = os.Stat(devicePath)
+	return err == nil
+}
+
+func isPseudoDisk(name string) bool {
+	for _, prefix := range []string{"loop", "ram", "zram", "fd"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func validDiskstatsWindow(

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -275,6 +275,84 @@ func buildDiskMetric(
 	return metrics, true
 }
 
+func evaluateThresholds(
+	currentRawStats []blockdevice.Diskstats,
+	lastRawStats map[string]*blockdevice.Diskstats,
+	lastMetrics map[string]diskStatus,
+	thresholds ioThresholds,
+	intervalSeconds uint64,
+) *reasonSnapshot {
+	currentDevices := make(map[string]struct{}, len(currentRawStats))
+	for i := range currentRawStats {
+		current := &currentRawStats[i]
+
+		if strings.HasPrefix(current.DeviceName, "md") {
+			continue
+		}
+		currentDevices[current.DeviceName] = struct{}{}
+
+		if previous, ok := lastRawStats[current.DeviceName]; ok {
+			if previous.MajorNumber != current.MajorNumber ||
+				previous.MinorNumber != current.MinorNumber {
+				delete(lastMetrics, current.DeviceName)
+				lastRawStats[current.DeviceName] = current
+				continue
+			}
+			metric, valid := buildDiskMetric(previous, current, intervalSeconds)
+			if !valid {
+				delete(lastMetrics, current.DeviceName)
+				lastRawStats[current.DeviceName] = current
+				continue
+			}
+
+			log.WithField("device", current.DeviceName).
+				WithField("io_util_percent", metric.IOUtil).
+				WithField("queue_size", metric.QueueSize).
+				WithField("read_kbps", metric.ReadBPS/1024).
+				WithField("write_kbps", metric.WriteBPS/1024).
+				WithField("read_iops", metric.ReadIOPS).
+				WithField("write_iops", metric.WriteIOPS).
+				WithField("read_await_ms", metric.ReadAwait).
+				WithField("write_await_ms", metric.WriteAwait).
+				Debug("sampled disk io metrics")
+
+			reasonType := thresholdReasonFor(
+				lastMetrics[current.DeviceName],
+				metric,
+				thresholds,
+				strings.HasPrefix(current.DeviceName, "nvme"),
+			)
+			if reasonType != ioReasonNone {
+				device := fmt.Sprintf(
+					"%s(%d:%d)",
+					current.DeviceName,
+					current.MajorNumber,
+					current.MinorNumber,
+				)
+				return &reasonSnapshot{
+					Type:        string(reasonType),
+					Device:      current.DeviceName,
+					MajorNumber: current.MajorNumber,
+					MinorNumber: current.MinorNumber,
+					IOStatus:    metric,
+					Summary: iotracingSummary(
+						reasonType,
+						device,
+						metric,
+						thresholds,
+					),
+				}
+			}
+
+			lastMetrics[current.DeviceName] = metric
+		}
+
+		lastRawStats[current.DeviceName] = current
+	}
+	deleteMissingDiskState(lastRawStats, lastMetrics, currentDevices)
+	return nil
+}
+
 func waitForDiskEvent(
 	ctx context.Context,
 	intervalSeconds uint64,
@@ -295,74 +373,15 @@ func waitForDiskEvent(
 				return nil, err
 			}
 
-			currentDevices := make(map[string]struct{}, len(currentRawStats))
-			for i := range currentRawStats {
-				current := &currentRawStats[i]
-
-				if strings.HasPrefix(current.DeviceName, "md") {
-					continue
-				}
-				currentDevices[current.DeviceName] = struct{}{}
-
-				if previous, ok := lastRawStats[current.DeviceName]; ok {
-					if previous.MajorNumber != current.MajorNumber ||
-						previous.MinorNumber != current.MinorNumber {
-						delete(lastMetrics, current.DeviceName)
-						lastRawStats[current.DeviceName] = current
-						continue
-					}
-					metric, valid := buildDiskMetric(previous, current, intervalSeconds)
-					if !valid {
-						delete(lastMetrics, current.DeviceName)
-						lastRawStats[current.DeviceName] = current
-						continue
-					}
-
-					log.WithField("device", current.DeviceName).
-						WithField("io_util_percent", metric.IOUtil).
-						WithField("queue_size", metric.QueueSize).
-						WithField("read_kbps", metric.ReadBPS/1024).
-						WithField("write_kbps", metric.WriteBPS/1024).
-						WithField("read_iops", metric.ReadIOPS).
-						WithField("write_iops", metric.WriteIOPS).
-						WithField("read_await_ms", metric.ReadAwait).
-						WithField("write_await_ms", metric.WriteAwait).
-						Debug("sampled disk io metrics")
-
-					reasonType := thresholdReasonFor(
-						lastMetrics[current.DeviceName],
-						metric,
-						thresholds,
-						strings.HasPrefix(current.DeviceName, "nvme"),
-					)
-					if reasonType != ioReasonNone {
-						device := fmt.Sprintf(
-							"%s(%d:%d)",
-							current.DeviceName,
-							current.MajorNumber,
-							current.MinorNumber,
-						)
-						return &reasonSnapshot{
-							Type:        string(reasonType),
-							Device:      current.DeviceName,
-							MajorNumber: current.MajorNumber,
-							MinorNumber: current.MinorNumber,
-							IOStatus:    metric,
-							Summary: iotracingSummary(
-								reasonType,
-								device,
-								metric,
-								thresholds,
-							),
-						}, nil
-					}
-
-					lastMetrics[current.DeviceName] = metric
-				}
-
-				lastRawStats[current.DeviceName] = current
+			if reason := evaluateThresholds(
+				currentRawStats,
+				lastRawStats,
+				lastMetrics,
+				thresholds,
+				intervalSeconds,
+			); reason != nil {
+				return reason, nil
 			}
-			deleteMissingDiskState(lastRawStats, lastMetrics, currentDevices)
 		}
 	}
 }

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -305,6 +305,12 @@ func waitForDiskEvent(
 				currentDevices[current.DeviceName] = struct{}{}
 
 				if previous, ok := lastRawStats[current.DeviceName]; ok {
+					if previous.MajorNumber != current.MajorNumber ||
+						previous.MinorNumber != current.MinorNumber {
+						delete(lastMetrics, current.DeviceName)
+						lastRawStats[current.DeviceName] = current
+						continue
+					}
 					metric := buildDiskMetric(previous, current, intervalSeconds)
 
 					log.WithField("device", current.DeviceName).

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -231,25 +231,36 @@ func readDiskStats() ([]blockdevice.Diskstats, error) {
 	return fs.ProcDiskstats()
 }
 
+func validDiskstatsWindow(
+	previous *blockdevice.Diskstats,
+	current *blockdevice.Diskstats,
+) bool {
+	if previous == nil || current == nil ||
+		previous.MajorNumber != current.MajorNumber ||
+		previous.MinorNumber != current.MinorNumber {
+		return false
+	}
+
+	// Kernel counters reset when a device is removed and re-registered
+	// under the same name (hotplug, driver rebind, LVM rebuild). Without
+	// this guard the reset causes uint64 underflow in the delta below,
+	// producing a fake metric that triggers a false IO alert.
+	return current.ReadIOs >= previous.ReadIOs &&
+		current.WriteIOs >= previous.WriteIOs &&
+		current.IOsTotalTicks >= previous.IOsTotalTicks &&
+		current.ReadSectors >= previous.ReadSectors &&
+		current.WriteSectors >= previous.WriteSectors &&
+		current.ReadTicks >= previous.ReadTicks &&
+		current.WriteTicks >= previous.WriteTicks &&
+		current.WeightedIOTicks >= previous.WeightedIOTicks
+}
+
 func buildDiskMetric(
 	previous *blockdevice.Diskstats,
 	current *blockdevice.Diskstats,
 	intervalSeconds uint64,
 ) (diskStatus, bool) {
-	if intervalSeconds == 0 {
-		return diskStatus{}, false
-	}
-	// Kernel counters reset when a device is removed and re-registered
-	// under the same name (hotplug, driver rebind, LVM rebuild). Without
-	// this guard the reset causes uint64 underflow in the delta below,
-	// producing a fake metric that triggers a false IO alert.
-	if current.ReadIOs < previous.ReadIOs || current.WriteIOs < previous.WriteIOs ||
-		current.IOsTotalTicks < previous.IOsTotalTicks ||
-		current.ReadSectors < previous.ReadSectors ||
-		current.WriteSectors < previous.WriteSectors ||
-		current.ReadTicks < previous.ReadTicks ||
-		current.WriteTicks < previous.WriteTicks ||
-		current.WeightedIOTicks < previous.WeightedIOTicks {
+	if intervalSeconds == 0 || !validDiskstatsWindow(previous, current) {
 		return diskStatus{}, false
 	}
 
@@ -292,12 +303,6 @@ func evaluateThresholds(
 		currentDevices[current.DeviceName] = struct{}{}
 
 		if previous, ok := lastRawStats[current.DeviceName]; ok {
-			if previous.MajorNumber != current.MajorNumber ||
-				previous.MinorNumber != current.MinorNumber {
-				delete(lastMetrics, current.DeviceName)
-				lastRawStats[current.DeviceName] = current
-				continue
-			}
 			metric, valid := buildDiskMetric(previous, current, intervalSeconds)
 			if !valid {
 				delete(lastMetrics, current.DeviceName)

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -235,9 +235,9 @@ func buildDiskMetric(
 	previous *blockdevice.Diskstats,
 	current *blockdevice.Diskstats,
 	intervalSeconds uint64,
-) diskStatus {
+) (diskStatus, bool) {
 	if intervalSeconds == 0 {
-		return diskStatus{}
+		return diskStatus{}, false
 	}
 	// Kernel counters reset when a device is removed and re-registered
 	// under the same name (hotplug, driver rebind, LVM rebuild). Without
@@ -250,7 +250,7 @@ func buildDiskMetric(
 		current.ReadTicks < previous.ReadTicks ||
 		current.WriteTicks < previous.WriteTicks ||
 		current.WeightedIOTicks < previous.WeightedIOTicks {
-		return diskStatus{}
+		return diskStatus{}, false
 	}
 
 	deltaReadIOs := current.ReadIOs - previous.ReadIOs
@@ -272,7 +272,7 @@ func buildDiskMetric(
 		metrics.WriteAwait = (current.WriteTicks - previous.WriteTicks) / deltaWriteIOs
 	}
 
-	return metrics
+	return metrics, true
 }
 
 func waitForDiskEvent(
@@ -311,7 +311,12 @@ func waitForDiskEvent(
 						lastRawStats[current.DeviceName] = current
 						continue
 					}
-					metric := buildDiskMetric(previous, current, intervalSeconds)
+					metric, valid := buildDiskMetric(previous, current, intervalSeconds)
+					if !valid {
+						delete(lastMetrics, current.DeviceName)
+						lastRawStats[current.DeviceName] = current
+						continue
+					}
 
 					log.WithField("device", current.DeviceName).
 						WithField("io_util_percent", metric.IOUtil).

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	internalconfig "huatuo-bamai/internal/config"
@@ -106,11 +107,17 @@ func newIOTracing() (*tracing.EventTracingAttr, error) {
 }
 
 type ioTracing struct {
+	childRunning atomic.Bool
+
 	thresholds              ioThresholds
 	samplingIntervalSeconds uint64
 	runDurationSeconds      uint64
 	maxProcesses            int
 	maxFilesPerProcess      int
+
+	readSnapshot func() (*rawDiskstatsSnapshot, error)
+	sampleTicks  <-chan time.Time
+	runChild     func(context.Context, *reasonSnapshot, uint64, int, int) error
 }
 
 type diskStatusSnapshot struct {
@@ -389,19 +396,14 @@ func evaluateThresholds(
 	snapshot *diskStatusSnapshot,
 	lastMetrics map[string]diskStatus,
 	thresholds ioThresholds,
-) *reasonSnapshot {
-	for name := range lastMetrics {
-		if _, valid := snapshot.devices[name]; !valid {
-			delete(lastMetrics, name)
-		}
-	}
-
+) (*reasonSnapshot, map[string]diskStatus) {
+	nextMetrics := make(map[string]diskStatus, len(snapshot.devices))
+	var firstReason *reasonSnapshot
 	for _, name := range snapshot.order {
-		if strings.HasPrefix(name, "md") {
-			continue
-		}
-
 		status := snapshot.devices[name]
+		previous, hadPrevious := lastMetrics[name]
+		nextMetrics[name] = status
+
 		log.WithField("device", name).
 			WithField("io_util_percent", status.IOUtil).
 			WithField("queue_size", status.QueueSize).
@@ -413,77 +415,41 @@ func evaluateThresholds(
 			WithField("write_await_ms", status.WriteAwait).
 			Debug("sampled disk io metrics")
 
+		if !hadPrevious || strings.HasPrefix(name, "md") || firstReason != nil {
+			continue
+		}
 		reasonType := thresholdReasonFor(
-			lastMetrics[name],
+			previous,
 			status,
 			thresholds,
 			strings.HasPrefix(name, "nvme"),
 		)
-		if reasonType != ioReasonNone {
-			device := raw.devices[name]
-			deviceLabel := fmt.Sprintf(
-				"%s(%d:%d)",
-				name,
-				device.MajorNumber,
-				device.MinorNumber,
-			)
-			return &reasonSnapshot{
-				Type:        string(reasonType),
-				Device:      name,
-				MajorNumber: device.MajorNumber,
-				MinorNumber: device.MinorNumber,
-				IOStatus:    status,
-				Summary: iotracingSummary(
-					reasonType,
-					deviceLabel,
-					status,
-					thresholds,
-				),
-			}
+		if reasonType == ioReasonNone {
+			continue
 		}
 
-		lastMetrics[name] = status
-	}
-	return nil
-}
-
-func waitForDiskEvent(
-	ctx context.Context,
-	interval time.Duration,
-	thresholds ioThresholds,
-) (*reasonSnapshot, error) {
-	var previous *rawDiskstatsSnapshot
-	lastMetrics := make(map[string]diskStatus)
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, types.ErrExitByCancelCtx
-		case <-ticker.C:
-			current, err := readRawDiskstatsSnapshot()
-			if err != nil {
-				return nil, err
-			}
-			if previous == nil {
-				previous = current
-				continue
-			}
-
-			snapshot := buildDiskStatusSnapshot(previous, current)
-			reason := evaluateThresholds(
-				current,
-				snapshot,
-				lastMetrics,
+		device := raw.devices[name]
+		deviceLabel := fmt.Sprintf(
+			"%s(%d:%d)",
+			name,
+			device.MajorNumber,
+			device.MinorNumber,
+		)
+		firstReason = &reasonSnapshot{
+			Type:        string(reasonType),
+			Device:      name,
+			MajorNumber: device.MajorNumber,
+			MinorNumber: device.MinorNumber,
+			IOStatus:    status,
+			Summary: iotracingSummary(
+				reasonType,
+				deviceLabel,
+				status,
 				thresholds,
-			)
-			if reason != nil {
-				return reason, nil
-			}
-			previous = current
+			),
 		}
 	}
+	return firstReason, nextMetrics
 }
 
 func deleteMissingDiskState(
@@ -624,29 +590,92 @@ func waitForSnapshotAfterExit(
 	return errors.Join(fmt.Errorf("iotracing exited: %w", exitErr), snapshotErr)
 }
 
-// Start waits for a disk-burst trigger then runs the iotracing tool as a
-// subprocess; results stream back via toolstream. The trigger reason is
-// stashed under a generated task ID so handleIotracingEvent can attach it.
+// Start owns the process's only diskstats read loop. Diagnostic children run
+// independently so sampling never pauses for them.
 func (i *ioTracing) Start(ctx context.Context) error {
-	reasonSnapshot, err := waitForDiskEvent(
-		ctx,
-		time.Duration(i.samplingIntervalSeconds)*time.Second,
-		i.thresholds,
-	)
-	if err != nil {
-		return err
+	interval := time.Duration(i.samplingIntervalSeconds) * time.Second
+	readSnapshot := i.readSnapshot
+	if readSnapshot == nil {
+		readSnapshot = readRawDiskstatsSnapshot
 	}
 
-	log.WithField("reason_snapshot", reasonSnapshot).
-		Debug("detected disk io event")
+	var childWG sync.WaitGroup
+	defer childWG.Wait()
 
-	return runIOTracingChild(
-		ctx,
-		reasonSnapshot,
-		i.runDurationSeconds,
-		i.maxProcesses,
-		i.maxFilesPerProcess,
-	)
+	var previous *rawDiskstatsSnapshot
+	if first, err := readSnapshot(); err != nil {
+		log.WithError(err).Warn("read initial /proc/diskstats")
+	} else {
+		previous = first
+	}
+
+	lastMetrics := make(map[string]diskStatus)
+	sampleTicks := i.sampleTicks
+	if sampleTicks == nil {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		sampleTicks = ticker.C
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return types.ErrExitByCancelCtx
+		case <-sampleTicks:
+			current, err := readSnapshot()
+			if err != nil {
+				log.WithError(err).Warn("read /proc/diskstats")
+				continue
+			}
+			if previous == nil {
+				previous = current
+				continue
+			}
+
+			snapshot := buildDiskStatusSnapshot(previous, current)
+			reason, nextMetrics := evaluateThresholds(
+				current,
+				snapshot,
+				lastMetrics,
+				i.thresholds,
+			)
+			lastMetrics = nextMetrics
+			if reason != nil {
+				i.startDiagnostic(ctx, reason, &childWG)
+			}
+			previous = current
+		}
+	}
+}
+
+func (i *ioTracing) startDiagnostic(
+	ctx context.Context,
+	reason *reasonSnapshot,
+	wg *sync.WaitGroup,
+) {
+	if !i.childRunning.CompareAndSwap(false, true) {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer i.childRunning.Store(false)
+
+		runChild := i.runChild
+		if runChild == nil {
+			runChild = runIOTracingChild
+		}
+		if err := runChild(
+			ctx,
+			reason,
+			i.runDurationSeconds,
+			i.maxProcesses,
+			i.maxFilesPerProcess,
+		); err != nil {
+			log.WithError(err).Warn("iotracing child")
+		}
+	}()
 }
 
 func waitForSnapshot(

--- a/core/autotracing/iotracing.go
+++ b/core/autotracing/iotracing.go
@@ -40,11 +40,10 @@ import (
 )
 
 const (
-	iotracingToolName                = "iotracing"
-	iotracingSnapshotTimeout         = 5 * time.Second
-	iotracingSnapshotSaveTimeout     = 30 * time.Second
-	iotracingProcessWaitTimeout      = 5 * time.Second
-	iotracingSamplingIntervalSeconds = 5
+	iotracingToolName            = "iotracing"
+	iotracingSnapshotTimeout     = 5 * time.Second
+	iotracingSnapshotSaveTimeout = 30 * time.Second
+	iotracingProcessWaitTimeout  = 5 * time.Second
 )
 
 // pendingReasons correlates an inflight subprocess invocation with
@@ -113,7 +112,7 @@ type ioTracing struct {
 	childRunning atomic.Bool
 
 	thresholds              ioThresholds
-	samplingIntervalSeconds uint64
+	samplingIntervalSeconds int64
 	runDurationSeconds      uint64
 	maxProcesses            int
 	maxFilesPerProcess      int
@@ -497,7 +496,7 @@ func newIOTracer(config *Config) (*ioTracing, error) {
 
 	return &ioTracing{
 		thresholds:              thresholds,
-		samplingIntervalSeconds: iotracingSamplingIntervalSeconds,
+		samplingIntervalSeconds: config.IOTracing.Interval,
 		runDurationSeconds:      config.IOTracing.RunTracingToolTimeout,
 		maxProcesses:            config.IOTracing.MaxProcDump,
 		maxFilesPerProcess:      config.IOTracing.MaxFilesPerProcDump,
@@ -596,7 +595,10 @@ func waitForSnapshotAfterExit(
 // Start owns the process's only diskstats read loop. Diagnostic children run
 // independently so sampling never pauses for them.
 func (i *ioTracing) Start(ctx context.Context) error {
-	interval := time.Duration(i.samplingIntervalSeconds) * time.Second
+	interval, err := ioTracingInterval(i.samplingIntervalSeconds)
+	if err != nil {
+		return err
+	}
 	readSnapshot := i.readSnapshot
 	if readSnapshot == nil {
 		readSnapshot = readRawDiskstatsSnapshot
@@ -614,27 +616,43 @@ func (i *ioTracing) Start(ctx context.Context) error {
 
 	lastMetrics := make(map[string]diskStatus)
 	sampleTicks := i.sampleTicks
+	var (
+		ticker          *time.Ticker
+		intervalChanges <-chan struct{}
+	)
 	if sampleTicks == nil {
-		ticker := time.NewTicker(interval)
+		ticker = time.NewTicker(interval)
 		defer ticker.Stop()
 		sampleTicks = ticker.C
+		intervalChanges = ioTracingIntervalChanged
 	}
 
 	for {
+		var nextInterval time.Duration
 		select {
 		case <-ctx.Done():
 			return types.ErrExitByCancelCtx
 		case <-sampleTicks:
-			current, err := readSnapshot()
-			if err != nil {
-				log.WithError(err).Warn("read /proc/diskstats")
+		case <-intervalChanges:
+			updated, intervalErr := ioTracingInterval(
+				ioTracingIntervalSeconds.Load(),
+			)
+			if intervalErr != nil {
+				log.WithError(intervalErr).Warn("apply iotracing interval")
 				continue
 			}
-			if previous == nil {
-				previous = current
+			if updated == interval {
 				continue
 			}
+			nextInterval = updated
+		}
 
+		current, readErr := readSnapshot()
+		if readErr != nil {
+			log.WithError(readErr).Warn("read /proc/diskstats")
+		} else if previous == nil {
+			previous = current
+		} else {
 			snapshot := buildDiskStatusSnapshot(previous, current)
 			// Neither this map nor its values are mutated after publication.
 			i.latest.Store(snapshot)
@@ -649,6 +667,11 @@ func (i *ioTracing) Start(ctx context.Context) error {
 				i.startDiagnostic(ctx, reason, &childWG)
 			}
 			previous = current
+		}
+
+		if nextInterval != 0 {
+			ticker.Reset(nextInterval)
+			interval = nextInterval
 		}
 	}
 }

--- a/core/autotracing/iotracing_diskstats_test.go
+++ b/core/autotracing/iotracing_diskstats_test.go
@@ -1,0 +1,289 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/internal/procfs/blockdevice"
+
+	promblockdevice "github.com/prometheus/procfs/blockdevice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildDiskMetricUsesActualElapsedTime(t *testing.T) {
+	previous := blockdevice.Diskstats{
+		Info: promblockdevice.Info{
+			MajorNumber: 8,
+			MinorNumber: 0,
+		},
+		IOStats: promblockdevice.IOStats{
+			ReadIOs:         100,
+			ReadSectors:     1000,
+			ReadTicks:       200,
+			WriteIOs:        50,
+			WriteSectors:    500,
+			WriteTicks:      100,
+			IOsTotalTicks:   1000,
+			WeightedIOTicks: 2000,
+		},
+	}
+	current := previous
+	current.ReadIOs += 4
+	current.ReadSectors += 20
+	current.ReadTicks += 12
+	current.WriteIOs += 2
+	current.WriteSectors += 8
+	current.WriteTicks += 10
+	current.IOsTotalTicks += 500
+	current.WeightedIOTicks += 600
+
+	got, ok := buildDiskMetric(&previous, &current, 2*time.Second)
+	require.True(t, ok)
+	assert.Equal(t, diskStatus{
+		ReadBPS:    5120,
+		ReadIOPS:   2,
+		ReadAwait:  3,
+		WriteBPS:   2048,
+		WriteIOPS:  1,
+		WriteAwait: 5,
+		IOUtil:     25,
+		QueueSize:  0.3,
+	}, got)
+}
+
+func TestBuildDiskMetricRejectsInvalidWindows(t *testing.T) {
+	previous := blockdevice.Diskstats{
+		Info: promblockdevice.Info{
+			MajorNumber: 8,
+			MinorNumber: 0,
+		},
+		IOStats: promblockdevice.IOStats{
+			ReadIOs:         10,
+			ReadSectors:     100,
+			ReadTicks:       20,
+			WriteIOs:        10,
+			WriteSectors:    100,
+			WriteTicks:      20,
+			IOsTotalTicks:   20,
+			WeightedIOTicks: 20,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*blockdevice.Diskstats)
+	}{
+		{name: "major changed", mutate: func(s *blockdevice.Diskstats) { s.MajorNumber++ }},
+		{name: "minor changed", mutate: func(s *blockdevice.Diskstats) { s.MinorNumber++ }},
+		{name: "read IOs reset", mutate: func(s *blockdevice.Diskstats) { s.ReadIOs-- }},
+		{name: "read sectors reset", mutate: func(s *blockdevice.Diskstats) { s.ReadSectors-- }},
+		{name: "read ticks reset", mutate: func(s *blockdevice.Diskstats) { s.ReadTicks-- }},
+		{name: "write IOs reset", mutate: func(s *blockdevice.Diskstats) { s.WriteIOs-- }},
+		{name: "write sectors reset", mutate: func(s *blockdevice.Diskstats) { s.WriteSectors-- }},
+		{name: "write ticks reset", mutate: func(s *blockdevice.Diskstats) { s.WriteTicks-- }},
+		{name: "IO ticks reset", mutate: func(s *blockdevice.Diskstats) { s.IOsTotalTicks-- }},
+		{name: "weighted IO ticks reset", mutate: func(s *blockdevice.Diskstats) { s.WeightedIOTicks-- }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			current := previous
+			test.mutate(&current)
+			_, ok := buildDiskMetric(&previous, &current, time.Second)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestBuildDiskStatusSnapshotDropsInvalidAndDisappearedDevices(t *testing.T) {
+	start := time.Unix(100, 0)
+	previous := &rawDiskstatsSnapshot{
+		timestamp: start,
+		devices: map[string]blockdevice.Diskstats{
+			"sda": {
+				Info: promblockdevice.Info{
+					DeviceName:  "sda",
+					MajorNumber: 8,
+					MinorNumber: 0,
+				},
+			},
+			"sdb": {
+				Info: promblockdevice.Info{
+					DeviceName:  "sdb",
+					MajorNumber: 8,
+					MinorNumber: 16,
+				},
+				IOStats: promblockdevice.IOStats{ReadSectors: 10},
+			},
+			"sdc": {
+				Info: promblockdevice.Info{
+					DeviceName:  "sdc",
+					MajorNumber: 8,
+					MinorNumber: 32,
+				},
+			},
+		},
+		order: []string{"sda", "sdb", "sdc"},
+	}
+	current := &rawDiskstatsSnapshot{
+		timestamp: start.Add(time.Second),
+		devices: map[string]blockdevice.Diskstats{
+			"sda": {
+				Info: promblockdevice.Info{
+					DeviceName:  "sda",
+					MajorNumber: 8,
+					MinorNumber: 0,
+				},
+			},
+			"sdb": {
+				Info: promblockdevice.Info{
+					DeviceName:  "sdb",
+					MajorNumber: 8,
+					MinorNumber: 16,
+				},
+				IOStats: promblockdevice.IOStats{ReadSectors: 9},
+			},
+		},
+		order: []string{"sda", "sdb"},
+	}
+
+	got := buildDiskStatusSnapshot(previous, current)
+	assert.Equal(t, []string{"sda"}, got.order)
+	assert.Contains(t, got.devices, "sda")
+	assert.NotContains(t, got.devices, "sdb")
+	assert.NotContains(t, got.devices, "sdc")
+}
+
+func TestIsMonitoredDiskFiltersPartitionsAndPseudoDevices(t *testing.T) {
+	originalPrefix := filepath.Dir(procfs.DefaultPath())
+	procfs.RootPrefix(t.TempDir())
+	t.Cleanup(func() {
+		procfs.RootPrefix(originalPrefix)
+	})
+
+	wholeDevicePath := filepath.Join(
+		procfs.DefaultPathByType("sys"),
+		"dev",
+		"block",
+		"8:0",
+	)
+	require.NoError(t, os.MkdirAll(wholeDevicePath, 0o755))
+
+	partitionPath := filepath.Join(
+		procfs.DefaultPathByType("sys"),
+		"dev",
+		"block",
+		"8:1",
+	)
+	require.NoError(t, os.MkdirAll(partitionPath, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(partitionPath, "partition"),
+		[]byte("1\n"),
+		0o600,
+	))
+
+	tests := []struct {
+		name string
+		stat *blockdevice.Diskstats
+		want bool
+	}{
+		{
+			name: "whole disk",
+			stat: &blockdevice.Diskstats{
+				Info: promblockdevice.Info{
+					DeviceName:  "sda",
+					MajorNumber: 8,
+					MinorNumber: 0,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "partition",
+			stat: &blockdevice.Diskstats{
+				Info: promblockdevice.Info{
+					DeviceName:  "sda1",
+					MajorNumber: 8,
+					MinorNumber: 1,
+				},
+			},
+		},
+		{
+			name: "loop",
+			stat: &blockdevice.Diskstats{
+				Info: promblockdevice.Info{DeviceName: "loop0"},
+			},
+		},
+		{
+			name: "ram",
+			stat: &blockdevice.Diskstats{
+				Info: promblockdevice.Info{DeviceName: "ram0"},
+			},
+		},
+		{
+			name: "zram",
+			stat: &blockdevice.Diskstats{
+				Info: promblockdevice.Info{DeviceName: "zram0"},
+			},
+		},
+		{
+			name: "floppy",
+			stat: &blockdevice.Diskstats{
+				Info: promblockdevice.Info{DeviceName: "fd0"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isMonitoredDisk(test.stat))
+		})
+	}
+}
+
+func TestMDSnapshotDoesNotTriggerDiagnostic(t *testing.T) {
+	status := diskStatus{IOUtil: 100}
+	snapshot := &diskStatusSnapshot{
+		devices: map[string]diskStatus{"md0": status},
+		order:   []string{"md0"},
+	}
+	raw := &rawDiskstatsSnapshot{
+		devices: map[string]blockdevice.Diskstats{
+			"md0": {
+				Info: promblockdevice.Info{
+					DeviceName:  "md0",
+					MajorNumber: 9,
+					MinorNumber: 0,
+				},
+			},
+		},
+	}
+
+	reason, next := evaluateThresholds(
+		raw,
+		snapshot,
+		map[string]diskStatus{"md0": status},
+		ioThresholds{UtilThreshold: 90},
+	)
+
+	assert.Nil(t, reason)
+	assert.Contains(t, next, "md0")
+}

--- a/core/autotracing/iotracing_metrics_test.go
+++ b/core/autotracing/iotracing_metrics_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIOTracingUpdateExportsLatestSnapshotWithoutReading(t *testing.T) {
+	status := diskStatus{
+		ReadBPS:    1.25,
+		WriteBPS:   2.5,
+		ReadIOPS:   3.75,
+		WriteIOPS:  4.5,
+		ReadAwait:  1250,
+		WriteAwait: 2500,
+		IOUtil:     7.25,
+		QueueSize:  0.125,
+	}
+	var readCalls atomic.Int32
+	tracer := &ioTracing{
+		readSnapshot: func() (*rawDiskstatsSnapshot, error) {
+			readCalls.Add(1)
+			return nil, errors.New("Update must not read diskstats")
+		},
+	}
+	tracer.latest.Store(&diskStatusSnapshot{
+		devices: map[string]diskStatus{"sda": status},
+		order:   []string{"sda"},
+	})
+
+	// Export rounds every gauge to two decimal places, so the published
+	// values are round2 of the snapshot fields rather than the raw floats.
+	wantValues := []float64{
+		round2(status.ReadBPS),
+		round2(status.WriteBPS),
+		round2(status.ReadIOPS),
+		round2(status.WriteIOPS),
+		round2(status.ReadAwait / 1000),
+		round2(status.WriteAwait / 1000),
+		round2(status.IOUtil),
+		round2(status.QueueSize),
+	}
+	for range 2 {
+		metrics, err := tracer.Update()
+		require.NoError(t, err)
+		require.Len(t, metrics, len(wantValues))
+		for i, want := range wantValues {
+			assert.Equal(t, want, metrics[i].Value)
+		}
+	}
+	assert.Zero(t, readCalls.Load())
+}
+
+func TestIOTracingUpdateRoundsExportedValuesToTwoDecimals(t *testing.T) {
+	status := diskStatus{
+		ReadBPS:    1234.567,
+		WriteBPS:   2345.678,
+		ReadIOPS:   3.3333,
+		WriteIOPS:  4.5555,
+		ReadAwait:  1250.333,
+		WriteAwait: 2500.666,
+		IOUtil:     94.999,
+		QueueSize:  0.123,
+	}
+	tracer := &ioTracing{}
+	tracer.latest.Store(&diskStatusSnapshot{
+		devices: map[string]diskStatus{"sda": status},
+		order:   []string{"sda"},
+	})
+
+	// await is stored in milliseconds and exported as seconds, so the value
+	// is rounded after the /1000 conversion.
+	wantValues := []float64{
+		1234.57,
+		2345.68,
+		3.33,
+		4.56,
+		1.25,
+		2.5,
+		95,
+		0.12,
+	}
+	metrics, err := tracer.Update()
+	require.NoError(t, err)
+	require.Len(t, metrics, len(wantValues))
+	for i, want := range wantValues {
+		assert.Equal(t, want, metrics[i].Value)
+	}
+}
+
+func TestIOTracingUpdateExportsMDSnapshot(t *testing.T) {
+	tracer := &ioTracing{}
+	tracer.latest.Store(&diskStatusSnapshot{
+		devices: map[string]diskStatus{"md0": {}},
+		order:   []string{"md0"},
+	})
+
+	metrics, err := tracer.Update()
+	require.NoError(t, err)
+	assert.Len(t, metrics, 8)
+}
+
+func TestIOTracingRealDiskstatsMetrics(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") != "true" {
+		t.Skip("Set TEST_INTEGRATION=true to run integration tests")
+	}
+
+	previous, err := readRawDiskstatsSnapshot()
+	require.NoError(t, err)
+	time.Sleep(time.Second)
+	current, err := readRawDiskstatsSnapshot()
+	require.NoError(t, err)
+
+	snapshot := buildDiskStatusSnapshot(previous, current)
+	device := strings.TrimSpace(os.Getenv("TEST_IOSTAT_DEVICE"))
+	if device != "" {
+		if _, ok := snapshot.devices[device]; !ok {
+			t.Fatalf("TEST_IOSTAT_DEVICE %q is not a monitored whole disk", device)
+		}
+		snapshot = &diskStatusSnapshot{
+			devices: map[string]diskStatus{device: snapshot.devices[device]},
+			order:   []string{device},
+		}
+	}
+	if len(snapshot.devices) == 0 {
+		t.Skip("no supported whole disk found")
+	}
+
+	tracer := &ioTracing{}
+	tracer.latest.Store(snapshot)
+	metrics, err := tracer.Update()
+	require.NoError(t, err)
+	assert.Len(t, metrics, len(snapshot.devices)*8)
+}

--- a/core/autotracing/iotracing_sampler_test.go
+++ b/core/autotracing/iotracing_sampler_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/procfs/blockdevice"
+	"huatuo-bamai/pkg/types"
+
+	promblockdevice "github.com/prometheus/procfs/blockdevice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIOTracingStartRetriesReadAndKeepsSamplingWhileChildRuns(t *testing.T) {
+	previousConfig := cfg
+	testConfig := DefaultConfig()
+	testConfig.IOTracing.RbpsThreshold = 1
+	testConfig.IOTracing.WbpsThreshold = 1
+	testConfig.IOTracing.UtilThreshold = 90
+	testConfig.IOTracing.AwaitThreshold = 100
+	testConfig.IOTracing.RunTracingToolTimeout = 1
+	cfg = &testConfig
+	t.Cleanup(func() {
+		cfg = previousConfig
+	})
+
+	startedAt := time.Unix(100, 0)
+	snapshot := func(
+		at time.Time,
+		readIOs,
+		readSectors,
+		readTicks,
+		ioTicks uint64,
+	) *rawDiskstatsSnapshot {
+		stat := blockdevice.Diskstats{
+			Info: promblockdevice.Info{
+				DeviceName:  "sda",
+				MajorNumber: 8,
+				MinorNumber: 0,
+			},
+			IOStats: promblockdevice.IOStats{
+				ReadIOs:         readIOs,
+				ReadSectors:     readSectors,
+				ReadTicks:       readTicks,
+				IOsTotalTicks:   ioTicks,
+				WeightedIOTicks: ioTicks,
+			},
+		}
+		return &rawDiskstatsSnapshot{
+			timestamp: at,
+			devices:   map[string]blockdevice.Diskstats{"sda": stat},
+			order:     []string{"sda"},
+		}
+	}
+
+	readFailure := errors.New("temporary diskstats failure")
+	reads := []struct {
+		snapshot *rawDiskstatsSnapshot
+		err      error
+	}{
+		{snapshot: snapshot(startedAt, 100, 1000, 100, 1000)},
+		{err: readFailure},
+		{snapshot: snapshot(startedAt.Add(2*time.Second), 120, 1040, 120, 3000)},
+		{snapshot: snapshot(startedAt.Add(3*time.Second), 130, 1060, 130, 4000)},
+		{err: readFailure},
+		{snapshot: snapshot(startedAt.Add(4*time.Second), 160, 1120, 160, 5000)},
+		{snapshot: snapshot(startedAt.Add(5*time.Second), 200, 1200, 200, 6000)},
+		{snapshot: snapshot(startedAt.Add(6*time.Second), 260, 1320, 260, 7000)},
+	}
+
+	var readIndex atomic.Int32
+	readCalls := make(chan int, len(reads))
+	ticks := make(chan time.Time)
+	childStarted := make(chan struct{}, 2)
+	releaseChild := make(chan struct{})
+	var childStarts atomic.Int32
+
+	tracer := &ioTracing{
+		thresholds: ioThresholds{
+			RBPSThreshold:  testConfig.IOTracing.RbpsThreshold,
+			WBPSThreshold:  testConfig.IOTracing.WbpsThreshold,
+			UtilThreshold:  testConfig.IOTracing.UtilThreshold,
+			AwaitThreshold: testConfig.IOTracing.AwaitThreshold,
+		},
+		samplingIntervalSeconds: testConfig.IOTracing.Interval,
+		readSnapshot: func() (*rawDiskstatsSnapshot, error) {
+			index := int(readIndex.Add(1)) - 1
+			if index >= len(reads) {
+				return nil, errors.New("unexpected diskstats read")
+			}
+			readCalls <- index + 1
+			return reads[index].snapshot, reads[index].err
+		},
+		sampleTicks: ticks,
+		runChild: func(
+			ctx context.Context,
+			_ *reasonSnapshot,
+			_ uint64,
+			_ int,
+			_ int,
+		) error {
+			childStarts.Add(1)
+			childStarted <- struct{}{}
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-releaseChild:
+				return nil
+			}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() {
+			close(releaseChild)
+		})
+		cancel()
+	})
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- tracer.Start(ctx)
+	}()
+
+	waitRead := func(want int) {
+		t.Helper()
+		select {
+		case got := <-readCalls:
+			assert.Equal(t, want, got)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for diskstats read %d", want)
+		}
+	}
+	tickAndWait := func(wantRead int) {
+		t.Helper()
+		select {
+		case ticks <- time.Now():
+		case <-time.After(time.Second):
+			t.Fatalf("timed out sending sample tick for read %d", wantRead)
+		}
+		waitRead(wantRead)
+	}
+	readIOpsIs := func(want float64) bool {
+		latest := tracer.latest.Load()
+		if latest == nil {
+			return false
+		}
+		status, ok := latest.devices["sda"]
+		return ok && status.ReadIOPS == want
+	}
+
+	waitRead(1)
+	tickAndWait(2)
+	assert.Nil(t, tracer.latest.Load())
+
+	tickAndWait(3)
+	require.Eventually(t, func() bool {
+		return readIOpsIs(10)
+	}, time.Second, time.Millisecond)
+
+	tickAndWait(4)
+	select {
+	case <-childStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for diagnostic child")
+	}
+	assert.Equal(t, int32(1), childStarts.Load())
+
+	tickAndWait(5)
+	assert.True(t, readIOpsIs(10))
+
+	tickAndWait(6)
+	require.Eventually(t, func() bool {
+		return readIOpsIs(30)
+	}, time.Second, time.Millisecond)
+	tickAndWait(7)
+	require.Eventually(t, func() bool {
+		return readIOpsIs(40)
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, int32(1), childStarts.Load())
+
+	releaseOnce.Do(func() {
+		close(releaseChild)
+	})
+	require.Eventually(t, func() bool {
+		return !tracer.childRunning.Load()
+	}, time.Second, time.Millisecond)
+
+	tickAndWait(8)
+	select {
+	case <-childStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for diagnostic child after the previous child exited")
+	}
+	assert.Equal(t, int32(2), childStarts.Load())
+	cancel()
+
+	select {
+	case err := <-startDone:
+		assert.ErrorIs(t, err, types.ErrExitByCancelCtx)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ioTracing.Start to stop")
+	}
+	assert.Equal(t, int32(2), childStarts.Load())
+}
+
+func TestIOTracingStartAppliesUpdatedIntervalImmediately(t *testing.T) {
+	previousConfig := cfg
+	testConfig := DefaultConfig()
+	testConfig.IOTracing.Interval = 60
+	testConfig.IOTracing.RbpsThreshold = 1
+	testConfig.IOTracing.WbpsThreshold = 1
+	testConfig.IOTracing.UtilThreshold = 90
+	testConfig.IOTracing.AwaitThreshold = 100
+	Set(&testConfig)
+	t.Cleanup(func() {
+		Set(previousConfig)
+	})
+
+	startedAt := time.Unix(100, 0)
+	snapshot := func(at time.Time, readIOs uint64) *rawDiskstatsSnapshot {
+		stat := blockdevice.Diskstats{
+			Info: promblockdevice.Info{
+				DeviceName:  "sda",
+				MajorNumber: 8,
+				MinorNumber: 0,
+			},
+			IOStats: promblockdevice.IOStats{ReadIOs: readIOs},
+		}
+		return &rawDiskstatsSnapshot{
+			timestamp: at,
+			devices:   map[string]blockdevice.Diskstats{"sda": stat},
+			order:     []string{"sda"},
+		}
+	}
+
+	reads := []*rawDiskstatsSnapshot{
+		snapshot(startedAt, 100),
+		snapshot(startedAt.Add(3*time.Minute), 280),
+		snapshot(startedAt.Add(3*time.Minute+5*time.Second), 330),
+	}
+	var readIndex atomic.Int32
+	readCalls := make(chan int, len(reads))
+	tracer := &ioTracing{
+		thresholds: ioThresholds{
+			RBPSThreshold:  testConfig.IOTracing.RbpsThreshold,
+			WBPSThreshold:  testConfig.IOTracing.WbpsThreshold,
+			UtilThreshold:  testConfig.IOTracing.UtilThreshold,
+			AwaitThreshold: testConfig.IOTracing.AwaitThreshold,
+		},
+		samplingIntervalSeconds: testConfig.IOTracing.Interval,
+		readSnapshot: func() (*rawDiskstatsSnapshot, error) {
+			index := int(readIndex.Add(1)) - 1
+			if index >= len(reads) {
+				return nil, errors.New("unexpected diskstats read")
+			}
+			readCalls <- index + 1
+			return reads[index], nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- tracer.Start(ctx)
+	}()
+
+	waitRead := func(want int, timeout time.Duration) {
+		t.Helper()
+		select {
+		case got := <-readCalls:
+			assert.Equal(t, want, got)
+		case <-time.After(timeout):
+			t.Fatalf("timed out waiting for diskstats read %d", want)
+		}
+	}
+	waitRead(1, time.Second)
+
+	updatedConfig := testConfig
+	updatedConfig.IOTracing.Interval = 1
+	Set(&updatedConfig)
+
+	waitRead(2, time.Second)
+	require.Eventually(t, func() bool {
+		latest := tracer.latest.Load()
+		return latest != nil && latest.devices["sda"].ReadIOPS == 1
+	}, time.Second, time.Millisecond)
+
+	waitRead(3, 2*time.Second)
+	require.Eventually(t, func() bool {
+		latest := tracer.latest.Load()
+		return latest != nil && latest.devices["sda"].ReadIOPS == 10
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-startDone:
+		assert.ErrorIs(t, err, types.ErrExitByCancelCtx)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ioTracing.Start to stop")
+	}
+}

--- a/core/autotracing/iotracing_test.go
+++ b/core/autotracing/iotracing_test.go
@@ -369,6 +369,7 @@ func TestNewIOTracerBindsConfig(t *testing.T) {
 
 func validIOTracingConfig() *Config {
 	config := &Config{}
+	config.IOTracing.Interval = defaultIOTracingIntervalSeconds
 	config.IOTracing.RbpsThreshold = 1
 	config.IOTracing.WbpsThreshold = 1
 	config.IOTracing.UtilThreshold = 1

--- a/core/autotracing/iotracing_test.go
+++ b/core/autotracing/iotracing_test.go
@@ -149,6 +149,52 @@ func TestWaitForSnapshotTimeouts(t *testing.T) {
 	})
 }
 
+func TestWaitForSnapshotAfterFailedExitKeepsReason(t *testing.T) {
+	const taskID = "failed-child-snapshot-task"
+	exitErr := errors.New("child failed")
+	pending := &pendingIOTracingReason{
+		reason:   &reasonSnapshot{Type: string(ioReasonUtil)},
+		received: make(chan struct{}),
+		result:   make(chan error, 1),
+	}
+	pendingReasons.Store(taskID, pending)
+	t.Cleanup(func() {
+		pendingReasons.Delete(taskID)
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waitForSnapshotAfterExit(
+			context.Background(),
+			taskID,
+			pending,
+			exitErr,
+		)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("wait returned before snapshot delivery: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	value, ok := pendingReasons.LoadAndDelete(taskID)
+	if !ok || value != pending {
+		t.Fatal("failed child did not retain its pending reason")
+	}
+	close(pending.received)
+	pending.result <- nil
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, exitErr) {
+			t.Fatalf("wait error = %v, want child exit error", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("wait did not finish after snapshot delivery")
+	}
+}
+
 func TestKillIOTracingProcessAndWait(t *testing.T) {
 	stopErr := errors.New("permission denied")
 	tests := []struct {

--- a/core/metrics/config.go
+++ b/core/metrics/config.go
@@ -61,14 +61,30 @@ type Config struct {
 	MountPointStat struct {
 		MountPointsIncluded string
 	}
+
+	IOHealth struct {
+		Enabled bool `default:"true"`
+	}
 }
 
-var cfg = &Config{}
+// DefaultConfig supplies defaults before TOML decoding so omitted sections
+// retain their shipped behavior.
+func DefaultConfig() Config {
+	var c Config
+	c.IOHealth.Enabled = true
+	return c
+}
+
+var cfg = func() *Config {
+	c := DefaultConfig()
+	return &c
+}()
 
 // Set updates the package level config.
 func Set(c *Config) {
 	if c == nil {
-		cfg = &Config{}
+		defaults := DefaultConfig()
+		cfg = &defaults
 		return
 	}
 	cfg = c

--- a/core/metrics/io_health.go
+++ b/core/metrics/io_health.go
@@ -48,6 +48,8 @@ type ioHealthCollectionErrorKey struct {
 }
 
 type ioHealthCollector struct {
+	resolver  ioHealthResolver
+	now       func() time.Time
 	saveEvent func(time.Time, types.IOHealthEvent) error
 
 	mu               sync.RWMutex
@@ -55,11 +57,22 @@ type ioHealthCollector struct {
 	collectionErrors map[ioHealthCollectionErrorKey]uint64
 }
 
-func newIOHealthCollector() *ioHealthCollector {
+func newIOHealthCollector(sysRoot string) *ioHealthCollector {
 	return &ioHealthCollector{
+		resolver:         newIOHealthResolver(sysRoot),
+		now:              time.Now,
 		saveEvent:        saveIOHealthEvent,
 		counters:         make(map[ioHealthCounterKey]uint64),
 		collectionErrors: make(map[ioHealthCollectionErrorKey]uint64),
+	}
+}
+
+func (c *ioHealthCollector) persistEvent(
+	triggeredAt time.Time,
+	event types.IOHealthEvent,
+) {
+	if err := c.saveEvent(triggeredAt, event); err != nil {
+		log.Warnf("io_health: save event: %v", err)
 	}
 }
 
@@ -90,9 +103,7 @@ func (c *ioHealthCollector) handleEvidenceResult(result health.EvidenceResult) {
 	}
 	c.mu.Unlock()
 
-	if err := c.saveEvent(result.TriggeredAt, result.Event); err != nil {
-		log.Warnf("io_health: save evidence event: %v", err)
-	}
+	c.persistEvent(result.TriggeredAt, result.Event)
 }
 
 // Update implements metric.Collector using only process-local counters.

--- a/core/metrics/io_health.go
+++ b/core/metrics/io_health.go
@@ -15,6 +15,8 @@
 package collector
 
 import (
+	"context"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -47,19 +49,33 @@ type ioHealthCollectionErrorKey struct {
 	reason string
 }
 
+type ioHealthMDWatcher interface {
+	Start(context.Context) error
+	Wait() error
+	Changes() <-chan health.MDChange
+}
+
 type ioHealthCollector struct {
-	resolver  ioHealthResolver
-	now       func() time.Time
-	saveEvent func(time.Time, types.IOHealthEvent) error
+	resolver       ioHealthResolver
+	procMDStatPath string
+	sysBlockPath   string
+	newMDWatcher   func(string, string) ioHealthMDWatcher
+	now            func() time.Time
+	saveEvent      func(time.Time, types.IOHealthEvent) error
 
 	mu               sync.RWMutex
 	counters         map[ioHealthCounterKey]uint64
 	collectionErrors map[ioHealthCollectionErrorKey]uint64
 }
 
-func newIOHealthCollector(sysRoot string) *ioHealthCollector {
+func newIOHealthCollector(sysRoot, procMDStatPath string) *ioHealthCollector {
 	return &ioHealthCollector{
-		resolver:         newIOHealthResolver(sysRoot),
+		resolver:       newIOHealthResolver(sysRoot),
+		procMDStatPath: procMDStatPath,
+		sysBlockPath:   filepath.Join(sysRoot, "block"),
+		newMDWatcher: func(procMDStatPath, sysBlockPath string) ioHealthMDWatcher {
+			return health.NewMDWatcher(procMDStatPath, sysBlockPath)
+		},
 		now:              time.Now,
 		saveEvent:        saveIOHealthEvent,
 		counters:         make(map[ioHealthCounterKey]uint64),

--- a/core/metrics/io_health.go
+++ b/core/metrics/io_health.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"sync"
+	"time"
+
+	"huatuo-bamai/internal/ioobserve/health"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+const ioHealthName = "io_health"
+
+const (
+	ioHealthCounterBlockError = iota + 1
+	ioHealthCounterNVMeTimeout
+	ioHealthCounterNVMeReset
+	ioHealthCounterSCSITimeout
+	ioHealthCounterSCSIDispatchError
+)
+
+type ioHealthCounterKey struct {
+	kind      uint8
+	device    string
+	operation string
+	status    string
+}
+
+type ioHealthCollectionErrorKey struct {
+	device string
+	reason string
+}
+
+type ioHealthCollector struct {
+	saveEvent func(time.Time, types.IOHealthEvent) error
+
+	mu               sync.RWMutex
+	counters         map[ioHealthCounterKey]uint64
+	collectionErrors map[ioHealthCollectionErrorKey]uint64
+}
+
+func newIOHealthCollector() *ioHealthCollector {
+	return &ioHealthCollector{
+		saveEvent:        saveIOHealthEvent,
+		counters:         make(map[ioHealthCounterKey]uint64),
+		collectionErrors: make(map[ioHealthCollectionErrorKey]uint64),
+	}
+}
+
+func saveIOHealthEvent(triggeredAt time.Time, event types.IOHealthEvent) error {
+	return tracing.Save(&tracing.WriteRequest{
+		TracerName: ioHealthName,
+		TracerTime: triggeredAt,
+		TracerData: event,
+	})
+}
+
+func (c *ioHealthCollector) incrementCounter(key ioHealthCounterKey) {
+	if key.device == "" {
+		key.device = "unknown"
+	}
+	c.mu.Lock()
+	c.counters[key]++
+	c.mu.Unlock()
+}
+
+func (c *ioHealthCollector) handleEvidenceResult(result health.EvidenceResult) {
+	c.mu.Lock()
+	for _, reason := range result.Reasons {
+		c.collectionErrors[ioHealthCollectionErrorKey{
+			device: result.Target,
+			reason: reason,
+		}]++
+	}
+	c.mu.Unlock()
+
+	if err := c.saveEvent(result.TriggeredAt, result.Event); err != nil {
+		log.Warnf("io_health: save evidence event: %v", err)
+	}
+}
+
+// Update implements metric.Collector using only process-local counters.
+func (c *ioHealthCollector) Update() ([]*metric.Data, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	metrics := make([]*metric.Data, 0, len(c.counters)+len(c.collectionErrors))
+	for key, value := range c.counters {
+		metrics = append(metrics, ioHealthKernelMetric(key, value))
+	}
+	for key, value := range c.collectionErrors {
+		metrics = append(metrics, metric.NewCounterData(
+			"collection_errors_total",
+			float64(value),
+			"Best-effort count of event-triggered health collection errors observed by this Huatuo process.",
+			map[string]string{
+				"device": key.device,
+				"reason": key.reason,
+			},
+		))
+	}
+	if len(metrics) == 0 {
+		return nil, metric.ErrNoData
+	}
+	return metrics, nil
+}
+
+func ioHealthKernelMetric(key ioHealthCounterKey, value uint64) *metric.Data {
+	switch key.kind {
+	case ioHealthCounterBlockError:
+		return metric.NewCounterData(
+			"block_errors_total",
+			float64(value),
+			"Best-effort block-layer error events observed by this Huatuo process.",
+			map[string]string{
+				"device":    key.device,
+				"operation": key.operation,
+				"status":    key.status,
+			},
+		)
+	case ioHealthCounterNVMeTimeout:
+		return metric.NewCounterData(
+			"nvme_timeouts_total",
+			float64(value),
+			"Best-effort NVMe timeout events observed by this Huatuo process.",
+			map[string]string{"device": key.device},
+		)
+	case ioHealthCounterNVMeReset:
+		return metric.NewCounterData(
+			"nvme_resets_total",
+			float64(value),
+			"Best-effort NVMe controller reset events observed by this Huatuo process.",
+			map[string]string{"device": key.device},
+		)
+	case ioHealthCounterSCSITimeout:
+		return metric.NewCounterData(
+			"scsi_timeouts_total",
+			float64(value),
+			"Best-effort SCSI command timeout events observed by this Huatuo process.",
+			map[string]string{"device": key.device},
+		)
+	default:
+		return metric.NewCounterData(
+			"scsi_dispatch_errors_total",
+			float64(value),
+			"Best-effort SCSI dispatch error events observed by this Huatuo process.",
+			map[string]string{
+				"device": key.device,
+				"status": key.status,
+			},
+		)
+	}
+}

--- a/core/metrics/io_health.go
+++ b/core/metrics/io_health.go
@@ -37,6 +37,21 @@ const (
 	ioHealthCounterSCSIDispatchError
 )
 
+func init() {
+	tracing.RegisterEventTracing(ioHealthName, newIOHealth)
+}
+
+func newIOHealth() (*tracing.EventTracingAttr, error) {
+	if !cfg.IOHealth.Enabled {
+		return nil, types.ErrNotSupported
+	}
+	return &tracing.EventTracingAttr{
+		TracingData: newIOHealthCollector("/sys", "/proc/mdstat"),
+		Interval:    ioHealthRestartWait,
+		Flag:        tracing.FlagMetric | tracing.FlagTracing,
+	}, nil
+}
+
 type ioHealthCounterKey struct {
 	kind      uint8
 	device    string

--- a/core/metrics/io_health_config_test.go
+++ b/core/metrics/io_health_config_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"huatuo-bamai/pkg/types"
+)
+
+func TestIOHealthFeatureGate(t *testing.T) {
+	config := DefaultConfig()
+	if !config.IOHealth.Enabled {
+		t.Fatal("IOHealth must default to enabled")
+	}
+
+	old := cfg
+	defer func() { cfg = old }()
+	config.IOHealth.Enabled = false
+	cfg = &config
+	if _, err := newIOHealth(); !errors.Is(err, types.ErrNotSupported) {
+		t.Fatalf("newIOHealth() error = %v, want ErrNotSupported", err)
+	}
+}

--- a/core/metrics/io_health_events.go
+++ b/core/metrics/io_health_events.go
@@ -46,6 +46,9 @@ const (
 	ioHealthTypeNVMeStateChange   = "nvme_state_change"
 	ioHealthTypeSCSITimeout       = "scsi_timeout"
 	ioHealthTypeSCSIDispatchError = "scsi_dispatch_error"
+	ioHealthTypeMDSyncAction      = "md_sync_action"
+	ioHealthTypeMDDegraded        = "md_degraded"
+	ioHealthTypeMDMemberState     = "md_member_state"
 )
 
 // These values mirror the stable REQ_OP definitions decoded from cmd_flags.
@@ -425,6 +428,47 @@ func (c *ioHealthCollector) handleKernelEvent(
 		})
 		c.collectEvidenceOrPersist(worker, triggeredAt, event, target)
 	}
+}
+
+func (c *ioHealthCollector) handleMDChange(
+	change health.MDChange,
+	worker ioHealthEvidenceSubmitter,
+) {
+	event := types.IOHealthEvent{
+		Array:    change.Array,
+		Member:   change.Member,
+		OldState: change.OldState,
+		NewState: change.NewState,
+	}
+	switch change.Field {
+	case health.MDFieldSyncAction:
+		event.Type = ioHealthTypeMDSyncAction
+	case health.MDFieldDegraded:
+		event.Type = ioHealthTypeMDDegraded
+	case health.MDFieldMemberState:
+		event.Type = ioHealthTypeMDMemberState
+	default:
+		return
+	}
+
+	if change.Field != health.MDFieldMemberState ||
+		!ioHealthMDMemberFault(change.NewState) {
+		c.persistEvent(change.ObservedAt, event)
+		return
+	}
+	target := c.resolver.resolveBlockName(change.Member)
+	event.Device = target.eventDevice
+	c.collectEvidenceOrPersist(worker, change.ObservedAt, event, target)
+}
+
+func ioHealthMDMemberFault(state string) bool {
+	for _, value := range strings.Split(state, ",") {
+		switch value {
+		case "faulty", "blocked", "write_error", health.MDMemberStateRemoved:
+			return true
+		}
+	}
+	return false
 }
 
 func (c *ioHealthCollector) collectEvidenceOrPersist(

--- a/core/metrics/io_health_events.go
+++ b/core/metrics/io_health_events.go
@@ -29,20 +29,27 @@ const (
 	ioHealthEventBlockError = iota + 1
 	ioHealthEventSCSITimeout
 	ioHealthEventSCSIDispatchError
+	ioHealthEventNVMeTimeout
+	ioHealthEventNVMeReset
+	ioHealthEventNVMeStateChange
 )
+
+const ioHealthNVMeControllerNameLength = 16
 
 // ioHealthPerfEvent mirrors struct health_event in bpf/io_health.c.
 type ioHealthPerfEvent struct {
-	Sector    uint64
-	Dev       uint32
-	Status    int32
-	Host      uint32
-	Channel   uint32
-	Target    uint32
-	LUN       uint32
-	Type      uint8
-	Operation uint8
-	Pad       [6]uint8
+	Sector      uint64
+	Dev         uint32
+	Status      int32
+	Host        uint32
+	Channel     uint32
+	Target      uint32
+	LUN         uint32
+	Controller  [ioHealthNVMeControllerNameLength]uint8
+	NewStateRaw uint32
+	Type        uint8
+	Operation   uint8
+	Pad         [2]uint8
 }
 
 type ioHealthHook struct {
@@ -60,15 +67,95 @@ var ioHealthBlockCompleteHook = ioHealthHook{
 	symbol:  "block_rq_complete",
 }
 
+var ioHealthNVMeMappingHook = ioHealthHook{
+	program: "kprobe_nvme_sysfs_show_state",
+	symbol:  "nvme_sysfs_show_state",
+}
+
+var ioHealthNVMeAddHooks = []ioHealthHook{
+	{
+		program: "kretprobe_nvme_cdev_add",
+		symbol:  "cdev_device_add",
+	},
+	{
+		program: "kprobe_nvme_cdev_add",
+		symbol:  "cdev_device_add",
+	},
+}
+
+var ioHealthNVMeDeleteHook = ioHealthHook{
+	program: "kprobe_nvme_cdev_del",
+	symbol:  "cdev_device_del",
+}
+
+var ioHealthNVMeStateHooks = []ioHealthHook{
+	{
+		program: "kretprobe_nvme_change_state",
+		symbol:  "nvme_change_ctrl_state",
+	},
+	{
+		program: "kprobe_nvme_change_state",
+		symbol:  "nvme_change_ctrl_state",
+	},
+}
+
 var ioHealthHooks = []ioHealthHook{
+	{program: "kprobe_nvme_timeout", symbol: "nvme_timeout"},
+	{program: "kprobe_nvme_reset", symbol: "nvme_reset_ctrl"},
 	{program: "trace_scsi_timeout", symbol: "scsi/scsi_dispatch_cmd_timeout"},
 	{program: "trace_scsi_dispatch_error", symbol: "scsi/scsi_dispatch_cmd_error"},
 }
 
 func attachIOHealthHooks(
 	object bpf.BPF,
+	primeNVMeControllers func() error,
 	legacyBlockCompleteSupported bool,
 ) (attached int) {
+	for _, hook := range ioHealthNVMeAddHooks {
+		if err := bpf.AttachIndependently(object, bpf.AttachOption{
+			ProgramName: hook.program,
+			Symbol:      hook.symbol,
+		}); err != nil {
+			log.Warnf("io_health: attach optional hook %s: %v", hook.symbol, err)
+			break
+		}
+	}
+	if err := bpf.AttachIndependently(object, bpf.AttachOption{
+		ProgramName: ioHealthNVMeDeleteHook.program,
+		Symbol:      ioHealthNVMeDeleteHook.symbol,
+	}); err != nil {
+		log.Warnf(
+			"io_health: attach optional hook %s: %v",
+			ioHealthNVMeDeleteHook.symbol,
+			err,
+		)
+	}
+
+	if err := bpf.AttachIndependently(object, bpf.AttachOption{
+		ProgramName: ioHealthNVMeMappingHook.program,
+		Symbol:      ioHealthNVMeMappingHook.symbol,
+	}); err != nil {
+		log.Warnf(
+			"io_health: attach optional hook %s: %v",
+			ioHealthNVMeMappingHook.symbol,
+			err,
+		)
+	} else {
+		if primeNVMeControllers != nil {
+			if err := primeNVMeControllers(); err != nil {
+				log.Warnf("io_health: map NVMe controllers: %v", err)
+			}
+		}
+		if err := bpf.DetachProgram(object, ioHealthNVMeMappingHook.program); err != nil {
+			log.Warnf(
+				"io_health: detach bootstrap hook %s: %v",
+				ioHealthNVMeMappingHook.symbol,
+				err,
+			)
+			return 0
+		}
+	}
+
 	err := bpf.AttachIndependently(object, bpf.AttachOption{
 		ProgramName: ioHealthBlockErrorHook.program,
 		Symbol:      ioHealthBlockErrorHook.symbol,
@@ -95,6 +182,21 @@ func attachIOHealthHooks(
 				attached++
 			}
 		}
+	}
+
+	stateHooksAttached := true
+	for _, hook := range ioHealthNVMeStateHooks {
+		if err := bpf.AttachIndependently(object, bpf.AttachOption{
+			ProgramName: hook.program,
+			Symbol:      hook.symbol,
+		}); err != nil {
+			log.Warnf("io_health: attach optional hook %s: %v", hook.symbol, err)
+			stateHooksAttached = false
+			break
+		}
+	}
+	if stateHooksAttached {
+		attached++
 	}
 
 	for _, hook := range ioHealthHooks {

--- a/core/metrics/io_health_events.go
+++ b/core/metrics/io_health_events.go
@@ -18,9 +18,12 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 
 	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/ioobserve/health"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/pkg/types"
 
 	"golang.org/x/sys/unix"
 )
@@ -35,6 +38,31 @@ const (
 )
 
 const ioHealthNVMeControllerNameLength = 16
+
+const (
+	ioHealthTypeBlockError        = "block_error"
+	ioHealthTypeNVMeTimeout       = "nvme_timeout"
+	ioHealthTypeNVMeReset         = "nvme_reset"
+	ioHealthTypeNVMeStateChange   = "nvme_state_change"
+	ioHealthTypeSCSITimeout       = "scsi_timeout"
+	ioHealthTypeSCSIDispatchError = "scsi_dispatch_error"
+)
+
+// These values mirror the stable REQ_OP definitions decoded from cmd_flags.
+const (
+	reqOpRead uint8 = iota
+	reqOpWrite
+	reqOpFlush
+	reqOpDiscard
+)
+
+// These values mirror the SCSI_MLQUEUE_* dispatch return values.
+const (
+	scsiMLQueueHostBusy   int32 = 0x1055
+	scsiMLQueueDeviceBusy int32 = 0x1056
+	scsiMLQueueEHRetry    int32 = 0x1057
+	scsiMLQueueTargetBusy int32 = 0x1058
+)
 
 // ioHealthPerfEvent mirrors struct health_event in bpf/io_health.c.
 type ioHealthPerfEvent struct {
@@ -51,6 +79,42 @@ type ioHealthPerfEvent struct {
 	Operation   uint8
 	Pad         [2]uint8
 }
+
+type ioHealthNVMeStateLayout uint8
+
+const (
+	ioHealthNVMeStateUnknown ioHealthNVMeStateLayout = iota
+	ioHealthNVMeStateLinux418
+	ioHealthNVMeStateLinux510
+)
+
+// Linux 4.18 includes ADMIN_ONLY. Linux 5.10 and later include
+// DELETING_NOIO instead, so their raw enum values require separate tables.
+var ioHealthNVMeStatesLinux418 = [...]string{
+	"new",
+	"live",
+	"admin_only",
+	"resetting",
+	"connecting",
+	"deleting",
+	"dead",
+}
+
+var ioHealthNVMeStatesLinux510 = [...]string{
+	"new",
+	"live",
+	"resetting",
+	"connecting",
+	"deleting",
+	"deleting_noio",
+	"dead",
+}
+
+var ioHealthHostKernelRelease = detectIOHealthKernelRelease()
+
+var ioHealthHostNVMeStateLayout = ioHealthNVMeStateLayoutForRelease(
+	ioHealthHostKernelRelease,
+)
 
 type ioHealthHook struct {
 	program string
@@ -251,4 +315,250 @@ func ioHealthLegacyBlockCompleteSupported(release string) bool {
 		return false
 	}
 	return major < 5 || (major == 5 && minor <= 15)
+}
+
+type ioHealthEvidenceSubmitter interface {
+	Submit(health.EvidenceRequest) bool
+}
+
+func (c *ioHealthCollector) handleKernelEvent(
+	raw ioHealthPerfEvent,
+	worker ioHealthEvidenceSubmitter,
+) {
+	triggeredAt := c.now()
+
+	// Block errors, NVMe timeouts, and SCSI anomalies may collect evidence
+	// after resolving one target. NVMe resets only update their counter and
+	// persist the event: the controller may be unavailable during reset, and a
+	// later nvme-cli query cannot recover its pre-reset state.
+	switch raw.Type {
+	case ioHealthEventBlockError:
+		target := c.resolver.resolveBlockDevice(raw.Dev)
+		event := types.IOHealthEvent{
+			Type:      ioHealthTypeBlockError,
+			Device:    target.eventDevice,
+			Operation: ioHealthOperation(raw.Operation),
+			Status:    ioHealthBlockStatus(raw.Status),
+			Sector:    uint64Pointer(raw.Sector),
+		}
+		c.incrementCounter(ioHealthCounterKey{
+			kind:      ioHealthCounterBlockError,
+			device:    event.Device,
+			operation: event.Operation,
+			status:    event.Status,
+		})
+		c.collectEvidenceOrPersist(worker, triggeredAt, event, target)
+
+	case ioHealthEventNVMeTimeout:
+		event := types.IOHealthEvent{
+			Type:   ioHealthTypeNVMeTimeout,
+			Device: "unknown",
+		}
+		var target ioHealthResolvedTarget
+		if raw.Dev != 0 {
+			target = c.resolver.resolveBlockDevice(raw.Dev)
+			event.Device = target.eventDevice
+		}
+		c.incrementCounter(ioHealthCounterKey{
+			kind:   ioHealthCounterNVMeTimeout,
+			device: event.Device,
+		})
+		if raw.Dev == 0 {
+			c.persistEvent(triggeredAt, event)
+			return
+		}
+		c.collectEvidenceOrPersist(worker, triggeredAt, event, target)
+
+	case ioHealthEventNVMeReset:
+		event := types.IOHealthEvent{
+			Type:   ioHealthTypeNVMeReset,
+			Device: ioHealthControllerName(raw.Controller),
+		}
+		c.incrementCounter(ioHealthCounterKey{
+			kind:   ioHealthCounterNVMeReset,
+			device: event.Device,
+		})
+		c.persistEvent(triggeredAt, event)
+
+	case ioHealthEventNVMeStateChange:
+		newStateRaw := raw.NewStateRaw
+		c.persistEvent(triggeredAt, types.IOHealthEvent{
+			Type:        ioHealthTypeNVMeStateChange,
+			Device:      ioHealthControllerName(raw.Controller),
+			NewState:    ioHealthNVMeStateName(ioHealthHostNVMeStateLayout, newStateRaw),
+			NewStateRaw: &newStateRaw,
+		})
+
+	case ioHealthEventSCSITimeout:
+		target := c.resolver.resolveSCSI(
+			raw.Host,
+			raw.Channel,
+			raw.Target,
+			raw.LUN,
+		)
+		event := types.IOHealthEvent{
+			Type:   ioHealthTypeSCSITimeout,
+			Device: target.eventDevice,
+		}
+		c.incrementCounter(ioHealthCounterKey{
+			kind:   ioHealthCounterSCSITimeout,
+			device: event.Device,
+		})
+		c.collectEvidenceOrPersist(worker, triggeredAt, event, target)
+
+	case ioHealthEventSCSIDispatchError:
+		target := c.resolver.resolveSCSI(
+			raw.Host,
+			raw.Channel,
+			raw.Target,
+			raw.LUN,
+		)
+		event := types.IOHealthEvent{
+			Type:   ioHealthTypeSCSIDispatchError,
+			Device: target.eventDevice,
+			Status: ioHealthSCSIDispatchStatus(raw.Status),
+		}
+		c.incrementCounter(ioHealthCounterKey{
+			kind:   ioHealthCounterSCSIDispatchError,
+			device: event.Device,
+			status: event.Status,
+		})
+		c.collectEvidenceOrPersist(worker, triggeredAt, event, target)
+	}
+}
+
+func (c *ioHealthCollector) collectEvidenceOrPersist(
+	worker ioHealthEvidenceSubmitter,
+	triggeredAt time.Time,
+	event types.IOHealthEvent,
+	target ioHealthResolvedTarget,
+) {
+	protocol := health.EvidenceProtocol("")
+	switch target.protocol {
+	case ioHealthProtocolNVMe:
+		protocol = health.EvidenceProtocolNVMe
+	case ioHealthProtocolSCSI:
+		protocol = health.EvidenceProtocolSCSI
+	}
+	if worker != nil && worker.Submit(health.EvidenceRequest{
+		Trigger:     event,
+		Target:      target.target,
+		Protocol:    protocol,
+		TriggeredAt: triggeredAt,
+		Reason:      target.reason,
+	}) {
+		return
+	}
+	c.persistEvent(triggeredAt, event)
+}
+
+func ioHealthControllerName(raw [ioHealthNVMeControllerNameLength]uint8) string {
+	length := len(raw)
+	for index, value := range raw {
+		if value == 0 {
+			length = index
+			break
+		}
+	}
+	name := string(raw[:length])
+	if !ioHealthNVMeControllerPattern.MatchString(name) {
+		return "unknown"
+	}
+	return name
+}
+
+func ioHealthNVMeStateLayoutForRelease(release string) ioHealthNVMeStateLayout {
+	major, minor, ok := ioHealthKernelVersion(release)
+	if !ok {
+		return ioHealthNVMeStateUnknown
+	}
+
+	if major == 4 && minor == 18 {
+		return ioHealthNVMeStateLinux418
+	}
+	if major > 5 || major == 5 && minor >= 10 {
+		return ioHealthNVMeStateLinux510
+	}
+	return ioHealthNVMeStateUnknown
+}
+
+func ioHealthNVMeStateName(layout ioHealthNVMeStateLayout, raw uint32) string {
+	switch layout {
+	case ioHealthNVMeStateLinux418:
+		if raw < uint32(len(ioHealthNVMeStatesLinux418)) {
+			return ioHealthNVMeStatesLinux418[raw]
+		}
+	case ioHealthNVMeStateLinux510:
+		if raw < uint32(len(ioHealthNVMeStatesLinux510)) {
+			return ioHealthNVMeStatesLinux510[raw]
+		}
+	}
+	return "unknown"
+}
+
+func ioHealthOperation(operation uint8) string {
+	switch operation {
+	case reqOpRead:
+		return "read"
+	case reqOpWrite:
+		return "write"
+	case reqOpFlush:
+		return "flush"
+	case reqOpDiscard:
+		return "discard"
+	default:
+		return "unknown"
+	}
+}
+
+func ioHealthBlockStatus(status int32) string {
+	switch status {
+	case -int32(unix.EOPNOTSUPP):
+		return "not_supported"
+	case -int32(unix.ETIMEDOUT):
+		return "timeout"
+	case -int32(unix.ENOSPC):
+		return "no_space"
+	case -int32(unix.ENOLINK),
+		-int32(unix.EREMOTEIO),
+		-int32(unix.EBADE):
+		return "transport"
+	case -int32(unix.ENODATA):
+		return "medium_error"
+	case -int32(unix.EILSEQ):
+		return "protection"
+	case -int32(unix.ENOMEM),
+		-int32(unix.EBUSY),
+		-int32(unix.EAGAIN),
+		-int32(unix.EREMCHG),
+		-int32(unix.ETOOMANYREFS),
+		-int32(unix.EOVERFLOW):
+		return "resource"
+	case -int32(unix.ENODEV):
+		return "offline"
+	default:
+		if status == 0 {
+			return "unknown"
+		}
+		return "io_error"
+	}
+}
+
+func ioHealthSCSIDispatchStatus(status int32) string {
+	switch status {
+	case scsiMLQueueHostBusy:
+		return "host_busy"
+	case scsiMLQueueDeviceBusy:
+		return "device_busy"
+	case scsiMLQueueEHRetry:
+		return "eh_retry"
+	case scsiMLQueueTargetBusy:
+		return "target_busy"
+	default:
+		return "unknown"
+	}
+}
+
+func uint64Pointer(value uint64) *uint64 {
+	return &value
 }

--- a/core/metrics/io_health_events.go
+++ b/core/metrics/io_health_events.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	ioHealthEventBlockError = 1
+	ioHealthEventBlockError = iota + 1
+	ioHealthEventSCSITimeout
+	ioHealthEventSCSIDispatchError
 )
 
 // ioHealthPerfEvent mirrors struct health_event in bpf/io_health.c.
@@ -34,6 +36,10 @@ type ioHealthPerfEvent struct {
 	Sector    uint64
 	Dev       uint32
 	Status    int32
+	Host      uint32
+	Channel   uint32
+	Target    uint32
+	LUN       uint32
 	Type      uint8
 	Operation uint8
 	Pad       [6]uint8
@@ -54,6 +60,11 @@ var ioHealthBlockCompleteHook = ioHealthHook{
 	symbol:  "block_rq_complete",
 }
 
+var ioHealthHooks = []ioHealthHook{
+	{program: "trace_scsi_timeout", symbol: "scsi/scsi_dispatch_cmd_timeout"},
+	{program: "trace_scsi_dispatch_error", symbol: "scsi/scsi_dispatch_cmd_error"},
+}
+
 func attachIOHealthHooks(
 	object bpf.BPF,
 	legacyBlockCompleteSupported bool,
@@ -63,28 +74,41 @@ func attachIOHealthHooks(
 		Symbol:      ioHealthBlockErrorHook.symbol,
 	})
 	if err == nil {
-		return 1
-	}
-	log.Warnf(
-		"io_health: attach optional hook %s: %v",
-		ioHealthBlockErrorHook.symbol,
-		err,
-	)
-	if !errors.Is(err, unix.ENOENT) || !legacyBlockCompleteSupported {
-		return 0
-	}
-	if err := bpf.AttachIndependently(object, bpf.AttachOption{
-		ProgramName: ioHealthBlockCompleteHook.program,
-		Symbol:      ioHealthBlockCompleteHook.symbol,
-	}); err != nil {
+		attached++
+	} else {
 		log.Warnf(
 			"io_health: attach optional hook %s: %v",
-			ioHealthBlockCompleteHook.symbol,
+			ioHealthBlockErrorHook.symbol,
 			err,
 		)
-		return 0
+		if errors.Is(err, unix.ENOENT) && legacyBlockCompleteSupported {
+			if err := bpf.AttachIndependently(object, bpf.AttachOption{
+				ProgramName: ioHealthBlockCompleteHook.program,
+				Symbol:      ioHealthBlockCompleteHook.symbol,
+			}); err != nil {
+				log.Warnf(
+					"io_health: attach optional hook %s: %v",
+					ioHealthBlockCompleteHook.symbol,
+					err,
+				)
+			} else {
+				attached++
+			}
+		}
 	}
-	return 1
+
+	for _, hook := range ioHealthHooks {
+		if err := bpf.AttachIndependently(object, bpf.AttachOption{
+			ProgramName: hook.program,
+			Symbol:      hook.symbol,
+		}); err != nil {
+			log.Warnf("io_health: attach optional hook %s: %v", hook.symbol, err)
+			continue
+		}
+		attached++
+	}
+
+	return attached
 }
 
 func detectIOHealthKernelRelease() string {

--- a/core/metrics/io_health_events.go
+++ b/core/metrics/io_health_events.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/log"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	ioHealthEventBlockError = 1
+)
+
+// ioHealthPerfEvent mirrors struct health_event in bpf/io_health.c.
+type ioHealthPerfEvent struct {
+	Sector    uint64
+	Dev       uint32
+	Status    int32
+	Type      uint8
+	Operation uint8
+	Pad       [6]uint8
+}
+
+type ioHealthHook struct {
+	program string
+	symbol  string
+}
+
+var ioHealthBlockErrorHook = ioHealthHook{
+	program: "trace_block_rq_error",
+	symbol:  "block/block_rq_error",
+}
+
+var ioHealthBlockCompleteHook = ioHealthHook{
+	program: "trace_block_rq_complete_error",
+	symbol:  "block_rq_complete",
+}
+
+func attachIOHealthHooks(
+	object bpf.BPF,
+	legacyBlockCompleteSupported bool,
+) (attached int) {
+	err := bpf.AttachIndependently(object, bpf.AttachOption{
+		ProgramName: ioHealthBlockErrorHook.program,
+		Symbol:      ioHealthBlockErrorHook.symbol,
+	})
+	if err == nil {
+		return 1
+	}
+	log.Warnf(
+		"io_health: attach optional hook %s: %v",
+		ioHealthBlockErrorHook.symbol,
+		err,
+	)
+	if !errors.Is(err, unix.ENOENT) || !legacyBlockCompleteSupported {
+		return 0
+	}
+	if err := bpf.AttachIndependently(object, bpf.AttachOption{
+		ProgramName: ioHealthBlockCompleteHook.program,
+		Symbol:      ioHealthBlockCompleteHook.symbol,
+	}); err != nil {
+		log.Warnf(
+			"io_health: attach optional hook %s: %v",
+			ioHealthBlockCompleteHook.symbol,
+			err,
+		)
+		return 0
+	}
+	return 1
+}
+
+func detectIOHealthKernelRelease() string {
+	var name unix.Utsname
+	if err := unix.Uname(&name); err != nil {
+		return ""
+	}
+
+	release := make([]byte, 0, len(name.Release))
+	for _, value := range name.Release {
+		if value == 0 {
+			break
+		}
+		release = append(release, byte(value))
+	}
+	return string(release)
+}
+
+func ioHealthKernelVersion(release string) (major, minor int, ok bool) {
+	parts := strings.SplitN(release, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
+
+func ioHealthLegacyBlockCompleteSupported(release string) bool {
+	major, minor, ok := ioHealthKernelVersion(release)
+	if !ok {
+		return false
+	}
+	return major < 5 || (major == 5 && minor <= 15)
+}

--- a/core/metrics/io_health_events_test.go
+++ b/core/metrics/io_health_events_test.go
@@ -1,0 +1,455 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/ioobserve/health"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/types"
+
+	"golang.org/x/sys/unix"
+)
+
+type recordingEvidenceSubmitter struct {
+	requests []health.EvidenceRequest
+	accept   bool
+}
+
+func (s *recordingEvidenceSubmitter) Submit(request health.EvidenceRequest) bool {
+	s.requests = append(s.requests, request)
+	return s.accept
+}
+
+type recordedIOHealthEvent struct {
+	at    time.Time
+	event types.IOHealthEvent
+}
+
+type ioHealthEventRecorder struct {
+	events []recordedIOHealthEvent
+}
+
+func (r *ioHealthEventRecorder) save(
+	at time.Time,
+	event types.IOHealthEvent,
+) error {
+	r.events = append(r.events, recordedIOHealthEvent{at: at, event: event})
+	return nil
+}
+
+func newRecordingIOHealthCollector(
+	t *testing.T,
+	root string,
+) (*ioHealthCollector, *ioHealthEventRecorder) {
+	t.Helper()
+	collector := newIOHealthCollector(root, filepath.Join(root, "proc", "mdstat"))
+	recorder := &ioHealthEventRecorder{}
+	collector.saveEvent = recorder.save
+	return collector, recorder
+}
+
+func writeIOHealthBlockDevice(
+	t *testing.T,
+	root, device string,
+	major, minor uint32,
+) uint32 {
+	t.Helper()
+	blockPath := filepath.Join(root, "class", "block", device)
+	if err := os.MkdirAll(filepath.Join(blockPath, "slaves"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	devBlockPath := filepath.Join(root, "dev", "block")
+	if err := os.MkdirAll(devBlockPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(
+		blockPath,
+		filepath.Join(devBlockPath, ioHealthDevName(major, minor)),
+	); err != nil {
+		t.Fatal(err)
+	}
+	return major<<20 | minor
+}
+
+func ioHealthDevName(major, minor uint32) string {
+	return fmt.Sprintf("%d:%d", major, minor)
+}
+
+func ioHealthControllerBytes(name string) [ioHealthNVMeControllerNameLength]uint8 {
+	var raw [ioHealthNVMeControllerNameLength]uint8
+	copy(raw[:], name)
+	return raw
+}
+
+func TestIOHealthKernelABIAndLabels(t *testing.T) {
+	if size := binary.Size(ioHealthPerfEvent{}); size != 56 {
+		t.Fatalf("ioHealthPerfEvent binary size = %d, want 56", size)
+	}
+	eventTypes := []int{
+		ioHealthEventBlockError,
+		ioHealthEventSCSITimeout,
+		ioHealthEventSCSIDispatchError,
+		ioHealthEventNVMeTimeout,
+		ioHealthEventNVMeReset,
+		ioHealthEventNVMeStateChange,
+	}
+	if want := []int{1, 2, 3, 4, 5, 6}; !reflect.DeepEqual(eventTypes, want) {
+		t.Fatalf("kernel event wire values = %v, want %v", eventTypes, want)
+	}
+
+	for _, test := range []struct {
+		raw  uint8
+		want string
+	}{
+		{raw: reqOpRead, want: "read"},
+		{raw: reqOpWrite, want: "write"},
+		{raw: reqOpFlush, want: "flush"},
+		{raw: reqOpDiscard, want: "discard"},
+		{raw: 255, want: "unknown"},
+	} {
+		if got := ioHealthOperation(test.raw); got != test.want {
+			t.Errorf("ioHealthOperation(%d) = %q, want %q", test.raw, got, test.want)
+		}
+	}
+
+	for _, test := range []struct {
+		raw  int32
+		want string
+	}{
+		{raw: -int32(unix.ETIMEDOUT), want: "timeout"},
+		{raw: -int32(unix.ENODATA), want: "medium_error"},
+		{raw: -int32(unix.ENOMEM), want: "resource"},
+		{raw: -int32(unix.ENODEV), want: "offline"},
+		{raw: 16, want: "io_error"},
+	} {
+		if got := ioHealthBlockStatus(test.raw); got != test.want {
+			t.Errorf("ioHealthBlockStatus(%d) = %q, want %q", test.raw, got, test.want)
+		}
+	}
+
+	if got := ioHealthSCSIDispatchStatus(scsiMLQueueTargetBusy); got != "target_busy" {
+		t.Fatalf("target-busy status = %q", got)
+	}
+	if got := ioHealthControllerName(ioHealthControllerBytes("nvme12")); got != "nvme12" {
+		t.Fatalf("controller name = %q, want nvme12", got)
+	}
+	if got := ioHealthControllerName(ioHealthControllerBytes("sda")); got != "unknown" {
+		t.Fatalf("invalid controller name = %q, want unknown", got)
+	}
+
+	for _, test := range []struct {
+		release string
+		want    ioHealthNVMeStateLayout
+	}{
+		{release: "4.18.0-193.6.3.el8_2", want: ioHealthNVMeStateLinux418},
+		{release: "5.10.0-216.0.0.115.oe2203sp4", want: ioHealthNVMeStateLinux510},
+		{release: "7.2.0-rc6", want: ioHealthNVMeStateLinux510},
+		{release: "5.4.0", want: ioHealthNVMeStateUnknown},
+		{release: "not-a-version", want: ioHealthNVMeStateUnknown},
+	} {
+		if got := ioHealthNVMeStateLayoutForRelease(test.release); got != test.want {
+			t.Errorf("state layout for %q = %d, want %d", test.release, got, test.want)
+		}
+	}
+	if got := ioHealthNVMeStateName(ioHealthNVMeStateLinux418, 5); got != "deleting" {
+		t.Fatalf("Linux 4.18 NVMe state 5 = %q, want deleting", got)
+	}
+	if got := ioHealthNVMeStateName(ioHealthNVMeStateLinux510, 5); got != "deleting_noio" {
+		t.Fatalf("Linux 5.10 NVMe state 5 = %q, want deleting_noio", got)
+	}
+}
+
+func TestIOHealthPersistsEachEvidenceTriggerExactlyOnce(t *testing.T) {
+	root := t.TempDir()
+	dev := writeIOHealthBlockDevice(t, root, "sda", 8, 0)
+	collector, recorder := newRecordingIOHealthCollector(t, root)
+	triggeredAt := []time.Time{time.Unix(123, 456), time.Unix(124, 456)}
+	nextTime := 0
+	collector.now = func() time.Time {
+		at := triggeredAt[nextTime]
+		nextTime++
+		return at
+	}
+	submitter := &recordingEvidenceSubmitter{accept: true}
+	raw := ioHealthPerfEvent{
+		Dev:       dev,
+		Status:    -int32(unix.ETIMEDOUT),
+		Type:      ioHealthEventBlockError,
+		Operation: reqOpRead,
+	}
+
+	collector.handleKernelEvent(raw, submitter)
+	if len(recorder.events) != 0 {
+		t.Fatalf("accepted request saved %d immediate events", len(recorder.events))
+	}
+	if len(submitter.requests) != 1 {
+		t.Fatalf("submitted requests = %d, want 1", len(submitter.requests))
+	}
+	request := submitter.requests[0]
+	if request.Target != "sda" ||
+		request.Protocol != health.EvidenceProtocolSCSI ||
+		request.TriggeredAt != triggeredAt[0] {
+		t.Fatalf("request = %+v", request)
+	}
+	if request.Trigger.Device != "sda" ||
+		request.Trigger.Operation != "read" ||
+		request.Trigger.Status != "timeout" ||
+		request.Trigger.Sector == nil ||
+		*request.Trigger.Sector != 0 {
+		t.Fatalf("trigger = %+v", request.Trigger)
+	}
+
+	submitter.accept = false
+	collector.handleKernelEvent(raw, submitter)
+	if len(recorder.events) != 1 || recorder.events[0].event.Type != ioHealthTypeBlockError {
+		t.Fatalf("suppressed event records = %+v", recorder.events)
+	}
+	collector.handleEvidenceResult(health.EvidenceResult{
+		Target:      submitter.requests[0].Target,
+		TriggeredAt: submitter.requests[0].TriggeredAt,
+		Event:       submitter.requests[0].Trigger,
+	})
+	if len(recorder.events) != 2 {
+		t.Fatalf("two raw events produced %d records", len(recorder.events))
+	}
+	recordsByTime := make(map[time.Time]int)
+	for _, record := range recorder.events {
+		recordsByTime[record.at]++
+	}
+	for _, at := range triggeredAt {
+		if recordsByTime[at] != 1 {
+			t.Fatalf("records by trigger time = %v, want one for %v", recordsByTime, at)
+		}
+	}
+	key := ioHealthCounterKey{
+		kind:      ioHealthCounterBlockError,
+		device:    "sda",
+		operation: "read",
+		status:    "timeout",
+	}
+	if got := collector.counters[key]; got != 2 {
+		t.Fatalf("block error counter = %d, want 2", got)
+	}
+}
+
+func TestIOHealthRoutesNVMeEventsWithoutResetEvidence(t *testing.T) {
+	root := t.TempDir()
+	dev := writeIOHealthBlockDevice(t, root, "nvme0c7n1", 259, 0)
+	collector, recorder := newRecordingIOHealthCollector(t, root)
+	submitter := &recordingEvidenceSubmitter{accept: true}
+
+	collector.handleKernelEvent(ioHealthPerfEvent{
+		Dev:  dev,
+		Type: ioHealthEventNVMeTimeout,
+	}, submitter)
+	if len(submitter.requests) != 1 ||
+		submitter.requests[0].Target != "nvme7" ||
+		submitter.requests[0].Protocol != health.EvidenceProtocolNVMe {
+		t.Fatalf("NVMe timeout requests = %+v", submitter.requests)
+	}
+
+	collector.handleKernelEvent(ioHealthPerfEvent{
+		Type: ioHealthEventNVMeTimeout,
+	}, submitter)
+	collector.handleKernelEvent(ioHealthPerfEvent{
+		Type:       ioHealthEventNVMeReset,
+		Controller: ioHealthControllerBytes("nvme7"),
+	}, submitter)
+	collector.handleKernelEvent(ioHealthPerfEvent{
+		Type: ioHealthEventNVMeReset,
+	}, submitter)
+	collector.handleKernelEvent(ioHealthPerfEvent{
+		Type:        ioHealthEventNVMeStateChange,
+		Controller:  ioHealthControllerBytes("nvme7"),
+		NewStateRaw: 1,
+	}, submitter)
+
+	if len(submitter.requests) != 1 {
+		t.Fatalf("admin/reset/state submitted requests = %+v", submitter.requests)
+	}
+	if len(recorder.events) != 4 {
+		t.Fatalf("direct NVMe events = %+v", recorder.events)
+	}
+	for index, want := range []struct {
+		typeName string
+		device   string
+	}{
+		{typeName: ioHealthTypeNVMeTimeout, device: "unknown"},
+		{typeName: ioHealthTypeNVMeReset, device: "nvme7"},
+		{typeName: ioHealthTypeNVMeReset, device: "unknown"},
+		{typeName: ioHealthTypeNVMeStateChange, device: "nvme7"},
+	} {
+		got := recorder.events[index].event
+		if got.Type != want.typeName || got.Device != want.device {
+			t.Fatalf("NVMe event %d = %+v, want %+v", index, got, want)
+		}
+	}
+	state := recorder.events[3].event
+	if state.NewState != "live" ||
+		state.NewStateRaw == nil || *state.NewStateRaw != 1 {
+		t.Fatalf("NVMe state event = %+v", state)
+	}
+	if got := collector.counters[ioHealthCounterKey{
+		kind:   ioHealthCounterNVMeReset,
+		device: "nvme7",
+	}]; got != 1 {
+		t.Fatalf("NVMe reset counter = %d, want 1", got)
+	}
+}
+
+func TestIOHealthRoutesFullSCSIHCTL(t *testing.T) {
+	root := t.TempDir()
+	const (
+		host    = uint32(70000)
+		channel = uint32(80000)
+		target  = uint32(90000)
+		lun     = uint32(100000)
+	)
+	if err := os.MkdirAll(filepath.Join(
+		root,
+		"class",
+		"scsi_device",
+		"70000:80000:90000:100000",
+		"device",
+		"block",
+		"sdz",
+	), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	collector, _ := newRecordingIOHealthCollector(t, root)
+	submitter := &recordingEvidenceSubmitter{accept: true}
+
+	collector.handleKernelEvent(ioHealthPerfEvent{
+		Type:    ioHealthEventSCSIDispatchError,
+		Status:  scsiMLQueueTargetBusy,
+		Host:    host,
+		Channel: channel,
+		Target:  target,
+		LUN:     lun,
+	}, submitter)
+
+	if len(submitter.requests) != 1 {
+		t.Fatalf("SCSI requests = %+v", submitter.requests)
+	}
+	request := submitter.requests[0]
+	if request.Target != "sdz" ||
+		request.Protocol != health.EvidenceProtocolSCSI ||
+		request.Trigger.Status != "target_busy" {
+		t.Fatalf("SCSI request = %+v", request)
+	}
+}
+
+func TestIOHealthRoutesMDTransitionsAndFaultEvidence(t *testing.T) {
+	root := t.TempDir()
+	writeIOHealthBlockDevice(t, root, "sdb", 8, 16)
+	collector, recorder := newRecordingIOHealthCollector(t, root)
+	submitter := &recordingEvidenceSubmitter{accept: true}
+	observedAt := time.Unix(321, 654)
+
+	for _, change := range []health.MDChange{
+		{
+			Array:      "md0",
+			Field:      health.MDFieldSyncAction,
+			OldState:   "idle",
+			NewState:   "recover",
+			ObservedAt: observedAt,
+		},
+		{
+			Array:      "md0",
+			Field:      health.MDFieldDegraded,
+			OldState:   "0",
+			NewState:   "1",
+			ObservedAt: observedAt,
+		},
+		{
+			Array:      "md0",
+			Member:     "sdb",
+			Field:      health.MDFieldMemberState,
+			OldState:   "spare",
+			NewState:   "in_sync",
+			ObservedAt: observedAt,
+		},
+	} {
+		collector.handleMDChange(change, submitter)
+	}
+	if len(recorder.events) != 3 || len(submitter.requests) != 0 {
+		t.Fatalf("ordinary MD records=%+v requests=%+v", recorder.events, submitter.requests)
+	}
+
+	for _, state := range []string{
+		"faulty",
+		"blocked",
+		"in_sync,write_error",
+		health.MDMemberStateRemoved,
+	} {
+		collector.handleMDChange(health.MDChange{
+			Array:      "md0",
+			Member:     "sdb",
+			Field:      health.MDFieldMemberState,
+			OldState:   "in_sync",
+			NewState:   state,
+			ObservedAt: observedAt,
+		}, submitter)
+	}
+	if len(submitter.requests) != 4 {
+		t.Fatalf("fault evidence requests = %+v", submitter.requests)
+	}
+	for _, request := range submitter.requests {
+		if request.Target != "sdb" ||
+			request.Protocol != health.EvidenceProtocolSCSI ||
+			request.Trigger.Type != ioHealthTypeMDMemberState ||
+			request.Trigger.Array != "md0" ||
+			request.Trigger.Member != "sdb" {
+			t.Fatalf("MD fault request = %+v", request)
+		}
+	}
+}
+
+func TestIOHealthEvidenceResultAddsOnlyCountersToScrape(t *testing.T) {
+	collector, recorder := newRecordingIOHealthCollector(t, t.TempDir())
+	if _, err := collector.Update(); !metric.IsNoDataError(err) {
+		t.Fatalf("empty Update() error = %v, want ErrNoData", err)
+	}
+
+	event := types.IOHealthEvent{
+		Type:   ioHealthTypeSCSITimeout,
+		Device: "sda",
+		SCSI:   &types.SCSIHealthEvidence{},
+	}
+	collector.handleEvidenceResult(health.EvidenceResult{
+		Target:      "sda",
+		TriggeredAt: time.Unix(1, 2),
+		Event:       event,
+		Reasons:     []string{health.CollectionReasonParseError},
+	})
+	if len(recorder.events) != 1 || recorder.events[0].event.SCSI == nil {
+		t.Fatalf("saved evidence events = %+v", recorder.events)
+	}
+	metrics, err := collector.Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if len(metrics) != 1 || metrics[0].Value != 1 {
+		t.Fatalf("scrape metrics = %+v, want one collection-error counter", metrics)
+	}
+}

--- a/core/metrics/io_health_hooks_test.go
+++ b/core/metrics/io_health_hooks_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+
+	"golang.org/x/sys/unix"
+)
+
+type fakeIOHealthAttachBPF struct {
+	bpf.BPF
+	attachErrors map[string]error
+	detachErr    error
+	detachAfter  []int
+	detached     []string
+	programs     []string
+	symbols      []string
+}
+
+func (f *fakeIOHealthAttachBPF) AttachWithOptions(options []bpf.AttachOption) error {
+	if len(options) != 1 {
+		return errors.New("test expects one independent attach option")
+	}
+	f.programs = append(f.programs, options[0].ProgramName)
+	f.symbols = append(f.symbols, options[0].Symbol)
+	return f.attachErrors[options[0].ProgramName]
+}
+
+func (f *fakeIOHealthAttachBPF) DetachProgram(programName string) error {
+	f.detachAfter = append(f.detachAfter, len(f.programs))
+	f.detached = append(f.detached, programName)
+	return f.detachErr
+}
+
+func TestAttachIOHealthHooksDetachesNVMeBootstrapAfterHotplugHooks(t *testing.T) {
+	object := &fakeIOHealthAttachBPF{}
+	primeAfter := -1
+	attached := attachIOHealthHooks(object, func() error {
+		primeAfter = len(object.programs)
+		return nil
+	}, false)
+
+	if want := len(ioHealthHooks) + 2; attached != want {
+		t.Fatalf("attached event sources = %d, want %d", attached, want)
+	}
+	wantPrograms := []string{
+		"kretprobe_nvme_cdev_add",
+		"kprobe_nvme_cdev_add",
+		"kprobe_nvme_cdev_del",
+		"kprobe_nvme_sysfs_show_state",
+		"trace_block_rq_error",
+		"kretprobe_nvme_change_state",
+		"kprobe_nvme_change_state",
+	}
+	for _, hook := range ioHealthHooks {
+		wantPrograms = append(wantPrograms, hook.program)
+	}
+	if !reflect.DeepEqual(object.programs, wantPrograms) {
+		t.Fatalf("attach programs = %v, want %v", object.programs, wantPrograms)
+	}
+	if got := object.symbols[4]; got != "block/block_rq_error" {
+		t.Fatalf("block error symbol = %q, want block/block_rq_error", got)
+	}
+	if primeAfter != 4 {
+		t.Fatalf("NVMe bootstrap ran after %d attaches, want 4", primeAfter)
+	}
+	if !reflect.DeepEqual(object.detachAfter, []int{4}) {
+		t.Fatalf("NVMe bootstrap detach points = %v, want [4]", object.detachAfter)
+	}
+	if !reflect.DeepEqual(object.detached, []string{"kprobe_nvme_sysfs_show_state"}) {
+		t.Fatalf("detached programs = %v", object.detached)
+	}
+}
+
+func TestAttachIOHealthHooksDegradesOptionalSources(t *testing.T) {
+	object := &fakeIOHealthAttachBPF{attachErrors: map[string]error{
+		"trace_block_rq_error":         unix.ENOENT,
+		"kprobe_nvme_sysfs_show_state": errors.New("mapping unavailable"),
+		"kretprobe_nvme_change_state":  errors.New("state unavailable"),
+	}}
+	primed := false
+	attached := attachIOHealthHooks(object, func() error {
+		primed = true
+		return nil
+	}, true)
+
+	if primed {
+		t.Fatal("NVMe bootstrap ran without the mapping hook")
+	}
+	if want := len(ioHealthHooks) + 1; attached != want {
+		t.Fatalf("attached event sources = %d, want %d", attached, want)
+	}
+	if len(object.detachAfter) != 0 {
+		t.Fatalf("detached without the NVMe bootstrap hook: %v", object.detachAfter)
+	}
+	for _, program := range object.programs {
+		if program == "kprobe_nvme_change_state" {
+			t.Fatalf("state entry attached after return hook failed: %v", object.programs)
+		}
+	}
+	wantPrefix := []string{
+		"kretprobe_nvme_cdev_add",
+		"kprobe_nvme_cdev_add",
+		"kprobe_nvme_cdev_del",
+		"kprobe_nvme_sysfs_show_state",
+		"trace_block_rq_error",
+		"trace_block_rq_complete_error",
+		"kretprobe_nvme_change_state",
+	}
+	if !reflect.DeepEqual(object.programs[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("attach prefix = %v, want %v", object.programs, wantPrefix)
+	}
+	if got := object.symbols[4:6]; !reflect.DeepEqual(got, []string{
+		"block/block_rq_error",
+		"block_rq_complete",
+	}) {
+		t.Fatalf("block error symbols = %v", got)
+	}
+}
+
+func TestAttachIOHealthHooksSkipsUnsupportedCompleteABI(t *testing.T) {
+	object := &fakeIOHealthAttachBPF{attachErrors: map[string]error{
+		"trace_block_rq_error": unix.ENOENT,
+	}}
+	attached := attachIOHealthHooks(object, nil, false)
+
+	if want := len(ioHealthHooks) + 1; attached != want {
+		t.Fatalf("attached event sources = %d, want %d", attached, want)
+	}
+	for _, program := range object.programs {
+		if program == "trace_block_rq_complete_error" {
+			t.Fatalf("completion fallback attached for unknown ABI: %v", object.programs)
+		}
+	}
+}
+
+func TestIOHealthLegacyBlockCompleteSupported(t *testing.T) {
+	for _, test := range []struct {
+		release string
+		want    bool
+	}{
+		{release: "4.18.0", want: true},
+		{release: "5.10.0-vendor", want: true},
+		{release: "5.15.12", want: true},
+		{release: "5.16.0"},
+		{release: "5.18.0"},
+		{release: "invalid"},
+	} {
+		t.Run(test.release, func(t *testing.T) {
+			if got := ioHealthLegacyBlockCompleteSupported(test.release); got != test.want {
+				t.Fatalf("legacy block completion support = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestAttachIOHealthHooksContinuesAfterNVMePrimeFailure(t *testing.T) {
+	object := &fakeIOHealthAttachBPF{}
+	attached := attachIOHealthHooks(object, func() error {
+		return errors.New("read controller state")
+	}, false)
+
+	if want := len(ioHealthHooks) + 2; attached != want {
+		t.Fatalf("attached event sources = %d, want %d", attached, want)
+	}
+	if len(object.programs) != len(ioHealthHooks)+7 {
+		t.Fatalf("attach programs after prime failure = %v", object.programs)
+	}
+	if !reflect.DeepEqual(object.detachAfter, []int{4}) {
+		t.Fatalf("NVMe bootstrap detach points = %v, want [4]", object.detachAfter)
+	}
+}
+
+func TestAttachIOHealthHooksStopsWhenNVMeBootstrapCannotDetach(t *testing.T) {
+	object := &fakeIOHealthAttachBPF{detachErr: errors.New("detach failed")}
+	attached := attachIOHealthHooks(object, func() error { return nil }, false)
+
+	if attached != 0 {
+		t.Fatalf("attached event sources = %d, want 0", attached)
+	}
+	if !reflect.DeepEqual(object.programs, []string{
+		"kretprobe_nvme_cdev_add",
+		"kprobe_nvme_cdev_add",
+		"kprobe_nvme_cdev_del",
+		"kprobe_nvme_sysfs_show_state",
+	}) {
+		t.Fatalf("programs after detach failure = %v", object.programs)
+	}
+}

--- a/core/metrics/io_health_integration_test.go
+++ b/core/metrics/io_health_integration_test.go
@@ -1,0 +1,268 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package collector
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/ioobserve/health"
+	"huatuo-bamai/pkg/types"
+
+	"golang.org/x/sys/unix"
+)
+
+const ioHealthIntegrationResultTimeout = 15 * time.Second
+
+func TestIOHealthRealCommandEvidence(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") != "true" {
+		t.Skip("Set TEST_INTEGRATION=true to run integration tests")
+	}
+	if os.Getenv("TEST_IO_CONFIRM_NON_SYSTEM") != "1" {
+		t.Skip("Set TEST_IO_CONFIRM_NON_SYSTEM=1 for dedicated test devices")
+	}
+
+	tests := []struct {
+		name        string
+		env         string
+		tool        string
+		protocol    health.EvidenceProtocol
+		triggerType string
+	}{
+		{
+			name:        "nvme",
+			env:         "TEST_NVME_DEVICE",
+			tool:        "nvme",
+			protocol:    health.EvidenceProtocolNVMe,
+			triggerType: ioHealthTypeNVMeTimeout,
+		},
+		{
+			name:        "scsi",
+			env:         "TEST_SCSI_DEVICE",
+			tool:        "smartctl",
+			protocol:    health.EvidenceProtocolSCSI,
+			triggerType: ioHealthTypeSCSITimeout,
+		},
+	}
+
+	selected := 0
+	for _, test := range tests {
+		rawDevice := strings.TrimSpace(os.Getenv(test.env))
+		if rawDevice == "" {
+			continue
+		}
+		selected++
+		t.Run(test.name, func(t *testing.T) {
+			device := requireIOHealthIntegrationDevice(
+				t,
+				rawDevice,
+				test.env,
+				test.protocol,
+			)
+			if _, err := exec.LookPath(test.tool); err != nil {
+				t.Skipf("%s is unavailable: %v", test.tool, err)
+			}
+			runIOHealthRealCommandEvidence(
+				t,
+				device,
+				test.protocol,
+				test.triggerType,
+			)
+		})
+	}
+	if selected == 0 {
+		t.Skip("Set TEST_NVME_DEVICE or TEST_SCSI_DEVICE")
+	}
+}
+
+func TestIOHealthRealTargetResolution(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") != "true" {
+		t.Skip("Set TEST_INTEGRATION=true to run integration tests")
+	}
+
+	tests := []struct {
+		name      string
+		env       string
+		multiLeaf bool
+	}{
+		{name: "unique leaf", env: "TEST_IO_UNIQUE_DEVICE"},
+		{name: "multiple leaves", env: "TEST_IO_MULTILEAF_DEVICE", multiLeaf: true},
+	}
+	selected := 0
+	for _, test := range tests {
+		device := strings.TrimSpace(os.Getenv(test.env))
+		if device == "" {
+			continue
+		}
+		selected++
+		t.Run(test.name, func(t *testing.T) {
+			if filepath.Base(device) != device {
+				t.Fatalf("%s must be a block device name, got %q", test.env, device)
+			}
+
+			resolver := newIOHealthResolver("/sys")
+			leaves, err := resolver.blockLeaves(device, make(map[string]bool))
+			if err != nil {
+				t.Fatalf("resolve %s leaves: %v", device, err)
+			}
+			target := resolver.resolveBlockName(device)
+			if test.multiLeaf {
+				if len(leaves) < 2 || target.target != "" ||
+					target.reason != health.CollectionReasonTargetUnsupported {
+					t.Fatalf("device %s leaves=%v target=%+v", device, leaves, target)
+				}
+				return
+			}
+			if len(leaves) != 1 || target.target == "" || target.reason != "" {
+				t.Fatalf("device %s leaves=%v target=%+v", device, leaves, target)
+			}
+		})
+	}
+	if selected == 0 {
+		t.Skip("Set TEST_IO_UNIQUE_DEVICE or TEST_IO_MULTILEAF_DEVICE")
+	}
+}
+
+func runIOHealthRealCommandEvidence(
+	t *testing.T,
+	device string,
+	protocol health.EvidenceProtocol,
+	triggerType string,
+) {
+	t.Helper()
+
+	collector := newIOHealthCollector("/sys", "/proc/mdstat")
+	saved := make(chan recordedIOHealthEvent, 1)
+	collector.saveEvent = func(at time.Time, event types.IOHealthEvent) error {
+		saved <- recordedIOHealthEvent{at: at, event: event}
+		return nil
+	}
+	worker := health.NewEvidenceWorker(health.EvidenceWorkerOptions{
+		OnResult: collector.handleEvidenceResult,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	defer func() {
+		cancel()
+		worker.Wait()
+	}()
+
+	triggeredAt := time.Now()
+	if !worker.Submit(health.EvidenceRequest{
+		Trigger: types.IOHealthEvent{
+			Type:   triggerType,
+			Device: device,
+		},
+		Target:      device,
+		Protocol:    protocol,
+		TriggeredAt: triggeredAt,
+	}) {
+		t.Fatal("production evidence worker rejected the explicit device")
+	}
+
+	select {
+	case got := <-saved:
+		if got.at != triggeredAt ||
+			got.event.Device != device ||
+			got.event.Type != triggerType {
+			t.Fatalf("saved event = %+v", got)
+		}
+		if got.event.CollectionStatus != "ok" &&
+			got.event.CollectionStatus != "partial" {
+			t.Fatalf("collection status = %q", got.event.CollectionStatus)
+		}
+		switch protocol {
+		case health.EvidenceProtocolNVMe:
+			if got.event.NVMe == nil || got.event.SCSI != nil {
+				t.Fatalf("NVMe evidence = %+v", got.event)
+			}
+		case health.EvidenceProtocolSCSI:
+			if got.event.SCSI == nil || got.event.NVMe != nil {
+				t.Fatalf("SCSI evidence = %+v", got.event)
+			}
+		}
+	case <-time.After(ioHealthIntegrationResultTimeout):
+		t.Fatal("timed out waiting for health command evidence")
+	}
+}
+
+func requireIOHealthIntegrationDevice(
+	t *testing.T,
+	rawDevice, envName string,
+	protocol health.EvidenceProtocol,
+) string {
+	t.Helper()
+
+	device := rawDevice
+	if filepath.IsAbs(device) {
+		if filepath.Clean(device) != device || filepath.Dir(device) != "/dev" {
+			t.Fatalf("%s must be /dev/<name> or <name>, got %q", envName, rawDevice)
+		}
+		device = filepath.Base(device)
+	}
+	if _, valid := healthCommandTargetForTest(device); !valid {
+		t.Fatalf("%s has an invalid device name %q", envName, rawDevice)
+	}
+	path := filepath.Join("/dev", device)
+	var stat unix.Stat_t
+	if err := unix.Stat(path, &stat); err != nil {
+		t.Skipf("stat %s: %v", path, err)
+	}
+
+	switch protocol {
+	case health.EvidenceProtocolNVMe:
+		if !ioHealthNVMeControllerPattern.MatchString(device) {
+			t.Fatalf("%s must name an NVMe controller", envName)
+		}
+		if stat.Mode&unix.S_IFMT != unix.S_IFCHR {
+			t.Skipf("%s is not an NVMe controller character device", path)
+		}
+		if _, err := os.Stat(filepath.Join("/sys/class/nvme", device)); err != nil {
+			t.Skipf("resolve %s in sysfs: %v", device, err)
+		}
+	case health.EvidenceProtocolSCSI:
+		if !strings.HasPrefix(device, "sd") {
+			t.Fatalf("%s must name a SCSI disk", envName)
+		}
+		if stat.Mode&unix.S_IFMT != unix.S_IFBLK {
+			t.Skipf("%s is not a block device", path)
+		}
+	}
+	return device
+}
+
+func healthCommandTargetForTest(target string) (string, bool) {
+	if target == "" || target == "." || target == ".." ||
+		filepath.Base(target) != target || strings.ContainsAny(target, `/\`) {
+		return "", false
+	}
+	for _, value := range target {
+		if value >= 'a' && value <= 'z' ||
+			value >= 'A' && value <= 'Z' ||
+			value >= '0' && value <= '9' ||
+			value == '-' || value == '_' || value == '.' {
+			continue
+		}
+		return "", false
+	}
+	return target, true
+}

--- a/core/metrics/io_health_resolver.go
+++ b/core/metrics/io_health_resolver.go
@@ -46,6 +46,7 @@ type ioHealthResolver struct {
 	sysDevBlockPath   string
 	sysClassBlockPath string
 	sysClassSCSIPath  string
+	sysClassNVMePath  string
 }
 
 func newIOHealthResolver(sysRoot string) ioHealthResolver {
@@ -53,7 +54,34 @@ func newIOHealthResolver(sysRoot string) ioHealthResolver {
 		sysDevBlockPath:   filepath.Join(sysRoot, "dev", "block"),
 		sysClassBlockPath: filepath.Join(sysRoot, "class", "block"),
 		sysClassSCSIPath:  filepath.Join(sysRoot, "class", "scsi_device"),
+		sysClassNVMePath:  filepath.Join(sysRoot, "class", "nvme"),
 	}
+}
+
+func (r ioHealthResolver) primeNVMeControllerNames() error {
+	entries, err := os.ReadDir(r.sysClassNVMePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var firstErr error
+	for _, entry := range entries {
+		controller := entry.Name()
+		if !ioHealthNVMeControllerPattern.MatchString(controller) {
+			continue
+		}
+		if _, err := os.ReadFile(filepath.Join(
+			r.sysClassNVMePath,
+			controller,
+			"state",
+		)); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("read %s state: %w", controller, err)
+		}
+	}
+	return firstErr
 }
 
 func (r ioHealthResolver) resolveBlockDevice(dev uint32) ioHealthResolvedTarget {

--- a/core/metrics/io_health_resolver.go
+++ b/core/metrics/io_health_resolver.go
@@ -1,0 +1,230 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"huatuo-bamai/internal/ioobserve/health"
+)
+
+const (
+	ioHealthProtocolNVMe = "nvme"
+	ioHealthProtocolSCSI = "scsi"
+)
+
+var (
+	ioHealthNVMeNamespacePattern  = regexp.MustCompile(`^nvme[0-9]+(?:c([0-9]+))?n[0-9]+$`)
+	ioHealthNVMeControllerPattern = regexp.MustCompile(`^nvme[0-9]+$`)
+)
+
+type ioHealthResolvedTarget struct {
+	eventDevice string
+	target      string
+	protocol    string
+	reason      string
+}
+
+type ioHealthResolver struct {
+	sysDevBlockPath   string
+	sysClassBlockPath string
+	sysClassSCSIPath  string
+}
+
+func newIOHealthResolver(sysRoot string) ioHealthResolver {
+	return ioHealthResolver{
+		sysDevBlockPath:   filepath.Join(sysRoot, "dev", "block"),
+		sysClassBlockPath: filepath.Join(sysRoot, "class", "block"),
+		sysClassSCSIPath:  filepath.Join(sysRoot, "class", "scsi_device"),
+	}
+}
+
+func (r ioHealthResolver) resolveBlockDevice(dev uint32) ioHealthResolvedTarget {
+	major := dev >> 20
+	minor := dev & ((1 << 20) - 1)
+	resolved, err := filepath.EvalSymlinks(filepath.Join(
+		r.sysDevBlockPath,
+		fmt.Sprintf("%d:%d", major, minor),
+	))
+	if err != nil {
+		return ioHealthResolvedTarget{
+			eventDevice: "unknown",
+			reason:      health.CollectionReasonTargetUnresolved,
+		}
+	}
+
+	device := filepath.Base(resolved)
+	if _, err := os.Stat(filepath.Join(resolved, "partition")); err == nil {
+		device = filepath.Base(filepath.Dir(resolved))
+	}
+	return r.resolveBlockName(device)
+}
+
+func (r ioHealthResolver) resolveBlockName(device string) ioHealthResolvedTarget {
+	if device == "" {
+		device = "unknown"
+	}
+	leaves, err := r.blockLeaves(device, make(map[string]bool))
+	if err != nil {
+		return ioHealthResolvedTarget{
+			eventDevice: device,
+			reason:      health.CollectionReasonTargetUnresolved,
+		}
+	}
+	if len(leaves) != 1 {
+		return ioHealthResolvedTarget{
+			eventDevice: device,
+			reason:      health.CollectionReasonTargetUnsupported,
+		}
+	}
+
+	target := leaves[0]
+	if match := ioHealthNVMeNamespacePattern.FindStringSubmatch(target); match != nil {
+		controller, ok := r.nvmeController(target, match[1])
+		if !ok {
+			return ioHealthResolvedTarget{
+				eventDevice: device,
+				reason:      health.CollectionReasonTargetUnsupported,
+			}
+		}
+		return ioHealthResolvedTarget{
+			eventDevice: device,
+			target:      controller,
+			protocol:    ioHealthProtocolNVMe,
+		}
+	}
+	if strings.HasPrefix(target, "sd") {
+		return ioHealthResolvedTarget{
+			eventDevice: device,
+			target:      target,
+			protocol:    ioHealthProtocolSCSI,
+		}
+	}
+	return ioHealthResolvedTarget{
+		eventDevice: device,
+		reason:      health.CollectionReasonTargetUnsupported,
+	}
+}
+
+func (r ioHealthResolver) blockLeaves(device string, visiting map[string]bool) ([]string, error) {
+	var err error
+	device, err = r.wholeDisk(device)
+	if err != nil {
+		return nil, err
+	}
+	if visiting[device] {
+		return nil, fmt.Errorf("block device dependency cycle at %s", device)
+	}
+	visiting[device] = true
+	defer delete(visiting, device)
+
+	entries, err := os.ReadDir(filepath.Join(r.sysClassBlockPath, device, "slaves"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{device}, nil
+		}
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return []string{device}, nil
+	}
+
+	unique := make(map[string]bool)
+	for _, entry := range entries {
+		leaves, err := r.blockLeaves(entry.Name(), visiting)
+		if err != nil {
+			return nil, err
+		}
+		for _, leaf := range leaves {
+			unique[leaf] = true
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for leaf := range unique {
+		result = append(result, leaf)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func (r ioHealthResolver) wholeDisk(device string) (string, error) {
+	path := filepath.Join(r.sysClassBlockPath, device)
+	if _, err := os.Stat(path); err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(filepath.Join(path, "partition")); err != nil {
+		if os.IsNotExist(err) {
+			return device, nil
+		}
+		return "", err
+	}
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	parent := filepath.Base(filepath.Dir(resolved))
+	if parent == "" || parent == "." || parent == string(filepath.Separator) {
+		return "", fmt.Errorf("resolve whole disk for %s", device)
+	}
+	return parent, nil
+}
+
+func (r ioHealthResolver) nvmeController(namespace, controllerInstance string) (string, bool) {
+	if controllerInstance != "" {
+		return "nvme" + controllerInstance, true
+	}
+
+	resolved, err := filepath.EvalSymlinks(filepath.Join(
+		r.sysClassBlockPath,
+		namespace,
+		"device",
+	))
+	if err != nil {
+		return "", false
+	}
+	for path := resolved; ; path = filepath.Dir(path) {
+		name := filepath.Base(path)
+		if ioHealthNVMeControllerPattern.MatchString(name) {
+			return name, true
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", false
+		}
+	}
+}
+
+func (r ioHealthResolver) resolveSCSI(host, channel, target, lun uint32) ioHealthResolvedTarget {
+	hctl := fmt.Sprintf("%d:%d:%d:%d", host, channel, target, lun)
+	entries, err := os.ReadDir(filepath.Join(r.sysClassSCSIPath, hctl, "device", "block"))
+	if err != nil || len(entries) != 1 {
+		return ioHealthResolvedTarget{
+			eventDevice: "unknown",
+			reason:      health.CollectionReasonTargetUnresolved,
+		}
+	}
+	device := entries[0].Name()
+	return ioHealthResolvedTarget{
+		eventDevice: device,
+		target:      device,
+		protocol:    ioHealthProtocolSCSI,
+	}
+}

--- a/core/metrics/io_health_resolver_test.go
+++ b/core/metrics/io_health_resolver_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/ioobserve/health"
+)
+
+func TestIOHealthResolverNormalizesRecursivePartitionLeaf(t *testing.T) {
+	root := t.TempDir()
+	physical := filepath.Join(root, "devices", "block", "sda")
+	partition := filepath.Join(physical, "sda1")
+	if err := os.MkdirAll(filepath.Join(physical, "slaves"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(partition, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(partition, "partition"), []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	classBlock := filepath.Join(root, "class", "block")
+	if err := os.MkdirAll(filepath.Join(classBlock, "dm-0", "slaves"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physical, filepath.Join(classBlock, "sda")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(partition, filepath.Join(classBlock, "sda1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(
+		partition,
+		filepath.Join(classBlock, "dm-0", "slaves", "sda1"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	target := newIOHealthResolver(root).resolveBlockName("dm-0")
+	if target.eventDevice != "dm-0" ||
+		target.target != "sda" ||
+		target.protocol != ioHealthProtocolSCSI ||
+		target.reason != "" {
+		t.Fatalf("resolved target = %+v", target)
+	}
+}
+
+func TestIOHealthResolverRejectsMultipleLeaves(t *testing.T) {
+	root := t.TempDir()
+	classBlock := filepath.Join(root, "class", "block")
+	for _, device := range []string{"sda", "sdb"} {
+		if err := os.MkdirAll(
+			filepath.Join(classBlock, device, "slaves"),
+			0o755,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(classBlock, "dm-0", "slaves"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, device := range []string{"sda", "sdb"} {
+		if err := os.Symlink(
+			filepath.Join(classBlock, device),
+			filepath.Join(classBlock, "dm-0", "slaves", device),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	target := newIOHealthResolver(root).resolveBlockName("dm-0")
+	if target.reason != health.CollectionReasonTargetUnsupported ||
+		target.target != "" {
+		t.Fatalf("resolved target = %+v", target)
+	}
+}
+
+func TestIOHealthResolverUsesExplicitNVMeControllerPath(t *testing.T) {
+	root := t.TempDir()
+	classBlock := filepath.Join(root, "class", "block")
+	if err := os.MkdirAll(
+		filepath.Join(classBlock, "nvme0c1n1", "slaves"),
+		0o755,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	target := newIOHealthResolver(root).resolveBlockName("nvme0c1n1")
+	if target.target != "nvme1" ||
+		target.protocol != ioHealthProtocolNVMe ||
+		target.reason != "" {
+		t.Fatalf("resolved target = %+v", target)
+	}
+}
+
+func TestIOHealthResolverRejectsUnattributedNVMeMultipathHead(t *testing.T) {
+	root := t.TempDir()
+	namespace := filepath.Join(
+		root,
+		"devices",
+		"virtual",
+		"nvme-subsystem",
+		"nvme-subsys0",
+		"nvme0n1",
+	)
+	if err := os.MkdirAll(namespace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	classNamespace := filepath.Join(root, "class", "block", "nvme0n1")
+	if err := os.MkdirAll(filepath.Join(classNamespace, "slaves"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(namespace, filepath.Join(classNamespace, "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	target := newIOHealthResolver(root).resolveBlockName("nvme0n1")
+	if target.reason != health.CollectionReasonTargetUnsupported || target.target != "" {
+		t.Fatalf("resolved target = %+v", target)
+	}
+}
+
+func TestIOHealthResolverTreatsMissingDeviceAsUnresolved(t *testing.T) {
+	target := newIOHealthResolver(t.TempDir()).resolveBlockName("gone")
+	if target.reason != health.CollectionReasonTargetUnresolved {
+		t.Fatalf("resolved target = %+v", target)
+	}
+}

--- a/core/metrics/io_health_resolver_test.go
+++ b/core/metrics/io_health_resolver_test.go
@@ -143,3 +143,33 @@ func TestIOHealthResolverTreatsMissingDeviceAsUnresolved(t *testing.T) {
 		t.Fatalf("resolved target = %+v", target)
 	}
 }
+
+func TestIOHealthResolverPrimesOnlyControllerStateFiles(t *testing.T) {
+	root := t.TempDir()
+	nvmeClass := filepath.Join(root, "class", "nvme")
+	controllerState := filepath.Join(nvmeClass, "nvme0", "state")
+	if err := os.MkdirAll(filepath.Dir(controllerState), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(controllerState, []byte("live\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ignoredState := filepath.Join(nvmeClass, "nvme0n1", "state")
+	if err := os.MkdirAll(ignoredState, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := newIOHealthResolver(root)
+	if err := resolver.primeNVMeControllerNames(); err != nil {
+		t.Fatalf("primeNVMeControllerNames() error = %v", err)
+	}
+	if err := os.Remove(controllerState); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(controllerState, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := resolver.primeNVMeControllerNames(); err == nil {
+		t.Fatal("primeNVMeControllerNames() error = nil, want state read error")
+	}
+}

--- a/core/metrics/io_health_runtime.go
+++ b/core/metrics/io_health_runtime.go
@@ -16,12 +16,154 @@ package collector
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"time"
 
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/ioobserve/health"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/pkg/types"
 )
 
-const ioHealthMDRetryInterval = 10 * time.Second
+const (
+	ioHealthRestartWait      = 10
+	ioHealthEventMap         = "health_events"
+	ioHealthPerfBufferBytes  = 8192
+	ioHealthBPFRetryInterval = ioHealthRestartWait * time.Second
+	ioHealthMDRetryInterval  = ioHealthRestartWait * time.Second
+)
+
+type ioHealthBPFLoader func(string, map[string]any) (bpf.BPF, error)
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/io_health.c -o $BPF_DIR/io_health.o
+
+func (c *ioHealthCollector) Start(ctx context.Context) error {
+	return c.start(ctx, bpf.LoadBPF, ioHealthBPFRetryInterval)
+}
+
+func (c *ioHealthCollector) start(
+	ctx context.Context,
+	loadBPF ioHealthBPFLoader,
+	retryInterval time.Duration,
+) error {
+	childCtx, cancel := context.WithCancel(ctx)
+	worker := health.NewEvidenceWorker(health.EvidenceWorkerOptions{
+		OnResult: c.handleEvidenceResult,
+	})
+	worker.Start(childCtx)
+
+	mdRetry := time.NewTicker(ioHealthMDRetryInterval)
+	var consumers sync.WaitGroup
+	consumers.Add(1)
+	go func() {
+		defer consumers.Done()
+		c.superviseMDWatcher(childCtx, worker, mdRetry.C)
+	}()
+
+	defer func() {
+		cancel()
+		mdRetry.Stop()
+		consumers.Wait()
+		worker.Wait()
+	}()
+
+	for {
+		attached, retryable, err := c.runBPFSession(childCtx, worker, loadBPF)
+		if ctx.Err() != nil {
+			if retryable {
+				return nil
+			}
+			return err
+		}
+		if err != nil {
+			if !retryable {
+				log.Warnf("io_health: kernel event source disabled: %v", err)
+				<-ctx.Done()
+				return nil
+			}
+			log.Warnf("io_health: kernel event source failed: %v; will retry", err)
+			if !waitIOHealthRetryAfter(ctx, retryInterval) {
+				return nil
+			}
+			continue
+		}
+		if attached == 0 {
+			log.Warnf(
+				"io_health: no kernel health hook is available; MD monitoring remains active",
+			)
+			<-ctx.Done()
+			return nil
+		}
+		if !waitIOHealthRetryAfter(ctx, retryInterval) {
+			return nil
+		}
+	}
+}
+
+func (c *ioHealthCollector) runBPFSession(
+	ctx context.Context,
+	worker ioHealthEvidenceSubmitter,
+	loadBPF ioHealthBPFLoader,
+) (attached int, retryable bool, retErr error) {
+	object, err := loadBPF("io_health.o", nil)
+	if err != nil {
+		return 0, true, fmt.Errorf("load BPF: %w", err)
+	}
+	defer func() {
+		if err := object.Close(); err != nil {
+			retryable = false
+			retErr = errors.Join(retErr, fmt.Errorf("close BPF: %w", err))
+		}
+	}()
+
+	reader, err := object.EventPipeByName(
+		ctx,
+		ioHealthEventMap,
+		ioHealthPerfBufferBytes,
+	)
+	if err != nil {
+		return 0, true, fmt.Errorf("open event pipe: %w", err)
+	}
+	defer func() {
+		if err := reader.Close(); err != nil {
+			retryable = false
+			retErr = errors.Join(retErr, fmt.Errorf("close event pipe: %w", err))
+		}
+	}()
+
+	attached = attachIOHealthHooks(
+		object,
+		c.resolver.primeNVMeControllerNames,
+		ioHealthLegacyBlockCompleteSupported(ioHealthHostKernelRelease),
+	)
+	if attached == 0 {
+		return 0, false, nil
+	}
+
+	for {
+		var event ioHealthPerfEvent
+		if err := reader.ReadInto(&event); err != nil {
+			if ctx.Err() != nil || errors.Is(err, types.ErrExitByCancelCtx) {
+				return attached, false, nil
+			}
+			return attached, true, fmt.Errorf("read event: %w", err)
+		}
+		c.handleKernelEvent(event, worker)
+	}
+}
+
+func waitIOHealthRetryAfter(ctx context.Context, interval time.Duration) bool {
+	retry := time.NewTimer(interval)
+	defer retry.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-retry.C:
+		return true
+	}
+}
 
 func (c *ioHealthCollector) superviseMDWatcher(
 	ctx context.Context,
@@ -71,7 +213,7 @@ func (c *ioHealthCollector) consumeMDWatcher(
 		select {
 		case <-ctx.Done():
 			<-waitResult
-			return ctx.Err()
+			return c.finishMDWatcher(ctx.Err(), changes, worker)
 		case change, ok := <-changes:
 			if ok {
 				c.handleMDChange(change, worker)
@@ -79,9 +221,28 @@ func (c *ioHealthCollector) consumeMDWatcher(
 				changes = nil
 			}
 		case err := <-waitResult:
+			return c.finishMDWatcher(err, changes, worker)
+		}
+	}
+}
+
+func (c *ioHealthCollector) finishMDWatcher(
+	err error,
+	changes <-chan health.MDChange,
+	worker ioHealthEvidenceSubmitter,
+) error {
+	for changes != nil {
+		select {
+		case change, ok := <-changes:
+			if !ok {
+				return err
+			}
+			c.handleMDChange(change, worker)
+		default:
 			return err
 		}
 	}
+	return err
 }
 
 func waitIOHealthRetry(ctx context.Context, retry <-chan time.Time) bool {

--- a/core/metrics/io_health_runtime.go
+++ b/core/metrics/io_health_runtime.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"time"
+
+	"huatuo-bamai/internal/log"
+)
+
+const ioHealthMDRetryInterval = 10 * time.Second
+
+func (c *ioHealthCollector) superviseMDWatcher(
+	ctx context.Context,
+	worker ioHealthEvidenceSubmitter,
+	retry <-chan time.Time,
+) {
+	for {
+		watcher := c.newMDWatcher(c.procMDStatPath, c.sysBlockPath)
+		if err := watcher.Start(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Warnf("io_health: start MD watcher: %v; will retry", err)
+			if !waitIOHealthRetry(ctx, retry) {
+				return
+			}
+			continue
+		}
+
+		err := c.consumeMDWatcher(ctx, watcher, worker)
+		if ctx.Err() != nil {
+			return
+		}
+		if err == nil {
+			log.Warnf("io_health: MD watcher stopped; will retry")
+		} else {
+			log.Warnf("io_health: MD watcher failed: %v; will retry", err)
+		}
+		if !waitIOHealthRetry(ctx, retry) {
+			return
+		}
+	}
+}
+
+func (c *ioHealthCollector) consumeMDWatcher(
+	ctx context.Context,
+	watcher ioHealthMDWatcher,
+	worker ioHealthEvidenceSubmitter,
+) error {
+	waitResult := make(chan error, 1)
+	go func() {
+		waitResult <- watcher.Wait()
+	}()
+
+	changes := watcher.Changes()
+	for {
+		select {
+		case <-ctx.Done():
+			<-waitResult
+			return ctx.Err()
+		case change, ok := <-changes:
+			if ok {
+				c.handleMDChange(change, worker)
+			} else {
+				changes = nil
+			}
+		case err := <-waitResult:
+			return err
+		}
+	}
+}
+
+func waitIOHealthRetry(ctx context.Context, retry <-chan time.Time) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-retry:
+		return true
+	}
+}

--- a/core/metrics/io_health_runtime_test.go
+++ b/core/metrics/io_health_runtime_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/ioobserve/health"
+	"huatuo-bamai/pkg/types"
+)
+
+type fakeIOHealthMDWatcher struct {
+	startErr error
+	changes  chan health.MDChange
+	stop     chan error
+	ctx      context.Context
+}
+
+type fakeIOHealthPerfReader struct {
+	ctx context.Context
+}
+
+func (r *fakeIOHealthPerfReader) ReadInto(any) error {
+	<-r.ctx.Done()
+	return types.ErrExitByCancelCtx
+}
+
+func (r *fakeIOHealthPerfReader) ReadBatch(func() any) ([]any, error) {
+	return nil, errors.New("unexpected batch read")
+}
+
+func (r *fakeIOHealthPerfReader) Close() error {
+	return nil
+}
+
+type fakeIOHealthRuntimeBPF struct {
+	bpf.BPF
+}
+
+func (b *fakeIOHealthRuntimeBPF) AttachWithOptions([]bpf.AttachOption) error {
+	return nil
+}
+
+func (b *fakeIOHealthRuntimeBPF) DetachProgram(string) error {
+	return nil
+}
+
+func (b *fakeIOHealthRuntimeBPF) EventPipeByName(
+	ctx context.Context,
+	_ string,
+	_ uint32,
+) (bpf.PerfEventReader, error) {
+	return &fakeIOHealthPerfReader{ctx: ctx}, nil
+}
+
+func (b *fakeIOHealthRuntimeBPF) Close() error {
+	return nil
+}
+
+func newFakeIOHealthMDWatcher() *fakeIOHealthMDWatcher {
+	return &fakeIOHealthMDWatcher{
+		changes: make(chan health.MDChange, 1),
+		stop:    make(chan error, 1),
+	}
+}
+
+func (w *fakeIOHealthMDWatcher) Start(ctx context.Context) error {
+	if w.startErr != nil {
+		return w.startErr
+	}
+	w.ctx = ctx
+	return nil
+}
+
+func (w *fakeIOHealthMDWatcher) Wait() error {
+	select {
+	case err := <-w.stop:
+		return err
+	case <-w.ctx.Done():
+		return nil
+	}
+}
+
+func (w *fakeIOHealthMDWatcher) Changes() <-chan health.MDChange {
+	return w.changes
+}
+
+func waitIOHealthAttempt(t *testing.T, attempts <-chan int, want int) {
+	t.Helper()
+	select {
+	case got := <-attempts:
+		if got != want {
+			t.Fatalf("watcher attempt = %d, want %d", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for watcher attempt %d", want)
+	}
+}
+
+func TestIOHealthMDSupervisorRetriesStartAndRuntimeFailures(t *testing.T) {
+	watchers := []*fakeIOHealthMDWatcher{
+		{startErr: errors.New("incomplete baseline")},
+		newFakeIOHealthMDWatcher(),
+		newFakeIOHealthMDWatcher(),
+	}
+	collector := newIOHealthCollector(t.TempDir(), filepath.Join(t.TempDir(), "mdstat"))
+	attempts := make(chan int, len(watchers))
+	next := 0
+	collector.newMDWatcher = func(string, string) ioHealthMDWatcher {
+		next++
+		attempts <- next
+		return watchers[next-1]
+	}
+	saved := make(chan types.IOHealthEvent, 1)
+	collector.saveEvent = func(_ time.Time, event types.IOHealthEvent) error {
+		saved <- event
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	retry := make(chan time.Time, 2)
+	done := make(chan struct{})
+	go func() {
+		collector.superviseMDWatcher(
+			ctx,
+			&recordingEvidenceSubmitter{accept: true},
+			retry,
+		)
+		close(done)
+	}()
+
+	waitIOHealthAttempt(t, attempts, 1)
+	retry <- time.Now()
+	waitIOHealthAttempt(t, attempts, 2)
+	watchers[1].stop <- errors.New("poll failed")
+	retry <- time.Now()
+	waitIOHealthAttempt(t, attempts, 3)
+	watchers[2].changes <- health.MDChange{
+		Array:      "md0",
+		Field:      health.MDFieldSyncAction,
+		OldState:   "idle",
+		NewState:   "recover",
+		ObservedAt: time.Unix(1, 2),
+	}
+	select {
+	case event := <-saved:
+		if event.Type != ioHealthTypeMDSyncAction || event.Array != "md0" {
+			t.Fatalf("saved MD event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for MD event after restart")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("MD supervisor did not stop after cancellation")
+	}
+}
+
+func TestIOHealthFinishMDWatcherDrainsChanges(t *testing.T) {
+	collector := newIOHealthCollector(t.TempDir(), filepath.Join(t.TempDir(), "mdstat"))
+	changes := make(chan health.MDChange, 1)
+	changes <- health.MDChange{
+		Array:      "md0",
+		Field:      health.MDFieldSyncAction,
+		OldState:   "idle",
+		NewState:   "recover",
+		ObservedAt: time.Unix(1, 2),
+	}
+
+	saved := make(chan types.IOHealthEvent, 1)
+	collector.saveEvent = func(_ time.Time, event types.IOHealthEvent) error {
+		saved <- event
+		return nil
+	}
+	err := collector.finishMDWatcher(
+		errors.New("poll failed"),
+		changes,
+		&recordingEvidenceSubmitter{accept: true},
+	)
+	if err == nil || err.Error() != "poll failed" {
+		t.Fatalf("watcher error = %v, want poll failed", err)
+	}
+	select {
+	case event := <-saved:
+		if event.Type != ioHealthTypeMDSyncAction {
+			t.Fatalf("saved drained MD event = %+v", event)
+		}
+	default:
+		t.Fatal("buffered MD event was not drained")
+	}
+}
+
+func TestIOHealthStartKeepsMDActiveAcrossBPFLoadFailures(t *testing.T) {
+	collector := newIOHealthCollector(t.TempDir(), filepath.Join(t.TempDir(), "mdstat"))
+	watcher := newFakeIOHealthMDWatcher()
+	mdStarted := make(chan struct{}, 1)
+	mdAttempts := 0
+	collector.newMDWatcher = func(string, string) ioHealthMDWatcher {
+		mdAttempts++
+		mdStarted <- struct{}{}
+		return watcher
+	}
+	saved := make(chan types.IOHealthEvent, 1)
+	collector.saveEvent = func(_ time.Time, event types.IOHealthEvent) error {
+		saved <- event
+		return nil
+	}
+	bpfAttempts := make(chan int, 2)
+	releaseFirstLoad := make(chan struct{})
+	attempt := 0
+	loadBPF := func(string, map[string]any) (bpf.BPF, error) {
+		attempt++
+		bpfAttempts <- attempt
+		if attempt == 1 {
+			<-releaseFirstLoad
+			return nil, errors.New("BPF unavailable")
+		}
+		return &fakeIOHealthRuntimeBPF{}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- collector.start(ctx, loadBPF, time.Millisecond)
+	}()
+
+	select {
+	case <-mdStarted:
+	case <-time.After(time.Second):
+		t.Fatal("MD watcher did not start")
+	}
+	watcher.changes <- health.MDChange{
+		Array:      "md0",
+		Field:      health.MDFieldSyncAction,
+		OldState:   "idle",
+		NewState:   "recover",
+		ObservedAt: time.Unix(1, 2),
+	}
+	select {
+	case event := <-saved:
+		if event.Type != ioHealthTypeMDSyncAction {
+			t.Fatalf("saved MD event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("MD watcher did not consume changes during BPF failures")
+	}
+	waitIOHealthAttempt(t, bpfAttempts, 1)
+	close(releaseFirstLoad)
+	waitIOHealthAttempt(t, bpfAttempts, 2)
+	select {
+	case err := <-done:
+		t.Fatalf("collector stopped after BPF failure: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("collector stop error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stop after cancellation")
+	}
+	if mdAttempts != 1 {
+		t.Fatalf("MD watcher starts = %d, want 1", mdAttempts)
+	}
+}
+
+func TestIOHealthCancellationDuringBPFLoadIsNormal(t *testing.T) {
+	collector := newIOHealthCollector(t.TempDir(), filepath.Join(t.TempDir(), "mdstat"))
+	watcher := newFakeIOHealthMDWatcher()
+	collector.newMDWatcher = func(string, string) ioHealthMDWatcher {
+		return watcher
+	}
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	loadBPF := func(string, map[string]any) (bpf.BPF, error) {
+		close(loadStarted)
+		<-releaseLoad
+		return nil, errors.New("BPF unavailable")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- collector.start(ctx, loadBPF, time.Hour)
+	}()
+	<-loadStarted
+	cancel()
+	close(releaseLoad)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("collector stop error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stop after cancellation")
+	}
+}

--- a/docs/development/io_monitoring_zh.md
+++ b/docs/development/io_monitoring_zh.md
@@ -1,0 +1,177 @@
+# IO 监测
+
+## 实现边界
+
+`iotracing` 是 `/proc/diskstats` 的唯一读取者。它持续计算相邻两次
+成功读取之间的 delta，并将同一个最新完整窗口用于 Prometheus 和
+自动诊断。诊断子进程运行时采样不会停止，也不会建立历史队列或第二个
+reader。
+
+`io_health` 记录 block、NVMe、SCSI 异常以及 NVMe、MD 状态变化事件。
+健康命令只在事件能唯一定位到一个 NVMe 或 SCSI 设备时执行；NVMe
+reset 只记录事件和 Counter。
+MD 生产代码只读取 `/proc/mdstat` 和 sysfs，不调用 `mdadm`。该模块不
+导出最近一次取证或设备当前状态。
+
+## 配置
+
+```toml
+[AutoTracing.IOTracing]
+    Interval = 5
+
+[MetricCollector.IOHealth]
+    Enabled = true
+```
+
+`Interval` 是 diskstats 采样周期，单位为秒。将 `iotracing` 加入
+`BlackList` 会同时关闭 diskstats 指标和自动诊断。
+
+## 采集字段与触发条件
+
+`iotracing` 使用设备名、major、minor 识别同一块整盘；read/write I/O
+次数计算 IOPS 和 await，sector 数按 512 字节计算 BPS，read/write ticks
+计算 await，I/O ticks 和 weighted I/O ticks 分别计算 util 和平均队列
+长度。计算使用相邻样本的实际间隔；分区及 loop、ram、zram、fd 等伪
+设备不进入结果。
+
+`io_health` 只抓取定位和分类事件需要的字段：
+
+| 事件 | 触发条件 | 抓取字段及用途 |
+| --- | --- | --- |
+| `block_error` | 优先使用 `block_rq_error`；Linux 4.18–5.15 在该 tracepoint 不存在时从 `block_rq_complete` 筛选负 errno 的普通数据请求 | dev 定位整盘，sector 记录起始位置，errno 和 operation 分类错误 |
+| `nvme_timeout` | 进入 `nvme_timeout` | request 对应的 dev 用于定位整盘 |
+| `nvme_reset` | 进入 `nvme_reset_ctrl` | controller 映射为 `nvmeN`；只记录，不执行 `nvme-cli` |
+| `nvme_state_change` | `nvme_change_ctrl_state` 返回状态已改变 | controller 定位设备，raw state 保留内核枚举值 |
+| `scsi_timeout` | 发出 `scsi_dispatch_cmd_timeout` | host、channel、id、lun 通过 sysfs 定位磁盘 |
+| `scsi_dispatch_error` | 发出 `scsi_dispatch_cmd_error` | HCTL 定位磁盘，return status 分类失败 |
+| `md_sync_action` | 初始扫描后 `sync_action` 变化 | array 和新旧值记录同步动作变化 |
+| `md_degraded` | 初始扫描后 `degraded` 变化 | array 和新旧值记录不可用成员数变化 |
+| `md_member_state` | 初始扫描后成员 state 变化或成员消失 | array、member 和新旧值记录成员变化 |
+
+HCTL、`dev_t`、controller 指针、`/proc/mdstat` 的 active 阵列和 sysfs
+`level` 仅用于解析或重建拓扑，不作为公共字段输出。NVMe 和 MD 状态事件
+也包含恢复、进入 `idle` 等正常方向的变化。
+
+`block_error`、NVMe timeout、SCSI 异常和进入 `faulty`、`blocked`、
+`write_error`、`removed` 的 MD 成员会尝试取证。只有唯一定位到 NVMe 或
+SCSI 设备时才执行命令，其他事件仍会保存。
+
+`iotracing` 自动诊断与健康事件相互独立。阈值必须连续两个完整窗口都
+超过：非 NVMe 设备可由 util 触发；NVMe 要求 util 与对应方向 BPS 同时
+超限；read/write await 也可以分别触发。
+
+## 输出字段
+
+### Prometheus 指标
+
+`huatuo_bamai_iotracing_` 下的指标都带 `device` 标签：
+
+- `read_bytes_per_second`、`write_bytes_per_second`：读写 BPS。
+- `read_iops`、`write_iops`：每秒读写操作数。
+- `read_await_seconds`、`write_await_seconds`：读写平均完成时间。
+- `io_utilization_percent`：磁盘忙碌时间占比。
+- `average_queue_size`：平均 I/O 队列长度。
+
+scrape 只读取 sampler 发布的不可变快照，不会再次读取 diskstats。
+
+`huatuo_bamai_io_health_` 输出进程启动后累计的 Counter：
+
+| 指标后缀 | 标签 | 含义 |
+| --- | --- | --- |
+| `block_errors_total` | device、operation、status | block 层错误次数 |
+| `nvme_timeouts_total` | device | NVMe timeout 次数 |
+| `nvme_resets_total` | device | NVMe controller reset 次数 |
+| `scsi_timeouts_total` | device | SCSI command timeout 次数 |
+| `scsi_dispatch_errors_total` | device、status | SCSI command 派发失败次数 |
+| `collection_errors_total` | device、reason | 事件触发的健康取证失败次数 |
+
+`reason` 当前包括 `target_unresolved`、`tool_unavailable`、
+`target_unsupported`、`timeout`、`exec_error`、`output_too_large` 和
+`parse_error`。
+
+MD 和 NVMe controller 状态变化只保存为事件，不导出当前状态 Gauge。
+
+### 健康事件
+
+每个事件单独保存。事件时间由外层 tracing 记录提供，`IOHealthEvent`
+本身按事件类型输出以下字段；不适用或未取得的可选字段会被省略：
+
+| 字段 | 含义 |
+| --- | --- |
+| `type` | 上表中的事件类型 |
+| `device` | 整盘设备名或 NVMe controller 名；无法定位时为 `unknown` |
+| `array`、`member` | MD 阵列及成员名 |
+| `old_state`、`new_state` | MD 的新旧值；NVMe 只输出翻译后的新状态 |
+| `new_state_raw` | NVMe controller 的原始状态枚举，防止 backport 造成误译 |
+| `operation`、`status`、`sector` | block 操作、归一化错误和请求起始 sector；sector 不含长度 |
+| `collection_status` | 取证结果：`ok`、`partial`、`unsupported`、`timeout` 或 `error` |
+| `nvme` | `nvme-cli` 返回并通过校验的 NVMe 白名单证据 |
+| `scsi` | `smartctl` 返回并通过校验的 SCSI 白名单证据 |
+
+NVMe 证据中，`critical_warning` 是健康警告位图，`media_errors_total` 是
+介质或数据完整性错误累计值；最多 8 条 `error_log` 分别保留
+`status_code_type`、`status_code`、`nsid` 和 `lba`。`error_count`、
+`sqid` 只用于过滤，不输出。
+
+SCSI 证据中，`smart_passed` 是总体健康结论；`information_exception`
+保存 ASC/ASCQ；`temperature` 保存当前和告警温度；`grown_defect_count`
+保存新增缺陷数；read/write/verify 分别保存 `gigabytes_processed`、
+`delayed_corrections`、`reread_rewrite_corrections` 和
+`uncorrected_errors`；`pending_defects` 保存总数及最多 8 个样本 LBA。
+`smartctl.exit_status` 只用于区分命令失败和健康告警，不输出。
+
+## 实机功能验证
+
+以下测试必须显式开启。设备参数只能指向测试环境，禁止选择系统盘。
+
+验证真实 diskstats 读取和指标转换：
+
+```bash
+TEST_INTEGRATION=true TEST_IOSTAT_DEVICE=sda \
+go test ./core/autotracing -run '^TestIOTracingRealDiskstatsMetrics$' -v
+```
+
+验证生产代码实际执行 `nvme` 或 `smartctl` 只读命令：
+
+```bash
+TEST_INTEGRATION=true TEST_IO_CONFIRM_NON_SYSTEM=1 \
+TEST_NVME_DEVICE=/dev/nvme0 \
+go test ./core/metrics -run '^TestIOHealthRealCommandEvidence$' -v
+
+TEST_INTEGRATION=true TEST_IO_CONFIRM_NON_SYSTEM=1 \
+TEST_SCSI_DEVICE=/dev/sdb \
+go test ./core/metrics -run '^TestIOHealthRealCommandEvidence$' -v
+```
+
+NVMe/SCSI 用例要求安装对应的 `nvme-cli`/`smartctl`，并具有目标设备的
+读取权限，通常需使用 root。MD 和 block 用例必须使用 root。
+
+验证真实 sysfs 中唯一 leaf 和多 leaf 的取证边界：
+
+```bash
+TEST_INTEGRATION=true TEST_IO_UNIQUE_DEVICE=sdb \
+TEST_IO_MULTILEAF_DEVICE=md0 \
+go test ./core/metrics -run '^TestIOHealthRealTargetResolution$' -v
+```
+
+验证临时 MD RAID 的状态和成员事件：
+
+```bash
+TEST_INTEGRATION=true \
+go test ./internal/ioobserve/health \
+  -run '^TestMDWatcherMonitorsMdadmLoopArray$' -v
+```
+
+该测试用 `mdadm` 和 loop 设备创建、销毁测试夹具；若 `raid1` 尚未加载，
+测试会执行 `modprobe raid1`，且不会卸载该模块。生产代码不会执行这些
+命令。真实 block error 链路需要先构建 `huatuo-bamai` 和
+`_output/bpf/io_health.o`，再运行：
+
+```bash
+bash integration/run.sh test_io_health_event.sh
+```
+
+该用例优先测试 `block_rq_error`；Linux 4.18–5.15 会改测
+`block_rq_complete`，Linux 5.16–5.17 因 ABI 不受支持而跳过。
+
+性能测试只在代表性物理机执行，不在 oevm 虚拟机执行。

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -584,6 +584,11 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
     [MetricCollector.MountPointStat]
         MountPointsIncluded = "(^/home$)|(^/$)|(^/boot$)"
 
+    # Event-driven block, NVMe, SCSI, and MD health monitoring. External
+    # health commands run only when an event identifies one target device.
+    [MetricCollector.IOHealth]
+        Enabled = true
+
 # Pod Configuration
 #
 # Configure these parameters for fetching pods from kubelet.

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -321,7 +321,12 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
     # The number of files per process displayed by iotracing tool.
     # Default: 5
     #
+    # - Interval
+    # The /proc/diskstats sampling interval in seconds.
+    # Default: 5
+    #
     [AutoTracing.IOTracing]
+        # Interval = 5
         # WbpsThreshold = 1500
         # RbpsThreshold = 2000
         # UtilThreshold = 90

--- a/integration/test_io_health_event.sh
+++ b/integration/test_io_health_event.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exercise the production io_health EventPipe with a disposable loop device.
+# Its backing store is a sealed memfd, so a bounded loop write fails without
+# formatting, mounting, or touching a real block device.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+
+loop_device=""
+memfd_pid=""
+memfd_path_file="${HUATUO_BAMAI_TEST_TMPDIR}/memfd.path"
+memfd_seal_request="${HUATUO_BAMAI_TEST_TMPDIR}/memfd.seal"
+memfd_sealed="${HUATUO_BAMAI_TEST_TMPDIR}/memfd.sealed"
+memfd_stop="${HUATUO_BAMAI_TEST_TMPDIR}/memfd.stop"
+
+cleanup_io_health_fixture() {
+	local status=$?
+	local cleanup_failed=0
+	trap - EXIT
+	set +e
+	if [[ -n "${loop_device}" ]]; then
+		if ! losetup -d "${loop_device}"; then
+			log_error "failed to detach ${loop_device}"
+			cleanup_failed=1
+		elif losetup "${loop_device}" > /dev/null 2>&1; then
+			log_error "${loop_device} remains attached after cleanup"
+			cleanup_failed=1
+		fi
+	fi
+	if [[ -n "${memfd_pid}" ]]; then
+		touch "${memfd_stop}"
+		if ! wait "${memfd_pid}"; then
+			log_error "sealed memfd helper exited unsuccessfully"
+			cleanup_failed=1
+		fi
+	fi
+	if [[ ${cleanup_failed} -ne 0 ]]; then
+		status=1
+	fi
+	exit "${status}"
+}
+trap cleanup_io_health_fixture EXIT
+
+write_io_health_event_config() {
+	cat > "${HUATUO_BAMAI_TEST_TMPDIR}/bamai.conf" << 'EOF'
+BlackList = ["metax_gpu", "ascend_npu", "softlockup", "ethtool", "netstat_hw", "netdev_rdma_link", "iolatency", "memory_free", "memory_reclaim", "reschedipi", "softirq", "iotracing"]
+
+[MetricCollector.IOHealth]
+    Enabled = true
+EOF
+}
+
+io_health_event_observed() {
+	local device=$1
+
+	huatuo_bamai_collect_metrics || return 1
+	awk -v device="${device}" '
+		$1 ~ /^huatuo_bamai_io_health_block_errors_total\{/ &&
+		$1 ~ ("device=\"" device "\"") &&
+		$1 ~ /operation="write"/ &&
+		$1 ~ /status="io_error"/ &&
+		$2 + 0 > 0 {
+			block_error = 1
+		}
+		$1 ~ /^huatuo_bamai_io_health_collection_errors_total\{/ &&
+		$1 ~ ("device=\"" device "\"") &&
+		$1 ~ /reason="target_unsupported"/ &&
+		$2 + 0 > 0 {
+			unsupported = 1
+		}
+		END { exit !(block_error && unsupported) }
+	' "${HUATUO_BAMAI_TEST_TMPDIR}/metrics.txt"
+}
+
+[[ ${EUID} -eq 0 ]] || skip "IO health event test requires root"
+
+for command in awk blockdev dd losetup python3 timeout; do
+	command -v "${command}" > /dev/null 2>&1 \
+		|| skip "IO health event test requires command: ${command}"
+done
+
+[[ -r /sys/kernel/btf/vmlinux ]] \
+	|| skip "IO health event test requires /sys/kernel/btf/vmlinux"
+[[ -x "${HUATUO_BAMAI_BIN}" ]] \
+	|| fatal "huatuo-bamai binary not found: ${HUATUO_BAMAI_BIN}"
+[[ -r "${ROOT_DIR}/_output/bpf/io_health.o" ]] \
+	|| fatal "io_health BPF object not found: ${ROOT_DIR}/_output/bpf/io_health.o"
+
+tracefs=""
+for candidate in /sys/kernel/tracing /sys/kernel/debug/tracing; do
+	if [[ -r "${candidate}/events/block/block_rq_complete/id" ]]; then
+		tracefs="${candidate}"
+		break
+	fi
+done
+[[ -n "${tracefs}" ]] \
+	|| skip "IO health event test requires block_rq_complete"
+if [[ -r "${tracefs}/events/block/block_rq_error/id" ]]; then
+	expected_block_hook='msg="attached BPF tracepoint" attach_target="block/block_rq_error"'
+else
+	if ! kernel_version_le 5 15 && kernel_version_le 5 17; then
+		skip "IO health block errors do not support the Linux 5.16-5.17 ABI"
+	fi
+	expected_block_hook='msg="attached BPF raw tracepoint" attach_target="block_rq_complete"'
+fi
+
+cat > "${HUATUO_BAMAI_TEST_TMPDIR}/sealed_memfd.py" << 'PY'
+import fcntl
+import os
+from pathlib import Path
+import sys
+import time
+
+path_file, seal_request, sealed_file, stop_file = map(Path, sys.argv[1:])
+fd = os.memfd_create("huatuo-io-health", os.MFD_ALLOW_SEALING)
+os.ftruncate(fd, 8 * 1024 * 1024)
+path_file.write_text(f"/proc/{os.getpid()}/fd/{fd}\n", encoding="ascii")
+
+while not seal_request.exists():
+    if stop_file.exists():
+        sys.exit(0)
+    time.sleep(0.05)
+
+fcntl.fcntl(fd, fcntl.F_ADD_SEALS, fcntl.F_SEAL_WRITE)
+sealed_file.touch()
+while not stop_file.exists():
+    time.sleep(0.05)
+PY
+
+python3 "${HUATUO_BAMAI_TEST_TMPDIR}/sealed_memfd.py" \
+	"${memfd_path_file}" \
+	"${memfd_seal_request}" \
+	"${memfd_sealed}" \
+	"${memfd_stop}" \
+	> "${HUATUO_BAMAI_TEST_TMPDIR}/sealed_memfd.log" 2>&1 &
+memfd_pid=$!
+wait_until 10 1 test -s "${memfd_path_file}" \
+	|| fatal "sealed memfd helper did not publish its backing path"
+memfd_path=$(< "${memfd_path_file}")
+
+loop_device=$(losetup --find --show "${memfd_path}") \
+	|| skip "IO health event test has no available loop device"
+loop_name=$(basename "${loop_device}")
+[[ -b "${loop_device}" ]] \
+	|| fatal "losetup did not create a block device: ${loop_device}"
+[[ "$(blockdev --getsize64 "${loop_device}")" -eq $((8 * 1024 * 1024)) ]] \
+	|| fatal "unexpected loop capacity for ${loop_device}"
+
+integration_huatuo_bamai_start write_io_health_event_config \
+	"--region" "dev" \
+	"--disable-storage" \
+	"--disable-kubelet" \
+	"--log-debug"
+
+wait_until 10 1 grep -qF \
+	"${expected_block_hook}" \
+	"${HUATUO_BAMAI_TEST_TMPDIR}/huatuo.log" \
+	|| fatal "io_health did not attach ${expected_block_hook}"
+
+touch "${memfd_seal_request}"
+wait_until 10 1 test -e "${memfd_sealed}" \
+	|| fatal "memfd helper could not seal the loop backing store"
+set +e
+timeout 10 dd \
+	if=/dev/zero \
+	of="${loop_device}" \
+	bs=4096 \
+	count=1 \
+	oflag=direct \
+	status=none
+write_status=$?
+set -e
+if [[ ${write_status} -eq 0 ]]; then
+	fatal "sealed loop backing store did not reject the test write"
+fi
+[[ ${write_status} -ne 124 ]] \
+	|| fatal "loop fault injection did not finish within 10 seconds"
+
+wait_until 15 1 io_health_event_observed "${loop_name}" \
+	|| fatal "io_health did not publish the loop block error"
+
+log_info "io_health observed a real block error for ${loop_name}"

--- a/internal/bpf/bpf.go
+++ b/internal/bpf/bpf.go
@@ -14,7 +14,10 @@
 
 package bpf
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // BPF is safe for concurrent use. Close waits for in-flight operations.
 // Resource access and attach methods started after Close return ErrClosed;
@@ -80,4 +83,36 @@ type BPF interface {
 
 	// DetachOnContextDone is a hook for context-driven detach handling.
 	DetachOnContextDone(ctx context.Context, cancel context.CancelFunc)
+}
+
+type independentAttacher interface {
+	attachIndependently(AttachOption) error
+}
+
+type programDetacher interface {
+	DetachProgram(string) error
+}
+
+// AttachIndependently asks a BPF implementation to attach one program without
+// rolling back links attached by earlier independent calls. It is intended for
+// collectors whose optional hooks may degrade separately.
+//
+// defaultBPF provides the independent rollback semantics. Other BPF
+// implementations fall back to their normal single-option AttachWithOptions
+// behavior and therefore retain only the guarantees of that implementation.
+func AttachIndependently(b BPF, opt AttachOption) error {
+	if attacher, ok := b.(independentAttacher); ok {
+		return attacher.attachIndependently(opt)
+	}
+	return b.AttachWithOptions([]AttachOption{opt})
+}
+
+// DetachProgram detaches links owned by one loaded program while preserving
+// links attached by other programs.
+func DetachProgram(b BPF, programName string) error {
+	detacher, ok := b.(programDetacher)
+	if !ok {
+		return fmt.Errorf("BPF %s does not support per-program detach", b.Name())
+	}
+	return detacher.DetachProgram(programName)
 }

--- a/internal/bpf/bpf_attach_default.go
+++ b/internal/bpf/bpf_attach_default.go
@@ -188,61 +188,59 @@ func (b *defaultBPF) attachWithOptions(opts []AttachOption) (err error) {
 	}()
 
 	for _, opt := range opts {
-		progID := b.ProgramIDByName(opt.ProgramName)
-		program, ok := b.programsByID[progID]
-		if !ok {
-			return fmt.Errorf("unknown BPF program %q", opt.ProgramName)
-		}
-
-		switch program.programType {
-		case ebpf.TracePoint:
-			attachOpts, parseErr := parseTracepointAttachOptions(program, opt.Symbol)
-			if parseErr != nil {
-				return parseErr
-			}
-			if err = b.attachTracepoint(attachOpts); err != nil {
-				return err
-			}
-		case ebpf.Kprobe:
-			attachOpts, parseErr := parseKprobeAttachOptions(
-				program,
-				opt.Symbol,
-				program.sectionPrefix == "kretprobe",
-				opt.Kprobe.RetprobeMaxActive,
-			)
-			if parseErr != nil {
-				return parseErr
-			}
-			if err = b.attachKprobe(attachOpts); err != nil {
-				return err
-			}
-		case ebpf.RawTracepoint:
-			attachOpts, parseErr := parseRawTracepointAttachOptions(program, opt.Symbol)
-			if parseErr != nil {
-				return parseErr
-			}
-			if err = b.attachRawTracepoint(attachOpts); err != nil {
-				return err
-			}
-		case ebpf.PerfEvent:
-			attachOpts, parseErr := parsePerfEventAttachOptions(
-				program,
-				opt.PerfEvent.SamplePeriod,
-				opt.PerfEvent.SampleFreq,
-				opt.PerfEvent.CPUIDs,
-			)
-			if parseErr != nil {
-				return parseErr
-			}
-			if err = b.attachPerfEvent(attachOpts); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unsupported BPF program type %q", program.programType)
+		if err = b.attachOne(opt); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func (b *defaultBPF) attachOne(opt AttachOption) error {
+	progID := b.ProgramIDByName(opt.ProgramName)
+	program, ok := b.programsByID[progID]
+	if !ok {
+		return fmt.Errorf("unknown BPF program %q", opt.ProgramName)
+	}
+
+	switch program.programType {
+	case ebpf.TracePoint:
+		attachOpts, err := parseTracepointAttachOptions(program, opt.Symbol)
+		if err != nil {
+			return err
+		}
+		return b.attachTracepoint(attachOpts)
+	case ebpf.Kprobe:
+		attachOpts, err := parseKprobeAttachOptions(
+			program,
+			opt.Symbol,
+			program.sectionPrefix == "kretprobe",
+			opt.Kprobe.RetprobeMaxActive,
+		)
+		if err != nil {
+			return err
+		}
+		return b.attachKprobe(attachOpts)
+	case ebpf.RawTracepoint:
+		attachOpts, err := parseRawTracepointAttachOptions(program, opt.Symbol)
+		if err != nil {
+			return err
+		}
+		return b.attachRawTracepoint(attachOpts)
+	case ebpf.PerfEvent:
+		attachOpts, err := parsePerfEventAttachOptions(
+			program,
+			opt.PerfEvent.SamplePeriod,
+			opt.PerfEvent.SampleFreq,
+			opt.PerfEvent.CPUIDs,
+		)
+		if err != nil {
+			return err
+		}
+		return b.attachPerfEvent(attachOpts)
+	default:
+		return fmt.Errorf("unsupported BPF program type %q", program.programType)
+	}
 }
 
 // Attach the default programs.

--- a/internal/bpf/bpf_attach_default.go
+++ b/internal/bpf/bpf_attach_default.go
@@ -243,6 +243,15 @@ func (b *defaultBPF) attachOne(opt AttachOption) error {
 	}
 }
 
+func (b *defaultBPF) attachIndependently(opt AttachOption) error {
+	if err := b.acquireWriteLock(); err != nil {
+		return err
+	}
+	defer b.mu.Unlock()
+
+	return b.attachOne(opt)
+}
+
 // Attach the default programs.
 func (b *defaultBPF) Attach() error {
 	if err := b.acquireWriteLock(); err != nil {
@@ -439,5 +448,36 @@ func (b *defaultBPF) detach() error {
 		b.perfEvent = nil
 	}
 
+	return errors.Join(detachErrs...)
+}
+
+// DetachProgram detaches every link owned by one program.
+func (b *defaultBPF) DetachProgram(programName string) error {
+	if err := b.acquireWriteLock(); err != nil {
+		return err
+	}
+	defer b.mu.Unlock()
+
+	progID := b.ProgramIDByName(programName)
+	program, ok := b.programsByID[progID]
+	if !ok {
+		return fmt.Errorf("unknown BPF program %q", programName)
+	}
+
+	var detachErrs []error
+	for linkKey, attachedLink := range program.links {
+		if attachedLink != nil {
+			if err := attachedLink.Close(); err != nil {
+				detachErrs = append(detachErrs, fmt.Errorf(
+					"detach link %q from program %q: %w",
+					linkKey,
+					programName,
+					err,
+				))
+				continue
+			}
+		}
+		delete(program.links, linkKey)
+	}
 	return errors.Join(detachErrs...)
 }

--- a/internal/bpf/bpf_default_test.go
+++ b/internal/bpf/bpf_default_test.go
@@ -515,6 +515,48 @@ func TestDefaultBPF_AttachWithOptions_SpecTypes(t *testing.T) {
 	}
 }
 
+func TestDefaultBPF_AttachIndependentlyPreservesEarlierLink(t *testing.T) {
+	b := loadMinimalBpfFromBytes(t)
+	defer b.Close()
+
+	const programName = "eventpipe_prog"
+	err := AttachIndependently(b, AttachOption{
+		ProgramName: programName,
+		Symbol:      "syscalls/sys_enter_nanosleep",
+	})
+	require.NoError(t, err)
+
+	progID := b.ProgramIDByName(programName)
+	program, ok := b.programsByID[progID]
+	require.True(t, ok)
+	require.Len(t, program.links, 1)
+
+	err = AttachIndependently(b, AttachOption{
+		ProgramName: "missing_program",
+		Symbol:      "syscalls/sys_enter_nanosleep",
+	})
+	require.Error(t, err)
+	require.Len(t, program.links, 1, "failed independent attach must not roll back an earlier link")
+}
+
+func TestDefaultBPF_DetachProgramPreservesOtherLinks(t *testing.T) {
+	b := loadMinimalBpfFromBytes(t)
+	defer b.Close()
+
+	require.NoError(t, AttachIndependently(b, AttachOption{
+		ProgramName: "eventpipe_prog",
+		Symbol:      "syscalls/sys_enter_nanosleep",
+	}))
+	require.NoError(t, AttachIndependently(b, AttachOption{
+		ProgramName: "test_kprobe",
+		Symbol:      "sys_openat",
+	}))
+
+	require.NoError(t, DetachProgram(b, "eventpipe_prog"))
+	require.Empty(t, b.programsByID[b.ProgramIDByName("eventpipe_prog")].links)
+	require.Len(t, b.programsByID[b.ProgramIDByName("test_kprobe")].links, 1)
+}
+
 // TestDefaultBPF_EventPipe_Flow tests the event pipe functionality.
 //
 // Covered functions:

--- a/internal/ioobserve/health/command_providers.go
+++ b/internal/ioobserve/health/command_providers.go
@@ -1,0 +1,321 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"huatuo-bamai/pkg/types"
+)
+
+const (
+	evidenceCommandTimeout = 5 * time.Second
+	evidenceOutputLimit    = 256 * 1024
+)
+
+type commandExecution struct {
+	stdout   []byte
+	stderr   []byte
+	exitCode int
+	tooLarge bool
+	err      error
+}
+
+type commandRunner func(context.Context, string, []string, int) commandExecution
+
+type boundedCommandOutput struct {
+	mu        sync.Mutex
+	remaining int
+	stdout    bytes.Buffer
+	stderr    bytes.Buffer
+	tooLarge  bool
+}
+
+type boundedStream struct {
+	output *boundedCommandOutput
+	stderr bool
+}
+
+func (w boundedStream) Write(p []byte) (int, error) {
+	w.output.mu.Lock()
+	defer w.output.mu.Unlock()
+
+	keep := len(p)
+	if keep > w.output.remaining {
+		keep = w.output.remaining
+		w.output.tooLarge = true
+	}
+	if keep > 0 {
+		if w.stderr {
+			_, _ = w.output.stderr.Write(p[:keep])
+		} else {
+			_, _ = w.output.stdout.Write(p[:keep])
+		}
+		w.output.remaining -= keep
+	}
+	return len(p), nil
+}
+
+func runEvidenceCommand(
+	ctx context.Context,
+	executable string,
+	args []string,
+	maxBytes int,
+) commandExecution {
+	output := &boundedCommandOutput{remaining: maxBytes}
+	cmd := exec.CommandContext(ctx, executable, args...)
+	cmd.Stdout = boundedStream{output: output}
+	cmd.Stderr = boundedStream{output: output, stderr: true}
+
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitCode = -1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+	return commandExecution{
+		stdout:   output.stdout.Bytes(),
+		stderr:   output.stderr.Bytes(),
+		exitCode: exitCode,
+		tooLarge: output.tooLarge,
+		err:      err,
+	}
+}
+
+func (w *EvidenceWorker) collectEvidence(
+	ctx context.Context,
+	request EvidenceRequest,
+	target string,
+) EvidenceResult {
+	result := EvidenceResult{
+		Target:      target,
+		TriggeredAt: request.TriggeredAt,
+		Event:       request.Trigger,
+	}
+	result.Event.NVMe = nil
+	result.Event.SCSI = nil
+
+	if request.Reason != "" {
+		result.Reasons = []string{request.Reason}
+		result.Event.CollectionStatus = "unsupported"
+		return result
+	}
+
+	switch request.Protocol {
+	case EvidenceProtocolNVMe:
+		result.Event.NVMe, result.Reasons = w.collectNVMe(ctx, request.Target)
+		result.Event.CollectionStatus = collectionStatus(
+			result.Event.NVMe != nil,
+			result.Reasons,
+		)
+	case EvidenceProtocolSCSI:
+		result.Event.SCSI, result.Reasons = w.collectSCSI(ctx, request.Target)
+		result.Event.CollectionStatus = collectionStatus(
+			result.Event.SCSI != nil,
+			result.Reasons,
+		)
+	default:
+		result.Reasons = []string{CollectionReasonTargetUnsupported}
+		result.Event.CollectionStatus = "unsupported"
+	}
+	return result
+}
+
+func (w *EvidenceWorker) collectNVMe(
+	ctx context.Context,
+	target string,
+) (*types.NVMeHealthEvidence, []string) {
+	executable, err := w.lookupPath("nvme")
+	if err != nil || executable == "" {
+		return nil, []string{CollectionReasonToolUnavailable}
+	}
+
+	devicePath := filepath.Join("/dev", target)
+	evidence := &types.NVMeHealthEvidence{}
+	trusted := false
+	reasons := reasonSet{}
+
+	smartResult := w.execute(ctx, executable, []string{
+		"smart-log", "-o", "json", devicePath,
+	})
+	if reason := commandFailureReason(smartResult); reason != "" {
+		reasons.add(reason)
+	} else {
+		smart, valid, complete := parseNVMeSMART(smartResult.stdout)
+		if valid {
+			evidence.CriticalWarning = smart.CriticalWarning
+			evidence.MediaErrorsTotal = smart.MediaErrorsTotal
+			trusted = true
+		}
+		if !valid || !complete {
+			reasons.add(CollectionReasonParseError)
+		}
+	}
+
+	errorResult := w.execute(ctx, executable, []string{
+		"error-log", "-e", "16", "-o", "json", devicePath,
+	})
+	if reason := commandFailureReason(errorResult); reason != "" {
+		reasons.add(reason)
+	} else {
+		errorLog, valid, complete := parseNVMeErrorLog(errorResult.stdout)
+		if valid {
+			evidence.ErrorLog = &errorLog
+			trusted = true
+		}
+		if !valid || !complete {
+			reasons.add(CollectionReasonParseError)
+		}
+	}
+
+	if !trusted {
+		return nil, reasons.values
+	}
+	return evidence, reasons.values
+}
+
+func (w *EvidenceWorker) collectSCSI(
+	ctx context.Context,
+	target string,
+) (*types.SCSIHealthEvidence, []string) {
+	executable, err := w.lookupPath("smartctl")
+	if err != nil || executable == "" {
+		return nil, []string{CollectionReasonToolUnavailable}
+	}
+
+	result := w.execute(ctx, executable, []string{
+		"--health",
+		"--attributes",
+		"--log=error",
+		"--json=c",
+		filepath.Join("/dev", target),
+	})
+	if reason := commandFailureReasonBeforeExit(result); reason != "" {
+		return nil, []string{reason}
+	}
+
+	evidence, trusted, complete, reportedExit := parseSCSIHealth(result.stdout)
+	reasons := reasonSet{}
+	if !trusted || !complete {
+		reasons.add(CollectionReasonParseError)
+	}
+
+	exitStatus := result.exitCode
+	if reportedExit != nil {
+		exitStatus |= int(*reportedExit)
+	}
+	// smartctl bits 0..2 mean command line, device access, or command
+	// execution failure. Bits 3..7 describe device health and do not make a
+	// successfully parsed collection fail.
+	if (result.err != nil && result.exitCode < 0) || exitStatus&0x07 != 0 {
+		reasons.add(CollectionReasonExecError)
+	}
+
+	if !trusted {
+		return nil, reasons.values
+	}
+	return evidence, reasons.values
+}
+
+func (w *EvidenceWorker) execute(
+	parent context.Context,
+	executable string,
+	args []string,
+) commandExecution {
+	ctx, cancel := context.WithTimeout(parent, w.commandTimeout)
+	defer cancel()
+
+	result := w.runCommand(ctx, executable, args, w.maxOutputBytes)
+	if ctx.Err() != nil {
+		result.err = ctx.Err()
+	}
+	return result
+}
+
+func commandFailureReason(result commandExecution) string {
+	if reason := commandFailureReasonBeforeExit(result); reason != "" {
+		return reason
+	}
+	if result.err != nil || result.exitCode != 0 {
+		return CollectionReasonExecError
+	}
+	return ""
+}
+
+func commandFailureReasonBeforeExit(result commandExecution) string {
+	if result.tooLarge {
+		return CollectionReasonOutputTooLarge
+	}
+	if errors.Is(result.err, context.DeadlineExceeded) {
+		return CollectionReasonTimeout
+	}
+	if result.err != nil && result.exitCode < 0 {
+		return CollectionReasonExecError
+	}
+	return ""
+}
+
+func collectionStatus(hasEvidence bool, reasons []string) string {
+	if hasEvidence {
+		if len(reasons) == 0 {
+			return "ok"
+		}
+		return "partial"
+	}
+	for _, reason := range reasons {
+		if reason == CollectionReasonTargetUnresolved ||
+			reason == CollectionReasonToolUnavailable ||
+			reason == CollectionReasonTargetUnsupported {
+			return "unsupported"
+		}
+	}
+	for _, reason := range reasons {
+		if reason == CollectionReasonTimeout {
+			return "timeout"
+		}
+	}
+	return "error"
+}
+
+type reasonSet struct {
+	seen   map[string]struct{}
+	values []string
+}
+
+func (s *reasonSet) add(reason string) {
+	if reason == "" {
+		return
+	}
+	if s.seen == nil {
+		s.seen = make(map[string]struct{})
+	}
+	if _, ok := s.seen[reason]; ok {
+		return
+	}
+	s.seen[reason] = struct{}{}
+	s.values = append(s.values, reason)
+}

--- a/internal/ioobserve/health/command_providers_test.go
+++ b/internal/ioobserve/health/command_providers_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestRunEvidenceCommandCapsCombinedOutput(t *testing.T) {
+	result := runEvidenceCommand(
+		context.Background(),
+		"/bin/sh",
+		[]string{
+			"-c",
+			"printf 12345678901234567890; printf abcdefghijklmnopqrst >&2",
+		},
+		32,
+	)
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	if !result.tooLarge {
+		t.Fatal("expected output_too_large")
+	}
+	if got := len(result.stdout) + len(result.stderr); got != 32 {
+		t.Fatalf("captured bytes = %d, want 32", got)
+	}
+}
+
+func TestParseNVMeEvidencePreservesPresenceAndFiltersErrorLog(t *testing.T) {
+	smart, valid, complete := parseNVMeSMART([]byte(
+		`{"critical_warning":0,"media_errors":"12"}`,
+	))
+	if !valid || !complete {
+		t.Fatalf("smart valid=%t complete=%t, want true/true", valid, complete)
+	}
+	if smart.CriticalWarning == nil || *smart.CriticalWarning != 0 {
+		t.Fatalf("critical_warning = %#v, want present zero", smart.CriticalWarning)
+	}
+	if smart.MediaErrorsTotal == nil || *smart.MediaErrorsTotal != 12 {
+		t.Fatalf("media_errors_total = %#v, want 12", smart.MediaErrorsTotal)
+	}
+
+	rawEntries := []map[string]any{
+		{
+			"error_count": 0,
+		},
+		{
+			"error_count":  1,
+			"sqid":         0,
+			"status_field": 1,
+			"nsid":         0,
+			"lba":          0,
+		},
+	}
+	for i := 1; i <= 9; i++ {
+		rawEntries = append(rawEntries, map[string]any{
+			"error_count":  i,
+			"sqid":         1,
+			"status_field": 0x280,
+			"nsid":         3,
+			"lba":          i,
+		})
+	}
+	data, err := json.Marshal(map[string]any{"errors": rawEntries})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errorLog, valid, complete := parseNVMeErrorLog(data)
+	if !valid || !complete {
+		t.Fatalf("error log valid=%t complete=%t, want true/true", valid, complete)
+	}
+	if len(errorLog) != maxEvidenceEntries {
+		t.Fatalf("error log entries = %d, want %d", len(errorLog), maxEvidenceEntries)
+	}
+	if errorLog[0].LBA != 1 || errorLog[7].LBA != 8 {
+		t.Fatalf("error log order/cap = %#v", errorLog)
+	}
+	if errorLog[0].StatusCodeType != 2 || errorLog[0].StatusCode != 0x80 {
+		t.Fatalf("decoded status = %#v, want SCT=2 SC=0x80", errorLog[0])
+	}
+}
+
+func TestParseNVMeErrorLogRejectsAllMalformedEntries(t *testing.T) {
+	entries, valid, complete := parseNVMeErrorLog([]byte(
+		`{"errors":[{"error_count":1,"status_field":640}]}`,
+	))
+	if valid || complete || len(entries) != 0 {
+		t.Fatalf(
+			"entries=%#v valid=%t complete=%t, want no trusted evidence",
+			entries,
+			valid,
+			complete,
+		)
+	}
+}
+
+func TestParseNVMeErrorLogSupportsNVMeCLI116And216(t *testing.T) {
+	// nvme-cli 1.16 and 2.16 expose the same Error Information Log fields.
+	// In particular, neither version emits an opcode.
+	fixtures := map[string]string{
+		"1.16": `{"errors":[{
+			"error_count":1,"sqid":1,"cmdid":7,"status_field":640,
+			"phase_tag":0,"parm_error_location":0,"lba":42,"nsid":3,
+			"vs":0,"trtype":0,"cs":0,"trtype_spec_info":0
+		}]}`,
+		"2.16": `{"errors":[{
+			"error_count":2,"sqid":2,"cmdid":8,"status_field":640,
+			"phase_tag":1,"parm_error_location":4,"lba":84,"nsid":6,
+			"vs":0,"trtype":0,"cs":0,"trtype_spec_info":0
+		}]}`,
+	}
+
+	for version, fixture := range fixtures {
+		t.Run(version, func(t *testing.T) {
+			entries, valid, complete := parseNVMeErrorLog([]byte(fixture))
+			if !valid || !complete || len(entries) != 1 {
+				t.Fatalf(
+					"entries=%#v valid=%t complete=%t, want one complete record",
+					entries,
+					valid,
+					complete,
+				)
+			}
+			if entries[0].StatusCodeType != 2 || entries[0].StatusCode != 0x80 {
+				t.Fatalf("decoded status = %#v, want SCT=2 SC=0x80", entries[0])
+			}
+		})
+	}
+}
+
+func TestParseSCSIHealthUsesOnlyWhitelistedStructuredFields(t *testing.T) {
+	data := []byte(`{
+		"smartctl":{"exit_status":8},
+		"smart_status":{
+			"passed":false,
+			"scsi":{"asc":93,"ascq":1,"ie_string":"discard me"}
+		},
+		"temperature":{"current":39,"drive_trip":65},
+		"scsi_grown_defect_list":0,
+		"scsi_error_counter_log":{
+			"read":{
+				"errors_corrected_by_eccfast":999,
+				"errors_corrected_by_eccdelayed":0,
+				"errors_corrected_by_rereads_rewrites":2,
+				"gigabytes_processed":"123.500",
+				"total_uncorrected_errors":4
+			},
+			"write":{"total_uncorrected_errors":0}
+		},
+		"scsi_pending_defects":{
+			"count":10,
+			"table":[
+				null,
+				{"lba":11},{"lba":12},{"lba":13},{"lba":14},{"lba":15},
+				{"lba":16},{"lba":17},{"lba":18},{"lba":19},{"lba":20}
+			]
+		}
+	}`)
+
+	evidence, valid, complete, exitStatus := parseSCSIHealth(data)
+	if !valid || !complete {
+		t.Fatalf("SCSI valid=%t complete=%t, want true/true", valid, complete)
+	}
+	if exitStatus == nil || *exitStatus != 8 {
+		t.Fatalf("exit status = %#v, want 8", exitStatus)
+	}
+	if evidence.SmartPassed == nil || *evidence.SmartPassed {
+		t.Fatalf("smart_passed = %#v, want present false", evidence.SmartPassed)
+	}
+	if evidence.InformationException == nil ||
+		evidence.InformationException.ASC != 93 ||
+		evidence.InformationException.ASCQ != 1 {
+		t.Fatalf("information exception = %#v", evidence.InformationException)
+	}
+	if evidence.Temperature == nil ||
+		evidence.Temperature.CurrentCelsius != 39 ||
+		evidence.Temperature.TripCelsius != 65 {
+		t.Fatalf("temperature = %#v", evidence.Temperature)
+	}
+	if evidence.GrownDefectCount == nil || *evidence.GrownDefectCount != 0 {
+		t.Fatalf("grown defects = %#v, want present zero", evidence.GrownDefectCount)
+	}
+	if evidence.Read == nil ||
+		evidence.Read.DelayedCorrections == nil ||
+		*evidence.Read.DelayedCorrections != 0 ||
+		evidence.Read.RereadRewriteCorrections == nil ||
+		*evidence.Read.RereadRewriteCorrections != 2 ||
+		evidence.Read.UncorrectedErrors == nil ||
+		*evidence.Read.UncorrectedErrors != 4 {
+		t.Fatalf("read counters = %#v", evidence.Read)
+	}
+	if evidence.PendingDefects == nil ||
+		evidence.PendingDefects.SampleLBAs == nil ||
+		len(*evidence.PendingDefects.SampleLBAs) != maxEvidenceEntries {
+		t.Fatalf("pending defects = %#v", evidence.PendingDefects)
+	}
+	if got := (*evidence.PendingDefects.SampleLBAs)[7]; got != 18 {
+		t.Fatalf("last retained pending LBA = %d, want 18", got)
+	}
+}
+
+func TestCollectSCSIAcceptsHealthExitBitsAndUsesWhitelistedCommand(t *testing.T) {
+	worker := NewEvidenceWorker(EvidenceWorkerOptions{})
+	worker.lookupPath = func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}
+	var command []string
+	worker.runCommand = func(
+		ctx context.Context,
+		executable string,
+		args []string,
+		maxBytes int,
+	) commandExecution {
+		command = append([]string(nil), args...)
+		return commandExecution{
+			stdout: []byte(
+				`{"smartctl":{"exit_status":8},"smart_status":{"passed":false}}`,
+			),
+			exitCode: 8,
+			err:      errors.New("smartctl reported failed health"),
+		}
+	}
+
+	evidence, reasons := worker.collectSCSI(context.Background(), "sda")
+	if evidence == nil || evidence.SmartPassed == nil || *evidence.SmartPassed {
+		t.Fatalf("SCSI evidence = %#v, want present failed health", evidence)
+	}
+	if len(reasons) != 0 {
+		t.Fatalf("collection reasons = %v, want none", reasons)
+	}
+	wantCommand := []string{
+		"--health",
+		"--attributes",
+		"--log=error",
+		"--json=c",
+		"/dev/sda",
+	}
+	if !reflect.DeepEqual(command, wantCommand) {
+		t.Fatalf("smartctl command = %q, want %q", command, wantCommand)
+	}
+}

--- a/internal/ioobserve/health/evidence_parser.go
+++ b/internal/ioobserve/health/evidence_parser.go
@@ -1,0 +1,586 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/pkg/types"
+)
+
+// Parsed health fields:
+//
+// NVMe:
+//   - critical_warning: controller health-warning bitmap.
+//   - media_errors: cumulative unrecovered media or data-integrity errors.
+//   - error_count: distinguishes populated error-log entries from empty slots.
+//   - status_code_type/status_code, sct/sc, or status_field: error class and code
+//     across supported nvme-cli JSON layouts.
+//   - sqid: filters common admin-command noise and is not retained as evidence.
+//   - nsid: namespace containing the failed command.
+//   - lba: logical block address associated with the error.
+//
+// SCSI:
+//   - smartctl.exit_status: distinguishes command failures from health findings.
+//   - smart_status.passed: overall SMART health result.
+//   - smart_status.scsi.asc/ascq: device-reported information exception.
+//   - temperature.current/drive_trip: current and trip temperatures.
+//   - scsi_grown_defect_list: defects added after the device entered service.
+//   - scsi_error_counter_log.read/write/verify: error groups by operation.
+//   - gigabytes_processed: processed capacity used as error-count context.
+//   - errors_corrected_by_eccdelayed: errors corrected by delayed ECC.
+//   - errors_corrected_by_rereads_rewrites: errors corrected by retry or rewrite.
+//   - total_uncorrected_errors: errors that the device could not recover.
+//   - scsi_pending_defects.count: total pending defects.
+//   - scsi_pending_defects.table[].lba: representative affected block addresses.
+
+const maxEvidenceEntries = 8
+
+func parseNVMeSMART(data []byte) (types.NVMeHealthEvidence, bool, bool) {
+	root, err := decodeObject(data)
+	if err != nil {
+		return types.NVMeHealthEvidence{}, false, false
+	}
+
+	evidence := types.NVMeHealthEvidence{}
+	complete := true
+	if raw, ok := root["critical_warning"]; ok {
+		value, valid := parseUint(raw, 8)
+		if valid {
+			criticalWarning := uint8(value)
+			evidence.CriticalWarning = &criticalWarning
+		} else {
+			complete = false
+		}
+	}
+	if raw, ok := root["media_errors"]; ok {
+		value, valid := parseUint(raw, 64)
+		if valid {
+			evidence.MediaErrorsTotal = &value
+		} else {
+			complete = false
+		}
+	}
+
+	valid := evidence.CriticalWarning != nil || evidence.MediaErrorsTotal != nil
+	return evidence, valid, complete
+}
+
+func parseNVMeErrorLog(data []byte) ([]types.NVMeErrorLogEntry, bool, bool) {
+	var rawEntries []json.RawMessage
+	if err := decodeJSON(data, &rawEntries); err != nil {
+		root, objectErr := decodeObject(data)
+		if objectErr != nil {
+			return nil, false, false
+		}
+		raw, ok := root["errors"]
+		if !ok || decodeJSON(raw, &rawEntries) != nil {
+			return nil, false, false
+		}
+	}
+	if rawEntries == nil {
+		return nil, false, false
+	}
+
+	entries := make([]types.NVMeErrorLogEntry, 0, min(len(rawEntries), maxEvidenceEntries))
+	complete := true
+	for _, raw := range rawEntries {
+		entry, keep, valid := parseNVMeErrorEntry(raw)
+		if !valid {
+			complete = false
+			continue
+		}
+		if keep && len(entries) < maxEvidenceEntries {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, complete || len(entries) != 0, complete
+}
+
+func parseNVMeErrorEntry(
+	data json.RawMessage,
+) (types.NVMeErrorLogEntry, bool, bool) {
+	entry := types.NVMeErrorLogEntry{}
+	root, err := decodeObject(data)
+	if err != nil {
+		return entry, false, false
+	}
+
+	errorCount, ok := requiredUint(root, "error_count", 64)
+	if !ok {
+		return entry, false, false
+	}
+	if errorCount == 0 {
+		return entry, false, true
+	}
+
+	statusCodeType, statusCode, ok := nvmeStatus(root)
+	if !ok {
+		return entry, false, false
+	}
+
+	// sqid is not retained evidence. Use it only when it positively identifies
+	// common admin-command noise; a missing sqid must not discard an otherwise
+	// complete public record.
+	sqid, hasSQID := optionalUint(root, "sqid", 16)
+	if hasSQID && sqid == 0 && statusCodeType == 0 &&
+		(statusCode == 0x01 || statusCode == 0x02) {
+		return entry, false, true
+	}
+
+	nsid, ok := requiredUint(root, "nsid", 32)
+	if !ok {
+		return entry, false, false
+	}
+	lba, ok := requiredUint(root, "lba", 64)
+	if !ok {
+		return entry, false, false
+	}
+
+	return types.NVMeErrorLogEntry{
+		StatusCodeType: uint8(statusCodeType),
+		StatusCode:     uint8(statusCode),
+		NSID:           uint32(nsid),
+		LBA:            lba,
+	}, true, true
+}
+
+func nvmeStatus(root map[string]json.RawMessage) (uint64, uint64, bool) {
+	statusCodeType, hasType := optionalUint(root, "status_code_type", 8)
+	statusCode, hasCode := optionalUint(root, "status_code", 8)
+	if hasType && hasCode {
+		return statusCodeType, statusCode, true
+	}
+	statusCodeType, hasType = optionalUint(root, "sct", 8)
+	statusCode, hasCode = optionalUint(root, "sc", 8)
+	if hasType && hasCode {
+		return statusCodeType, statusCode, true
+	}
+
+	statusField, ok := requiredUint(root, "status_field", 16)
+	if !ok {
+		return 0, 0, false
+	}
+	// nvme-cli removes the phase tag before placing status_field in JSON.
+	return statusField >> 8 & 0x7, statusField & 0xff, true
+}
+
+func parseSCSIHealth(
+	data []byte,
+) (*types.SCSIHealthEvidence, bool, bool, *uint8) {
+	root, err := decodeObject(data)
+	if err != nil {
+		return nil, false, false, nil
+	}
+
+	evidence := &types.SCSIHealthEvidence{}
+	complete := true
+	var exitStatus *uint8
+
+	if raw, ok := root["smartctl"]; ok {
+		smartctl, valid := rawObject(raw)
+		if !valid {
+			complete = false
+		} else if rawExit, ok := smartctl["exit_status"]; ok {
+			value, valid := parseUint(rawExit, 8)
+			if valid {
+				status := uint8(value)
+				exitStatus = &status
+			} else {
+				complete = false
+			}
+		}
+	}
+
+	if raw, ok := root["smart_status"]; ok {
+		status, valid := rawObject(raw)
+		if !valid {
+			complete = false
+		} else {
+			if rawPassed, ok := status["passed"]; ok {
+				passed, valid := parseBool(rawPassed)
+				if valid {
+					evidence.SmartPassed = &passed
+				} else {
+					complete = false
+				}
+			}
+			if rawSCSI, ok := status["scsi"]; ok {
+				scsi, valid := rawObject(rawSCSI)
+				if !valid {
+					complete = false
+				} else {
+					asc, hasASC := optionalUint(scsi, "asc", 8)
+					ascq, hasASCQ := optionalUint(scsi, "ascq", 8)
+					if hasASC && hasASCQ {
+						evidence.InformationException = &types.SCSIInformationException{
+							ASC:  uint8(asc),
+							ASCQ: uint8(ascq),
+						}
+					} else if hasInvalidKey(scsi, "asc", hasASC) ||
+						hasInvalidKey(scsi, "ascq", hasASCQ) {
+						complete = false
+					}
+				}
+			}
+		}
+	}
+
+	if raw, ok := root["temperature"]; ok {
+		temperature, valid := rawObject(raw)
+		if !valid {
+			complete = false
+		} else {
+			current, hasCurrent := optionalInt(temperature, "current")
+			trip, hasTrip := optionalInt(temperature, "drive_trip")
+			if hasCurrent && hasTrip {
+				evidence.Temperature = &types.SCSITemperature{
+					CurrentCelsius: current,
+					TripCelsius:    trip,
+				}
+			} else if hasInvalidKey(temperature, "current", hasCurrent) ||
+				hasInvalidKey(temperature, "drive_trip", hasTrip) {
+				complete = false
+			}
+		}
+	}
+
+	if raw, ok := root["scsi_grown_defect_list"]; ok {
+		value, valid := parseUint(raw, 64)
+		if valid {
+			evidence.GrownDefectCount = &value
+		} else {
+			complete = false
+		}
+	}
+
+	if raw, ok := root["scsi_error_counter_log"]; ok {
+		groups, valid := rawObject(raw)
+		if !valid {
+			complete = false
+		} else {
+			evidence.Read, complete = parseSCSIErrorGroup(groups, "read", complete)
+			evidence.Write, complete = parseSCSIErrorGroup(groups, "write", complete)
+			evidence.Verify, complete = parseSCSIErrorGroup(groups, "verify", complete)
+		}
+	}
+
+	if raw, ok := root["scsi_pending_defects"]; ok {
+		pending, valid, pendingComplete := parseSCSIPending(raw)
+		if valid {
+			evidence.PendingDefects = pending
+		}
+		if !pendingComplete {
+			complete = false
+		}
+	}
+
+	trusted := hasSCSIEvidence(evidence)
+	return evidence, trusted, complete, exitStatus
+}
+
+func parseSCSIErrorGroup(
+	groups map[string]json.RawMessage,
+	name string,
+	complete bool,
+) (*types.SCSIErrorStats, bool) {
+	raw, ok := groups[name]
+	if !ok {
+		return nil, complete
+	}
+	group, valid := rawObject(raw)
+	if !valid {
+		return nil, false
+	}
+
+	stats := &types.SCSIErrorStats{}
+	if rawValue, ok := group["gigabytes_processed"]; ok {
+		value, valid := parseFloat(rawValue)
+		if valid && value >= 0 {
+			stats.GigabytesProcessed = &value
+		} else {
+			complete = false
+		}
+	}
+	parseCounter := func(key string, destination **uint64) {
+		rawValue, ok := group[key]
+		if !ok {
+			return
+		}
+		value, valid := parseUint(rawValue, 64)
+		if !valid {
+			complete = false
+			return
+		}
+		*destination = &value
+	}
+	parseCounter("errors_corrected_by_eccdelayed", &stats.DelayedCorrections)
+	parseCounter(
+		"errors_corrected_by_rereads_rewrites",
+		&stats.RereadRewriteCorrections,
+	)
+	parseCounter("total_uncorrected_errors", &stats.UncorrectedErrors)
+
+	if stats.GigabytesProcessed == nil &&
+		stats.DelayedCorrections == nil &&
+		stats.RereadRewriteCorrections == nil &&
+		stats.UncorrectedErrors == nil {
+		return nil, complete
+	}
+	return stats, complete
+}
+
+func parseSCSIPending(
+	data json.RawMessage,
+) (*types.SCSIPendingDefects, bool, bool) {
+	root, valid := rawObject(data)
+	if !valid {
+		return nil, false, false
+	}
+	count, ok := requiredUint(root, "count", 64)
+	if !ok {
+		return nil, false, false
+	}
+
+	lbas := make([]uint64, 0, maxEvidenceEntries)
+	var sampleLBAs *[]uint64
+	complete := true
+	if rawTable, ok := root["table"]; ok {
+		var table []json.RawMessage
+		if decodeJSON(rawTable, &table) == nil {
+			if table == nil {
+				complete = false
+			} else {
+				for _, row := range table {
+					if len(lbas) >= maxEvidenceEntries {
+						break
+					}
+					if len(bytes.TrimSpace(row)) == 0 ||
+						bytes.Equal(bytes.TrimSpace(row), []byte("null")) {
+						continue
+					}
+					lba, valid := pendingLBA(row)
+					if !valid {
+						complete = false
+						continue
+					}
+					lbas = append(lbas, lba)
+				}
+				sampleLBAs = &lbas
+			}
+		} else {
+			var object map[string]json.RawMessage
+			if decodeJSON(rawTable, &object) != nil || object == nil {
+				complete = false
+			} else {
+				keys := make([]int, 0, len(object))
+				rows := make(map[int]json.RawMessage, len(object))
+				for key, row := range object {
+					index, err := strconv.Atoi(key)
+					if err != nil {
+						complete = false
+						continue
+					}
+					keys = append(keys, index)
+					rows[index] = row
+				}
+				sort.Ints(keys)
+				for _, key := range keys {
+					if len(lbas) >= maxEvidenceEntries {
+						break
+					}
+					lba, valid := pendingLBA(rows[key])
+					if !valid {
+						complete = false
+						continue
+					}
+					lbas = append(lbas, lba)
+				}
+				sampleLBAs = &lbas
+			}
+		}
+	} else if count == 0 {
+		sampleLBAs = &lbas
+	}
+
+	return &types.SCSIPendingDefects{
+		Count:      count,
+		SampleLBAs: sampleLBAs,
+	}, true, complete
+}
+
+func pendingLBA(data json.RawMessage) (uint64, bool) {
+	row, valid := rawObject(data)
+	if !valid {
+		return 0, false
+	}
+	return requiredUint(row, "lba", 64)
+}
+
+func hasSCSIEvidence(evidence *types.SCSIHealthEvidence) bool {
+	return evidence.SmartPassed != nil ||
+		evidence.InformationException != nil ||
+		evidence.Temperature != nil ||
+		evidence.GrownDefectCount != nil ||
+		evidence.Read != nil ||
+		evidence.Write != nil ||
+		evidence.Verify != nil ||
+		evidence.PendingDefects != nil
+}
+
+func decodeObject(data []byte) (map[string]json.RawMessage, error) {
+	var object map[string]json.RawMessage
+	if err := decodeJSON(data, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return object, nil
+}
+
+func rawObject(data json.RawMessage) (map[string]json.RawMessage, bool) {
+	object, err := decodeObject(data)
+	return object, err == nil
+}
+
+func decodeJSON(data []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func requiredUint(
+	object map[string]json.RawMessage,
+	key string,
+	bits int,
+) (uint64, bool) {
+	raw, ok := object[key]
+	if !ok {
+		return 0, false
+	}
+	return parseUint(raw, bits)
+}
+
+func optionalUint(
+	object map[string]json.RawMessage,
+	key string,
+	bits int,
+) (uint64, bool) {
+	raw, ok := object[key]
+	if !ok {
+		return 0, false
+	}
+	return parseUint(raw, bits)
+}
+
+func parseUint(data json.RawMessage, bits int) (uint64, bool) {
+	var value any
+	if decodeJSON(data, &value) != nil {
+		return 0, false
+	}
+
+	var text string
+	switch typed := value.(type) {
+	case json.Number:
+		text = typed.String()
+	case string:
+		text = strings.ReplaceAll(strings.TrimSpace(typed), ",", "")
+	default:
+		return 0, false
+	}
+	base := 10
+	if strings.HasPrefix(text, "0x") || strings.HasPrefix(text, "0X") {
+		base = 0
+	}
+	parsed, err := strconv.ParseUint(text, base, bits)
+	return parsed, err == nil
+}
+
+func optionalInt(
+	object map[string]json.RawMessage,
+	key string,
+) (int64, bool) {
+	raw, ok := object[key]
+	if !ok {
+		return 0, false
+	}
+	var value any
+	if decodeJSON(raw, &value) != nil {
+		return 0, false
+	}
+	switch typed := value.(type) {
+	case json.Number:
+		parsed, err := strconv.ParseInt(typed.String(), 10, 64)
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func parseFloat(data json.RawMessage) (float64, bool) {
+	var value any
+	if decodeJSON(data, &value) != nil {
+		return 0, false
+	}
+	var text string
+	switch typed := value.(type) {
+	case json.Number:
+		text = typed.String()
+	case string:
+		text = strings.TrimSpace(typed)
+	default:
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(text, 64)
+	return parsed, err == nil && !math.IsNaN(parsed) && !math.IsInf(parsed, 0)
+}
+
+func parseBool(data json.RawMessage) (bool, bool) {
+	var value bool
+	if decodeJSON(data, &value) != nil {
+		return false, false
+	}
+	return value, true
+}
+
+func hasInvalidKey(
+	object map[string]json.RawMessage,
+	key string,
+	valid bool,
+) bool {
+	_, present := object[key]
+	return present && !valid
+}

--- a/internal/ioobserve/health/evidence_worker.go
+++ b/internal/ioobserve/health/evidence_worker.go
@@ -15,6 +15,10 @@
 package health
 
 import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
 	"time"
 
 	"huatuo-bamai/pkg/types"
@@ -33,9 +37,14 @@ const (
 	CollectionReasonExecError         = "exec_error"
 	CollectionReasonOutputTooLarge    = "output_too_large"
 	CollectionReasonParseError        = "parse_error"
+
+	evidenceCooldown = 60 * time.Second
 )
 
-// EvidenceRequest describes one event-triggered health collection.
+// EvidenceRequest describes one event-triggered health collection. Target is
+// the command device name and metric key (for example "nvme0" or "sda"), not a
+// path. An empty Target is accepted only as an unsupported attempt; the
+// Trigger device is then used for de-duplication and error accounting.
 type EvidenceRequest struct {
 	Trigger     types.IOHealthEvent
 	Target      string
@@ -44,7 +53,9 @@ type EvidenceRequest struct {
 	Reason      string
 }
 
-// EvidenceResult contains one bounded health collection result.
+// EvidenceResult is delivered exactly once for every request accepted by
+// Submit. Event already contains collection_status and the bounded evidence.
+// Reasons is de-duplicated and contains only the public bounded reason enum.
 type EvidenceResult struct {
 	Target      string
 	TriggeredAt time.Time
@@ -52,11 +63,230 @@ type EvidenceResult struct {
 	Reasons     []string
 }
 
-// EvidenceWorker holds the dependencies used by one bounded collection.
-// Queue ownership and event scheduling are added separately.
+type EvidenceWorkerOptions struct {
+	OnResult func(EvidenceResult)
+}
+
+type queuedEvidenceRequest struct {
+	request EvidenceRequest
+	key     string
+	target  string
+}
+
+// EvidenceWorker owns one serial external-command queue. In-flight and
+// cooldown state admit at most one request per target, so repeated events for
+// one disk cannot grow the queue. Serial execution intentionally avoids adding
+// command load to several unhealthy storage paths at once. One worker lives
+// for the collector run, so its state remains intact across BPF session
+// retries.
 type EvidenceWorker struct {
+	onResult func(EvidenceResult)
+
+	mu            sync.Mutex
+	queue         []queuedEvidenceRequest
+	inflight      map[string]struct{}
+	cooldownUntil map[string]time.Time
+	wake          chan struct{}
+	done          chan struct{}
+	started       bool
+	stopped       bool
+	ctx           context.Context
+
+	now            func() time.Time
 	lookupPath     func(string) (string, error)
 	runCommand     commandRunner
+	cooldown       time.Duration
 	commandTimeout time.Duration
 	maxOutputBytes int
+}
+
+func NewEvidenceWorker(options EvidenceWorkerOptions) *EvidenceWorker {
+	onResult := options.OnResult
+	if onResult == nil {
+		onResult = func(EvidenceResult) {}
+	}
+	return &EvidenceWorker{
+		onResult:       onResult,
+		inflight:       make(map[string]struct{}),
+		cooldownUntil:  make(map[string]time.Time),
+		wake:           make(chan struct{}, 1),
+		done:           make(chan struct{}),
+		now:            time.Now,
+		lookupPath:     exec.LookPath,
+		runCommand:     runEvidenceCommand,
+		cooldown:       evidenceCooldown,
+		commandTimeout: evidenceCommandTimeout,
+		maxOutputBytes: evidenceOutputLimit,
+	}
+}
+
+// Start starts the worker goroutine. Repeated calls do not create additional
+// workers.
+func (w *EvidenceWorker) Start(ctx context.Context) {
+	w.mu.Lock()
+	if w.started {
+		w.mu.Unlock()
+		return
+	}
+	w.started = true
+	w.ctx = ctx
+	w.mu.Unlock()
+
+	go w.loop(ctx)
+}
+
+// Submit is non-blocking and safe for concurrent perf-reader callers. It
+// returns true only when this trigger becomes a new queued attempt.
+func (w *EvidenceWorker) Submit(request EvidenceRequest) bool {
+	request, target, key, ok := w.prepare(request)
+	if !ok {
+		return false
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.started || w.stopped || w.ctx.Err() != nil {
+		return false
+	}
+	if _, ok := w.inflight[key]; ok {
+		return false
+	}
+	if w.now().Before(w.cooldownUntil[key]) {
+		return false
+	}
+
+	w.inflight[key] = struct{}{}
+	w.queue = append(w.queue, queuedEvidenceRequest{
+		request: request,
+		key:     key,
+		target:  target,
+	})
+	select {
+	case w.wake <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func (w *EvidenceWorker) Wait() {
+	<-w.done
+}
+
+func (w *EvidenceWorker) loop(ctx context.Context) {
+	defer func() {
+		w.mu.Lock()
+		w.stopped = true
+		w.mu.Unlock()
+		close(w.done)
+	}()
+
+	for {
+		if request, ok := w.take(); ok {
+			result := w.collectEvidence(ctx, request.request, request.target)
+			w.onResult(result)
+			w.finish(request.key)
+			continue
+		}
+		select {
+		case <-w.wake:
+		case <-ctx.Done():
+			// No new submissions are accepted after cancellation. Requests
+			// already accepted are drained with the cancelled context so each
+			// still receives exactly one callback.
+			if !w.hasQueued() {
+				return
+			}
+		}
+	}
+}
+
+func (w *EvidenceWorker) take() (queuedEvidenceRequest, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.queue) == 0 {
+		return queuedEvidenceRequest{}, false
+	}
+
+	request := w.queue[0]
+	w.queue[0] = queuedEvidenceRequest{}
+	w.queue = w.queue[1:]
+	w.cooldownUntil[request.key] = w.now().Add(w.cooldown)
+	return request, true
+}
+
+func (w *EvidenceWorker) finish(key string) {
+	w.mu.Lock()
+	delete(w.inflight, key)
+	w.mu.Unlock()
+}
+
+func (w *EvidenceWorker) hasQueued() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.queue) != 0
+}
+
+func (w *EvidenceWorker) prepare(
+	request EvidenceRequest,
+) (EvidenceRequest, string, string, bool) {
+	if request.Trigger.Device == "" {
+		request.Trigger.Device = "unknown"
+	}
+	request.Trigger.CollectionStatus = ""
+	request.Trigger.NVMe = nil
+	request.Trigger.SCSI = nil
+
+	if request.TriggeredAt.IsZero() {
+		request.TriggeredAt = w.now()
+	}
+	if request.Reason != "" &&
+		request.Reason != CollectionReasonTargetUnresolved &&
+		request.Reason != CollectionReasonTargetUnsupported {
+		return EvidenceRequest{}, "", "", false
+	}
+
+	target, validTarget := commandTarget(request.Target)
+	if !validTarget {
+		request.Target = ""
+		if request.Reason == "" {
+			request.Reason = CollectionReasonTargetUnresolved
+		}
+	} else {
+		request.Target = target
+	}
+	if request.Reason == "" &&
+		request.Protocol != EvidenceProtocolNVMe &&
+		request.Protocol != EvidenceProtocolSCSI {
+		request.Reason = CollectionReasonTargetUnsupported
+	}
+
+	resultTarget := request.Target
+	if resultTarget == "" {
+		resultTarget = request.Trigger.Device
+	}
+	key := resultTarget
+	if strings.TrimSpace(key) == "" {
+		key = "unknown"
+		resultTarget = key
+	}
+	return request, resultTarget, key, true
+}
+
+func commandTarget(target string) (string, bool) {
+	if target == "" || target == "." || target == ".." {
+		return "", false
+	}
+	if strings.ContainsAny(target, `/\`) {
+		return "", false
+	}
+	for _, r := range target {
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return "", false
+	}
+	return target, true
 }

--- a/internal/ioobserve/health/evidence_worker.go
+++ b/internal/ioobserve/health/evidence_worker.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"time"
+
+	"huatuo-bamai/pkg/types"
+)
+
+type EvidenceProtocol string
+
+const (
+	EvidenceProtocolNVMe EvidenceProtocol = "nvme"
+	EvidenceProtocolSCSI EvidenceProtocol = "scsi"
+
+	CollectionReasonTargetUnresolved  = "target_unresolved"
+	CollectionReasonToolUnavailable   = "tool_unavailable"
+	CollectionReasonTargetUnsupported = "target_unsupported"
+	CollectionReasonTimeout           = "timeout"
+	CollectionReasonExecError         = "exec_error"
+	CollectionReasonOutputTooLarge    = "output_too_large"
+	CollectionReasonParseError        = "parse_error"
+)
+
+// EvidenceRequest describes one event-triggered health collection.
+type EvidenceRequest struct {
+	Trigger     types.IOHealthEvent
+	Target      string
+	Protocol    EvidenceProtocol
+	TriggeredAt time.Time
+	Reason      string
+}
+
+// EvidenceResult contains one bounded health collection result.
+type EvidenceResult struct {
+	Target      string
+	TriggeredAt time.Time
+	Event       types.IOHealthEvent
+	Reasons     []string
+}
+
+// EvidenceWorker holds the dependencies used by one bounded collection.
+// Queue ownership and event scheduling are added separately.
+type EvidenceWorker struct {
+	lookupPath     func(string) (string, error)
+	runCommand     commandRunner
+	commandTimeout time.Duration
+	maxOutputBytes int
+}

--- a/internal/ioobserve/health/evidence_worker_test.go
+++ b/internal/ioobserve/health/evidence_worker_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"huatuo-bamai/pkg/types"
+)
+
+func TestEvidenceWorkerSerializesDeduplicatesAndAppliesCooldown(t *testing.T) {
+	clock := &fakeEvidenceClock{now: time.Unix(100, 0)}
+	results := make(chan EvidenceResult, 3)
+	started := make(chan string, 8)
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	var active atomic.Int32
+	var maximum atomic.Int32
+
+	worker := NewEvidenceWorker(EvidenceWorkerOptions{
+		OnResult: func(result EvidenceResult) {
+			results <- result
+		},
+	})
+	worker.now = clock.Now
+	worker.lookupPath = func(name string) (string, error) {
+		return "/usr/bin/" + name, nil
+	}
+	worker.commandTimeout = time.Hour
+	worker.runCommand = func(
+		ctx context.Context,
+		executable string,
+		args []string,
+		maxBytes int,
+	) commandExecution {
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			old := maximum.Load()
+			if current <= old || maximum.CompareAndSwap(old, current) {
+				break
+			}
+		}
+		started <- args[len(args)-1]
+		if calls.Add(1) == 1 {
+			select {
+			case <-releaseFirst:
+			case <-ctx.Done():
+				return commandExecution{exitCode: -1, err: ctx.Err()}
+			}
+		}
+		switch args[0] {
+		case "smart-log":
+			return commandExecution{
+				stdout:   []byte(`{"critical_warning":0,"media_errors":0}`),
+				exitCode: 0,
+			}
+		case "error-log":
+			return commandExecution{
+				stdout:   []byte(`{"errors":[]}`),
+				exitCode: 0,
+			}
+		default:
+			return commandExecution{exitCode: -1, err: errors.New("unexpected command")}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	request := func(target string) EvidenceRequest {
+		return EvidenceRequest{
+			Trigger: types.IOHealthEvent{
+				Type:   "nvme_timeout",
+				Device: target + "n1",
+			},
+			Target:      target,
+			Protocol:    EvidenceProtocolNVMe,
+			TriggeredAt: time.Unix(50, 0),
+		}
+	}
+	if !worker.Submit(request("nvme0")) {
+		t.Fatal("first nvme0 trigger was not accepted")
+	}
+	if got := <-started; got != "/dev/nvme0" {
+		t.Fatalf("first command target = %q, want /dev/nvme0", got)
+	}
+	if worker.Submit(request("nvme0")) {
+		t.Fatal("running nvme0 trigger should have been merged")
+	}
+	if !worker.Submit(request("nvme1")) {
+		t.Fatal("nvme1 trigger was not accepted")
+	}
+	if worker.Submit(request("nvme1")) {
+		t.Fatal("pending nvme1 trigger should have been merged")
+	}
+	close(releaseFirst)
+
+	first := receiveEvidenceResult(t, results)
+	second := receiveEvidenceResult(t, results)
+	if first.Target != "nvme0" || second.Target != "nvme1" {
+		t.Fatalf("result order = %q, %q", first.Target, second.Target)
+	}
+	if first.Event.CollectionStatus != "ok" ||
+		second.Event.CollectionStatus != "ok" {
+		t.Fatalf("collection statuses = %q, %q", first.Event.CollectionStatus, second.Event.CollectionStatus)
+	}
+	if maximum.Load() != 1 {
+		t.Fatalf("maximum concurrent commands = %d, want 1", maximum.Load())
+	}
+	if worker.Submit(request("nvme0")) {
+		t.Fatal("nvme0 trigger inside cooldown should not be accepted")
+	}
+
+	clock.Advance(evidenceCooldown)
+	if !worker.Submit(request("nvme0")) {
+		t.Fatal("nvme0 trigger after cooldown was not accepted")
+	}
+	if result := receiveEvidenceResult(t, results); result.Target != "nvme0" {
+		t.Fatalf("post-cooldown result target = %q, want nvme0", result.Target)
+	}
+
+	cancel()
+	worker.Wait()
+}
+
+func TestEvidenceWorkerReportsUnsupportedAttemptWithoutCommand(t *testing.T) {
+	results := make(chan EvidenceResult, 1)
+	var commandCalled atomic.Bool
+	worker := NewEvidenceWorker(EvidenceWorkerOptions{
+		OnResult: func(result EvidenceResult) {
+			results <- result
+		},
+	})
+	worker.runCommand = func(
+		context.Context,
+		string,
+		[]string,
+		int,
+	) commandExecution {
+		commandCalled.Store(true)
+		return commandExecution{exitCode: -1, err: errors.New("unexpected command")}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	if !worker.Submit(EvidenceRequest{
+		Trigger: types.IOHealthEvent{
+			Type:   "block_error",
+			Device: "dm-0",
+		},
+		Protocol: EvidenceProtocolSCSI,
+		Reason:   CollectionReasonTargetUnsupported,
+	}) {
+		t.Fatal("unsupported attempt was not accepted")
+	}
+	result := receiveEvidenceResult(t, results)
+	if result.Target != "dm-0" ||
+		result.Event.CollectionStatus != "unsupported" ||
+		len(result.Reasons) != 1 ||
+		result.Reasons[0] != CollectionReasonTargetUnsupported {
+		t.Fatalf("unsupported result = %#v", result)
+	}
+	if commandCalled.Load() {
+		t.Fatal("unsupported attempt executed a command")
+	}
+	cancel()
+	worker.Wait()
+}
+
+type fakeEvidenceClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeEvidenceClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeEvidenceClock) Advance(duration time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(duration)
+	c.mu.Unlock()
+}
+
+func receiveEvidenceResult(
+	t *testing.T,
+	results <-chan EvidenceResult,
+) EvidenceResult {
+	t.Helper()
+	select {
+	case result := <-results:
+		return result
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for evidence result")
+		return EvidenceResult{}
+	}
+}

--- a/internal/ioobserve/health/md_provider.go
+++ b/internal/ioobserve/health/md_provider.go
@@ -20,6 +20,14 @@
 //     repair, reshape, frozen, or unknown transitions.
 //   - /sys/block/mdX/md/degraded reports unavailable-member count changes.
 //
+// MD member monitoring:
+//
+//   - /sys/block/mdX/md/dev-*/state reports changes to all kernel state tokens.
+//   - degraded notifications refresh every member so simultaneous changes are
+//     emitted separately.
+//   - topology rebuilds report a previously known member that disappears as
+//     removed.
+//
 // The files are opened once and waited on with poll notifications. Initial
 // values establish a baseline; only later transitions are emitted. No periodic
 // polling or external mdadm command is used.
@@ -49,6 +57,7 @@ const (
 	mdLevel        = "level"
 	mdSyncAction   = "sync_action"
 	mdDegraded     = "degraded"
+	mdMemberState  = "state"
 	mdMaxReadBytes = 4096
 	mdStatMaxBytes = 1 << 20
 )
@@ -56,9 +65,10 @@ const (
 type mdPollFunc func([]unix.PollFd, int) (int, error)
 
 type mdWatchFile struct {
-	file  *os.File
-	array string
-	field string
+	file   *os.File
+	array  string
+	member string
+	field  string
 }
 
 type mdArrayState struct {
@@ -77,6 +87,7 @@ type MDWatcher struct {
 
 	mu      sync.RWMutex
 	arrays  map[string]mdArrayState
+	members map[string]map[string]string
 	files   map[int32]*mdWatchFile
 	changes chan MDChange
 
@@ -99,6 +110,7 @@ func newMDWatcher(procMDStatPath, sysBlockPath string, poll mdPollFunc) *MDWatch
 		poll:           poll,
 		now:            time.Now,
 		arrays:         make(map[string]mdArrayState),
+		members:        make(map[string]map[string]string),
 		files:          make(map[int32]*mdWatchFile),
 		changes:        make(chan MDChange, 64),
 		wakeRead:       -1,
@@ -260,7 +272,14 @@ func (w *MDWatcher) handleEvent(target *mdWatchFile, events int16) error {
 	case mdSyncAction:
 		return w.handleSyncActionEventLocked(target)
 	case mdDegraded:
-		return w.handleDegradedEventLocked(target)
+		if err := w.handleDegradedEventLocked(target); err != nil {
+			return err
+		}
+		for _, change := range w.refreshMemberStatesLocked(target.array) {
+			w.emitChangeLocked(change)
+		}
+	case mdMemberState:
+		return w.handleMemberEventLocked(target)
 	}
 	return nil
 }
@@ -288,6 +307,27 @@ func (w *MDWatcher) handleSyncActionEventLocked(target *mdWatchFile) error {
 	status.syncAction = action
 	w.arrays[target.array] = status
 	w.emitChangeLocked(change)
+	return nil
+}
+
+func (w *MDWatcher) handleMemberEventLocked(target *mdWatchFile) error {
+	value, err := readOpenMDFile(target.file)
+	if err != nil {
+		return w.rebuildAfterErrorLocked(target, err)
+	}
+	state := normalizeMDMemberState(value)
+	oldState := w.members[target.array][target.member]
+	if state == oldState {
+		return nil
+	}
+	w.members[target.array][target.member] = state
+	w.emitChangeLocked(MDChange{
+		Array:    target.array,
+		Member:   target.member,
+		Field:    MDFieldMemberState,
+		OldState: oldState,
+		NewState: state,
+	})
 	return nil
 }
 
@@ -323,7 +363,8 @@ func (w *MDWatcher) handleDegradedEventLocked(target *mdWatchFile) error {
 }
 
 func (w *MDWatcher) rebuildAfterErrorLocked(target *mdWatchFile, err error) error {
-	log.Warnf("md watcher: read %s/%s: %v", target.array, target.field, err)
+	log.Warnf("md watcher: read %s/%s/%s: %v",
+		target.array, target.member, target.field, err)
 	if rebuildErr := w.rebuildLocked(true); rebuildErr != nil {
 		return fmt.Errorf("md watcher: rebuild watches: %w", rebuildErr)
 	}
@@ -353,9 +394,11 @@ func (w *MDWatcher) rebuildLocked(emitChanges bool) error {
 	sort.Strings(devices)
 
 	nextArrays := make(map[string]mdArrayState, len(devices))
+	nextMembers := make(map[string]map[string]string, len(devices))
 	for _, device := range devices {
 		mdDir := filepath.Join(w.sysBlockPath, device, "md")
 		status := mdArrayState{}
+		nextMembers[device] = make(map[string]string)
 
 		if err := addMDAttributeWatch(nextFiles, mdDir, device, mdLevel, nil); err != nil {
 			return fmt.Errorf("md watcher: read %s level: %w", device, err)
@@ -381,17 +424,52 @@ func (w *MDWatcher) rebuildLocked(emitChanges bool) error {
 		if degradedErr != nil {
 			return fmt.Errorf("md watcher: parse %s degraded: %w", device, degradedErr)
 		}
+
+		memberEntries, err := os.ReadDir(mdDir)
+		if err != nil {
+			return fmt.Errorf("md watcher: enumerate %s members: %w", device, err)
+		}
+		for _, entry := range memberEntries {
+			entryName := entry.Name()
+			if !strings.HasPrefix(entryName, "dev-") {
+				continue
+			}
+			member := strings.TrimPrefix(entryName, "dev-")
+			if member == "" {
+				continue
+			}
+			statePath := filepath.Join(mdDir, entryName, mdMemberState)
+			if err := addMDPathWatch(
+				nextFiles,
+				statePath,
+				device,
+				member,
+				mdMemberState,
+				func(value string) {
+					nextMembers[device][member] = normalizeMDMemberState(value)
+				},
+			); err != nil {
+				return fmt.Errorf(
+					"md watcher: read %s member %s: %w",
+					device,
+					member,
+					err,
+				)
+			}
+		}
 		nextArrays[device] = status
 	}
 
 	var changes []MDChange
 	if emitChanges {
 		changes = changedMDArrayFields(w.arrays, nextArrays)
+		changes = append(changes, changedMDMembers(w.members, nextMembers)...)
 	}
 
 	oldFiles := w.files
 	w.files = nextFiles
 	w.arrays = nextArrays
+	w.members = nextMembers
 	committed = true
 	for _, change := range changes {
 		w.emitChangeLocked(change)
@@ -438,6 +516,87 @@ func changedMDArrayFields(
 	return changes
 }
 
+func changedMDMembers(
+	previous, current map[string]map[string]string,
+) []MDChange {
+	arrays := make([]string, 0, len(current))
+	for array := range current {
+		arrays = append(arrays, array)
+	}
+	sort.Strings(arrays)
+
+	var changes []MDChange
+	for _, array := range arrays {
+		oldMembers, ok := previous[array]
+		if !ok {
+			continue
+		}
+		members := make([]string, 0, len(oldMembers))
+		for member := range oldMembers {
+			members = append(members, member)
+		}
+		sort.Strings(members)
+		for _, member := range members {
+			oldState := oldMembers[member]
+			newState, exists := current[array][member]
+			if !exists {
+				newState = MDMemberStateRemoved
+			}
+			if oldState == newState {
+				continue
+			}
+			changes = append(changes, MDChange{
+				Array:    array,
+				Member:   member,
+				Field:    MDFieldMemberState,
+				OldState: oldState,
+				NewState: newState,
+			})
+		}
+	}
+	return changes
+}
+
+func (w *MDWatcher) refreshMemberStatesLocked(array string) []MDChange {
+	targets := make([]*mdWatchFile, 0)
+	for _, target := range w.files {
+		if target.array == array && target.field == mdMemberState {
+			targets = append(targets, target)
+		}
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].member < targets[j].member
+	})
+
+	var changes []MDChange
+	for _, target := range targets {
+		value, err := readOpenMDFile(target.file)
+		if err != nil {
+			log.Warnf(
+				"md watcher: %s member %s state: %v",
+				array,
+				target.member,
+				err,
+			)
+			continue
+		}
+		state := normalizeMDMemberState(value)
+		oldState := w.members[array][target.member]
+		if state == oldState {
+			continue
+		}
+		w.members[array][target.member] = state
+		changes = append(changes, MDChange{
+			Array:    array,
+			Member:   target.member,
+			Field:    MDFieldMemberState,
+			OldState: oldState,
+			NewState: state,
+		})
+	}
+	return changes
+}
+
 func (w *MDWatcher) emitChangeLocked(change MDChange) {
 	change.ObservedAt = w.now()
 	select {
@@ -462,7 +621,14 @@ func addMDAttributeWatch(
 	mdDir, array, field string,
 	consume func(string),
 ) error {
-	return addMDPathWatch(files, filepath.Join(mdDir, field), array, field, consume)
+	return addMDPathWatch(
+		files,
+		filepath.Join(mdDir, field),
+		array,
+		"",
+		field,
+		consume,
+	)
 }
 
 func addOptionalMDAttributeWatch(
@@ -479,7 +645,7 @@ func addOptionalMDAttributeWatch(
 
 func addMDPathWatch(
 	files map[int32]*mdWatchFile,
-	path, array, field string,
+	path, array, member, field string,
 	consume func(string),
 ) error {
 	file, value, err := openMDWatchFile(path)
@@ -490,9 +656,10 @@ func addMDPathWatch(
 		consume(value)
 	}
 	files[int32(file.Fd())] = &mdWatchFile{
-		file:  file,
-		array: array,
-		field: field,
+		file:   file,
+		array:  array,
+		member: member,
+		field:  field,
 	}
 	return nil
 }
@@ -569,4 +736,12 @@ func normalizeMDSyncAction(value string) string {
 	default:
 		return "unknown"
 	}
+}
+
+func normalizeMDMemberState(value string) string {
+	fields := strings.FieldsFunc(strings.ToLower(value), func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	sort.Strings(fields)
+	return strings.Join(fields, ",")
 }

--- a/internal/ioobserve/health/md_provider.go
+++ b/internal/ioobserve/health/md_provider.go
@@ -1,0 +1,572 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// MD array monitoring:
+//
+//   - /proc/mdstat discovers active arrays and notifies topology changes.
+//   - /sys/block/mdX/md/level notifies layout changes and rebuilds the watches.
+//   - /sys/block/mdX/md/sync_action reports idle, resync, recover, check,
+//     repair, reshape, frozen, or unknown transitions.
+//   - /sys/block/mdX/md/degraded reports unavailable-member count changes.
+//
+// The files are opened once and waited on with poll notifications. Initial
+// values establish a baseline; only later transitions are emitted. No periodic
+// polling or external mdadm command is used.
+
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"huatuo-bamai/internal/log"
+)
+
+const (
+	mdStatField    = "mdstat"
+	mdLevel        = "level"
+	mdSyncAction   = "sync_action"
+	mdDegraded     = "degraded"
+	mdMaxReadBytes = 4096
+	mdStatMaxBytes = 1 << 20
+)
+
+type mdPollFunc func([]unix.PollFd, int) (int, error)
+
+type mdWatchFile struct {
+	file  *os.File
+	array string
+	field string
+}
+
+type mdArrayState struct {
+	syncAction string
+	degraded   string
+}
+
+// MDWatcher reports MD state transitions using procfs and sysfs
+// notifications. It does not poll or execute external commands.
+type MDWatcher struct {
+	procMDStatPath string
+	sysBlockPath   string
+	poll           mdPollFunc
+	now            func() time.Time
+	ctx            context.Context
+
+	mu      sync.RWMutex
+	arrays  map[string]mdArrayState
+	files   map[int32]*mdWatchFile
+	changes chan MDChange
+
+	lifecycleMu sync.Mutex
+	started     bool
+	done        chan struct{}
+	wakeRead    int
+	runErr      error
+}
+
+// NewMDWatcher creates the single MD notification watcher.
+func NewMDWatcher(procMDStatPath, sysBlockPath string) *MDWatcher {
+	return newMDWatcher(procMDStatPath, sysBlockPath, unix.Poll)
+}
+
+func newMDWatcher(procMDStatPath, sysBlockPath string, poll mdPollFunc) *MDWatcher {
+	return &MDWatcher{
+		procMDStatPath: procMDStatPath,
+		sysBlockPath:   sysBlockPath,
+		poll:           poll,
+		now:            time.Now,
+		arrays:         make(map[string]mdArrayState),
+		files:          make(map[int32]*mdWatchFile),
+		changes:        make(chan MDChange, 64),
+		wakeRead:       -1,
+	}
+}
+
+// Start reads the initial MD topology once, establishes notification watches,
+// and starts the event loop. A watcher is started at most once.
+func (w *MDWatcher) Start(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	w.lifecycleMu.Lock()
+	defer w.lifecycleMu.Unlock()
+	if w.started {
+		return fmt.Errorf("md watcher already started")
+	}
+
+	wake := []int{-1, -1}
+	if err := unix.Pipe2(wake, unix.O_CLOEXEC|unix.O_NONBLOCK); err != nil {
+		return fmt.Errorf("md watcher: create wake pipe: %w", err)
+	}
+
+	w.mu.Lock()
+	w.ctx = ctx
+	err := w.rebuildLocked(false)
+	w.mu.Unlock()
+	if err != nil {
+		unix.Close(wake[0])
+		unix.Close(wake[1])
+		return err
+	}
+
+	w.started = true
+	w.done = make(chan struct{})
+	w.wakeRead = wake[0]
+	go w.run(ctx, wake[0], wake[1], w.done)
+	return nil
+}
+
+// Wait waits for the active watcher, if any, to stop and reports a fatal poll
+// error. Context cancellation is a normal stop and returns nil.
+func (w *MDWatcher) Wait() error {
+	w.lifecycleMu.Lock()
+	done := w.done
+	w.lifecycleMu.Unlock()
+	if done != nil {
+		<-done
+	}
+	w.lifecycleMu.Lock()
+	defer w.lifecycleMu.Unlock()
+	return w.runErr
+}
+
+// Changes returns state transitions observed after the initial baseline.
+func (w *MDWatcher) Changes() <-chan MDChange {
+	return w.changes
+}
+
+func (w *MDWatcher) run(ctx context.Context, wakeRead, wakeWrite int, done chan struct{}) {
+	wakerDone := make(chan struct{})
+	stopWaker := make(chan struct{})
+	go func() {
+		defer close(wakerDone)
+		select {
+		case <-ctx.Done():
+			_, _ = unix.Write(wakeWrite, []byte{1})
+		case <-stopWaker:
+		}
+	}()
+
+	runErr := w.pollLoop(wakeRead)
+	if runErr != nil {
+		log.Warnf("md watcher stopped after poll error: %v", runErr)
+	}
+	close(stopWaker)
+	<-wakerDone
+	unix.Close(wakeRead)
+	unix.Close(wakeWrite)
+
+	w.mu.Lock()
+	w.closeFilesLocked()
+	w.mu.Unlock()
+
+	w.lifecycleMu.Lock()
+	w.wakeRead = -1
+	w.runErr = runErr
+	close(done)
+	w.lifecycleMu.Unlock()
+}
+
+func (w *MDWatcher) pollLoop(wakeRead int) error {
+	for {
+		pollFDs, targets := w.pollFDs(wakeRead)
+		_, err := w.poll(pollFDs, -1)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("poll MD files: %w", err)
+		}
+		if pollFDs[0].Revents != 0 {
+			return nil
+		}
+		for i := 1; i < len(pollFDs); i++ {
+			if pollFDs[i].Revents != 0 {
+				if err := w.handleEvent(targets[i], pollFDs[i].Revents); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+func (w *MDWatcher) pollFDs(wakeRead int) ([]unix.PollFd, []*mdWatchFile) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	pollFDs := make([]unix.PollFd, 1, len(w.files)+1)
+	targets := make([]*mdWatchFile, 1, len(w.files)+1)
+	pollFDs[0] = unix.PollFd{Fd: int32(wakeRead), Events: unix.POLLIN}
+	for fd, target := range w.files {
+		// mdstat_poll always advertises POLLIN|POLLRDNORM, so requesting
+		// either would make this loop spin. MD changes add POLLPRI|POLLERR;
+		// POLLERR is reported even when it isn't in the requested mask.
+		// The watched sysfs attributes likewise signal changes with POLLPRI.
+		pollFDs = append(pollFDs, unix.PollFd{Fd: fd, Events: unix.POLLPRI})
+		targets = append(targets, target)
+	}
+	return pollFDs, targets
+}
+
+func (w *MDWatcher) handleEvent(target *mdWatchFile, events int16) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	fd := int32(target.file.Fd())
+	if w.files[fd] != target {
+		return nil
+	}
+	if events&(unix.POLLHUP|unix.POLLNVAL) != 0 ||
+		events&unix.POLLERR != 0 && events&unix.POLLPRI == 0 {
+		return w.rebuildAfterErrorLocked(
+			target,
+			fmt.Errorf("poll events %#x", events),
+		)
+	}
+
+	switch target.field {
+	case mdStatField, mdLevel:
+		if err := w.rebuildLocked(true); err != nil {
+			return fmt.Errorf(
+				"md watcher: rebuild after %s notification: %w",
+				target.field,
+				err,
+			)
+		}
+	case mdSyncAction:
+		return w.handleSyncActionEventLocked(target)
+	case mdDegraded:
+		return w.handleDegradedEventLocked(target)
+	}
+	return nil
+}
+
+func (w *MDWatcher) handleSyncActionEventLocked(target *mdWatchFile) error {
+	value, err := readOpenMDFile(target.file)
+	if err != nil {
+		return w.rebuildAfterErrorLocked(target, err)
+	}
+
+	status, ok := w.arrays[target.array]
+	if !ok {
+		return nil
+	}
+	action := normalizeMDSyncAction(value)
+	if action == status.syncAction {
+		return nil
+	}
+	change := MDChange{
+		Array:    target.array,
+		Field:    MDFieldSyncAction,
+		OldState: status.syncAction,
+		NewState: action,
+	}
+	status.syncAction = action
+	w.arrays[target.array] = status
+	w.emitChangeLocked(change)
+	return nil
+}
+
+func (w *MDWatcher) handleDegradedEventLocked(target *mdWatchFile) error {
+	value, err := readOpenMDFile(target.file)
+	if err != nil {
+		return w.rebuildAfterErrorLocked(target, err)
+	}
+	degraded, err := parseMDDegraded(value)
+	if err != nil {
+		log.Warnf("md watcher: %s degraded: %v", target.array, err)
+		return nil
+	}
+
+	status, ok := w.arrays[target.array]
+	if !ok {
+		return nil
+	}
+	value = strconv.Itoa(degraded)
+	if value == status.degraded {
+		return nil
+	}
+	change := MDChange{
+		Array:    target.array,
+		Field:    MDFieldDegraded,
+		OldState: status.degraded,
+		NewState: value,
+	}
+	status.degraded = value
+	w.arrays[target.array] = status
+	w.emitChangeLocked(change)
+	return nil
+}
+
+func (w *MDWatcher) rebuildAfterErrorLocked(target *mdWatchFile, err error) error {
+	log.Warnf("md watcher: read %s/%s: %v", target.array, target.field, err)
+	if rebuildErr := w.rebuildLocked(true); rebuildErr != nil {
+		return fmt.Errorf("md watcher: rebuild watches: %w", rebuildErr)
+	}
+	return nil
+}
+
+func (w *MDWatcher) rebuildLocked(emitChanges bool) error {
+	nextFiles := make(map[int32]*mdWatchFile)
+	committed := false
+	defer func() {
+		if !committed {
+			closeMDWatchFiles(nextFiles)
+		}
+	}()
+
+	mdstat, data, err := openMDStatWatchFile(w.procMDStatPath)
+	if err != nil {
+		return fmt.Errorf("md watcher: open %s: %w", w.procMDStatPath, err)
+	}
+	nextFiles[int32(mdstat.Fd())] = &mdWatchFile{file: mdstat, field: mdStatField}
+
+	active := parseActiveMDStatDevices(data)
+	devices := make([]string, 0, len(active))
+	for device := range active {
+		devices = append(devices, device)
+	}
+	sort.Strings(devices)
+
+	nextArrays := make(map[string]mdArrayState, len(devices))
+	for _, device := range devices {
+		mdDir := filepath.Join(w.sysBlockPath, device, "md")
+		status := mdArrayState{}
+
+		if err := addMDAttributeWatch(nextFiles, mdDir, device, mdLevel, nil); err != nil {
+			return fmt.Errorf("md watcher: read %s level: %w", device, err)
+		}
+		if err := addOptionalMDAttributeWatch(nextFiles, mdDir, device, mdSyncAction,
+			func(value string) {
+				status.syncAction = normalizeMDSyncAction(value)
+			}); err != nil {
+			return fmt.Errorf("md watcher: read %s sync_action: %w", device, err)
+		}
+		var degradedErr error
+		if err := addOptionalMDAttributeWatch(nextFiles, mdDir, device, mdDegraded,
+			func(value string) {
+				degraded, err := parseMDDegraded(value)
+				if err != nil {
+					degradedErr = err
+					return
+				}
+				status.degraded = strconv.Itoa(degraded)
+			}); err != nil {
+			return fmt.Errorf("md watcher: read %s degraded: %w", device, err)
+		}
+		if degradedErr != nil {
+			return fmt.Errorf("md watcher: parse %s degraded: %w", device, degradedErr)
+		}
+		nextArrays[device] = status
+	}
+
+	var changes []MDChange
+	if emitChanges {
+		changes = changedMDArrayFields(w.arrays, nextArrays)
+	}
+
+	oldFiles := w.files
+	w.files = nextFiles
+	w.arrays = nextArrays
+	committed = true
+	for _, change := range changes {
+		w.emitChangeLocked(change)
+	}
+	closeMDWatchFiles(oldFiles)
+	return nil
+}
+
+func changedMDArrayFields(
+	previous, current map[string]mdArrayState,
+) []MDChange {
+	arrays := make([]string, 0, len(current))
+	for array := range current {
+		arrays = append(arrays, array)
+	}
+	sort.Strings(arrays)
+
+	var changes []MDChange
+	for _, array := range arrays {
+		oldState, ok := previous[array]
+		if !ok {
+			continue
+		}
+		newState := current[array]
+		if oldState.syncAction != "" && newState.syncAction != "" &&
+			oldState.syncAction != newState.syncAction {
+			changes = append(changes, MDChange{
+				Array:    array,
+				Field:    MDFieldSyncAction,
+				OldState: oldState.syncAction,
+				NewState: newState.syncAction,
+			})
+		}
+		if oldState.degraded != "" && newState.degraded != "" &&
+			oldState.degraded != newState.degraded {
+			changes = append(changes, MDChange{
+				Array:    array,
+				Field:    MDFieldDegraded,
+				OldState: oldState.degraded,
+				NewState: newState.degraded,
+			})
+		}
+	}
+	return changes
+}
+
+func (w *MDWatcher) emitChangeLocked(change MDChange) {
+	change.ObservedAt = w.now()
+	select {
+	case w.changes <- change:
+	case <-w.ctx.Done():
+	}
+}
+
+func (w *MDWatcher) closeFilesLocked() {
+	closeMDWatchFiles(w.files)
+	clear(w.files)
+}
+
+func closeMDWatchFiles(files map[int32]*mdWatchFile) {
+	for _, target := range files {
+		_ = target.file.Close()
+	}
+}
+
+func addMDAttributeWatch(
+	files map[int32]*mdWatchFile,
+	mdDir, array, field string,
+	consume func(string),
+) error {
+	return addMDPathWatch(files, filepath.Join(mdDir, field), array, field, consume)
+}
+
+func addOptionalMDAttributeWatch(
+	files map[int32]*mdWatchFile,
+	mdDir, array, field string,
+	consume func(string),
+) error {
+	err := addMDAttributeWatch(files, mdDir, array, field, consume)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func addMDPathWatch(
+	files map[int32]*mdWatchFile,
+	path, array, field string,
+	consume func(string),
+) error {
+	file, value, err := openMDWatchFile(path)
+	if err != nil {
+		return err
+	}
+	if consume != nil {
+		consume(value)
+	}
+	files[int32(file.Fd())] = &mdWatchFile{
+		file:  file,
+		array: array,
+		field: field,
+	}
+	return nil
+}
+
+func openMDWatchFile(path string) (*os.File, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	value, err := readOpenMDFileLimit(file, mdMaxReadBytes)
+	if err != nil {
+		_ = file.Close()
+		return nil, "", err
+	}
+	return file, value, nil
+}
+
+func openMDStatWatchFile(path string) (*os.File, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, "", err
+	}
+	value, err := readOpenMDFileLimit(file, mdStatMaxBytes)
+	if err != nil {
+		_ = file.Close()
+		return nil, "", err
+	}
+	return file, value, nil
+}
+
+func readOpenMDFile(file *os.File) (string, error) {
+	return readOpenMDFileLimit(file, mdMaxReadBytes)
+}
+
+func readOpenMDFileLimit(file *os.File, limit int64) (string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, limit))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func parseActiveMDStatDevices(data string) map[string]bool {
+	devices := make(map[string]bool)
+	for _, line := range strings.Split(data, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[1] == ":" && fields[2] == "active" &&
+			strings.HasPrefix(fields[0], "md") {
+			devices[fields[0]] = true
+		}
+	}
+	return devices
+}
+
+func parseMDDegraded(value string) (int, error) {
+	degraded, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || degraded < 0 {
+		if err == nil {
+			err = fmt.Errorf("negative value %d", degraded)
+		}
+		return 0, err
+	}
+	return degraded, nil
+}
+
+func normalizeMDSyncAction(value string) string {
+	action := strings.ToLower(strings.TrimSpace(value))
+	switch action {
+	case "idle", "resync", "recover", "check", "repair", "reshape", "frozen":
+		return action
+	default:
+		return "unknown"
+	}
+}

--- a/internal/ioobserve/health/md_provider_integration_test.go
+++ b/internal/ioobserve/health/md_provider_integration_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	mdIntegrationCommandTimeout = 15 * time.Second
+	mdIntegrationEventTimeout   = 15 * time.Second
+	mdIntegrationQuietPeriod    = 500 * time.Millisecond
+	mdIntegrationImageSize      = 64 << 20
+)
+
+// Integration test (real MD RAID and loop devices):
+//
+//	TEST_INTEGRATION=true go test -v -run TestMDWatcherMonitorsMdadmLoopArray \
+//	  ./internal/ioobserve/health
+func TestMDWatcherMonitorsMdadmLoopArray(t *testing.T) {
+	mdadm, losetup := requireMDIntegrationEnvironment(t)
+
+	workDir := t.TempDir()
+	images := []string{
+		filepath.Join(workDir, "member-0.img"),
+		filepath.Join(workDir, "member-1.img"),
+	}
+	for _, image := range images {
+		if err := os.WriteFile(image, nil, 0o600); err != nil {
+			t.Fatalf("create loop backing file %s: %v", image, err)
+		}
+		if err := os.Truncate(image, mdIntegrationImageSize); err != nil {
+			t.Fatalf("size loop backing file %s: %v", image, err)
+		}
+	}
+
+	mdDevice := findUnusedMDIntegrationDevice(t)
+	mdName := filepath.Base(mdDevice)
+	mdSysfsPath := filepath.Join("/sys/block", mdName)
+
+	var (
+		loopDevices  []string
+		arrayCreated bool
+		watcher      *MDWatcher
+		cancel       context.CancelFunc
+	)
+	t.Cleanup(func() {
+		if cancel != nil {
+			cancel()
+			if err := watcher.Wait(); err != nil {
+				t.Errorf("stop MD watcher: %v", err)
+			}
+		}
+
+		if _, err := os.Stat(mdSysfsPath); err == nil {
+			runMDIntegrationCleanup(t, mdadm, "--stop", "--force", mdDevice)
+			waitForMDIntegrationPath(t, mdSysfsPath, false)
+		} else if !os.IsNotExist(err) {
+			t.Errorf("check MD device %s during cleanup: %v", mdDevice, err)
+		}
+
+		if arrayCreated {
+			for _, loopDevice := range loopDevices {
+				runMDIntegrationCleanup(t, mdadm,
+					"--zero-superblock", "--force", loopDevice)
+			}
+		}
+		for _, loopDevice := range loopDevices {
+			runMDIntegrationCleanup(t, losetup, "--detach", loopDevice)
+			waitForMDIntegrationLoopDetach(t, loopDevice)
+		}
+	})
+
+	for _, image := range images {
+		output := runMDIntegrationCommand(t, losetup, "--find", "--show", image)
+		loopDevice := strings.TrimSpace(output)
+		if !strings.HasPrefix(loopDevice, "/dev/loop") ||
+			strings.Contains(loopDevice, "\n") {
+			t.Fatalf("losetup returned invalid loop device %q", output)
+		}
+		loopDevices = append(loopDevices, loopDevice)
+	}
+
+	runMDIntegrationCommand(t, mdadm,
+		"--create", mdDevice,
+		"--metadata=1.2",
+		"--level=1",
+		"--raid-devices=2",
+		"--assume-clean",
+		"--run",
+		"--force",
+		loopDevices[0], loopDevices[1],
+	)
+	arrayCreated = true
+	waitForMDIntegrationPath(t, mdSysfsPath, true)
+
+	watcher = NewMDWatcher("/proc/mdstat", "/sys/block")
+	ctx, stop := context.WithCancel(context.Background())
+	cancel = stop
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("start MD watcher: %v", err)
+	}
+
+	assertNoMDIntegrationChange(t, watcher)
+
+	failedMember := filepath.Base(loopDevices[1])
+	runMDIntegrationCommand(t, mdadm, mdDevice, "--fail", loopDevices[1])
+	waitForMDIntegrationFailure(t, watcher, mdName, failedMember)
+
+	runMDIntegrationCommand(t, mdadm, "--stop", "--force", mdDevice)
+	waitForMDIntegrationPath(t, mdSysfsPath, false)
+}
+
+func requireMDIntegrationEnvironment(t *testing.T) (string, string) {
+	t.Helper()
+	if os.Getenv("TEST_INTEGRATION") != "true" {
+		t.Skip("Set TEST_INTEGRATION=true to run integration tests")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("MD integration test requires root privileges")
+	}
+
+	mdadm, err := exec.LookPath("mdadm")
+	if err != nil {
+		t.Skipf("MD integration test requires mdadm: %v", err)
+	}
+	losetup, err := exec.LookPath("losetup")
+	if err != nil {
+		t.Skipf("MD integration test requires losetup: %v", err)
+	}
+	if _, err := os.Stat("/proc/mdstat"); err != nil {
+		t.Skipf("MD integration test requires /proc/mdstat: %v", err)
+	}
+	requireRAID1IntegrationPersonality(t)
+	return mdadm, losetup
+}
+
+func requireRAID1IntegrationPersonality(t *testing.T) {
+	t.Helper()
+	mdstat, err := os.ReadFile("/proc/mdstat")
+	if err != nil {
+		t.Skipf("read /proc/mdstat: %v", err)
+	}
+	if strings.Contains(string(mdstat), "[raid1]") {
+		return
+	}
+
+	modprobe, err := exec.LookPath("modprobe")
+	if err != nil {
+		t.Skip("RAID1 kernel personality is not loaded and modprobe is unavailable")
+	}
+	if output, err := executeMDIntegrationCommand(modprobe, "raid1"); err != nil {
+		t.Skipf("RAID1 kernel personality is unavailable: %v; output: %s", err, output)
+	}
+	mdstat, err = os.ReadFile("/proc/mdstat")
+	if err != nil || !strings.Contains(string(mdstat), "[raid1]") {
+		t.Skip("modprobe completed but the RAID1 kernel personality is unavailable")
+	}
+}
+
+func findUnusedMDIntegrationDevice(t *testing.T) string {
+	t.Helper()
+	for minor := 127; minor >= 0; minor-- {
+		name := fmt.Sprintf("md%d", minor)
+		if _, err := os.Stat(filepath.Join("/sys/block", name)); !os.IsNotExist(err) {
+			continue
+		}
+		device := filepath.Join("/dev", name)
+		info, err := os.Stat(device)
+		if os.IsNotExist(err) || err == nil && info.Mode()&os.ModeDevice != 0 {
+			return device
+		}
+	}
+	t.Fatal("no unused /dev/md device is available")
+	return ""
+}
+
+func waitForMDIntegrationFailure(
+	t *testing.T,
+	watcher *MDWatcher,
+	array, member string,
+) {
+	t.Helper()
+	timer := time.NewTimer(mdIntegrationEventTimeout)
+	defer timer.Stop()
+
+	memberFault := false
+	degraded := false
+	for {
+		if degraded && memberFault {
+			quietTimer := time.NewTimer(mdIntegrationQuietPeriod)
+			defer quietTimer.Stop()
+			select {
+			case change := <-watcher.Changes():
+				if change.Field == MDFieldMemberState && change.Member == member {
+					t.Fatalf("received duplicate MD member fault notification: %+v", change)
+				}
+			case <-quietTimer.C:
+				return
+			}
+		}
+
+		select {
+		case change := <-watcher.Changes():
+			switch change.Field {
+			case MDFieldDegraded:
+				if change.Array == array && change.NewState == "1" {
+					degraded = true
+				}
+			case MDFieldMemberState:
+				if change.Member == member {
+					assertMDIntegrationFailureChange(t, change, array, member)
+					if memberFault {
+						t.Fatalf("received duplicate MD member fault: %+v", change)
+					}
+					memberFault = true
+				}
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s/%s fault and degraded=1",
+				array, member)
+		}
+	}
+}
+
+func assertMDIntegrationFailureChange(
+	t *testing.T,
+	change MDChange,
+	array, member string,
+) {
+	t.Helper()
+	if change.Array != array || change.Member != member ||
+		change.Field != MDFieldMemberState ||
+		!mdIntegrationStateContains(change.OldState, "in_sync") ||
+		!mdIntegrationStateContains(change.NewState, "faulty") ||
+		change.ObservedAt.IsZero() {
+		t.Fatalf("MD member change = %+v, want %s/%s in_sync -> faulty",
+			change, array, member)
+	}
+}
+
+func mdIntegrationStateContains(state, target string) bool {
+	for _, value := range strings.Split(state, ",") {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNoMDIntegrationChange(t *testing.T, watcher *MDWatcher) {
+	t.Helper()
+	select {
+	case change := <-watcher.Changes():
+		t.Fatalf("unexpected initial MD change: %+v", change)
+	default:
+	}
+}
+
+func waitForMDIntegrationPath(t *testing.T, path string, wantExists bool) {
+	t.Helper()
+	deadline := time.Now().Add(mdIntegrationEventTimeout)
+	for {
+		_, err := os.Stat(path)
+		exists := err == nil
+		if exists == wantExists {
+			return
+		}
+		if err != nil && !os.IsNotExist(err) {
+			t.Errorf("stat %s: %v", path, err)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("timed out waiting for %s existence=%t", path, wantExists)
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func runMDIntegrationCommand(t *testing.T, name string, args ...string) string {
+	t.Helper()
+	output, err := executeMDIntegrationCommand(name, args...)
+	if err != nil {
+		t.Fatalf("%v; output: %s", err, output)
+	}
+	return output
+}
+
+func runMDIntegrationCleanup(t *testing.T, name string, args ...string) {
+	t.Helper()
+	output, err := executeMDIntegrationCommand(name, args...)
+	if err != nil {
+		t.Errorf("MD integration cleanup: %v; output: %s", err, output)
+	}
+}
+
+func waitForMDIntegrationLoopDetach(t *testing.T, loopDevice string) {
+	t.Helper()
+	backingFile := filepath.Join(
+		"/sys/block", filepath.Base(loopDevice), "loop", "backing_file",
+	)
+	waitForMDIntegrationPath(t, backingFile, false)
+}
+
+func executeMDIntegrationCommand(name string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), mdIntegrationCommandTimeout)
+	defer cancel()
+	command := exec.CommandContext(ctx, name, args...)
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		return strings.TrimSpace(string(output)),
+			fmt.Errorf("command %s timed out: %w", name, ctx.Err())
+	}
+	if err != nil {
+		return strings.TrimSpace(string(output)),
+			fmt.Errorf("command %s %s failed: %w",
+				name, strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/ioobserve/health/md_provider_integration_test.go
+++ b/internal/ioobserve/health/md_provider_integration_test.go
@@ -213,9 +213,21 @@ func waitForMDIntegrationFailure(
 			defer quietTimer.Stop()
 			select {
 			case change := <-watcher.Changes():
+				// mdadm --fail can move a RAID1 member through intermediate
+				// states (in_sync -> blocked,faulty -> faulty) before it
+				// settles, so an extra member transition is legitimate. Only a
+				// no-op duplicate or a transition out of a failed state is
+				// spurious.
 				if change.Field == MDFieldMemberState && change.Member == member {
-					t.Fatalf("received duplicate MD member fault notification: %+v", change)
+					if change.OldState == change.NewState {
+						t.Fatalf("received duplicate MD member state notification: %+v", change)
+					}
+					if !mdIntegrationStateContains(change.NewState, "faulty") &&
+						!mdIntegrationStateContains(change.NewState, "blocked") {
+						t.Fatalf("MD member %s left its failed state: %+v", member, change)
+					}
 				}
+				continue
 			case <-quietTimer.C:
 				return
 			}
@@ -230,11 +242,13 @@ func waitForMDIntegrationFailure(
 				}
 			case MDFieldMemberState:
 				if change.Member == member {
-					assertMDIntegrationFailureChange(t, change, array, member)
-					if memberFault {
-						t.Fatalf("received duplicate MD member fault: %+v", change)
+					if change.OldState == change.NewState {
+						t.Fatalf("received duplicate MD member state notification: %+v", change)
 					}
-					memberFault = true
+					if !memberFault {
+						assertMDIntegrationFailureChange(t, change, array, member)
+						memberFault = true
+					}
 				}
 			}
 		case <-timer.C:

--- a/internal/ioobserve/health/md_provider_test.go
+++ b/internal/ioobserve/health/md_provider_test.go
@@ -1,0 +1,815 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type mdFixture struct {
+	mdstat   string
+	sysBlock string
+}
+
+type mdPollResult struct {
+	fd     int32
+	events int16
+	err    error
+}
+
+type fakeMDPoller struct {
+	results chan mdPollResult
+}
+
+func newFakeMDPoller() *fakeMDPoller {
+	return &fakeMDPoller{results: make(chan mdPollResult, 16)}
+}
+
+func (p *fakeMDPoller) poll(fds []unix.PollFd, _ int) (int, error) {
+	result := <-p.results
+	if result.err != nil {
+		return 0, result.err
+	}
+	for i := range fds {
+		if fds[i].Fd == result.fd {
+			fds[i].Revents = result.events
+			return 1, nil
+		}
+	}
+	return 0, unix.EINTR
+}
+
+func (p *fakeMDPoller) trigger(fd int32) {
+	p.results <- mdPollResult{fd: fd, events: unix.POLLPRI | unix.POLLERR}
+}
+
+func (p *fakeMDPoller) fail(err error) {
+	p.results <- mdPollResult{err: err}
+}
+
+func setupMDFixture(t *testing.T, devices map[string]map[string]string) mdFixture {
+	t.Helper()
+	root := t.TempDir()
+	mdstat := filepath.Join(root, "proc", "mdstat")
+	sysBlock := filepath.Join(root, "sys", "block")
+	if err := os.MkdirAll(filepath.Dir(mdstat), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sysBlock, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for device, files := range devices {
+		writeMDDevice(t, sysBlock, device, files)
+	}
+	deviceNames := make([]string, 0, len(devices))
+	for device := range devices {
+		deviceNames = append(deviceNames, device)
+	}
+	writeMDStatFixture(t, mdstat, deviceNames...)
+	return mdFixture{mdstat: mdstat, sysBlock: sysBlock}
+}
+
+func writeMDStatFixture(t *testing.T, path string, devices ...string) {
+	writeMDStatFixtureForLevel(t, path, "raid1", devices...)
+}
+
+func writeMDStatFixtureForLevel(
+	t *testing.T,
+	path, level string,
+	devices ...string,
+) {
+	t.Helper()
+	sort.Strings(devices)
+	var content strings.Builder
+	fmt.Fprintf(&content, "Personalities : [%s]\n", level)
+	for _, device := range devices {
+		fmt.Fprintf(&content, "%s : active %s\n", device, level)
+	}
+	content.WriteString("unused devices: <none>\n")
+	if err := os.WriteFile(path, []byte(content.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMDDevice(t *testing.T, sysBlock, device string, files map[string]string) {
+	t.Helper()
+	mdDir := filepath.Join(sysBlock, device, "md")
+	for name, content := range files {
+		path := filepath.Join(mdDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func startMDWatcher(t *testing.T, fixture mdFixture) (*MDWatcher, *fakeMDPoller, context.CancelFunc) {
+	t.Helper()
+	poller := newFakeMDPoller()
+	watcher := newMDWatcher(fixture.mdstat, fixture.sysBlock, poller.poll)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := watcher.Start(ctx); err != nil {
+		cancel()
+		t.Fatalf("Start() error = %v", err)
+	}
+	return watcher, poller, cancel
+}
+
+func stopMDWatcher(
+	t *testing.T,
+	watcher *MDWatcher,
+	poller *fakeMDPoller,
+	cancel context.CancelFunc,
+) {
+	t.Helper()
+	watcher.lifecycleMu.Lock()
+	wakeRead := watcher.wakeRead
+	watcher.lifecycleMu.Unlock()
+	cancel()
+	poller.trigger(int32(wakeRead))
+	watcher.Wait()
+}
+
+func mdFileFD(t *testing.T, watcher *MDWatcher, array, member, field string) int32 {
+	t.Helper()
+	return int32(mdFileTarget(t, watcher, array, member, field).file.Fd())
+}
+
+func mdFileTarget(
+	t *testing.T,
+	watcher *MDWatcher,
+	array, member, field string,
+) *mdWatchFile {
+	t.Helper()
+	watcher.mu.RLock()
+	defer watcher.mu.RUnlock()
+	for _, target := range watcher.files {
+		if target.array == array && target.member == member && target.field == field {
+			return target
+		}
+	}
+	t.Fatalf("watch %s/%s/%s not found", array, member, field)
+	return nil
+}
+
+func waitMDChange(t *testing.T, watcher *MDWatcher, match func(MDChange) bool) MDChange {
+	t.Helper()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case change := <-watcher.Changes():
+			if match(change) {
+				return change
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for MD change")
+		}
+	}
+}
+
+func assertNoMDChange(t *testing.T, watcher *MDWatcher) {
+	t.Helper()
+	select {
+	case change := <-watcher.Changes():
+		t.Fatalf("unexpected MD change: %+v", change)
+	default:
+	}
+}
+
+func assertMDMemberWatchPreserved(
+	t *testing.T,
+	watcher *MDWatcher,
+	previous *mdWatchFile,
+	array, member, state string,
+) {
+	t.Helper()
+
+	current := mdFileTarget(t, watcher, array, member, mdMemberState)
+	if current != previous {
+		t.Fatalf("%s/%s watch was replaced after failed rebuild", array, member)
+	}
+	watcher.mu.RLock()
+	currentState := watcher.members[array][member]
+	watcher.mu.RUnlock()
+	if currentState != state {
+		t.Fatalf("%s/%s state = %q, want %q", array, member, currentState, state)
+	}
+	value, err := readOpenMDFile(current.file)
+	if err != nil {
+		t.Fatalf("preserved %s/%s watch cannot be read: %v", array, member, err)
+	}
+	if value != state {
+		t.Fatalf("preserved %s/%s watch value = %q, want %q", array, member, value, state)
+	}
+	assertNoMDChange(t, watcher)
+}
+
+func TestMDWatcherReportsTransitionsAfterInitialBaseline(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:                    "raid1\n",
+			mdSyncAction:               "idle\n",
+			mdDegraded:                 "0\n",
+			"dev-sda/" + mdMemberState: "in_sync\n",
+			"dev-sdb/" + mdMemberState: "in_sync\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	assertNoMDChange(t, watcher)
+
+	syncPath := filepath.Join(fixture.sysBlock, "md0", "md", mdSyncAction)
+	if err := os.WriteFile(syncPath, []byte("recover\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	poller.trigger(mdFileFD(t, watcher, "md0", "", mdSyncAction))
+	change := waitMDChange(t, watcher, func(change MDChange) bool {
+		return change.Field == MDFieldSyncAction
+	})
+	if change.Array != "md0" || change.Member != "" ||
+		change.OldState != "idle" || change.NewState != "recover" ||
+		change.ObservedAt.IsZero() {
+		t.Fatalf("sync change = %+v", change)
+	}
+
+	memberPath := filepath.Join(fixture.sysBlock, "md0", "md", "dev-sdb", mdMemberState)
+	if err := os.WriteFile(memberPath, []byte("faulty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	poller.trigger(mdFileFD(t, watcher, "md0", "sdb", mdMemberState))
+	change = waitMDChange(t, watcher, func(change MDChange) bool {
+		return change.Field == MDFieldMemberState
+	})
+	if change.Array != "md0" || change.Member != "sdb" ||
+		change.OldState != "in_sync" || change.NewState != "faulty" ||
+		change.ObservedAt.IsZero() {
+		t.Fatalf("member change = %+v", change)
+	}
+
+	degradedPath := filepath.Join(fixture.sysBlock, "md0", "md", mdDegraded)
+	if err := os.WriteFile(degradedPath, []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	poller.trigger(mdFileFD(t, watcher, "md0", "", mdDegraded))
+	change = waitMDChange(t, watcher, func(change MDChange) bool {
+		return change.Field == MDFieldDegraded
+	})
+	if change.Array != "md0" || change.OldState != "0" ||
+		change.NewState != "1" {
+		t.Fatalf("degraded change = %+v", change)
+	}
+	assertNoMDChange(t, watcher)
+}
+
+func TestMDWatcherStartsWithoutRedundancyAttributes(t *testing.T) {
+	for _, level := range []string{"raid0", "linear"} {
+		t.Run(level, func(t *testing.T) {
+			fixture := setupMDFixture(t, map[string]map[string]string{
+				"md0": {
+					mdLevel:                    level + "\n",
+					"dev-sda/" + mdMemberState: "in_sync\n",
+				},
+			})
+			writeMDStatFixtureForLevel(t, fixture.mdstat, level, "md0")
+			watcher, poller, cancel := startMDWatcher(t, fixture)
+			defer stopMDWatcher(t, watcher, poller, cancel)
+
+			statePath := filepath.Join(
+				fixture.sysBlock,
+				"md0",
+				"md",
+				"dev-sda",
+				mdMemberState,
+			)
+			if err := os.WriteFile(statePath, []byte("faulty\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			poller.trigger(mdFileFD(t, watcher, "md0", "sda", mdMemberState))
+
+			change := waitMDChange(t, watcher, func(change MDChange) bool {
+				return change.Field == MDFieldMemberState
+			})
+			if change.Array != "md0" || change.Member != "sda" ||
+				change.OldState != "in_sync" || change.NewState != "faulty" {
+				t.Fatalf("member change = %+v", change)
+			}
+		})
+	}
+}
+
+func TestMDWatcherStopsAfterNotificationRebuildFailure(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		array string
+		field string
+	}{
+		{name: "mdstat", field: mdStatField},
+		{name: "level", array: "md0", field: mdLevel},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := setupMDFixture(t, map[string]map[string]string{
+				"md0": {
+					mdLevel:                    "raid1\n",
+					mdSyncAction:               "idle\n",
+					mdDegraded:                 "0\n",
+					"dev-sda/" + mdMemberState: "in_sync\n",
+				},
+			})
+			watcher, poller, cancel := startMDWatcher(t, fixture)
+			defer stopMDWatcher(t, watcher, poller, cancel)
+
+			statePath := filepath.Join(
+				fixture.sysBlock,
+				"md0",
+				"md",
+				"dev-sda",
+				mdMemberState,
+			)
+			if err := os.Remove(statePath); err != nil {
+				t.Fatal(err)
+			}
+			poller.trigger(mdFileFD(t, watcher, test.array, "", test.field))
+			sentinel := errors.New("unexpected second poll")
+			poller.fail(sentinel)
+
+			err := watcher.Wait()
+			if err == nil {
+				t.Fatal("Wait() error = nil, want rebuild error")
+			}
+			if errors.Is(err, sentinel) {
+				t.Fatalf("Wait() error = %v, watcher continued polling", err)
+			}
+			if !strings.Contains(err.Error(), "rebuild after "+test.field+" notification") {
+				t.Fatalf("Wait() error = %v, want notification rebuild context", err)
+			}
+		})
+	}
+}
+
+func TestMDWatcherPollsOnlyForPriorityChanges(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:      "raid1\n",
+			mdSyncAction: "idle\n",
+			mdDegraded:   "0\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	watcher.lifecycleMu.Lock()
+	wakeRead := watcher.wakeRead
+	watcher.lifecycleMu.Unlock()
+	pollFDs, targets := watcher.pollFDs(wakeRead)
+	if len(pollFDs) != len(targets) || len(pollFDs) < 2 {
+		t.Fatalf("poll set has %d fds and %d targets", len(pollFDs), len(targets))
+	}
+	if pollFDs[0].Events != unix.POLLIN {
+		t.Fatalf("wake pipe events = %#x, want POLLIN", pollFDs[0].Events)
+	}
+	for i := 1; i < len(pollFDs); i++ {
+		if pollFDs[i].Events != unix.POLLPRI {
+			t.Fatalf(
+				"watch %s events = %#x, want POLLPRI",
+				targets[i].field,
+				pollFDs[i].Events,
+			)
+		}
+	}
+}
+
+func TestMDWatcherRebuildPreservesMemberFaultNotification(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:                    "raid1\n",
+			mdSyncAction:               "idle\n",
+			mdDegraded:                 "0\n",
+			"dev-sda/" + mdMemberState: "in_sync\n",
+			"dev-sdb/" + mdMemberState: "in_sync\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	mdstatTarget := mdFileTarget(t, watcher, "", "", mdStatField)
+	memberTarget := mdFileTarget(t, watcher, "md0", "sdb", mdMemberState)
+	memberPath := filepath.Join(fixture.sysBlock, "md0", "md", "dev-sdb", mdMemberState)
+	if err := os.WriteFile(memberPath, []byte("faulty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A real fault can make mdstat and the member fd ready together. Model
+	// mdstat being handled first: rebuild replaces and closes memberTarget,
+	// so the state diff must preserve the notification before the stale fd is
+	// ignored.
+	watcher.handleEvent(mdstatTarget, unix.POLLPRI|unix.POLLERR)
+	watcher.handleEvent(memberTarget, unix.POLLPRI|unix.POLLERR)
+
+	select {
+	case change := <-watcher.Changes():
+		if change.Array != "md0" || change.Member != "sdb" ||
+			change.Field != MDFieldMemberState ||
+			change.OldState != "in_sync" || change.NewState != "faulty" {
+			t.Fatalf("member change = %+v", change)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for rebuilt member change")
+	}
+	assertNoMDChange(t, watcher)
+}
+
+func TestMDWatcherEmitsEveryMemberFaultSeenWithDegradedChange(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:                    "raid1\n",
+			mdSyncAction:               "idle\n",
+			mdDegraded:                 "0\n",
+			"dev-sda/" + mdMemberState: "in_sync\n",
+			"dev-sdb/" + mdMemberState: "in_sync\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	degradedTarget := mdFileTarget(t, watcher, "md0", "", mdDegraded)
+	memberTargets := []*mdWatchFile{
+		mdFileTarget(t, watcher, "md0", "sda", mdMemberState),
+		mdFileTarget(t, watcher, "md0", "sdb", mdMemberState),
+	}
+	mdDir := filepath.Join(fixture.sysBlock, "md0", "md")
+	for _, member := range []string{"sda", "sdb"} {
+		if err := os.WriteFile(
+			filepath.Join(mdDir, "dev-"+member, mdMemberState),
+			[]byte("faulty\n"),
+			0o644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(mdDir, mdDegraded), []byte("2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher.handleEvent(degradedTarget, unix.POLLPRI|unix.POLLERR)
+	degraded := waitMDChange(t, watcher, func(change MDChange) bool {
+		return change.Field == MDFieldDegraded
+	})
+	if degraded.OldState != "0" || degraded.NewState != "2" {
+		t.Fatalf("degraded change = %+v", degraded)
+	}
+	changes := make(map[string]MDChange)
+	for range 2 {
+		select {
+		case change := <-watcher.Changes():
+			changes[change.Member] = change
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for both faulted member changes")
+		}
+	}
+	for _, member := range []string{"sda", "sdb"} {
+		change, ok := changes[member]
+		if !ok || change.Array != "md0" ||
+			change.Field != MDFieldMemberState ||
+			change.OldState != "in_sync" || change.NewState != "faulty" {
+			t.Fatalf("%s change = %+v, present=%t", member, change, ok)
+		}
+	}
+
+	// Member fds can already be ready when degraded is processed. Their stale
+	// notifications must not duplicate changes whose cache was refreshed above.
+	for _, target := range memberTargets {
+		watcher.handleEvent(target, unix.POLLPRI|unix.POLLERR)
+	}
+	assertNoMDChange(t, watcher)
+}
+
+func TestMDWatcherReportsRemovedMemberFromActiveArray(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:                    "raid1\n",
+			mdSyncAction:               "idle\n",
+			mdDegraded:                 "0\n",
+			"dev-sda/" + mdMemberState: "in_sync\n",
+			"dev-sdb/" + mdMemberState: "in_sync\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	mdstatTarget := mdFileTarget(t, watcher, "", "", mdStatField)
+	mdDir := filepath.Join(fixture.sysBlock, "md0", "md")
+	if err := os.RemoveAll(filepath.Join(mdDir, "dev-sdb")); err != nil {
+		t.Fatal(err)
+	}
+	watcher.handleEvent(mdstatTarget, unix.POLLPRI|unix.POLLERR)
+
+	select {
+	case change := <-watcher.Changes():
+		if change.Array != "md0" || change.Member != "sdb" ||
+			change.Field != MDFieldMemberState ||
+			change.OldState != "in_sync" ||
+			change.NewState != MDMemberStateRemoved {
+			t.Fatalf("removed member change = %+v", change)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for removed member change")
+	}
+
+	// Adding a replacement or expansion member is not a health failure.
+	writeMDDevice(t, fixture.sysBlock, "md0", map[string]string{
+		"dev-sdc/" + mdMemberState: "spare\n",
+	})
+	mdstatTarget = mdFileTarget(t, watcher, "", "", mdStatField)
+	watcher.handleEvent(mdstatTarget, unix.POLLPRI|unix.POLLERR)
+	assertNoMDChange(t, watcher)
+}
+
+func TestMDWatcherReportsMemberWriteError(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:                    "raid1\n",
+			mdSyncAction:               "idle\n",
+			mdDegraded:                 "0\n",
+			"dev-sda/" + mdMemberState: "in_sync\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	statePath := filepath.Join(
+		fixture.sysBlock,
+		"md0",
+		"md",
+		"dev-sda",
+		mdMemberState,
+	)
+	if err := os.WriteFile(statePath, []byte("in_sync,write_error\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	poller.trigger(mdFileFD(t, watcher, "md0", "sda", mdMemberState))
+
+	change := waitMDChange(t, watcher, func(change MDChange) bool {
+		return change.Field == MDFieldMemberState
+	})
+	if change.Member != "sda" || change.OldState != "in_sync" ||
+		change.NewState != "in_sync,write_error" {
+		t.Fatalf("write_error change = %+v", change)
+	}
+}
+
+func TestMDWatcherRejectsIncompleteArrayBaseline(t *testing.T) {
+	tests := []struct {
+		name       string
+		field      string
+		breakField func(*testing.T, string)
+	}{
+		{
+			name:  "unreadable sync action",
+			field: mdSyncAction,
+			breakField: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "unreadable level",
+			field: mdLevel,
+			breakField: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "malformed degraded",
+			field: mdDegraded,
+			breakField: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("invalid\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := setupMDFixture(t, map[string]map[string]string{
+				"md0": {
+					mdLevel:      "raid1\n",
+					mdSyncAction: "idle\n",
+					mdDegraded:   "0\n",
+				},
+			})
+			path := filepath.Join(fixture.sysBlock, "md0", "md", test.field)
+			test.breakField(t, path)
+
+			poller := newFakeMDPoller()
+			watcher := newMDWatcher(fixture.mdstat, fixture.sysBlock, poller.poll)
+			ctx, cancel := context.WithCancel(context.Background())
+			err := watcher.Start(ctx)
+			if err == nil {
+				stopMDWatcher(t, watcher, poller, cancel)
+				t.Fatal("Start() error = nil, want incomplete baseline error")
+			}
+			cancel()
+		})
+	}
+}
+
+func TestMDWatcherRejectsIncompleteMemberStateRebuild(t *testing.T) {
+	tests := []struct {
+		name       string
+		breakState func(*testing.T, string)
+	}{
+		{
+			name: "missing state",
+			breakState: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "unreadable state",
+			breakState: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := setupMDFixture(t, map[string]map[string]string{
+				"md0": {
+					mdLevel:                    "raid1\n",
+					mdSyncAction:               "idle\n",
+					mdDegraded:                 "0\n",
+					"dev-sda/" + mdMemberState: "in_sync\n",
+					"dev-sdb/" + mdMemberState: "in_sync\n",
+				},
+			})
+			watcher, poller, cancel := startMDWatcher(t, fixture)
+			defer stopMDWatcher(t, watcher, poller, cancel)
+
+			previous := mdFileTarget(t, watcher, "md0", "sdb", mdMemberState)
+			statePath := filepath.Join(
+				fixture.sysBlock,
+				"md0",
+				"md",
+				"dev-sdb",
+				mdMemberState,
+			)
+			test.breakState(t, statePath)
+
+			watcher.mu.Lock()
+			err := watcher.rebuildLocked(true)
+			watcher.mu.Unlock()
+			if err == nil {
+				t.Fatal("rebuildLocked() error = nil, want member state error")
+			}
+			assertMDMemberWatchPreserved(
+				t,
+				watcher,
+				previous,
+				"md0",
+				"sdb",
+				"in_sync",
+			)
+		})
+	}
+}
+
+func TestMDWatcherRejectsIncompleteMemberEnumeration(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:                    "raid1\n",
+			mdSyncAction:               "idle\n",
+			mdDegraded:                 "0\n",
+			"dev-sda/" + mdMemberState: "in_sync\n",
+			"dev-sdb/" + mdMemberState: "in_sync\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	previous := mdFileTarget(t, watcher, "md0", "sdb", mdMemberState)
+	mdDir := filepath.Join(fixture.sysBlock, "md0", "md")
+	if err := os.RemoveAll(mdDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mdDir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher.mu.Lock()
+	err := watcher.rebuildLocked(true)
+	watcher.mu.Unlock()
+	if err == nil {
+		t.Fatal("rebuildLocked() error = nil, want member enumeration error")
+	}
+	assertMDMemberWatchPreserved(t, watcher, previous, "md0", "sdb", "in_sync")
+}
+
+func TestMDWatcherReportsArrayChangeDuringTopologyRebuild(t *testing.T) {
+	fixture := setupMDFixture(t, map[string]map[string]string{
+		"md0": {
+			mdLevel:      "raid1\n",
+			mdSyncAction: "idle\n",
+			mdDegraded:   "0\n",
+		},
+	})
+	watcher, poller, cancel := startMDWatcher(t, fixture)
+	defer stopMDWatcher(t, watcher, poller, cancel)
+
+	levelPath := filepath.Join(fixture.sysBlock, "md0", "md", mdLevel)
+	syncPath := filepath.Join(fixture.sysBlock, "md0", "md", mdSyncAction)
+	if err := os.WriteFile(levelPath, []byte("raid10\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(syncPath, []byte("reshape\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	poller.trigger(mdFileFD(t, watcher, "md0", "", mdLevel))
+	change := waitMDChange(t, watcher, func(change MDChange) bool {
+		return change.Field == MDFieldSyncAction
+	})
+	if change.Array != "md0" || change.OldState != "idle" ||
+		change.NewState != "reshape" {
+		t.Fatalf("sync change = %+v", change)
+	}
+
+	writeMDDevice(t, fixture.sysBlock, "md1", map[string]string{
+		mdLevel:      "raid1\n",
+		mdSyncAction: "resync\n",
+		mdDegraded:   "1\n",
+	})
+	writeMDStatFixture(t, fixture.mdstat, "md0", "md1")
+	watcher.handleEvent(
+		mdFileTarget(t, watcher, "", "", mdStatField),
+		unix.POLLPRI|unix.POLLERR,
+	)
+	_ = mdFileTarget(t, watcher, "md1", "", mdSyncAction)
+	assertNoMDChange(t, watcher)
+
+	writeMDStatFixture(t, fixture.mdstat, "md1")
+	watcher.handleEvent(
+		mdFileTarget(t, watcher, "", "", mdStatField),
+		unix.POLLPRI|unix.POLLERR,
+	)
+	assertNoMDChange(t, watcher)
+}
+
+func TestNormalizeMDSyncAction(t *testing.T) {
+	for input, want := range map[string]string{
+		"recover\n": "recover",
+		"FROZEN":    "frozen",
+		"reserved":  "unknown",
+		"":          "unknown",
+	} {
+		if got := normalizeMDSyncAction(input); got != want {
+			t.Fatalf("normalizeMDSyncAction(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/ioobserve/health/provider.go
+++ b/internal/ioobserve/health/provider.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import "time"
+
+const (
+	MDFieldSyncAction = "sync_action"
+	MDFieldDegraded   = "degraded"
+)
+
+// MDChange describes one observed MD state transition. Member is empty for
+// array-level fields.
+type MDChange struct {
+	Array      string
+	Member     string
+	Field      string
+	OldState   string
+	NewState   string
+	ObservedAt time.Time
+}

--- a/internal/ioobserve/health/provider.go
+++ b/internal/ioobserve/health/provider.go
@@ -17,8 +17,13 @@ package health
 import "time"
 
 const (
-	MDFieldSyncAction = "sync_action"
-	MDFieldDegraded   = "degraded"
+	MDFieldSyncAction  = "sync_action"
+	MDFieldDegraded    = "degraded"
+	MDFieldMemberState = "member_state"
+
+	// MDMemberStateRemoved is emitted when a member disappears from an active
+	// array before its final state notification can be read.
+	MDMemberStateRemoved = "removed"
 )
 
 // MDChange describes one observed MD state transition. Member is empty for

--- a/pkg/types/io_event.go
+++ b/pkg/types/io_event.go
@@ -1,0 +1,92 @@
+// Copyright 2025, 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// IOHealthEvent is the persisted payload for one IO health event and its
+// optional event-triggered evidence. Event identity and trigger time remain in
+// the outer tracing document.
+type IOHealthEvent struct {
+	Type             string              `json:"type"`
+	Device           string              `json:"device,omitempty"`
+	Array            string              `json:"array,omitempty"`
+	Member           string              `json:"member,omitempty"`
+	OldState         string              `json:"old_state,omitempty"`
+	NewState         string              `json:"new_state,omitempty"`
+	NewStateRaw      *uint32             `json:"new_state_raw,omitempty"`
+	Operation        string              `json:"operation,omitempty"`
+	Status           string              `json:"status,omitempty"`
+	Sector           *uint64             `json:"sector,omitempty"`
+	CollectionStatus string              `json:"collection_status,omitempty"`
+	NVMe             *NVMeHealthEvidence `json:"nvme,omitempty"`
+	SCSI             *SCSIHealthEvidence `json:"scsi,omitempty"`
+}
+
+// NVMeHealthEvidence contains the bounded fields retained from one
+// event-triggered nvme-cli collection.
+type NVMeHealthEvidence struct {
+	CriticalWarning  *uint8               `json:"critical_warning,omitempty"`
+	MediaErrorsTotal *uint64              `json:"media_errors_total,omitempty"`
+	ErrorLog         *[]NVMeErrorLogEntry `json:"error_log,omitempty"`
+}
+
+// NVMeErrorLogEntry is one retained NVMe Error Information Log entry.
+// Fields deliberately do not use omitempty because zero is meaningful.
+type NVMeErrorLogEntry struct {
+	StatusCodeType uint8  `json:"status_code_type"`
+	StatusCode     uint8  `json:"status_code"`
+	NSID           uint32 `json:"nsid"`
+	LBA            uint64 `json:"lba"`
+}
+
+// SCSIHealthEvidence contains the bounded fields retained from one
+// event-triggered smartctl collection.
+type SCSIHealthEvidence struct {
+	SmartPassed          *bool                     `json:"smart_passed,omitempty"`
+	InformationException *SCSIInformationException `json:"information_exception,omitempty"`
+	Temperature          *SCSITemperature          `json:"temperature,omitempty"`
+	GrownDefectCount     *uint64                   `json:"grown_defect_count,omitempty"`
+	Read                 *SCSIErrorStats           `json:"read,omitempty"`
+	Write                *SCSIErrorStats           `json:"write,omitempty"`
+	Verify               *SCSIErrorStats           `json:"verify,omitempty"`
+	PendingDefects       *SCSIPendingDefects       `json:"pending_defects,omitempty"`
+}
+
+// SCSIInformationException is the ASC/ASCQ pair reported by smartctl.
+type SCSIInformationException struct {
+	ASC  uint8 `json:"asc"`
+	ASCQ uint8 `json:"ascq"`
+}
+
+// SCSITemperature is emitted only when both current and trip values exist.
+type SCSITemperature struct {
+	CurrentCelsius int64 `json:"current_celsius"`
+	TripCelsius    int64 `json:"trip_celsius"`
+}
+
+// SCSIErrorStats holds one read, write, or verify error-counter group.
+type SCSIErrorStats struct {
+	GigabytesProcessed       *float64 `json:"gigabytes_processed,omitempty"`
+	DelayedCorrections       *uint64  `json:"delayed_corrections,omitempty"`
+	RereadRewriteCorrections *uint64  `json:"reread_rewrite_corrections,omitempty"`
+	UncorrectedErrors        *uint64  `json:"uncorrected_errors,omitempty"`
+}
+
+// SCSIPendingDefects retains the total count and, when supplied by smartctl,
+// up to eight representative LBAs. A pointer to an empty slice represents a
+// successful empty list and therefore marshals as [] instead of being absent.
+type SCSIPendingDefects struct {
+	Count      uint64    `json:"count"`
+	SampleLBAs *[]uint64 `json:"sample_lbas,omitempty"`
+}

--- a/pkg/types/io_event_test.go
+++ b/pkg/types/io_event_test.go
@@ -1,0 +1,194 @@
+// Copyright 2025, 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIOHealthEventPreservesZeroValuesAndEmptyLists(t *testing.T) {
+	zeroWarning := uint8(0)
+	zeroMediaErrors := uint64(0)
+	emptyErrorLog := []NVMeErrorLogEntry{}
+	sector := uint64(0)
+	event := IOHealthEvent{
+		Type:             "nvme_timeout",
+		Device:           "nvme0n1",
+		Sector:           &sector,
+		CollectionStatus: "ok",
+		NVMe: &NVMeHealthEvidence{
+			CriticalWarning:  &zeroWarning,
+			MediaErrorsTotal: &zeroMediaErrors,
+			ErrorLog:         &emptyErrorLog,
+		},
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if fields["sector"] != float64(0) {
+		t.Fatalf("sector = %#v, want explicit zero", fields["sector"])
+	}
+	nvme, ok := fields["nvme"].(map[string]any)
+	if !ok {
+		t.Fatalf("nvme evidence missing: %s", data)
+	}
+	if nvme["critical_warning"] != float64(0) || nvme["media_errors_total"] != float64(0) {
+		t.Fatalf("zero-valued NVMe evidence was lost: %#v", nvme)
+	}
+	errorLog, ok := nvme["error_log"].([]any)
+	if !ok || len(errorLog) != 0 {
+		t.Fatalf("error_log = %#v, want []", nvme["error_log"])
+	}
+
+	var decoded IOHealthEvent
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal into struct failed: %v", err)
+	}
+	if decoded.Sector == nil || decoded.NVMe == nil ||
+		decoded.NVMe.CriticalWarning == nil || decoded.NVMe.MediaErrorsTotal == nil ||
+		decoded.NVMe.ErrorLog == nil || len(*decoded.NVMe.ErrorLog) != 0 {
+		t.Fatalf("health event did not preserve field presence: %+v", decoded)
+	}
+}
+
+func TestIOHealthSCSIEventPreservesFalseZeroAndEmptyList(t *testing.T) {
+	smartPassed := false
+	grownDefects := uint64(0)
+	processedGB := float64(0)
+	delayedCorrections := uint64(0)
+	emptyLBAs := []uint64{}
+	event := IOHealthEvent{
+		Type:             "scsi_timeout",
+		Device:           "sda",
+		CollectionStatus: "ok",
+		SCSI: &SCSIHealthEvidence{
+			SmartPassed:      &smartPassed,
+			GrownDefectCount: &grownDefects,
+			Read: &SCSIErrorStats{
+				GigabytesProcessed: &processedGB,
+				DelayedCorrections: &delayedCorrections,
+			},
+			PendingDefects: &SCSIPendingDefects{
+				Count:      0,
+				SampleLBAs: &emptyLBAs,
+			},
+		},
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	scsi, ok := fields["scsi"].(map[string]any)
+	if !ok {
+		t.Fatalf("SCSI evidence missing: %s", data)
+	}
+	if scsi["smart_passed"] != false || scsi["grown_defect_count"] != float64(0) {
+		t.Fatalf("false/zero-valued SCSI evidence was lost: %#v", scsi)
+	}
+	read, ok := scsi["read"].(map[string]any)
+	if !ok ||
+		read["gigabytes_processed"] != float64(0) ||
+		read["delayed_corrections"] != float64(0) {
+		t.Fatalf("zero-valued SCSI read counters were lost: %#v", scsi["read"])
+	}
+	pending, ok := scsi["pending_defects"].(map[string]any)
+	if !ok || pending["count"] != float64(0) {
+		t.Fatalf("pending defects = %#v, want explicit zero count", scsi["pending_defects"])
+	}
+	sampleLBAs, ok := pending["sample_lbas"].([]any)
+	if !ok || len(sampleLBAs) != 0 {
+		t.Fatalf("sample_lbas = %#v, want []", pending["sample_lbas"])
+	}
+
+	var decoded IOHealthEvent
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal into struct failed: %v", err)
+	}
+	if decoded.SCSI == nil ||
+		decoded.SCSI.SmartPassed == nil || *decoded.SCSI.SmartPassed ||
+		decoded.SCSI.GrownDefectCount == nil || *decoded.SCSI.GrownDefectCount != 0 ||
+		decoded.SCSI.Read == nil ||
+		decoded.SCSI.Read.GigabytesProcessed == nil ||
+		decoded.SCSI.Read.DelayedCorrections == nil ||
+		decoded.SCSI.PendingDefects == nil ||
+		decoded.SCSI.PendingDefects.SampleLBAs == nil ||
+		len(*decoded.SCSI.PendingDefects.SampleLBAs) != 0 {
+		t.Fatalf("SCSI health event did not preserve field presence: %+v", decoded)
+	}
+}
+
+func TestIOHealthTransitionOmitsEvidenceFields(t *testing.T) {
+	event := IOHealthEvent{
+		Type:     "md_member_state",
+		Array:    "md0",
+		Member:   "sdb",
+		OldState: "in_sync",
+		NewState: "faulty",
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if fields["array"] != "md0" || fields["member"] != "sdb" ||
+		fields["old_state"] != "in_sync" || fields["new_state"] != "faulty" {
+		t.Fatalf("transition fields = %#v", fields)
+	}
+	for _, field := range []string{"device", "collection_status", "nvme", "scsi"} {
+		if _, ok := fields[field]; ok {
+			t.Fatalf("empty %s was serialized: %s", field, data)
+		}
+	}
+}
+
+func TestIOHealthNVMeTransitionPreservesRawState(t *testing.T) {
+	raw := uint32(0)
+	event := IOHealthEvent{
+		Type:        "nvme_state_change",
+		Device:      "nvme0",
+		NewState:    "new",
+		NewStateRaw: &raw,
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if fields["new_state"] != "new" || fields["new_state_raw"] != float64(0) {
+		t.Fatalf("NVMe state fields = %#v", fields)
+	}
+}

--- a/pkg/types/iotracing.go
+++ b/pkg/types/iotracing.go
@@ -14,12 +14,17 @@
 
 package types
 
+// IOTracingFailureReader means the perf reader failed before the capture
+// window completed. Data collected before the failure may still be present.
+const IOTracingFailureReader = "reader_error"
+
 // IOTracingSnapshot is the wire schema produced by one iotracing run and
 // sent to huatuo-bamai over toolstream. The trigger reason snapshot is
 // attached by the daemon after receipt and is not part of this payload.
 type IOTracingSnapshot struct {
-	Processes   []ProcessFileIOStats `json:"process_file_io_stats"`
-	StallStacks []IOScheduleEvent    `json:"io_schedule_timeout_stacks"`
+	FailureReason string               `json:"failure_reason,omitempty"`
+	Processes     []ProcessFileIOStats `json:"process_file_io_stats"`
+	StallStacks   []IOScheduleEvent    `json:"io_schedule_timeout_stacks"`
 }
 
 // IOScheduleEvent records one task that spent longer than the configured


### PR DESCRIPTION
本 PR 进一步完善 huatuo 的 IO 可观测能力，由两个相互协作的模块组成。

详见文档：docs/development/io_monitoring_zh.md

iotracing 持续采样 /proc/diskstats，得到指标：读写吞吐（BPS）、IOPS、await、磁盘利用率与平均队列长度确。当利用率、await 或吞吐超过阈值时，会触发一次有界自动诊断，采集进程/文件 IO 与 IO 调度阻塞堆栈。采样间隔可配置。

io_health 从内核事件监测块设备、SCSI、NVMe 与 MD 的健康状况：IO 错误、SCSI 超时、NVMe 超时/复位/状态变化，以及 MD 阵列/成员状态变化。当某个事件能唯一定位到 NVMe 或 SCSI 设备时，会使用 nvme-cli/smartctl 对磁盘进行状态查询取证。