### PR TITLE
fix(ci): wait for apt package lock

### DIFF
--- a/.github/workflows/scripts/qemu-2-run-in-vm.sh
+++ b/.github/workflows/scripts/qemu-2-run-in-vm.sh
@@ -100,6 +100,8 @@ function install_golang() {
 function prapre_test_env() {
 	case $OS_DISTRO in
 	ubuntu*)
+		# dpkg uses POSIX locks, so let apt wait for the lock itself.
+		local -a apt_get=(sudo apt-get -o DPkg::Lock::Timeout=300)
 		packages=(
 			# basic
 			"make" "libbpf-dev" "clang" "git" "gcc" "jq" "capnproto"
@@ -119,13 +121,14 @@ function prapre_test_env() {
 
 		if [ "${#missing_packages[@]}" -gt 0 ]; then
 			echo "installing missing packages: ${missing_packages[*]}"
-			sudo apt-get update
-			# wait for unattended-upgrades to release /var/lib/dpkg/lock-frontend
-			sudo flock --wait 300 /var/lib/dpkg/lock-frontend true || true
-			sudo apt-get install -y "${missing_packages[@]}"
+			"${apt_get[@]}" update
+			"${apt_get[@]}" install -y "${missing_packages[@]}"
 		fi
 		# Ubuntu 20.04 Default clang-10 Has a CO-RE Relocation Bug (Fixed in LLVM 12 / D87153) — Use clang-12 Instead
-		[[ "$OS_DISTRO" != "ubuntu20.04" ]] || { sudo apt-get install -y clang-12 && sudo ln -sf /usr/bin/clang-12 /usr/local/bin/clang; }
+		if [[ "$OS_DISTRO" == "ubuntu20.04" ]]; then
+			"${apt_get[@]}" install -y clang-12
+			sudo ln -sf /usr/bin/clang-12 /usr/local/bin/clang
+		fi
 		;;
 	esac
 


### PR DESCRIPTION
## What

- Replace the detached `flock` check with apt's native lock timeout.
- Apply the timeout to all package operations in the guest setup.

## Why

The previous command released its lock before `apt-get` started, and `flock`
does not coordinate with the POSIX lock used by dpkg. An unattended upgrade
could therefore acquire the frontend lock and make the job exit with code 100.

Observed failure:

- Ubuntu 24.04: https://github.com/ccfos/huatuo/actions/runs/31157731039/job/92800817399

## Testing

- `bash -n .github/workflows/scripts/qemu-2-run-in-vm.sh`
- `shfmt -i 0 -bn -sr -d .github/workflows/scripts/qemu-2-run-in-vm.sh`
- Ubuntu 20.04 apt 2.0.10 lock-contention test
- Ubuntu 24.04 apt 2.8.3 lock-contention test
- `make check`
