### PR TITLE
fix(metrics): guard cpu_stat deltaWaitRunSum uint64 underflow (Fixes #536)

### DIFF
--- a/core/metrics/cpu_stat.go
+++ b/core/metrics/cpu_stat.go
@@ -145,7 +145,7 @@ func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Containe
 		stat.waitrateWaitSum = float64(deltaWaitSum) * 100 / float64(waitSumDenom)
 	}
 
-	deltaWaitRunSum := deltaHierarchyWaitSum + stat.cpuTotal - cpu.cpuTotal
+	deltaWaitRunSum := deltaHierarchyWaitSum + deltaCpuUsage
 	if deltaWaitRunSum == 0 {
 		stat.waitrateHierarchy = 0
 		stat.waitrateInner = 0


### PR DESCRIPTION
## Fix #536: guard cpu_stat deltaWaitRunSum uint64 underflow

### Problem

In `core/metrics/cpu_stat.go`, `updateDataCache` computes:

```go
deltaWaitRunSum := deltaHierarchyWaitSum + stat.cpuTotal - cpu.cpuTotal
```

When cgroup CPU counters reset (container restart / cgroup recreation), `stat.cpuTotal < cpu.cpuTotal`, causing a **uint64 underflow**. The code already guards this at line 136 by setting `deltaCpuUsage = 0` when `stat.cpuTotal <= cpu.cpuTotal`, but line 148 uses the raw subtraction instead of the guarded value.

### Fix

Replace `stat.cpuTotal - cpu.cpuTotal` with the already-guarded `deltaCpuUsage`:

```diff
- deltaWaitRunSum := deltaHierarchyWaitSum + stat.cpuTotal - cpu.cpuTotal
+ deltaWaitRunSum := deltaHierarchyWaitSum + deltaCpuUsage
```

When counter reset occurs, `deltaCpuUsage = 0`, so `deltaWaitRunSum` correctly equals `deltaHierarchyWaitSum` without underflow.

Fixes #536