### PR TITLE
feat(storage): export tracing documents to ClickHouse

### DIFF
--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -57,8 +59,43 @@ type LocalFileConfig struct {
 	MaxRotatedFiles int    `default:"10"`
 }
 
+var clickHouseIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ClickHouseConfig controls the optional ClickHouse event store.
+type ClickHouseConfig struct {
+	Address  string
+	Username string
+	Password string
+	Database string `default:"default"`
+	Table    string `default:"huatuo_bamai"`
+}
+
+// Enabled reports whether an address opts in to ClickHouse storage.
+func (c *ClickHouseConfig) Enabled() bool {
+	return strings.TrimSpace(c.Address) != ""
+}
+
+// Validate rejects incomplete or unsafe ClickHouse HTTP configurations.
+func (c *ClickHouseConfig) Validate() error {
+	if !c.Enabled() {
+		return nil
+	}
+	u, err := url.Parse(c.Address)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("invalid ClickHouse HTTP address %q", c.Address)
+	}
+	if !clickHouseIdentifierPattern.MatchString(c.Database) {
+		return fmt.Errorf("invalid ClickHouse database %q", c.Database)
+	}
+	if !clickHouseIdentifierPattern.MatchString(c.Table) {
+		return fmt.Errorf("invalid ClickHouse table %q", c.Table)
+	}
+	return nil
+}
+
 // StorageConfig controls tracing data storage.
 type StorageConfig struct {
+	ClickHouse    ClickHouseConfig
 	Elasticsearch internalconfig.ElasticsearchConfig
 	LocalFile     LocalFileConfig
 }
@@ -205,6 +242,9 @@ func (c TasksConfig) Validate() error {
 
 // Validate rejects invalid storage settings.
 func (c *StorageConfig) Validate() error {
+	if err := c.ClickHouse.Validate(); err != nil {
+		return fmt.Errorf("validating ClickHouse config: %w", err)
+	}
 	if err := c.Elasticsearch.Validate(); err != nil {
 		return fmt.Errorf("validating Elasticsearch config: %w", err)
 	}

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -204,6 +204,37 @@ Address = "http://127.0.0.1:9200"
 	}
 }
 
+func TestLoadEnablesClickHouseConfig(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "huatuo-bamai.conf", `
+[Storage.ClickHouse]
+Address = "http://127.0.0.1:8123"
+Username = "huatuo"
+Password = "secret"
+`)
+
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !Get().Storage.ClickHouse.Enabled() {
+		t.Fatal("ClickHouse is disabled with an HTTP address")
+	}
+	if Get().Storage.ClickHouse.Database != "default" || Get().Storage.ClickHouse.Table != "huatuo_bamai" {
+		t.Fatalf("ClickHouse defaults = %q.%q", Get().Storage.ClickHouse.Database, Get().Storage.ClickHouse.Table)
+	}
+}
+
+func TestLoadRejectsInvalidClickHouseConfig(t *testing.T) {
+	path := writeConfigFile(t, t.TempDir(), "huatuo-bamai.conf", `
+[Storage.ClickHouse]
+Address = "tcp://127.0.0.1:9000"
+`)
+
+	err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "invalid ClickHouse HTTP address") {
+		t.Fatalf("Load() error = %v, want invalid ClickHouse address error", err)
+	}
+}
+
 func TestLoadRejectsLegacyKeys(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -68,6 +68,21 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 		tracingMetadataStores = append(tracingMetadataStores, localFileStore)
 	}
 
+	if cfg.Storage.ClickHouse.Enabled() {
+		clickHouseStore, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
+			Driver:             "clickhouse",
+			ClickHouseAddress:  cfg.Storage.ClickHouse.Address,
+			ClickHouseUsername: cfg.Storage.ClickHouse.Username,
+			ClickHousePassword: cfg.Storage.ClickHouse.Password,
+			ClickHouseDatabase: cfg.Storage.ClickHouse.Database,
+			ClickHouseTable:    cfg.Storage.ClickHouse.Table,
+		}, tracing.DocumentCollection, tracing.DocumentStoreMapper{})
+		if err != nil {
+			return fmt.Errorf("new tracing document store (ClickHouse): %w", err)
+		}
+		tracingMetadataStores = append(tracingMetadataStores, clickHouseStore)
+	}
+
 	if len(tracingMetadataStores) > 0 {
 		tracing.SetTracingStore(
 			tracingMetadataStores,

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -201,7 +201,22 @@ idle timeout; 15–60 seconds is typical.
 
 **Overall**: ES/OS storage persists kernel tracing and event data for later search and analysis.
 
-#### 6.2 Local File Storage
+#### 6.2 ClickHouse Storage
+
+ClickHouse can receive tracing documents through its HTTP interface. Configure an existing database; HUATUO creates the MergeTree table automatically. The backend is currently an event sink, so interactive HUATUO task and profile queries continue to use Elasticsearch/OpenSearch.
+
+```toml
+[Storage.ClickHouse]
+    Address = "http://127.0.0.1:8123"
+    Username = "default"
+    Password = "REPLACE_WITH_PASSWORD"
+    Database = "default"
+    Table = "huatuo_bamai"
+```
+
+Leave `Address` empty to disable the backend. `Database` and `Table` must be plain ClickHouse identifiers.
+
+#### 6.3 Local File Storage
 
 ```bash
 # LocalFile Storage

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -200,7 +200,22 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
 
 **整体说明**：ES/OS 存储用于持久化内核追踪和事件数据，便于后续检索与分析。如果用户不关心 Linux 内核事件、Autotracing 数据则可以关闭该配置。
 
-#### 6.2 本地文件存储
+#### 6.2 ClickHouse 存储
+
+ClickHouse 可通过 HTTP 接口接收追踪文档。请预先创建数据库，HUATUO 会自动创建 MergeTree 表。当前该后端作为事件写入端使用；HUATUO 的交互式任务与性能剖析查询仍使用 Elasticsearch/OpenSearch。
+
+```toml
+[Storage.ClickHouse]
+    Address = "http://127.0.0.1:8123"
+    Username = "default"
+    Password = "REPLACE_WITH_PASSWORD"
+    Database = "default"
+    Table = "huatuo_bamai"
+```
+
+将 `Address` 留空即可禁用该后端。`Database` 和 `Table` 必须是普通的 ClickHouse 标识符。
+
+#### 6.3 本地文件存储
 
 ```bash
 # LocalFile Storage

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -100,6 +100,19 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
 
+    # ClickHouse Storage
+    #
+    # Write tracing documents through ClickHouse's HTTP interface. The target
+    # database must already exist; the table is created automatically. Leave
+    # Address empty to disable this sink.
+    #
+    [Storage.ClickHouse]
+        # Address = "http://127.0.0.1:8123"
+        # Username = "default"
+        # Password = "REPLACE_WITH_PASSWORD"
+        # Database = "default"
+        # Table = "huatuo_bamai"
+
     # LocalFile Storage
     #
     # Store data to local directory for troubleshooting on the host machine.

--- a/internal/storage/backends.go
+++ b/internal/storage/backends.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	// Register all built-in storage backends.
+	_ "huatuo-bamai/internal/storage/clickhouse"
 	_ "huatuo-bamai/internal/storage/elasticsearch"
 	_ "huatuo-bamai/internal/storage/localfile"
 	_ "huatuo-bamai/internal/storage/sqlite"

--- a/internal/storage/clickhouse/clickhouse.go
+++ b/internal/storage/clickhouse/clickhouse.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clickhouse implements a write-only ClickHouse storage backend.
+package clickhouse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+const requestTimeout = 30 * time.Second
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Storage writes HUATUO documents through ClickHouse's HTTP interface.
+type Storage struct {
+	client     httpDoer
+	address    string
+	username   string
+	password   string
+	database   string
+	table      string
+	collection string
+}
+
+var _ driver.Backend = (*Storage)(nil)
+
+func init() {
+	driver.RegisterBackend("clickhouse", func(cfg *driver.Config) (driver.Backend, error) {
+		return NewBackend(cfg.ClickHouseAddress, cfg.ClickHouseUsername, cfg.ClickHousePassword, cfg.ClickHouseDatabase, cfg.ClickHouseTable)
+	})
+}
+
+// NewBackend creates a ClickHouse event store using the HTTP protocol.
+func NewBackend(address, username, password, database, table string) (*Storage, error) {
+	u, err := url.Parse(strings.TrimRight(address, "/"))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil, fmt.Errorf("ClickHouse backend: invalid HTTP address %q", address)
+	}
+	if !identifierPattern.MatchString(database) || !identifierPattern.MatchString(table) {
+		return nil, errors.New("ClickHouse backend: database and table must be identifiers")
+	}
+	return &Storage{
+		client:   &http.Client{Timeout: requestTimeout},
+		address:  strings.TrimRight(address, "/"),
+		username: username,
+		password: password,
+		database: database,
+		table:    table,
+	}, nil
+}
+
+func (s *Storage) Init(ctx context.Context, collection string, _ []driver.Index) error {
+	if strings.TrimSpace(collection) == "" {
+		return errors.New("ClickHouse backend: collection must not be empty")
+	}
+	s.collection = collection
+	query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s`.`%s` (collection LowCardinality(String), id String, data String, fields String, observed_at DateTime64(3, 'UTC') DEFAULT now64(3)) ENGINE = MergeTree ORDER BY (collection, observed_at, id)", s.database, s.table)
+	return s.execute(ctx, query, nil)
+}
+
+func (s *Storage) Save(ctx context.Context, rec driver.Record) error {
+	if rec.ID == "" {
+		return fmt.Errorf("%w: empty id", driver.ErrInvalidField)
+	}
+	if s.collection == "" {
+		return errors.New("ClickHouse backend: not initialized")
+	}
+	fields, err := json.Marshal(rec.Fields)
+	if err != nil {
+		return fmt.Errorf("ClickHouse backend: encode fields: %w", err)
+	}
+	row, err := json.Marshal(struct {
+		Collection string `json:"collection"`
+		ID         string `json:"id"`
+		Data       string `json:"data"`
+		Fields     string `json:"fields"`
+	}{s.collection, rec.ID, string(rec.Data), string(fields)})
+	if err != nil {
+		return fmt.Errorf("ClickHouse backend: encode row: %w", err)
+	}
+	row = append(row, '\n')
+	query := fmt.Sprintf("INSERT INTO `%s`.`%s` (collection, id, data, fields) FORMAT JSONEachRow", s.database, s.table)
+	return s.execute(ctx, query, row)
+}
+
+func (s *Storage) execute(ctx context.Context, query string, body []byte) error {
+	u, err := url.Parse(s.address)
+	if err != nil {
+		return err
+	}
+	values := u.Query()
+	values.Set("query", query)
+	u.RawQuery = values.Encode()
+	req, err := http.NewRequestWithContext(driver.WithContext(ctx), http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("ClickHouse backend: create request: %w", err)
+	}
+	if s.username != "" {
+		req.SetBasicAuth(s.username, s.password)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ClickHouse backend: request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("ClickHouse backend: status %s: %s", resp.Status, strings.TrimSpace(string(message)))
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func (s *Storage) Get(context.Context, string) (driver.Record, error) {
+	return driver.Record{}, driver.ErrUnsupported
+}
+func (s *Storage) Delete(context.Context, string) error { return driver.ErrUnsupported }
+func (s *Storage) Query(context.Context, driver.Query) ([]driver.Record, error) {
+	return nil, driver.ErrUnsupported
+}
+
+func (s *Storage) Count(context.Context, driver.Query) (int64, error) {
+	return 0, driver.ErrUnsupported
+}
+
+func (s *Storage) Values(context.Context, string, driver.Query, int) ([]string, error) {
+	return nil, driver.ErrUnsupported
+}
+func (s *Storage) Close(context.Context) error { return nil }

--- a/internal/storage/clickhouse/clickhouse_test.go
+++ b/internal/storage/clickhouse/clickhouse_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clickhouse
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+func TestStorageInitAndSave(t *testing.T) {
+	type request struct {
+		query, body, username, password string
+	}
+	requests := make(chan request, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		username, password, _ := r.BasicAuth()
+		requests <- request{r.URL.Query().Get("query"), string(body), username, password}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	backend, err := NewBackend(server.URL, "huatuo", "secret", "observability", "events")
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	if err := backend.Init(t.Context(), "tracing_documents", nil); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := backend.Save(t.Context(), driver.Record{
+		ID:     "trace-20260809",
+		Data:   []byte(`{"tracer_name":"oom"}`),
+		Fields: map[string]any{"tracer_name": "oom", "region": "cn-beijing"},
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	create := <-requests
+	if !strings.Contains(create.query, "CREATE TABLE IF NOT EXISTS `observability`.`events`") {
+		t.Errorf("create query = %q", create.query)
+	}
+	insert := <-requests
+	if !strings.Contains(insert.query, "FORMAT JSONEachRow") {
+		t.Errorf("insert query = %q", insert.query)
+	}
+	if insert.username != "huatuo" || insert.password != "secret" {
+		t.Errorf("basic auth = %q/%q", insert.username, insert.password)
+	}
+	var row struct {
+		Collection string `json:"collection"`
+		ID         string `json:"id"`
+		Data       string `json:"data"`
+		Fields     string `json:"fields"`
+	}
+	if err := json.Unmarshal([]byte(insert.body), &row); err != nil {
+		t.Fatalf("decode row: %v", err)
+	}
+	if row.Collection != "tracing_documents" || row.ID != "trace-20260809" || row.Data != `{"tracer_name":"oom"}` {
+		t.Errorf("row = %+v", row)
+	}
+	if !strings.Contains(row.Fields, `"region":"cn-beijing"`) {
+		t.Errorf("fields = %q", row.Fields)
+	}
+}
+
+func TestStorageReportsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	backend, err := NewBackend(server.URL, "", "", "default", "events")
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	err = backend.Init(t.Context(), "tracing_documents", nil)
+	if err == nil || !strings.Contains(err.Error(), "database unavailable") {
+		t.Fatalf("Init() error = %v", err)
+	}
+}
+
+func TestStorageValidationAndUnsupportedOperations(t *testing.T) {
+	if _, err := NewBackend("tcp://localhost:9000", "", "", "default", "events"); err == nil {
+		t.Fatal("NewBackend() error = nil for non-HTTP address")
+	}
+	if _, err := NewBackend("http://localhost:8123", "", "", "bad-name", "events"); err == nil {
+		t.Fatal("NewBackend() error = nil for invalid database")
+	}
+	backend := &Storage{}
+	if err := backend.Save(t.Context(), driver.Record{}); !errors.Is(err, driver.ErrInvalidField) {
+		t.Fatalf("Save() error = %v, want ErrInvalidField", err)
+	}
+	if _, err := backend.Get(t.Context(), "id"); !errors.Is(err, driver.ErrUnsupported) {
+		t.Fatalf("Get() error = %v, want ErrUnsupported", err)
+	}
+}

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -57,6 +57,12 @@ type Config struct {
 	ESUsername  string
 	ESPassword  string
 	ESIndex     string
+
+	ClickHouseAddress  string
+	ClickHouseUsername string
+	ClickHousePassword string
+	ClickHouseDatabase string
+	ClickHouseTable    string
 }
 
 // Op is a storage query operator.


### PR DESCRIPTION
## Summary
- add an optional ClickHouse HTTP storage backend for tracing documents
- create a MergeTree table during backend initialization
- write document payloads and indexed metadata with JSONEachRow
- validate endpoint and SQL identifiers, propagate HTTP errors, and document configuration in English and Chinese

The backend is a write-only event sink; interactive task and profile queries remain on Elasticsearch/OpenSearch.

Fixes #28

## Testing
- `make check`
- `go test ./internal/storage/clickhouse ./cmd/huatuo-bamai/config ./cmd/huatuo-bamai`
- `make unit` (all relevant tests pass; the WSL host cannot run the existing real eBPF attach and cgroup interface tests)