### PR TITLE
fix(matcher): validate issue filter expressions

### DIFF
--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -24,6 +24,7 @@ import (
 	"huatuo-bamai/core/events"
 	collector "huatuo-bamai/core/metrics"
 	internalconfig "huatuo-bamai/internal/config"
+	"huatuo-bamai/internal/matcher"
 )
 
 // LogConfig controls process logging.
@@ -130,6 +131,12 @@ func (c *BamaiConfig) Validate() error {
 	}
 	if err := c.Pod.Validate(); err != nil {
 		return fmt.Errorf("validating pod config: %w", err)
+	}
+	if err := matcher.ValidateClassifications(c.AutoTracing.IssuesList); err != nil {
+		return fmt.Errorf("validating autotracing issues list: %w", err)
+	}
+	if err := matcher.ValidateClassifications(c.EventTracing.IssuesList); err != nil {
+		return fmt.Errorf("validating event tracing issues list: %w", err)
 	}
 	return nil
 }

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -271,6 +271,20 @@ func TestBamaiConfigValidate(t *testing.T) {
 			},
 			wantErr: "kubelet read-only port",
 		},
+		{
+			name: "invalid autotracing issue expression",
+			mutate: func(cfg *BamaiConfig) {
+				cfg.AutoTracing.IssuesList = [][]string{{"broken", "["}}
+			},
+			wantErr: "validating autotracing issues list",
+		},
+		{
+			name: "invalid event tracing issue shape",
+			mutate: func(cfg *BamaiConfig) {
+				cfg.EventTracing.IssuesList = [][]string{{"missing-expression"}}
+			},
+			wantErr: "validating event tracing issues list",
+		},
 	}
 
 	for _, tt := range tests {
@@ -282,6 +296,18 @@ func TestBamaiConfigValidate(t *testing.T) {
 				t.Fatalf("Validate() error = %v, want contain %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestLoadRejectsInvalidIssuesListExpression(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "huatuo-bamai.conf", `
+[EventTracing]
+IssuesList = [["broken", "["]]
+`)
+	err := Load(path)
+	if err == nil || !strings.Contains(err.Error(),
+		`rule 0 "broken" has invalid regular expression "["`) {
+		t.Fatalf("Load() error = %v, want actionable expression error", err)
 	}
 }
 

--- a/internal/matcher/classify.go
+++ b/internal/matcher/classify.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,27 @@
 package matcher
 
 import (
+	"fmt"
 	"regexp"
 )
+
+// ValidateClassifications validates the name and regular expression in every
+// classification rule.
+func ValidateClassifications(patternList [][]string) error {
+	for i, pattern := range patternList {
+		if len(pattern) != 2 {
+			return fmt.Errorf("rule %d must contain a name and regular expression", i)
+		}
+		if pattern[0] == "" {
+			return fmt.Errorf("rule %d has an empty name", i)
+		}
+		if _, err := regexp.Compile(pattern[1]); err != nil {
+			return fmt.Errorf("rule %d %q has invalid regular expression %q: %w",
+				i, pattern[0], pattern[1], err)
+		}
+	}
+	return nil
+}
 
 func Classify(patternList [][]string, value string) (string, bool) {
 	for _, p := range patternList {
@@ -24,7 +43,10 @@ func Classify(patternList [][]string, value string) (string, bool) {
 			return "none", false
 		}
 
-		reg := regexp.MustCompile(p[1])
+		reg, err := regexp.Compile(p[1])
+		if err != nil {
+			return "none", false
+		}
 		if reg.MatchString(value) {
 			return p[0], true
 		}

--- a/internal/matcher/classify_test.go
+++ b/internal/matcher/classify_test.go
@@ -40,6 +40,7 @@ func TestClassify(t *testing.T) {
 		{"no match", [][]string{{"a", "aaa"}, {"b", "bbb"}}, "xxx", "none", false},
 		{"wrong group len 1", [][]string{{"x"}}, "any", "none", false},
 		{"wrong group len 3", [][]string{{"x", "y", "z"}}, "any", "none", false},
+		{"invalid regex", [][]string{{"x", "["}}, "any", "none", false},
 		{"anchors match", [][]string{{"x", "^foo$"}}, "foo", "x", true},
 		{"anchors no match", [][]string{{"x", "^foo$"}}, "foobar", "none", false},
 	}
@@ -48,6 +49,35 @@ func TestClassify(t *testing.T) {
 			got, matched := Classify(tt.issues, tt.value)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.matched, matched)
+		})
+	}
+}
+
+func TestValidateClassifications(t *testing.T) {
+	tests := []struct {
+		name    string
+		rules   [][]string
+		wantErr string
+	}{
+		{name: "empty list"},
+		{name: "valid", rules: [][]string{{"memory", "memory.*"}}},
+		{name: "missing expression", rules: [][]string{{"memory"}}, wantErr: "rule 0"},
+		{name: "empty name", rules: [][]string{{"", "memory.*"}}, wantErr: "empty name"},
+		{
+			name:    "invalid expression",
+			rules:   [][]string{{"memory", "["}},
+			wantErr: `rule 0 "memory" has invalid regular expression "["`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateClassifications(tt.rules)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #533

## Summary

- validate every `IssuesList` rule shape, name, and regular expression
- reject invalid AutoTracing and EventTracing rules during config loading
- replace `regexp.MustCompile` in the runtime matcher with safe compilation
- return an actionable error containing the rule index, name, and expression

## Root cause

`IssuesList` is operator-controlled configuration, but its expressions were
only compiled when an event reached `matcher.Classify`. The matcher used
`regexp.MustCompile`, so a configuration typo passed startup and later panicked
the agent when dload, net_rx_latency, or dropwatch processed an event.

## Verification

Executed on `WZU_4080_Tail` after generating the BPF ABI and Cap'n Proto files:

```text
go test ./internal/matcher ./cmd/huatuo-bamai/config
ok  huatuo-bamai/internal/matcher
ok  huatuo-bamai/cmd/huatuo-bamai/config

make check
0 lint issues
```
