### PR TITLE
fix(metrics): check scanner.Scan return value in parseNetStat to prevent panic (Fixes #543)

### DIFF
--- a/core/metrics/net_netstat.go
+++ b/core/metrics/net_netstat.go
@@ -138,7 +138,9 @@ func parseNetStat(fileName string) (map[string]map[string]string, error) {
 	for scanner.Scan() {
 		nameParts := strings.Split(scanner.Text(), " ")
 
-		scanner.Scan()
+		if !scanner.Scan() {
+			break
+		}
 		valueParts := strings.Split(scanner.Text(), " ")
 
 		// remove trailing ":"


### PR DESCRIPTION
## Fix #543: check scanner.Scan return value in parseNetStat to prevent panic

### Problem

`parseNetStat` reads `/proc/<pid>/net/netstat` and `/proc/<pid>/net/snmp` in name-value pairs. The second `scanner.Scan()` call does not check the return value. When the file is truncated (odd number of lines) or empty, `scanner.Text()` returns stale or empty text, causing `nameParts[0][:len(nameParts[0])-1]` to panic with index out of range on an empty string.

### Fix

Check the return value of `scanner.Scan()` and break out of the loop when it returns `false`:

```diff
  for scanner.Scan() {
      nameParts := strings.Split(scanner.Text(), " ")

-     scanner.Scan()
+     if !scanner.Scan() {
+         break
+     }
      valueParts := strings.Split(scanner.Text(), " ")
```

When the second scan fails, the function returns whatever stats were collected so far instead of panicking.

Fixes #543