### PR TITLE
fix(metrics): guard net_arp count-1 underflow producing negative metric (Fixes #540)

### DIFF
--- a/core/metrics/net_arp.go
+++ b/core/metrics/net_arp.go
@@ -60,7 +60,7 @@ func nodeArpCacheEntries() ([]*metric.Data, error) {
 	}
 
 	return []*metric.Data{
-		metric.NewGaugeData("entries", float64(count-1), "host init namespace", nil),
+		metric.NewGaugeData("entries", float64(max(count-1, 0)), "host init namespace", nil),
 		metric.NewGaugeData("total", float64(cache.Stats["entries"]), "all entries in arp_cache for containers and host netns", nil),
 	}, nil
 }
@@ -80,7 +80,7 @@ func (c *arpCollector) Update() ([]*metric.Data, error) {
 			return data, err
 		}
 
-		data = append(data, metric.NewContainerGaugeData(container, "entries", float64(count-1), "arp entries in container netns", nil))
+		data = append(data, metric.NewContainerGaugeData(container, "entries", float64(max(count-1, 0)), "arp entries in container netns", nil))
 	}
 
 	entries, err := nodeArpCacheEntries()


### PR DESCRIPTION
## Fix #540: guard net_arp count-1 underflow producing negative metric

### Problem

When `/proc/<pid>/net/arp` is empty (0 lines), `CountLines()` returns 0, and `count-1` evaluates to -1. `float64(-1)` produces a negative gauge value for the "entries" metric, which is meaningless and can trigger false-positive Prometheus alerts.

### Fix

Use `max(count-1, 0)` to clamp the value at zero for both host and per-container ARP entry counts.

Fixes #540