### PR TITLE
feat(deploy): add profiling compose profile

### DIFF
--- a/.github/workflows/sync-web-on-change.yml
+++ b/.github/workflows/sync-web-on-change.yml
@@ -19,6 +19,9 @@ on:
 
 jobs:
   sync:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: checkout huatuo

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ endif
 IMAGE := $(IMAGE_REPO):$(IMAGE_TAG)
 
 COMPOSE_DEV := docker compose \
+	--profile full \
 	--project-directory $(ROOT_DIR)/build/docker \
 	-f $(ROOT_DIR)/build/docker/docker-compose.yml \
 	-f $(ROOT_DIR)/build/docker/docker-compose.dev.yml

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ HUATUO is now listed in the [CNCF Landscape](https://landscape.cncf.io/?item=obs
 
 - **Quick Setup**
 
-  To launch the full stack (Elasticsearch, Prometheus, Grafana, and huatuo) using Docker Compose:
+  To launch the full stack (Elasticsearch, Prometheus, Pyroscope, Grafana, and huatuo) using Docker Compose:
 
-        $ docker compose --project-directory ./build/docker up
+        $ COMPOSE_PROFILES=full docker compose --project-directory ./build/docker up
 
   Once running, access the monitoring dashboard at http://localhost:3000.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -72,9 +72,9 @@ HUATUO 已进入 [CNCF Landscape](https://landscape.cncf.io/?item=observability-
 
 - **快速搭建**
 
-  使用 Docker Compose 一键启动 Elasticsearch、Prometheus、Grafana 和 huatuo 全栈服务：
+  使用 Docker Compose 一键启动 Elasticsearch、Prometheus、Pyroscope、Grafana 和 huatuo 全栈服务：
     ```bash
-    $ docker compose --project-directory ./build/docker up
+    $ COMPOSE_PROFILES=full docker compose --project-directory ./build/docker up
     ```
   服务启动后，通过浏览器访问 http://localhost:3000 即可查看监控大盘。
 

--- a/build/docker/.env
+++ b/build/docker/.env
@@ -11,6 +11,9 @@ ELASTICSEARCH_HOST='localhost'
 # prometheus
 PROMETHEUS_VERSION=v2.53.3 # LTS v2.53
 
+# Pyroscope
+PYROSCOPE_VERSION=2.0.2
+
 # Grafana
 GRAFANA_VERSION=12.0.3
 # Plugins

--- a/build/docker/compose-profiles_test.sh
+++ b/build/docker/compose-profiles_test.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+#
+# Copyright 2026 The HuaTuo Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+project_dir=$(CDPATH= cd -- "${script_dir}/../.." && pwd)
+
+assert_services() {
+	profile=$1
+	expected=$2
+	actual=$(
+		COMPOSE_PROFILES=$profile docker compose \
+			--project-directory "$script_dir" \
+			config --services \
+			| sort \
+			| tr '\n' ' ' \
+			| sed 's/[[:space:]]*$//'
+	)
+	if [ "$actual" != "$expected" ]; then
+		echo "$profile services: got '$actual', want '$expected'." >&2
+		return 1
+	fi
+}
+
+assert_services profiling "grafana huatuo-bamai pyroscope"
+assert_services full \
+	"elasticsearch grafana huatuo-apiserver huatuo-bamai prometheus pyroscope"
+
+profiling_compose=$(
+	COMPOSE_PROFILES=profiling docker compose \
+		--project-directory "$script_dir" config
+)
+printf '%s\n' "$profiling_compose" \
+	| grep -q 'HUATUO_MODE: profiling'
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT HUP INT TERM
+mkdir -p "$test_dir/run/bin" "$test_dir/run/conf"
+cp "$project_dir/huatuo-bamai.conf" "$test_dir/source.conf"
+
+printf '%s\n' \
+	'#!/bin/sh' \
+	'config_dir=' \
+	'config_file=' \
+	'while [ "$#" -gt 0 ]; do' \
+	'	case "$1" in' \
+	'	--config-dir) config_dir=$2; shift 2 ;;' \
+	'	--config) config_file=$2; shift 2 ;;' \
+	'	--disable-kubelet) disable_kubelet=true; shift ;;' \
+	'	*) shift ;;' \
+	'	esac' \
+	'done' \
+	'test "${disable_kubelet:-}" = true' \
+	'cat "${config_dir}/${config_file}"' \
+	> "$test_dir/run/bin/huatuo-bamai"
+chmod +x "$test_dir/run/bin/huatuo-bamai"
+
+mkdir -p "$test_dir/fake-bin"
+printf '%s\n' \
+	'#!/bin/sh' \
+	': >"${CURL_MARKER:?}"' \
+	'printf "HTTP/1.1 200 OK\\r\\n\\r\\n200"' \
+	> "$test_dir/fake-bin/curl"
+chmod +x "$test_dir/fake-bin/curl"
+
+PATH="$test_dir/fake-bin:$PATH" \
+	CURL_MARKER="$test_dir/curl-called" \
+	RUN_PATH="$test_dir/run" \
+	CONFIG_FILE="$test_dir/source.conf" \
+	HUATUO_MODE=profiling \
+	PYROSCOPE_ADDRESS=http://127.0.0.1:4040 \
+	"$script_dir/run.sh" > "$test_dir/rendered.conf"
+
+test ! -e "$test_dir/curl-called"
+grep -q 'Address = ""' "$test_dir/rendered.conf"
+grep -q 'Address = "http://127.0.0.1:4040"' "$test_dir/rendered.conf"
+cmp "$project_dir/huatuo-bamai.conf" "$test_dir/source.conf"
+
+PATH="$test_dir/fake-bin:$PATH" \
+	CURL_MARKER="$test_dir/curl-called" \
+	RUN_PATH="$test_dir/run" \
+	CONFIG_FILE="$test_dir/source.conf" \
+	HUATUO_MODE=full \
+	PYROSCOPE_ADDRESS=http://127.0.0.1:4040 \
+	ELASTICSEARCH_INIT_DELAY_SECONDS=0 \
+	"$script_dir/run.sh" > "$test_dir/full.conf"
+
+test -e "$test_dir/curl-called"
+grep -q 'Address = "http://127.0.0.1:9200"' "$test_dir/full.conf"
+grep -q 'Address = "http://127.0.0.1:4040"' "$test_dir/full.conf"
+cmp "$project_dir/huatuo-bamai.conf" "$test_dir/source.conf"
+
+if RUN_PATH="$test_dir/run" \
+	CONFIG_FILE="$test_dir/source.conf" \
+	HUATUO_MODE=unknown \
+	"$script_dir/run.sh" > /dev/null 2>&1; then
+	echo "run.sh accepted an unknown HUATUO_MODE." >&2
+	exit 1
+fi

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   elasticsearch:
+    profiles: ["full"]
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.15.5}
     container_name: elasticsearch
     network_mode: host
@@ -18,13 +19,21 @@ services:
       start_period: 20s
 
   prometheus:
+    profiles: ["full"]
     image: prom/prometheus:${PROMETHEUS_VERSION:-v2.53.3}
     container_name: prometheus
     network_mode: host
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
 
+  pyroscope:
+    profiles: ["full", "profiling"]
+    image: grafana/pyroscope:${PYROSCOPE_VERSION:-2.0.2}
+    container_name: pyroscope
+    network_mode: host
+
   grafana:
+    profiles: ["full", "profiling"]
     image: grafana/grafana-oss:${GRAFANA_VERSION:-12.0.3}
     container_name: grafana
     network_mode: host
@@ -37,11 +46,9 @@ services:
       - ./grafana/datasources/infinity.yaml:/etc/grafana/provisioning/datasources/infinity.yaml:ro
       - ./grafana/datasources/pyroscope.yaml:/etc/grafana/provisioning/datasources/pyroscope.yaml:ro
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
-    depends_on:
-      - prometheus
-      - elasticsearch
 
   huatuo-apiserver:
+    profiles: ["full"]
     image: huatuo/huatuo-bamai:latest
     container_name: huatuo-apiserver
     network_mode: host
@@ -61,6 +68,7 @@ services:
         condition: service_started
 
   huatuo-bamai:
+    profiles: ["full", "profiling"]
     image: huatuo/huatuo-bamai:latest
     container_name: huatuo-bamai
     network_mode: host
@@ -71,19 +79,15 @@ services:
     environment:
       ELASTICSEARCH_HOST: ${ELASTICSEARCH_HOST:-}
       ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
-      RUN_PATH: ${RUN_PATH:-}
+      HUATUO_MODE: ${COMPOSE_PROFILES:-full}
+      PYROSCOPE_ADDRESS: ${PYROSCOPE_ADDRESS:-http://127.0.0.1:4040}
+      RUN_PATH: ${RUN_PATH:-/home/huatuo-bamai}
     volumes:
       - /sys:/sys:rw
       - /proc:/proc:rw
       - /run:/run:rw
       - /etc:/etc:ro
       - /var:/var:ro
-      - ../../huatuo-bamai.conf:${RUN_PATH}/conf/huatuo-bamai.conf:rw
-    command: ["./bin/huatuo-bamai", "--region", "example", "--config", "huatuo-bamai.conf", "--disable-kubelet"]
-    depends_on:
-      elasticsearch:
-        condition: service_healthy
-      prometheus:
-        condition: service_started
-      grafana:
-        condition: service_started
+      - ../../huatuo-bamai.conf:${RUN_PATH:-/home/huatuo-bamai}/conf/huatuo-bamai.conf:ro
+      - ./run.sh:${RUN_PATH:-/home/huatuo-bamai}/run.sh:ro
+    command: ["./run.sh"]

--- a/build/docker/grafana/datasources/pyroscope.yaml
+++ b/build/docker/grafana/datasources/pyroscope.yaml
@@ -13,3 +13,13 @@ datasources:
     secureJsonData:
       httpHeaderValue1: 'Bearer REPLACE_WITH_RANDOM_HEX'
     editable: false
+
+  - name: huatuo-bamai-pyroscope
+    type: grafana-pyroscope-datasource
+    uid: huatuo-bamai-pyroscope
+    access: proxy
+    orgId: 1
+    url: http://127.0.0.1:4040
+    jsonData:
+      minStep: '1s'
+    editable: false

--- a/build/docker/run.sh
+++ b/build/docker/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2025 The HuaTuo Authors
+# Copyright 2025, 2026 The HuaTuo Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,22 +15,120 @@
 # limitations under the License.
 #
 
+set -eu
+
 ELASTICSEARCH_HOST=${ELASTICSEARCH_HOST:-localhost}
 ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-huatuo-bamai}
-
 RUN_PATH=${RUN_PATH:-/home/huatuo-bamai}
+CONFIG_FILE=${CONFIG_FILE:-${RUN_PATH}/conf/huatuo-bamai.conf}
+HUATUO_MODE=${HUATUO_MODE:-full}
+PYROSCOPE_ADDRESS=${PYROSCOPE_ADDRESS:-http://127.0.0.1:4040}
+ELASTICSEARCH_WAIT_SECONDS=${ELASTICSEARCH_WAIT_SECONDS:-180}
+ELASTICSEARCH_INIT_DELAY_SECONDS=${ELASTICSEARCH_INIT_DELAY_SECONDS:-5}
 
-# Wait for Elasticsearch to be ready
+profile_enabled() {
+	case ",${HUATUO_MODE}," in
+	*,"$1",*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+prepare_runtime_config() {
+	mode=$1
+	if [ ! -f "$CONFIG_FILE" ]; then
+		echo "huatuo-bamai config not found: $CONFIG_FILE" >&2
+		return 1
+	fi
+
+	case "$PYROSCOPE_ADDRESS" in
+	http://* | https://*) ;;
+	*)
+		echo "PYROSCOPE_ADDRESS must use http or https." >&2
+		return 1
+		;;
+	esac
+	case "$PYROSCOPE_ADDRESS" in
+	*\"* | *\\*)
+		echo "PYROSCOPE_ADDRESS must not contain quotes or backslashes." >&2
+		return 1
+		;;
+	esac
+
+	runtime_config="${RUN_PATH}/conf/huatuo-bamai-${mode}.conf"
+	temp_config="${runtime_config}.tmp.$$"
+	disable_elasticsearch=false
+	if [ "$mode" = "profiling" ]; then
+		disable_elasticsearch=true
+	fi
+	if ! awk \
+		-v disable_elasticsearch="$disable_elasticsearch" \
+		-v pyroscope_address="$PYROSCOPE_ADDRESS" '
+		/^[[:space:]]*\[Storage\.Elasticsearch\][[:space:]]*$/ {
+			section = "es"
+			print
+			next
+		}
+		/^[[:space:]]*\[Storage\.Pyroscope\][[:space:]]*$/ {
+			section = "pyroscope"
+			seen_pyroscope = 1
+			print
+			next
+		}
+		/^[[:space:]]*\[[^]]+\][[:space:]]*$/ {
+			section = ""
+			print
+			next
+		}
+		section == "es" &&
+			/^[[:space:]]*Address[[:space:]]*=/ {
+			seen_es_address = 1
+			if (disable_elasticsearch == "true") {
+				print "        Address = \"\""
+			} else {
+				print
+			}
+			next
+		}
+		section == "pyroscope" &&
+			/^[[:space:]]*#?[[:space:]]*Address[[:space:]]*=/ {
+			printf "        Address = \"%s\"\n", pyroscope_address
+			seen_pyroscope_address = 1
+			next
+		}
+		{ print }
+		END {
+			if (!seen_es_address ||
+				!seen_pyroscope ||
+				!seen_pyroscope_address) {
+				exit 42
+			}
+		}
+	' "$CONFIG_FILE" > "$temp_config"; then
+		rm -f "$temp_config"
+		echo "Storage.Elasticsearch or Storage.Pyroscope is missing from $CONFIG_FILE." >&2
+		return 1
+	fi
+
+	chmod 600 "$temp_config"
+	mv "$temp_config" "$runtime_config"
+	CONFIG_FILE=$runtime_config
+	if [ "$mode" = "profiling" ]; then
+		echo "Profiling mode: Elasticsearch is disabled and Pyroscope is enabled."
+	else
+		echo "Full mode: Elasticsearch and Pyroscope are enabled."
+	fi
+}
+
 wait_for_elasticsearch() {
 	target_url="http://${ELASTICSEARCH_HOST}:9200/"
 
-	# Try to extract Elasticsearch address from config file
-	if [ -f "huatuo-bamai.conf" ]; then
-		# Extract Address from [Storage.Elasticsearch] section
-		# sed: range from [Storage.Elasticsearch] to next section start [
-		# grep: find Address line
-		# awk: extract text between double quotes
-		conf_addr=$(sed -n '/\[Storage\.Elasticsearch\]/,/\[.*\]/p' huatuo-bamai.conf | grep '^[[:space:]]*Address' | head -n 1 | awk -F'"' '{print $2}')
+	if [ -f "$CONFIG_FILE" ]; then
+		conf_addr=$(
+			sed -n '/\[Storage\.Elasticsearch\]/,/\[.*\]/p' "$CONFIG_FILE" \
+				| grep '^[[:space:]]*Address' \
+				| head -n 1 \
+				| awk -F'"' '{print $2}'
+		)
 
 		if [ -n "$conf_addr" ]; then
 			echo "Found Elasticsearch address in config: $conf_addr"
@@ -38,40 +136,41 @@ wait_for_elasticsearch() {
 		fi
 	fi
 
-	args="-s -D- -m15 -w '%{http_code}' ${target_url}"
-	if [ -n "${ELASTIC_PASSWORD}" ]; then
-		args="$args -u elastic:${ELASTIC_PASSWORD}"
-	fi
-
 	result=1
 	output=""
-
-	# retry for up to 180 seconds
-	for sec in $(seq 1 180); do
+	sec=1
+	while [ "$sec" -le "$ELASTICSEARCH_WAIT_SECONDS" ]; do
 		exit_code=0
-		output=$(eval "curl $args") || exit_code=$?
-		# echo "exec curl $args, exit code: $exit_code, output: $output"
-		if [ $exit_code -ne 0 ]; then
+		if [ -n "$ELASTIC_PASSWORD" ]; then
+			output=$(
+				curl -sS -D- -m15 -w '%{http_code}' \
+					-u "elastic:${ELASTIC_PASSWORD}" "$target_url"
+			) || exit_code=$?
+		else
+			output=$(curl -sS -D- -m15 -w '%{http_code}' "$target_url") \
+				|| exit_code=$?
+		fi
+		if [ "$exit_code" -ne 0 ]; then
 			result=$exit_code
 		fi
 
-		# Extract the last three characters of the output to check the HTTP status code
-		http_code=$(echo "$output" | tail -c 4)
-		if [ "$http_code" -eq 200 ]; then
+		http_code=$(printf '%s' "$output" | tail -c 3)
+		if [ "$http_code" = "200" ]; then
 			result=0
 			break
 		fi
 
 		echo "Waiting for Elasticsearch ready... ${sec}s"
 		sleep 1
+		sec=$((sec + 1))
 	done
 
-	if [ $result -ne 0 ] && [ "$http_code" -ne 000 ]; then
-		echo "$output" | head -c -3
+	if [ "$result" -ne 0 ] && [ "$http_code" != "000" ]; then
+		printf '%s' "$output" | head -c -3
 	fi
 
-	if [ $result -ne 0 ]; then
-		case $result in
+	if [ "$result" -ne 0 ]; then
+		case "$result" in
 		6)
 			echo 'Could not resolve host. Is Elasticsearch running?'
 			;;
@@ -86,14 +185,29 @@ wait_for_elasticsearch() {
 			;;
 		esac
 
-		exit $result
+		return "$result"
 	fi
 }
 
-wait_for_elasticsearch
-sleep 5 # Waiting for initialization of Elasticsearch built-in users
-echo "Elasticsearch is ready."
+if profile_enabled profiling; then
+	if profile_enabled full; then
+		echo "HUATUO_MODE must select either full or profiling, not both." >&2
+		exit 1
+	fi
+	prepare_runtime_config profiling
+elif profile_enabled full; then
+	prepare_runtime_config full
+	wait_for_elasticsearch
+	sleep "$ELASTICSEARCH_INIT_DELAY_SECONDS"
+	echo "Elasticsearch is ready."
+else
+	echo "HUATUO_MODE must select full or profiling." >&2
+	exit 1
+fi
 
-# Run huatuo-bamai
-cd $RUN_PATH
-exec ./bin/huatuo-bamai --region example --config huatuo-bamai.conf
+cd "$RUN_PATH"
+exec ./bin/huatuo-bamai \
+	--region example \
+	--config-dir "$(dirname "$CONFIG_FILE")" \
+	--config "$(basename "$CONFIG_FILE")" \
+	--disable-kubelet

--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -53,10 +53,21 @@ type LocalFileConfig struct {
 	MaxRotatedFiles int    `default:"10"`
 }
 
+// PyroscopeConfig controls pprof profile storage in Pyroscope.
+type PyroscopeConfig struct {
+	Address        string
+	AppNamePrefix  string
+	Username       string
+	Password       string
+	BearerToken    string
+	TimeoutSeconds int `default:"5"`
+}
+
 // StorageConfig controls tracing data storage.
 type StorageConfig struct {
 	Elasticsearch internalconfig.ElasticsearchConfig
 	LocalFile     LocalFileConfig
+	Pyroscope     PyroscopeConfig
 }
 
 // TasksConfig controls locally running tracing tasks.

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -58,6 +58,12 @@ Path = "records"
 RotationSizeMiB = 64
 MaxRotatedFiles = 4
 
+[Storage.Pyroscope]
+Address = "https://profiles.example.com"
+AppNamePrefix = "production.huatuo"
+BearerToken = "token-1"
+TimeoutSeconds = 8
+
 [AutoTracing]
 IssuesList = [["dload", "jbd2"]]
 
@@ -113,6 +119,24 @@ ExcludedOnContainer = "writeback"
 		MaxRotatedFiles: 4,
 	}) {
 		t.Errorf("Storage.LocalFile = %+v, want overrides", Get().Storage.LocalFile)
+	}
+	if Get().Storage.Pyroscope.Address != "https://profiles.example.com" {
+		t.Errorf("unexpected Pyroscope address: %q", Get().Storage.Pyroscope.Address)
+	}
+	if Get().Storage.Pyroscope.AppNamePrefix != "production.huatuo" {
+		t.Errorf(
+			"unexpected Pyroscope app name prefix: %q",
+			Get().Storage.Pyroscope.AppNamePrefix,
+		)
+	}
+	if Get().Storage.Pyroscope.BearerToken != "token-1" {
+		t.Errorf("unexpected Pyroscope bearer token")
+	}
+	if Get().Storage.Pyroscope.TimeoutSeconds != 8 {
+		t.Errorf(
+			"unexpected Pyroscope timeout: %d",
+			Get().Storage.Pyroscope.TimeoutSeconds,
+		)
 	}
 	if len(Get().AutoTracing.IssuesList) != 1 {
 		t.Errorf("unexpected AutoTracing.IssuesList length: %d", len(Get().AutoTracing.IssuesList))

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
@@ -80,8 +81,28 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
 	}
 
+	profileStores, err := newProfileStores(context.Background(), cfg)
+	if err != nil {
+		return err
+	}
+	if len(profileStores) > 0 {
+		tracing.SetProfileStore(
+			profileStores,
+			tracing.DocumentOptions{Region: storageRegion},
+		)
+	}
+
+	return nil
+}
+
+func newProfileStores(
+	ctx context.Context,
+	cfg *config.BamaiConfig,
+) ([]*storage.Store[*tracing.Document], error) {
+	profileStores := make([]*storage.Store[*tracing.Document], 0, 2)
+
 	if cfg.Storage.Elasticsearch.Enabled() {
-		profileStore, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
+		profileStore, err := storage.NewFromConfig[*tracing.Document](ctx, &driver.Config{
 			Driver:      "elasticsearch",
 			ESAddresses: strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
 			ESUsername:  cfg.Storage.Elasticsearch.Username,
@@ -89,13 +110,43 @@ func initStorage(storageRegion string, cfg *config.BamaiConfig) error {
 			ESIndex:     cfg.Storage.Elasticsearch.Index,
 		}, profiler.MetadataCollection, tracing.ProfileDocumentStoreMapper{})
 		if err != nil {
-			return fmt.Errorf("new profiling document store (elasticsearch): %w", err)
+			return nil, fmt.Errorf("new profiling document store (elasticsearch): %w", err)
 		}
-		tracing.SetProfileStore(
-			[]*storage.Store[*tracing.Document]{profileStore},
-			tracing.DocumentOptions{Region: storageRegion},
-		)
+		profileStores = append(profileStores, profileStore)
 	}
 
-	return nil
+	if cfg.Storage.Pyroscope.Address != "" {
+		profileStore, err := storage.NewFromConfig[*tracing.Document](ctx, &driver.Config{
+			Driver:                  "pyroscope",
+			PyroscopeAddress:        cfg.Storage.Pyroscope.Address,
+			PyroscopeAppNamePrefix:  cfg.Storage.Pyroscope.AppNamePrefix,
+			PyroscopeUsername:       cfg.Storage.Pyroscope.Username,
+			PyroscopePassword:       cfg.Storage.Pyroscope.Password,
+			PyroscopeBearerToken:    cfg.Storage.Pyroscope.BearerToken,
+			PyroscopeTimeoutSeconds: cfg.Storage.Pyroscope.TimeoutSeconds,
+		}, profiler.MetadataCollection, tracing.PprofDocumentStoreMapper{})
+		if err != nil {
+			cleanupErr := closeProfileStores(ctx, profileStores)
+			return nil, errors.Join(
+				fmt.Errorf("new profiling document store (pyroscope): %w", err),
+				cleanupErr,
+			)
+		}
+		profileStores = append(profileStores, profileStore)
+	}
+
+	return profileStores, nil
+}
+
+func closeProfileStores(
+	ctx context.Context,
+	stores []*storage.Store[*tracing.Document],
+) error {
+	var errs []error
+	for _, store := range stores {
+		if err := store.Close(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("close profiling document store %s: %w", store.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/huatuo-bamai/storage_test.go
+++ b/cmd/huatuo-bamai/storage_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"huatuo-bamai/cmd/huatuo-bamai/config"
+)
+
+func TestNewProfileStoresRegistersElasticsearchAndPyroscope(t *testing.T) {
+	elasticsearch := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Elastic-Product", "Elasticsearch")
+			_, _ = w.Write([]byte(
+				`{"name":"test","version":{"number":"7.17.0"}}`,
+			))
+		},
+	))
+	t.Cleanup(elasticsearch.Close)
+
+	cfg := &config.BamaiConfig{}
+	cfg.Storage.Elasticsearch.Address = elasticsearch.URL
+	cfg.Storage.Elasticsearch.Username = "elastic"
+	cfg.Storage.Elasticsearch.Password = "secret"
+	cfg.Storage.Elasticsearch.Index = "profiles"
+	cfg.Storage.Pyroscope.Address = "http://127.0.0.1:4040"
+
+	stores, err := newProfileStores(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("newProfileStores returned error: %v", err)
+	}
+	defer func() {
+		if err := closeProfileStores(context.Background(), stores); err != nil {
+			t.Errorf("closeProfileStores returned error: %v", err)
+		}
+	}()
+
+	if len(stores) != 2 {
+		t.Fatalf("store count = %d, want 2", len(stores))
+	}
+	if stores[0].Name != "elasticsearch" {
+		t.Errorf("stores[0].Name = %q, want elasticsearch", stores[0].Name)
+	}
+	if stores[1].Name != "pyroscope" {
+		t.Errorf("stores[1].Name = %q, want pyroscope", stores[1].Name)
+	}
+}
+
+func TestNewProfileStoresRejectsInvalidPyroscopeAuthentication(t *testing.T) {
+	cfg := &config.BamaiConfig{}
+	cfg.Storage.Pyroscope.Address = "http://127.0.0.1:4040"
+	cfg.Storage.Pyroscope.Username = "user"
+
+	if _, err := newProfileStores(context.Background(), cfg); err == nil {
+		t.Fatal("newProfileStores error = nil, want authentication error")
+	}
+}

--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -416,13 +416,13 @@ func (c *cpuIdleTracing) saveCPUIdleTrace(
 		return fmt.Errorf("decode container perf output: %w", err)
 	}
 
-	if err := tracing.Save(&tracing.WriteRequest{
+	if err := saveAutotracingCPUEvent(&tracing.WriteRequest{
 		TracerName:    cpuIdleTracerName,
 		ContainerID:   state.containerID,
 		TracerTime:    traceTime,
 		TracerData:    &tracerData,
 		TracerRunType: tracing.TracerRunTypeAutotracing,
-	}); err != nil {
+	}, c.perfDuration, tracerData.FlameData); err != nil {
 		return fmt.Errorf("save container cpu trace: %w", err)
 	}
 

--- a/core/autotracing/cpusys.go
+++ b/core/autotracing/cpusys.go
@@ -249,12 +249,12 @@ func (c *cpuSysTracing) saveCPUSysTrace(
 		return fmt.Errorf("decode system-wide perf output: %w", err)
 	}
 
-	if err := tracing.Save(&tracing.WriteRequest{
+	if err := saveAutotracingCPUEvent(&tracing.WriteRequest{
 		TracerName:    cpuSysTracerName,
 		TracerTime:    traceTime,
 		TracerData:    &tracerData,
 		TracerRunType: tracing.TracerRunTypeAutotracing,
-	}); err != nil {
+	}, c.perfDuration, tracerData.FlameData); err != nil {
 		return fmt.Errorf("save cpu system trace: %w", err)
 	}
 	return nil

--- a/core/autotracing/profile_store.go
+++ b/core/autotracing/profile_store.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/pkg/tracing"
+
+	"github.com/rs/xid"
+)
+
+const autotracingProfileSampleRate = 99
+
+func saveAutotracingCPUEvent(
+	request *tracing.WriteRequest,
+	duration time.Duration,
+	frames []flamegraph.FrameData,
+) error {
+	if request.TracerID == "" {
+		request.TracerID = xid.New().String()
+	}
+
+	tracingErr := tracing.Save(request)
+	profileData, profileErr := profiler.ParseFlamegraphFrames(
+		request.TracerTime,
+		duration,
+		profiler.ProfileTypeCpuSample,
+		frames,
+		&profiler.ParseOption{SampleRate: autotracingProfileSampleRate},
+	)
+	if profileErr == nil {
+		profileErr = tracing.SaveProfile(&tracing.WriteRequest{
+			TracerName:    request.TracerName,
+			TracerID:      request.TracerID,
+			ContainerID:   request.ContainerID,
+			TracerTime:    request.TracerTime,
+			TracerData:    &profctx.TracerData{FlameData: profileData},
+			TracerRunType: tracing.TracerRunTypeAutotracing,
+		})
+	}
+
+	return errors.Join(
+		wrapAutotracingSaveError("JSON event", tracingErr),
+		wrapAutotracingSaveError("pprof profile", profileErr),
+	)
+}
+
+func wrapAutotracingSaveError(target string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("save AutoTracing %s: %w", target, err)
+}

--- a/core/autotracing/profile_store_test.go
+++ b/core/autotracing/profile_store_test.go
@@ -1,0 +1,404 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/storage"
+	"huatuo-bamai/internal/storage/driver"
+	"huatuo-bamai/pkg/tracing"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestSaveCPUSysTraceWritesJSONAndPprof(t *testing.T) {
+	tracingBackend := &captureProfileBackend{}
+	profileBackend := &captureProfileBackend{}
+	configureAutotracingStores(t, tracingBackend, profileBackend)
+
+	start := time.Unix(1700000000, 123).UTC()
+	duration := 10 * time.Second
+	rawFrames := []byte(`[
+		{"level":0,"value":5,"self":0,"label":"root"},
+		{"level":1,"value":5,"self":5,"label":"leaf"}
+	]`)
+	cpu := &cpuSysTracing{
+		perfDuration: duration,
+		threshold: cpuSysThreshold{
+			usage: 45,
+			delta: 20,
+		},
+	}
+	err := cpu.saveCPUSysTrace(
+		start,
+		cpuSysState{
+			systemPercent:      70,
+			systemPercentDelta: 25,
+		},
+		rawFrames,
+	)
+	if err != nil {
+		t.Fatalf("saveCPUSysTrace returned error: %v", err)
+	}
+
+	if len(tracingBackend.records) != 1 {
+		t.Fatalf(
+			"tracing records = %d, want 1",
+			len(tracingBackend.records),
+		)
+	}
+	if len(profileBackend.records) != 1 {
+		t.Fatalf(
+			"profile records = %d, want 1",
+			len(profileBackend.records),
+		)
+	}
+
+	var event struct {
+		TracerID      string            `json:"tracer_id"`
+		TracerName    string            `json:"tracer_name"`
+		TracerRunType string            `json:"tracer_type"`
+		TracerData    cpuSysTracingData `json:"tracer_data"`
+	}
+	if err := json.Unmarshal(tracingBackend.records[0].Data, &event); err != nil {
+		t.Fatalf("decode tracing JSON: %v", err)
+	}
+	if event.TracerID == "" {
+		t.Fatal("tracing event has an empty tracer_id")
+	}
+	if event.TracerName != "cpusys" {
+		t.Errorf("tracer_name = %q, want cpusys", event.TracerName)
+	}
+	if event.TracerRunType != tracing.TracerRunTypeAutotracing {
+		t.Errorf(
+			"tracer_type = %q, want %q",
+			event.TracerRunType,
+			tracing.TracerRunTypeAutotracing,
+		)
+	}
+	if len(event.TracerData.FlameData) != 2 {
+		t.Fatalf(
+			"JSON flame frames = %d, want 2",
+			len(event.TracerData.FlameData),
+		)
+	}
+
+	profileRecord := profileBackend.records[0]
+	assertProfileField(t, profileRecord, "tracer_id", event.TracerID)
+	assertProfileField(t, profileRecord, "tracer_name", "cpusys")
+	assertProfileField(
+		t,
+		profileRecord,
+		"tracer_type",
+		tracing.TracerRunTypeAutotracing,
+	)
+	assertProfileField(
+		t,
+		profileRecord,
+		"profile_type",
+		profiler.ProfileTypeCpuSample,
+	)
+	assertProfileField(t, profileRecord, "hostname", "test-host")
+
+	if got := profileRecord.Fields["profile_start_time"]; got != start {
+		t.Errorf("profile_start_time = %v, want %v", got, start)
+	}
+	if got := profileRecord.Fields["profile_end_time"]; got != start.Add(duration) {
+		t.Errorf(
+			"profile_end_time = %v, want %v",
+			got,
+			start.Add(duration),
+		)
+	}
+
+	var profile ptree.Profile
+	if err := profile.UnmarshalVT(profileRecord.Data); err != nil {
+		t.Fatalf("decode pprof protobuf: %v", err)
+	}
+	if profile.TimeNanos != start.UnixNano() {
+		t.Errorf(
+			"profile TimeNanos = %d, want %d",
+			profile.TimeNanos,
+			start.UnixNano(),
+		)
+	}
+	if profile.DurationNanos != int64(duration) {
+		t.Errorf(
+			"profile DurationNanos = %d, want %d",
+			profile.DurationNanos,
+			duration,
+		)
+	}
+}
+
+func TestSaveAutotracingCPUEventPreservesOneSideOnFailure(t *testing.T) {
+	t.Run("JSON backend fails", func(t *testing.T) {
+		saveErr := errors.New("JSON backend unavailable")
+		tracingBackend := &captureProfileBackend{saveErr: saveErr}
+		profileBackend := &captureProfileBackend{}
+		configureAutotracingStores(t, tracingBackend, profileBackend)
+
+		err := saveAutotracingCPUEvent(
+			&tracing.WriteRequest{
+				TracerName:    "cpusys",
+				TracerTime:    time.Unix(1700000000, 0).UTC(),
+				TracerData:    map[string]any{"flamedata": "preserved"},
+				TracerRunType: tracing.TracerRunTypeAutotracing,
+			},
+			time.Second,
+			validAutotracingFrames(),
+		)
+		if !errors.Is(err, saveErr) {
+			t.Fatalf("error = %v, want JSON backend error", err)
+		}
+		if len(profileBackend.records) != 1 {
+			t.Fatalf(
+				"profile records = %d, want 1 after JSON failure",
+				len(profileBackend.records),
+			)
+		}
+	})
+
+	t.Run("pprof conversion fails", func(t *testing.T) {
+		tracingBackend := &captureProfileBackend{}
+		profileBackend := &captureProfileBackend{}
+		configureAutotracingStores(t, tracingBackend, profileBackend)
+
+		err := saveAutotracingCPUEvent(
+			&tracing.WriteRequest{
+				TracerName:    "cpusys",
+				TracerTime:    time.Unix(1700000000, 0).UTC(),
+				TracerData:    map[string]any{"flamedata": "preserved"},
+				TracerRunType: tracing.TracerRunTypeAutotracing,
+			},
+			time.Second,
+			[]flamegraph.FrameData{
+				{Level: 0, Value: 1, Self: -1, Label: "invalid"},
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "self value") {
+			t.Fatalf("error = %v, want negative self error", err)
+		}
+		if len(tracingBackend.records) != 1 {
+			t.Fatalf(
+				"tracing records = %d, want 1 after conversion failure",
+				len(tracingBackend.records),
+			)
+		}
+		if len(profileBackend.records) != 0 {
+			t.Fatalf(
+				"profile records = %d, want 0 for invalid profile",
+				len(profileBackend.records),
+			)
+		}
+	})
+
+	t.Run("pprof backend fails", func(t *testing.T) {
+		saveErr := errors.New("pprof backend unavailable")
+		tracingBackend := &captureProfileBackend{}
+		profileBackend := &captureProfileBackend{saveErr: saveErr}
+		configureAutotracingStores(t, tracingBackend, profileBackend)
+
+		err := saveAutotracingCPUEvent(
+			&tracing.WriteRequest{
+				TracerName:    "cpusys",
+				TracerTime:    time.Unix(1700000000, 0).UTC(),
+				TracerData:    map[string]any{"flamedata": "preserved"},
+				TracerRunType: tracing.TracerRunTypeAutotracing,
+			},
+			time.Second,
+			validAutotracingFrames(),
+		)
+		if !errors.Is(err, saveErr) {
+			t.Fatalf("error = %v, want pprof backend error", err)
+		}
+		if len(tracingBackend.records) != 1 {
+			t.Fatalf(
+				"tracing records = %d, want 1 after pprof failure",
+				len(tracingBackend.records),
+			)
+		}
+	})
+}
+
+func configureAutotracingStores(
+	t *testing.T,
+	tracingBackend *captureProfileBackend,
+	profileBackend *captureProfileBackend,
+) {
+	t.Helper()
+	tracingStore, err := storage.NewStore[*tracing.Document](
+		context.Background(),
+		"capture-json",
+		tracingBackend,
+		tracing.DocumentCollection,
+		tracing.DocumentStoreMapper{},
+	)
+	if err != nil {
+		t.Fatalf("new tracing store: %v", err)
+	}
+	profileStore, err := storage.NewStore[*tracing.Document](
+		context.Background(),
+		"capture-pprof",
+		profileBackend,
+		profiler.MetadataCollection,
+		captureProfileMapper{},
+	)
+	if err != nil {
+		t.Fatalf("new profile store: %v", err)
+	}
+	options := tracing.DocumentOptions{Hostname: "test-host", Region: "test"}
+	tracing.SetTracingStore(
+		[]*storage.Store[*tracing.Document]{tracingStore},
+		options,
+	)
+	tracing.SetProfileStore(
+		[]*storage.Store[*tracing.Document]{profileStore},
+		options,
+	)
+	t.Cleanup(func() {
+		tracing.SetTracingStore(nil, tracing.DocumentOptions{})
+		tracing.SetProfileStore(nil, tracing.DocumentOptions{})
+	})
+}
+
+func validAutotracingFrames() []flamegraph.FrameData {
+	return []flamegraph.FrameData{
+		{Level: 0, Value: 1, Self: 1, Label: "root"},
+	}
+}
+
+func assertProfileField(
+	t *testing.T,
+	record driver.Record,
+	field string,
+	want string,
+) {
+	t.Helper()
+	if got := record.Fields[field]; got != want {
+		t.Errorf("%s = %v, want %q", field, got, want)
+	}
+}
+
+type captureProfileMapper struct {
+	tracing.ProfileDocumentStoreMapper
+}
+
+func (captureProfileMapper) Encode(document *tracing.Document) ([]byte, error) {
+	data, err := captureProfileData(document)
+	if err != nil {
+		return nil, err
+	}
+	return data.Profile.MarshalVT()
+}
+
+func (captureProfileMapper) Fields(
+	document *tracing.Document,
+) (map[string]any, error) {
+	fields, err := (tracing.ProfileDocumentStoreMapper{}).Fields(document)
+	if err != nil {
+		return nil, err
+	}
+	data, err := captureProfileData(document)
+	if err != nil {
+		return nil, err
+	}
+
+	start := time.Unix(0, data.Profile.TimeNanos).UTC()
+	fields["profile_type"] = data.ProfileType
+	fields["profile_start_time"] = start
+	fields["profile_end_time"] = start.Add(
+		time.Duration(data.Profile.DurationNanos),
+	)
+	return fields, nil
+}
+
+func captureProfileData(
+	document *tracing.Document,
+) (*profiler.ProfileData, error) {
+	data, ok := document.TracerData.(*profctx.TracerData)
+	if !ok || data == nil || data.FlameData == nil {
+		return nil, errors.New("capture profile mapper: profile data is missing")
+	}
+	return data.FlameData, nil
+}
+
+type captureProfileBackend struct {
+	records []driver.Record
+	saveErr error
+}
+
+func (*captureProfileBackend) Init(
+	context.Context,
+	string,
+	[]driver.Index,
+) error {
+	return nil
+}
+
+func (b *captureProfileBackend) Save(
+	_ context.Context,
+	record driver.Record,
+) error {
+	b.records = append(b.records, record)
+	return b.saveErr
+}
+
+func (*captureProfileBackend) Get(
+	context.Context,
+	string,
+) (driver.Record, error) {
+	return driver.Record{}, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Delete(context.Context, string) error {
+	return driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Query(
+	context.Context,
+	driver.Query,
+) ([]driver.Record, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Count(
+	context.Context,
+	driver.Query,
+) (int64, error) {
+	return 0, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Values(
+	context.Context,
+	string,
+	driver.Query,
+	int,
+) ([]string, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+func (*captureProfileBackend) Close(context.Context) error {
+	return nil
+}

--- a/core/autotracing/profiler_ingest.go
+++ b/core/autotracing/profiler_ingest.go
@@ -17,18 +17,19 @@ package autotracing
 import (
 	"time"
 
+	profctx "huatuo-bamai/internal/profiler/context"
 	"huatuo-bamai/internal/toolstream"
 	"huatuo-bamai/pkg/tracing"
 )
 
 // ProfilerEvent is the payload sent by the profiler subprocess over toolstream.
 type ProfilerEvent struct {
-	TracerID      string `json:"tracer_id,omitempty"`
-	ContainerID   string `json:"container_id,omitempty"`
-	TracerName    string `json:"tracer_name,omitempty"`
-	TracerRunType string `json:"tracer_type,omitempty"`
-	TracerTime    string `json:"tracer_time"`
-	TracerData    any    `json:"tracer_data,omitempty"`
+	TracerID      string              `json:"tracer_id,omitempty"`
+	ContainerID   string              `json:"container_id,omitempty"`
+	TracerName    string              `json:"tracer_name,omitempty"`
+	TracerRunType string              `json:"tracer_type,omitempty"`
+	TracerTime    string              `json:"tracer_time"`
+	TracerData    *profctx.TracerData `json:"tracer_data,omitempty"`
 }
 
 const profilerEventTimeLayout = "2006-01-02 15:04:05.000 -0700"

--- a/core/autotracing/profiler_ingest_test.go
+++ b/core/autotracing/profiler_ingest_test.go
@@ -15,8 +15,14 @@
 package autotracing
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
 )
 
 func TestParseProfilerEventTime(t *testing.T) {
@@ -73,10 +79,40 @@ func TestHandleProfilerEventNoStore(t *testing.T) {
 		TracerName:    "profiler",
 		TracerRunType: "autotracing",
 		TracerTime:    "2026-07-06 12:30:45.123 +0800",
-		TracerData:    map[string]any{"flamedata": map[string]any{"profile_type": "cpu"}},
+		TracerData:    &profctx.TracerData{},
 	}
 
 	if err := handleProfilerEvent(nil, ev); err != nil {
 		t.Fatalf("handleProfilerEvent() error = %v, want nil", err)
+	}
+}
+
+func TestProfilerEventPreservesPprofPayload(t *testing.T) {
+	source := &ProfilerEvent{
+		TracerID: "tracer-123",
+		TracerData: &profctx.TracerData{
+			FlameData: &profiler.ProfileData{
+				ProfileType: profiler.ProfileTypeCpuSample,
+				Profile: ptree.Profile{
+					TimeNanos:     1700000000000000000,
+					DurationNanos: int64(10 * time.Second),
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	var decoded ProfilerEvent
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	if decoded.TracerData == nil || decoded.TracerData.FlameData == nil {
+		t.Fatal("decoded profiler event is missing flamedata")
+	}
+	if got := decoded.TracerData.FlameData.Profile.TimeNanos; got != 1700000000000000000 {
+		t.Errorf("decoded TimeNanos = %d, want 1700000000000000000", got)
 	}
 }

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -243,7 +243,35 @@ idle timeout; 15–60 seconds is typical.
 
   Default: 10.
 
-  **Description**: Oldest files are automatically deleted once the limit is reached, controlling disk usage.
+**Description**: Oldest files are automatically deleted once the limit is reached, controlling disk usage.
+
+#### 6.3 Pyroscope Profile Storage
+
+```toml
+[Storage.Pyroscope]
+    Address = "https://profiles.example.com"
+    AppNamePrefix = "huatuo"
+    # Username = "profiles-user"
+    # Password = "change-me"
+    # BearerToken = "token"
+    TimeoutSeconds = 5
+```
+
+- **Address**: Pyroscope server base URL. An empty value disables this
+  backend. The backend appends `/ingest` and accepts only HTTP or HTTPS URLs.
+- **AppNamePrefix**: Prefix for Pyroscope application names. The default is
+  `huatuo`.
+- **Username / Password**: Optional Basic Auth credentials. Both fields must
+  be set together.
+- **BearerToken**: Optional bearer token. It cannot be combined with Basic
+  Auth.
+- **TimeoutSeconds**: Timeout for each ingest request. The default is 5
+  seconds.
+
+Pyroscope stores profiling data as pprof protobuf. Elasticsearch can remain
+enabled at the same time and continues to store its existing JSON profiling
+documents. Use HTTPS when credentials leave the local host, and restrict
+configuration-file permissions because authentication fields contain secrets.
 
 ### 7. Automatic Tracing
 

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -277,6 +277,10 @@ configuration-file permissions because authentication fields contain secrets.
 
 The automatic tracing module is one of HUATUO’s intelligent features. It triggers specific performance tracing based on thresholds, reducing manual intervention.
 
+CPUIdle and CPUSys traces keep their existing JSON event and also write a CPU
+pprof profile with the same tracer ID. The profile uses `cpu:nanoseconds`
+samples at 99 Hz. Profile storage failures do not discard the JSON event.
+
 #### 7.1 CPUIdle Automatic Tracing — Sudden High CPU Usage in Containers
 
 ```bash

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -242,6 +242,29 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
 
   **说明**：超过数量后自动删除最早文件，控制磁盘空间使用。
 
+#### 6.3 Pyroscope Profile 存储
+
+```toml
+[Storage.Pyroscope]
+    Address = "https://profiles.example.com"
+    AppNamePrefix = "huatuo"
+    # Username = "profiles-user"
+    # Password = "change-me"
+    # BearerToken = "token"
+    TimeoutSeconds = 5
+```
+
+- **Address**：Pyroscope 服务的基础地址。留空时禁用该后端。后端会自动
+  追加 `/ingest`，且只接受 HTTP 或 HTTPS 地址。
+- **AppNamePrefix**：Pyroscope 应用名称前缀，默认值为 `huatuo`。
+- **Username / Password**：可选的 Basic Auth 凭据，必须同时配置。
+- **BearerToken**：可选的 Bearer Token，不能与 Basic Auth 同时配置。
+- **TimeoutSeconds**：单次写入请求的超时时间，默认值为 5 秒。
+
+Pyroscope 使用 pprof protobuf 保存 profiling 数据。可以同时启用
+Elasticsearch；Elasticsearch 会继续保存现有 JSON profiling 文档。凭据需要
+离开本机时应使用 HTTPS，并限制配置文件权限，避免认证信息泄露。
+
 ### 7. 自动追踪配置
 
 自动追踪模块是 HUATUO 的智能特性之一，可根据阈值自动触发特定性能追踪，减少人工干预。

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -269,6 +269,10 @@ Elasticsearch；Elasticsearch 会继续保存现有 JSON profiling 文档。凭�
 
 自动追踪模块是 HUATUO 的智能特性之一，可根据阈值自动触发特定性能追踪，减少人工干预。
 
+CPUIdle 和 CPUSys 会保留原有 JSON 事件，并使用相同的 tracer ID 额外写入
+CPU pprof。该 profile 以 99 Hz 采样，样本单位为 `cpu:nanoseconds`。
+profile 存储失败不会丢弃 JSON 事件。
+
 #### 7.1 CPUIdle 自动追踪 — 容器突发高 CPU 使用场景
 
 ```bash

--- a/docs/deployment/docker_en.md
+++ b/docs/deployment/docker_en.md
@@ -48,10 +48,26 @@ collection jobs, and observed resource peaks.
 
 ### Start containers with Docker
 
-The `docker compose` command allows you to quickly set up a complete local environment where you manage the collector, Elasticsearch, Prometheus, Grafana, and other components yourself.
+[Docker Compose](https://docs.docker.com/compose/) allows you to run either
+the complete stack or a profile-only stack.
 
 ```bash
-$ docker compose --project-directory ./build/docker up
+$ COMPOSE_PROFILES=full docker compose --project-directory ./build/docker up
 ```
 
-For installation instructions, see https://docs.docker.com/compose/install/linux/.
+The `full` profile starts huatuo-bamai, Elasticsearch, Prometheus, Pyroscope,
+Grafana, and huatuo-apiserver.
+
+To collect profiles into Pyroscope without Elasticsearch, Prometheus, or
+huatuo-apiserver:
+
+```bash
+$ COMPOSE_PROFILES=profiling docker compose --project-directory ./build/docker up
+```
+
+The profiling profile starts only huatuo-bamai, Pyroscope, and Grafana.
+huatuo-bamai does not wait for Elasticsearch and starts with kubelet discovery
+disabled, so kubelet client certificates are not required. Open Grafana at
+http://localhost:3000 and use the `huatuo-bamai-pyroscope` data source.
+
+For Docker Compose installation instructions, see https://docs.docker.com/compose/install/linux/.

--- a/docs/deployment/docker_zh.md
+++ b/docs/deployment/docker_zh.md
@@ -45,10 +45,25 @@ docker stats huatuo-bamai
 
 ### 使用 Docker Compose 启动容器
 
-通过 [Docker Compose](https://docs.docker.com/compose/) 可在本地快速搭建一套完整环境，自行管理采集器、Elasticsearch、Prometheus、Grafana 等组件。
+通过 [Docker Compose](https://docs.docker.com/compose/) 可以启动完整服务，
+也可以仅启动 profiling 所需服务。
 
 ```bash
-$ docker compose --project-directory ./build/docker up
+$ COMPOSE_PROFILES=full docker compose --project-directory ./build/docker up
 ```
+
+`full` profile 会启动 huatuo-bamai、Elasticsearch、Prometheus、Pyroscope、
+Grafana 和 huatuo-apiserver。
+
+如果只需将 profiling 数据写入 Pyroscope：
+
+```bash
+$ COMPOSE_PROFILES=profiling docker compose --project-directory ./build/docker up
+```
+
+`profiling` profile 只启动 huatuo-bamai、Pyroscope 和 Grafana，不启动或等待
+Elasticsearch、Prometheus、huatuo-apiserver。huatuo-bamai 会禁用 kubelet
+发现，因此无需 kubelet 客户端证书。Grafana 地址为 http://localhost:3000，
+数据源选择 `huatuo-bamai-pyroscope`。
 
 > Docker Compose 安装方法请参阅 https://docs.docker.com/compose/install/linux/。

--- a/docs/quick-start_en.md
+++ b/docs/quick-start_en.md
@@ -43,10 +43,10 @@ If you want to understand the underlying principles and deploy HUATUO to your ow
 If you want to further understand HUATUO's operational mechanisms, architecture design, monitoring dashboard, and custom deployment, you can quickly set up a complete local environment using docker compose.
 
 ```bash
-$ docker compose --project-directory ./build/docker up
+$ COMPOSE_PROFILES=full docker compose --project-directory ./build/docker up
 ```
 
-This command pulls the latest images and starts components including [elasticsearch](https://www.elastic.co), [prometheus](https://prometheus.io), [grafana](https://grafana.com)，huatuo-bamai. After successful command execution, open your browser and visit [http://localhost:3000](http://localhost:3000) to access the monitoring dashboard (Grafana default admin account: admin, password: admin; Since your system is in normal state, the Events and AutoTracing dashboards typically won't display data).
+This command pulls the configured images and starts components including [Elasticsearch](https://www.elastic.co), [Prometheus](https://prometheus.io), [Pyroscope](https://grafana.com/oss/pyroscope/), [Grafana](https://grafana.com), and huatuo-bamai. After successful command execution, open your browser and visit [http://localhost:3000](http://localhost:3000) to access the monitoring dashboard (Grafana default admin account: admin, password: admin; since your system is in a normal state, the Events and AutoTracing dashboards typically won't display data).
 
 ![HUATUO huatuo-bamai Component Operation Diagram](/docs/img/quickstart-components.png)
 

--- a/docs/quick-start_zh.md
+++ b/docs/quick-start_zh.md
@@ -47,10 +47,10 @@ $ curl -s localhost:19704/metrics
 
 #### 2.2 Docker Compose 启动
 
-通过 docker compose，可以快速地在本地搭建部署一套完整的环境。该命令拉取最新镜像，启动 [elasticsearch](https://www.elastic.co), [prometheus](https://prometheus.io), [grafana](https://grafana.com)，huatuo-bamai 等组件。命令执行成功后，打开浏览器访问 [http://localhost:3000](http://localhost:3000) 即可浏览监控大盘（grafana 默认管理员账户：admin 密码：admin； 系统正常状态不会触发 Events, AutoTracing）。
+通过 docker compose，可以快速地在本地搭建部署一套完整的环境。该命令拉取配置的镜像，启动 [Elasticsearch](https://www.elastic.co)、[Prometheus](https://prometheus.io)、[Pyroscope](https://grafana.com/oss/pyroscope/)、[Grafana](https://grafana.com) 和 huatuo-bamai 等组件。命令执行成功后，打开浏览器访问 [http://localhost:3000](http://localhost:3000) 即可浏览监控大盘（Grafana 默认管理员账户：admin，密码：admin；系统正常状态不会触发 Events、AutoTracing）。
 
 ```bash
-$ docker compose --project-directory ./build/docker up
+$ COMPOSE_PROFILES=full docker compose --project-directory ./build/docker up
 ```
 
 ![HUATUO 组件之 huatuo-bamai 运行示意图](/docs/img/quickstart-components.png)

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -122,6 +122,21 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
         # RotationSizeMiB = 100
         # MaxRotatedFiles = 10
 
+    # Pyroscope profile storage
+    #
+    # Pyroscope receives pprof protobuf profiles independently of ES/OS.
+    # Leave Address empty to disable it. Address is the server base URL; the
+    # backend appends /ingest. Use either Username and Password for Basic Auth,
+    # or BearerToken, but not both.
+    #
+    [Storage.Pyroscope]
+        # Address = "http://127.0.0.1:4040"
+        # AppNamePrefix = "huatuo"
+        # Username = ""
+        # Password = ""
+        # BearerToken = ""
+        # TimeoutSeconds = 5
+
 # Autotracing configuration.
 #
 # - IssuesList

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -74,6 +74,14 @@ type TracerData struct {
 	FlameData  *profiler.ProfileData `json:"flamedata"`
 }
 
+// ProfileData exposes the native profile without coupling storage to this envelope.
+func (d *TracerData) ProfileData() *profiler.ProfileData {
+	if d == nil {
+		return nil
+	}
+	return d.FlameData
+}
+
 func NewProfilerContext(cliCtx *cli.Context, logBuf *bytes.Buffer) (*ProfilerContext, error) {
 	ctx, cancel := context.WithCancel(cliCtx.Context)
 

--- a/internal/profiler/flamegraph.go
+++ b/internal/profiler/flamegraph.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"fmt"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+)
+
+// ParseFlamegraphFrames converts depth-first nested flame graph frames into a
+// pprof profile. Only self values are samples because value is the aggregate
+// width of a frame and would otherwise count child samples twice.
+func ParseFlamegraphFrames(
+	startTime time.Time,
+	duration time.Duration,
+	profileType string,
+	frames []flamegraph.FrameData,
+	opt *ParseOption,
+) (*ProfileData, error) {
+	if startTime.IsZero() {
+		return nil, fmt.Errorf("flame graph start time is zero")
+	}
+	if duration <= 0 {
+		return nil, fmt.Errorf("flame graph duration must be positive")
+	}
+	if profileType == ProfileTypeCpuSample &&
+		(opt == nil || opt.SampleRate <= 0) {
+		return nil, fmt.Errorf("CPU flame graph sample rate must be positive")
+	}
+
+	stack := make([][]byte, 0, 32)
+	tree := make([]*TreeItem, 0, len(frames))
+	for i, frame := range frames {
+		if frame.Level < 0 || frame.Level > int64(len(stack)) {
+			return nil, fmt.Errorf(
+				"frame %d: invalid level %d for stack depth %d",
+				i,
+				frame.Level,
+				len(stack),
+			)
+		}
+		if frame.Value < 0 {
+			return nil, fmt.Errorf(
+				"frame %d: aggregate value must not be negative",
+				i,
+			)
+		}
+		if frame.Self < 0 {
+			return nil, fmt.Errorf(
+				"frame %d: self value must not be negative",
+				i,
+			)
+		}
+		if frame.Self > frame.Value {
+			return nil, fmt.Errorf(
+				"frame %d: self value %d exceeds aggregate value %d",
+				i,
+				frame.Self,
+				frame.Value,
+			)
+		}
+
+		stack = stack[:int(frame.Level)]
+		label := frame.Label
+		if label == "" {
+			label = "(unknown)"
+		}
+		stack = append(stack, []byte(label))
+		if frame.Self == 0 {
+			continue
+		}
+
+		itemStack := make([][]byte, len(stack))
+		for j := range stack {
+			itemStack[j] = append([]byte(nil), stack[j]...)
+		}
+		tree = append(tree, &TreeItem{
+			Stack: itemStack,
+			Value: uint64(frame.Self),
+		})
+	}
+
+	if len(tree) == 0 {
+		return nil, fmt.Errorf("flame graph has no positive self samples")
+	}
+
+	profile, err := ParseTree(startTime, profileType, tree, opt)
+	if err != nil {
+		return nil, err
+	}
+	profile.Profile.DurationNanos = int64(duration)
+	return profile, nil
+}

--- a/internal/profiler/flamegraph_test.go
+++ b/internal/profiler/flamegraph_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/flamegraph"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestParseFlamegraphFramesBuildsCPUProfile(t *testing.T) {
+	start := time.Unix(1700000000, 123).UTC()
+	duration := 10 * time.Second
+	profileData, err := ParseFlamegraphFrames(
+		start,
+		duration,
+		ProfileTypeCpuSample,
+		[]flamegraph.FrameData{
+			{Level: 0, Value: 5, Label: "root"},
+			{Level: 1, Value: 3, Self: 3, Label: "left"},
+			{Level: 1, Value: 2, Self: 2, Label: "right"},
+		},
+		&ParseOption{SampleRate: 100},
+	)
+	if err != nil {
+		t.Fatalf("ParseFlamegraphFrames returned error: %v", err)
+	}
+
+	profile := &profileData.Profile
+	if profileData.ProfileType != ProfileTypeCpuSample {
+		t.Errorf(
+			"ProfileType = %q, want %q",
+			profileData.ProfileType,
+			ProfileTypeCpuSample,
+		)
+	}
+	if got := profile.TimeNanos; got != start.UnixNano() {
+		t.Errorf("TimeNanos = %d, want %d", got, start.UnixNano())
+	}
+	if got := time.Duration(profile.DurationNanos); got != duration {
+		t.Errorf("DurationNanos = %s, want %s", got, duration)
+	}
+	if got := time.Duration(profile.Period); got != 10*time.Millisecond {
+		t.Errorf("Period = %s, want %s", got, 10*time.Millisecond)
+	}
+	if len(profile.Sample) != 2 {
+		t.Fatalf("samples = %d, want 2", len(profile.Sample))
+	}
+
+	assertValueType(
+		t,
+		profile.StringTable,
+		profile.SampleType[0],
+		"cpu",
+		"nanoseconds",
+	)
+	assertValueType(
+		t,
+		profile.StringTable,
+		profile.PeriodType,
+		"cpu",
+		"nanoseconds",
+	)
+
+	var total int64
+	for _, sample := range profile.Sample {
+		if len(sample.Value) != 1 {
+			t.Fatalf("sample values = %v, want one value", sample.Value)
+		}
+		total += sample.Value[0]
+	}
+	if want := int64(50 * time.Millisecond); total != want {
+		t.Errorf("sample total = %d, want %d", total, want)
+	}
+}
+
+func TestParseFlamegraphFramesRejectsInvalidInput(t *testing.T) {
+	start := time.Unix(1700000000, 0).UTC()
+	valid := []flamegraph.FrameData{
+		{Level: 0, Value: 1, Self: 1, Label: "root"},
+	}
+	tests := []struct {
+		name     string
+		start    time.Time
+		duration time.Duration
+		frames   []flamegraph.FrameData
+		opt      *ParseOption
+		wantErr  string
+	}{
+		{
+			name:     "zero timestamp",
+			duration: time.Second,
+			frames:   valid,
+			opt:      &ParseOption{SampleRate: 99},
+			wantErr:  "start time is zero",
+		},
+		{
+			name:    "zero duration",
+			start:   start,
+			frames:  valid,
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "duration must be positive",
+		},
+		{
+			name:     "missing sample rate",
+			start:    start,
+			duration: time.Second,
+			frames:   valid,
+			wantErr:  "sample rate must be positive",
+		},
+		{
+			name:     "level gap",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Label: "root"},
+				{Level: 2, Value: 1, Self: 1, Label: "leaf"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "invalid level",
+		},
+		{
+			name:     "negative aggregate",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: -1, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "aggregate value must not be negative",
+		},
+		{
+			name:     "negative self",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Self: -1, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "self value must not be negative",
+		},
+		{
+			name:     "self exceeds aggregate",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Self: 2, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "exceeds aggregate",
+		},
+		{
+			name:     "empty samples",
+			start:    start,
+			duration: time.Second,
+			frames: []flamegraph.FrameData{
+				{Level: 0, Value: 1, Label: "root"},
+			},
+			opt:     &ParseOption{SampleRate: 99},
+			wantErr: "no positive self samples",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseFlamegraphFrames(
+				tt.start,
+				tt.duration,
+				ProfileTypeCpuSample,
+				tt.frames,
+				tt.opt,
+			)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func assertValueType(
+	t *testing.T,
+	stringTable []string,
+	valueType *ptree.ValueType,
+	wantType string,
+	wantUnit string,
+) {
+	t.Helper()
+	if valueType == nil {
+		t.Fatal("value type is nil")
+	}
+	if got := stringTable[valueType.Type]; got != wantType {
+		t.Errorf("type = %q, want %q", got, wantType)
+	}
+	if got := stringTable[valueType.Unit]; got != wantUnit {
+		t.Errorf("unit = %q, want %q", got, wantUnit)
+	}
+}

--- a/internal/storage/backends.go
+++ b/internal/storage/backends.go
@@ -18,5 +18,6 @@ import (
 	// Register all built-in storage backends.
 	_ "huatuo-bamai/internal/storage/elasticsearch"
 	_ "huatuo-bamai/internal/storage/localfile"
+	_ "huatuo-bamai/internal/storage/pyroscope"
 	_ "huatuo-bamai/internal/storage/sqlite"
 )

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -57,6 +57,13 @@ type Config struct {
 	ESUsername  string
 	ESPassword  string
 	ESIndex     string
+
+	PyroscopeAddress        string
+	PyroscopeAppNamePrefix  string
+	PyroscopeUsername       string
+	PyroscopePassword       string
+	PyroscopeBearerToken    string
+	PyroscopeTimeoutSeconds int
 }
 
 // Op is a storage query operator.

--- a/internal/storage/pyroscope/pyroscope.go
+++ b/internal/storage/pyroscope/pyroscope.go
@@ -1,0 +1,405 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pyroscope implements a write-only pprof storage backend.
+package pyroscope
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+const (
+	defaultAppNamePrefix    = "huatuo"
+	defaultTimeoutSeconds   = 5
+	maxErrorResponseBytes   = 4 * 1024
+	pprofFormat             = "pprof"
+	protobufContentType     = "application/octet-stream"
+	authorizationHeaderName = "Authorization"
+)
+
+// Config contains Pyroscope backend settings.
+type Config struct {
+	Address        string
+	AppNamePrefix  string
+	Username       string
+	Password       string
+	BearerToken    string
+	TimeoutSeconds int
+}
+
+// Storage pushes protobuf-encoded pprof profiles to Pyroscope's HTTP ingest API.
+type Storage struct {
+	ingestURL     *url.URL
+	appNamePrefix string
+	username      string
+	password      string
+	bearerToken   string
+	httpClient    *http.Client
+}
+
+var _ driver.Backend = (*Storage)(nil)
+
+func init() {
+	driver.RegisterBackend("pyroscope", func(cfg *driver.Config) (driver.Backend, error) {
+		return NewBackend(&Config{
+			Address:        cfg.PyroscopeAddress,
+			AppNamePrefix:  cfg.PyroscopeAppNamePrefix,
+			Username:       cfg.PyroscopeUsername,
+			Password:       cfg.PyroscopePassword,
+			BearerToken:    cfg.PyroscopeBearerToken,
+			TimeoutSeconds: cfg.PyroscopeTimeoutSeconds,
+		})
+	})
+}
+
+// NewBackend creates a Pyroscope storage backend.
+func NewBackend(cfg *Config) (*Storage, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("pyroscope: config is nil")
+	}
+
+	endpoint, err := parseAddress(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	username, password, token, err := validateAuthentication(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	timeoutSeconds := cfg.TimeoutSeconds
+	switch {
+	case timeoutSeconds < 0:
+		return nil, fmt.Errorf("pyroscope: timeout seconds must not be negative")
+	case timeoutSeconds == 0:
+		timeoutSeconds = defaultTimeoutSeconds
+	}
+
+	appNamePrefix := sanitizeNamePart(strings.TrimSpace(cfg.AppNamePrefix))
+	if appNamePrefix == "" {
+		appNamePrefix = defaultAppNamePrefix
+	}
+
+	return newBackendWithHTTPClient(
+		endpoint,
+		appNamePrefix,
+		username,
+		password,
+		token,
+		&http.Client{
+			Timeout: time.Duration(timeoutSeconds) * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	), nil
+}
+
+func parseAddress(address string) (*url.URL, error) {
+	rawAddress := strings.TrimSpace(address)
+	if rawAddress == "" {
+		return nil, fmt.Errorf("pyroscope: address is empty")
+	}
+	endpoint, err := url.Parse(rawAddress)
+	if err != nil {
+		return nil, fmt.Errorf("pyroscope: parse address: %w", err)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return nil, fmt.Errorf(
+			"pyroscope: address scheme must be http or https, got %q",
+			endpoint.Scheme,
+		)
+	}
+	if endpoint.Host == "" || endpoint.Opaque != "" {
+		return nil, fmt.Errorf("pyroscope: address must include a host")
+	}
+	if endpoint.User != nil {
+		return nil, fmt.Errorf("pyroscope: URL credentials are not allowed; use authentication fields")
+	}
+	if endpoint.RawQuery != "" || endpoint.ForceQuery || endpoint.Fragment != "" {
+		return nil, fmt.Errorf("pyroscope: address must not include a query or fragment")
+	}
+
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/ingest"
+	endpoint.RawPath = ""
+	return endpoint, nil
+}
+
+func validateAuthentication(cfg *Config) (string, string, string, error) {
+	hasUsername := cfg.Username != ""
+	hasPassword := cfg.Password != ""
+	token := cfg.BearerToken
+	switch {
+	case hasUsername != hasPassword:
+		return "", "", "", fmt.Errorf(
+			"pyroscope: username and password must be configured together",
+		)
+	case strings.Contains(cfg.Username, ":"):
+		return "", "", "", fmt.Errorf(
+			"pyroscope: basic authentication username must not contain a colon",
+		)
+	case token != "" && hasUsername:
+		return "", "", "", fmt.Errorf(
+			"pyroscope: basic authentication and bearer token are mutually exclusive",
+		)
+	case containsControl(cfg.Username) || containsControl(cfg.Password) ||
+		containsControl(token):
+		return "", "", "", fmt.Errorf(
+			"pyroscope: authentication fields must not contain control characters",
+		)
+	case strings.TrimSpace(token) != token:
+		return "", "", "", fmt.Errorf(
+			"pyroscope: bearer token must not have surrounding whitespace",
+		)
+	default:
+		return cfg.Username, cfg.Password, token, nil
+	}
+}
+
+func containsControl(value string) bool {
+	return strings.IndexFunc(value, unicode.IsControl) >= 0
+}
+
+func newBackendWithHTTPClient(
+	endpoint *url.URL,
+	appNamePrefix string,
+	username string,
+	password string,
+	bearerToken string,
+	httpClient *http.Client,
+) *Storage {
+	return &Storage{
+		ingestURL:     endpoint,
+		appNamePrefix: appNamePrefix,
+		username:      username,
+		password:      password,
+		bearerToken:   bearerToken,
+		httpClient:    httpClient,
+	}
+}
+
+// Init is a no-op because Pyroscope owns its profile schema.
+func (b *Storage) Init(context.Context, string, []driver.Index) error {
+	return nil
+}
+
+// Save uploads one pprof protobuf payload.
+func (b *Storage) Save(ctx context.Context, rec driver.Record) error {
+	if len(rec.Data) == 0 {
+		return fmt.Errorf("pyroscope: profile data is empty")
+	}
+
+	endpoint := *b.ingestURL
+	start := profileStart(rec.Fields)
+	end := profileEnd(rec.Fields, start)
+	query := endpoint.Query()
+	query.Set("name", b.applicationName(rec.Fields))
+	query.Set("from", strconv.FormatInt(start.Unix(), 10))
+	query.Set("until", strconv.FormatInt(end.Unix(), 10))
+	query.Set("format", pprofFormat)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(
+		driver.WithContext(ctx),
+		http.MethodPost,
+		endpoint.String(),
+		bytes.NewReader(rec.Data),
+	)
+	if err != nil {
+		return fmt.Errorf("pyroscope: create ingest request: %w", err)
+	}
+	req.Header.Set("Content-Type", protobufContentType)
+	switch {
+	case b.bearerToken != "":
+		req.Header.Set(authorizationHeaderName, "Bearer "+b.bearerToken)
+	case b.username != "":
+		req.SetBasicAuth(b.username, b.password)
+	}
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("pyroscope: ingest profile: %w", err)
+	}
+
+	body, responseErr := readAndCloseResponse(resp)
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		message := strings.Join(strings.Fields(string(body)), " ")
+		if message == "" {
+			message = resp.Status
+		}
+		statusErr := fmt.Errorf(
+			"pyroscope: ingest returned status %d: %s",
+			resp.StatusCode,
+			message,
+		)
+		return errors.Join(statusErr, responseErr)
+	}
+	if responseErr != nil {
+		return fmt.Errorf("pyroscope: consume ingest response: %w", responseErr)
+	}
+	return nil
+}
+
+func readAndCloseResponse(resp *http.Response) ([]byte, error) {
+	if resp.Body == nil {
+		return nil, fmt.Errorf("response body is nil")
+	}
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorResponseBytes))
+	_, drainErr := io.Copy(io.Discard, resp.Body)
+	closeErr := resp.Body.Close()
+	return body, errors.Join(readErr, drainErr, closeErr)
+}
+
+// Get is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Get(context.Context, string) (driver.Record, error) {
+	return driver.Record{}, driver.ErrUnsupportedOp
+}
+
+// Delete is unsupported because Pyroscope owns profile retention.
+func (b *Storage) Delete(context.Context, string) error {
+	return driver.ErrUnsupportedOp
+}
+
+// Query is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Query(context.Context, driver.Query) ([]driver.Record, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+// Count is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Count(context.Context, driver.Query) (int64, error) {
+	return 0, driver.ErrUnsupportedOp
+}
+
+// Values is unsupported because Pyroscope owns profile queries.
+func (b *Storage) Values(context.Context, string, driver.Query, int) ([]string, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+// Close releases no resources because the HTTP client owns no background worker.
+func (b *Storage) Close(context.Context) error {
+	return nil
+}
+
+func (b *Storage) applicationName(fields map[string]any) string {
+	name := b.appNamePrefix
+	if tracerName := sanitizeNamePart(stringField(fields, "tracer_name")); tracerName != "" {
+		name += "." + tracerName
+	}
+
+	labels := []struct {
+		name  string
+		field string
+	}{
+		{name: "tracer_id", field: "tracer_id"},
+		{name: "tracer_name", field: "tracer_name"},
+		{name: "hostname", field: "hostname"},
+		{name: "region", field: "region"},
+		{name: "container_id", field: "container_id"},
+		{name: "container_hostname", field: "container_hostname"},
+		{name: "tracer_type", field: "tracer_type"},
+		{name: "profile_type", field: "profile_type"},
+	}
+
+	values := make([]string, 0, len(labels))
+	for _, label := range labels {
+		value := sanitizeLabelValue(stringField(fields, label.field))
+		if value == "" {
+			continue
+		}
+		values = append(values, label.name+"="+value)
+	}
+	if len(values) > 0 {
+		name += "{" + strings.Join(values, ",") + "}"
+	}
+	return name
+}
+
+func profileStart(fields map[string]any) time.Time {
+	if value, ok := timeField(fields, "profile_start_time"); ok {
+		return value.UTC()
+	}
+	if value, ok := timeField(fields, "tracer_time"); ok {
+		return value.UTC()
+	}
+	if value, ok := timeField(fields, "uploaded_time"); ok {
+		return value.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func profileEnd(fields map[string]any, start time.Time) time.Time {
+	if value, ok := timeField(fields, "profile_end_time"); ok && value.After(start) {
+		return value.UTC()
+	}
+	return start.Add(time.Second)
+}
+
+func timeField(fields map[string]any, name string) (time.Time, bool) {
+	value, ok := fields[name]
+	if !ok {
+		return time.Time{}, false
+	}
+	switch typed := value.(type) {
+	case time.Time:
+		return typed, !typed.IsZero()
+	case *time.Time:
+		if typed == nil {
+			return time.Time{}, false
+		}
+		return *typed, !typed.IsZero()
+	default:
+		return time.Time{}, false
+	}
+}
+
+func stringField(fields map[string]any, name string) string {
+	value, _ := fields[name].(string)
+	return strings.TrimSpace(value)
+}
+
+func sanitizeNamePart(value string) string {
+	return sanitizeProfilePart(value, true)
+}
+
+func sanitizeLabelValue(value string) string {
+	return sanitizeProfilePart(value, false)
+}
+
+func sanitizeProfilePart(value string, allowDot bool) string {
+	var result strings.Builder
+	result.Grow(len(value))
+	for _, current := range strings.TrimSpace(value) {
+		if unicode.IsLetter(current) || unicode.IsDigit(current) ||
+			current == '_' || current == '-' || current == '/' ||
+			(allowDot && current == '.') {
+			result.WriteRune(current)
+			continue
+		}
+		result.WriteByte('_')
+	}
+	return strings.Trim(result.String(), "_")
+}

--- a/internal/storage/pyroscope/pyroscope_test.go
+++ b/internal/storage/pyroscope/pyroscope_test.go
@@ -1,0 +1,282 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pyroscope
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+func TestStorageSaveIngestsPprof(t *testing.T) {
+	profile := []byte{0x0a, 0x01, 0x00}
+	start := time.Unix(1700000000, 0).UTC()
+	end := start.Add(10 * time.Second)
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/base/ingest" {
+			t.Errorf("path = %s, want /base/ingest", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("format"); got != pprofFormat {
+			t.Errorf("format = %q, want %q", got, pprofFormat)
+		}
+		if got := r.URL.Query().Get("from"); got != strconv.FormatInt(start.Unix(), 10) {
+			t.Errorf("from = %q, want %d", got, start.Unix())
+		}
+		if got := r.URL.Query().Get("until"); got != strconv.FormatInt(end.Unix(), 10) {
+			t.Errorf("until = %q, want %d", got, end.Unix())
+		}
+		wantName := "huatuo.profiler{tracer_id=trace-1,tracer_name=profiler," +
+			"hostname=node-a,region=cn-hz,container_id=container-1," +
+			"tracer_type=autotracing,profile_type=cpu}"
+		if got := r.URL.Query().Get("name"); got != wantName {
+			t.Errorf("name = %q, want %q", got, wantName)
+		}
+		if got := r.Header.Get("Content-Type"); got != protobufContentType {
+			t.Errorf("Content-Type = %q, want %q", got, protobufContentType)
+		}
+		if got := r.Header.Get(authorizationHeaderName); got != "Bearer token-1" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !bytes.Equal(body, profile) {
+			t.Errorf("body = %v, want %v", body, profile)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	endpoint, _ := url.Parse("http://pyroscope.test/base/ingest")
+	backend := newBackendWithHTTPClient(
+		endpoint,
+		"huatuo",
+		"",
+		"",
+		"token-1",
+		httpClient,
+	)
+	err := backend.Save(context.Background(), driver.Record{
+		ID:   "trace-1",
+		Data: profile,
+		Fields: map[string]any{
+			"profile_start_time": start,
+			"profile_end_time":   end,
+			"profile_type":       "cpu",
+			"tracer_id":          "trace-1",
+			"tracer_name":        "profiler",
+			"hostname":           "node-a",
+			"region":             "cn-hz",
+			"container_id":       "container-1",
+			"tracer_type":        "autotracing",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+}
+
+func TestStorageSaveUsesBasicAuthentication(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != "user" || password != "secret" {
+			t.Errorf("BasicAuth = (%q, %q, %v)", username, password, ok)
+		}
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+	endpoint, _ := url.Parse("https://pyroscope.test/ingest")
+	backend := newBackendWithHTTPClient(endpoint, "huatuo", "user", "secret", "", httpClient)
+	if err := backend.Save(context.Background(), driver.Record{Data: []byte{1}}); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+}
+
+func TestStorageSaveClosesErrorResponse(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("ingest failed")}
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})}
+	endpoint, _ := url.Parse("http://pyroscope.test/ingest")
+	backend := newBackendWithHTTPClient(endpoint, "huatuo", "", "", "", httpClient)
+	err := backend.Save(context.Background(), driver.Record{Data: []byte{1}})
+	if err == nil || !strings.Contains(err.Error(), "status 500: ingest failed") {
+		t.Fatalf("Save error = %v, want status and response", err)
+	}
+	if !body.closed.Load() {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestStorageSaveHonorsContext(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		return nil, r.Context().Err()
+	})}
+	endpoint, _ := url.Parse("http://pyroscope.test/ingest")
+	backend := newBackendWithHTTPClient(endpoint, "huatuo", "", "", "", httpClient)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := backend.Save(ctx, driver.Record{Data: []byte{1}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Save error = %v, want context.Canceled", err)
+	}
+}
+
+func TestNewBackendRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{name: "nil config", cfg: nil},
+		{name: "empty address", cfg: &Config{}},
+		{name: "missing scheme", cfg: &Config{Address: "127.0.0.1:4040"}},
+		{name: "unsupported scheme", cfg: &Config{Address: "ftp://127.0.0.1"}},
+		{name: "URL credentials", cfg: &Config{Address: "http://user:secret@127.0.0.1"}},
+		{name: "query", cfg: &Config{Address: "http://127.0.0.1?tenant=a"}},
+		{name: "fragment", cfg: &Config{Address: "http://127.0.0.1#fragment"}},
+		{
+			name: "incomplete basic authentication",
+			cfg:  &Config{Address: "http://127.0.0.1", Username: "user"},
+		},
+		{
+			name: "colon in basic authentication username",
+			cfg: &Config{
+				Address:  "http://127.0.0.1",
+				Username: "user:name",
+				Password: "secret",
+			},
+		},
+		{
+			name: "multiple authentication methods",
+			cfg: &Config{
+				Address:     "http://127.0.0.1",
+				Username:    "user",
+				Password:    "secret",
+				BearerToken: "token",
+			},
+		},
+		{
+			name: "control character in token",
+			cfg:  &Config{Address: "http://127.0.0.1", BearerToken: "a\nb"},
+		},
+		{
+			name: "surrounding whitespace in token",
+			cfg:  &Config{Address: "http://127.0.0.1", BearerToken: " token"},
+		},
+		{
+			name: "negative timeout",
+			cfg:  &Config{Address: "http://127.0.0.1", TimeoutSeconds: -1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewBackend(tt.cfg); err == nil {
+				t.Fatalf("NewBackend(%#v) error = nil", tt.cfg)
+			}
+		})
+	}
+}
+
+func TestStorageDoesNotFollowRedirects(t *testing.T) {
+	var targetRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		targetRequests.Add(1)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	backend, err := NewBackend(&Config{Address: source.URL})
+	if err != nil {
+		t.Fatalf("NewBackend returned error: %v", err)
+	}
+	err = backend.Save(context.Background(), driver.Record{Data: []byte{1}})
+	if err == nil || !strings.Contains(err.Error(), "status 307") {
+		t.Fatalf("Save error = %v, want redirect status", err)
+	}
+	if targetRequests.Load() != 0 {
+		t.Fatalf("redirect target requests = %d, want 0", targetRequests.Load())
+	}
+}
+
+func TestStorageReadOperationsAreUnsupported(t *testing.T) {
+	backend, err := NewBackend(&Config{Address: "http://127.0.0.1:4040"})
+	if err != nil {
+		t.Fatalf("NewBackend returned error: %v", err)
+	}
+	if _, err := backend.Get(context.Background(), "id"); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Get error = %v, want ErrUnsupportedOp", err)
+	}
+	if err := backend.Delete(context.Background(), "id"); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Delete error = %v, want ErrUnsupportedOp", err)
+	}
+	if _, err := backend.Query(context.Background(), driver.Query{}); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Query error = %v, want ErrUnsupportedOp", err)
+	}
+	if _, err := backend.Count(context.Background(), driver.Query{}); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Count error = %v, want ErrUnsupportedOp", err)
+	}
+	if _, err := backend.Values(context.Background(), "field", driver.Query{}, 1); !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("Values error = %v, want ErrUnsupportedOp", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed atomic.Bool
+}
+
+func (b *trackingReadCloser) Close() error {
+	b.closed.Store(true)
+	return nil
+}

--- a/pkg/tracing/document_pprof.go
+++ b/pkg/tracing/document_pprof.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"fmt"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	"huatuo-bamai/internal/storage/driver"
+)
+
+// PprofDocumentStoreMapper encodes profiling documents for profile-native
+// backends. Elasticsearch continues to use ProfileDocumentStoreMapper and JSON.
+type PprofDocumentStoreMapper struct {
+	ProfileDocumentStoreMapper
+}
+
+// Encode serializes the embedded pprof profile as protobuf.
+func (PprofDocumentStoreMapper) Encode(document *Document) ([]byte, error) {
+	profileData, err := profileDataFromDocument(document)
+	if err != nil {
+		return nil, err
+	}
+	return profileData.Profile.MarshalVT()
+}
+
+// Decode is unsupported because the Pyroscope backend is write-only.
+func (PprofDocumentStoreMapper) Decode([]byte) (*Document, error) {
+	return nil, driver.ErrUnsupportedOp
+}
+
+// Fields adds profile timestamps and type to the document metadata.
+func (PprofDocumentStoreMapper) Fields(document *Document) (map[string]any, error) {
+	fields, err := (ProfileDocumentStoreMapper{}).Fields(document)
+	if err != nil {
+		return nil, err
+	}
+
+	profileData, err := profileDataFromDocument(document)
+	if err != nil {
+		return nil, err
+	}
+	fields["profile_type"] = profileData.ProfileType
+
+	start := time.Unix(0, profileData.Profile.TimeNanos).UTC()
+	if profileData.Profile.TimeNanos == 0 {
+		start = tracingDocumentTimeValue(document.TracerTime, document.UploadedTime)
+	}
+	fields["profile_start_time"] = start
+
+	end := start.Add(time.Duration(profileData.Profile.DurationNanos))
+	if !end.After(start) {
+		end = start.Add(time.Second)
+	}
+	fields["profile_end_time"] = end
+
+	return fields, nil
+}
+
+// Indexes lists metadata consumed by the Pyroscope ingest backend.
+func (PprofDocumentStoreMapper) Indexes() []driver.Index {
+	indexes := (ProfileDocumentStoreMapper{}).Indexes()
+	return append(indexes,
+		driver.Index{Field: "profile_type"},
+		driver.Index{Field: "profile_start_time"},
+		driver.Index{Field: "profile_end_time"},
+	)
+}
+
+func profileDataFromDocument(document *Document) (*profiler.ProfileData, error) {
+	if document == nil {
+		return nil, fmt.Errorf("pprof document is nil")
+	}
+
+	var profileData *profiler.ProfileData
+	switch value := document.TracerData.(type) {
+	case *profiler.ProfileData:
+		profileData = value
+	case profiler.ProfileData:
+		profileData = &value
+	case interface{ ProfileData() *profiler.ProfileData }:
+		profileData = value.ProfileData()
+	default:
+		return nil, fmt.Errorf(
+			"pprof document tracer_data has unsupported type %T",
+			document.TracerData,
+		)
+	}
+	if profileData == nil {
+		return nil, fmt.Errorf("pprof document is missing tracer_data.flamedata")
+	}
+	return profileData, nil
+}

--- a/pkg/tracing/document_pprof_test.go
+++ b/pkg/tracing/document_pprof_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	"huatuo-bamai/internal/storage/driver"
+
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+func TestPprofDocumentStoreMapperEncodesProtobuf(t *testing.T) {
+	start := time.Unix(1700000000, 123).UTC()
+	profileData := &profiler.ProfileData{
+		ProfileType: profiler.ProfileTypeCpuSample,
+		Profile: ptree.Profile{
+			StringTable:   []string{"", "cpu", "nanoseconds"},
+			TimeNanos:     start.UnixNano(),
+			DurationNanos: int64(10 * time.Second),
+		},
+	}
+	document := &Document{
+		TracerID:   "trace-1",
+		TracerTime: start.Format(tracingDocumentTimeLayout),
+		TracerData: testProfileEnvelope{profileData: profileData},
+	}
+
+	mapper := PprofDocumentStoreMapper{}
+	raw, err := mapper.Encode(document)
+	if err != nil {
+		t.Fatalf("Encode returned error: %v", err)
+	}
+	var decoded ptree.Profile
+	if err := decoded.UnmarshalVT(raw); err != nil {
+		t.Fatalf("UnmarshalVT returned error: %v", err)
+	}
+	if decoded.TimeNanos != start.UnixNano() {
+		t.Errorf("TimeNanos = %d, want %d", decoded.TimeNanos, start.UnixNano())
+	}
+
+	fields, err := mapper.Fields(document)
+	if err != nil {
+		t.Fatalf("Fields returned error: %v", err)
+	}
+	if got := fields["profile_type"]; got != profiler.ProfileTypeCpuSample {
+		t.Errorf("profile_type = %v, want %q", got, profiler.ProfileTypeCpuSample)
+	}
+	if got := fields["profile_start_time"]; got != start {
+		t.Errorf("profile_start_time = %v, want %v", got, start)
+	}
+	if got := fields["profile_end_time"]; got != start.Add(10*time.Second) {
+		t.Errorf("profile_end_time = %v, want %v", got, start.Add(10*time.Second))
+	}
+}
+
+func TestPprofDocumentStoreMapperRejectsMissingProfile(t *testing.T) {
+	mapper := PprofDocumentStoreMapper{}
+	if _, err := mapper.Encode(&Document{TracerData: testProfileEnvelope{}}); err == nil {
+		t.Fatal("Encode error = nil, want missing profile error")
+	}
+}
+
+func TestPprofDocumentStoreMapperDecodeIsUnsupported(t *testing.T) {
+	_, err := (PprofDocumentStoreMapper{}).Decode(nil)
+	if !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Fatalf("Decode error = %v, want ErrUnsupportedOp", err)
+	}
+}
+
+type testProfileEnvelope struct {
+	profileData *profiler.ProfileData
+}
+
+func (e testProfileEnvelope) ProfileData() *profiler.ProfileData {
+	return e.profileData
+}


### PR DESCRIPTION
## Summary

- add a standalone profiling deployment mode
- start huatuo-bamai, Pyroscope, and Grafana by default
- retain Elasticsearch, Prometheus, and huatuo-apiserver in full mode
- document and test the supported Compose service sets

## Validation

- [ ] GitHub Actions