### PR TITLE
fix(test): avoid metrics assertion SIGPIPE

### DIFF
--- a/integration/lib.sh
+++ b/integration/lib.sh
@@ -413,8 +413,6 @@ huatuo_bamai_await_metrics() {
 }
 
 # check_metrics <desc> <present_pattern>... [-- <absent_pattern>...]
-# Single-pass metric assertion: verifies present patterns exist and absent
-# patterns do not, using at most 2 grep invocations regardless of pattern count.
 check_metrics() {
 	local desc=$1
 	shift
@@ -441,16 +439,10 @@ check_metrics() {
 	fi
 
 	if [[ ${#present[@]} -gt 0 ]]; then
-		local present_re
-		present_re=$(
-			IFS='|'
-			echo "${present[*]}"
-		)
-		local matches
-		matches=$(grep -oE "${prefix}(${present_re})" "$metrics_file" || true)
 		local pat
 		for pat in "${present[@]}"; do
-			echo "$matches" | grep -q "$pat" || fatal "${desc}: expected present but not found: ${pat}"
+			grep -qE "${prefix}(${pat})" "$metrics_file" \
+				|| fatal "${desc}: expected present but not found: ${pat}"
 		done
 	fi
 }

--- a/integration/test_metrics_include_filter.sh
+++ b/integration/test_metrics_include_filter.sh
@@ -39,3 +39,12 @@ check_metrics "include filter" \
 	'netdev_.*device="eth1"' 'netdev_.*device="docker0"' \
 	'mountpoint_perm_ro{.*mountpoint="/sys/fs/cgroup"' \
 	'mountpoint_perm_ro{.*mountpoint="/home/root/containers'
+
+# Large output exposed SIGPIPE when check_metrics piped matches into grep -q.
+metrics_file="${HUATUO_BAMAI_TEST_TMPDIR}/metrics.txt"
+for ((i = 0; i < 4096; i++)); do
+	printf 'huatuo_bamai_synthetic_metric_%04d{padding="%080d"} 1\n' \
+		"${i}" 0
+done > "${metrics_file}"
+
+check_metrics "large metrics output" "synthetic_metric_.*"


### PR DESCRIPTION
## What

- Match required metrics directly against the scrape file.
- Add a regression test with output larger than a pipe buffer.

## Why

`check_metrics` piped cached matches into `grep -q` under `pipefail`.
After finding a match, `grep` could exit early and leave the producer with
SIGPIPE, turning a successful assertion into a flaky failure.

Observed failures:

- Ubuntu 20.04: https://github.com/ccfos/huatuo/actions/runs/31157731039/job/92800817279
- Ubuntu 22.04: https://github.com/ccfos/huatuo/actions/runs/31157731039/job/92800817266

## Testing

- `bash integration/run.sh test_metrics_check.sh 20`
- `bash -n integration/lib.sh integration/test_metrics_check.sh`
- `shfmt -i 0 -bn -sr -d integration/lib.sh integration/test_metrics_check.sh`
- `make check`
