### PR TITLE
fix(ci): skip web sync for fork pull requests

### DIFF
--- a/.github/workflows/sync-web-on-change.yml
+++ b/.github/workflows/sync-web-on-change.yml
@@ -19,6 +19,9 @@ on:
 
 jobs:
   sync:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: checkout huatuo


### PR DESCRIPTION
## Summary

- skip web synchronization for pull requests from forks
- avoid requiring repository secrets on contributor branches
- retain synchronization for trusted repository branches

## Validation

- [ ] GitHub Actions