### PR TITLE
fix(metrics): guard metax_gpu ListDieClocks empty slice panic (Fixes #538)

### DIFF
--- a/core/metrics/metax_gpu.go
+++ b/core/metrics/metax_gpu.go
@@ -454,7 +454,7 @@ func metaxCollectDieMetrics(ctx context.Context, gpuId, dieId uint32, series gpu
 				return nil, fmt.Errorf("failed to %s: %w", operationListClocks, err)
 			}
 			log.Debugf("operation %s not supported on gpu %d die %d", operationListClocks, gpuId, dieId)
-		} else {
+		} else if len(values) > 0 {
 			metrics = append(
 				metrics,
 				metric.NewGaugeData("clock_mhz", float64(values[0]), "GPU clock.", map[string]string{


### PR DESCRIPTION
## Fix #538: guard metax_gpu ListDieClocks empty slice panic

### Problem

When `mxSmlGetDieClocks` succeeds but returns `size=0` (GPU idle/reset state), `ListDieClocks` returns an empty `[]uint32{}` with `nil` error. The code accesses `values[0]` unconditionally, causing an **index out of range panic**.

### Fix

Add a length check before accessing `values[0]`:

```diff
- } else {
+ } else if len(values) > 0 {
```

When the slice is empty, the metric is simply skipped.

Fixes #538