### PR TITLE
feat(storage): configure Elasticsearch index lifecycle

### DIFF
--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -42,11 +42,12 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 	tracingMetadataStores := make([]*storage.Store[*tracing.Document], 0, 2)
 	if cfg.Storage.Elasticsearch.Enabled() {
 		store, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
-			Driver:      "elasticsearch",
-			ESAddresses: strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
-			ESUsername:  cfg.Storage.Elasticsearch.Username,
-			ESPassword:  cfg.Storage.Elasticsearch.Password,
-			ESIndex:     cfg.Storage.Elasticsearch.Index,
+			Driver:             "elasticsearch",
+			ESAddresses:        strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
+			ESUsername:         cfg.Storage.Elasticsearch.Username,
+			ESPassword:         cfg.Storage.Elasticsearch.Password,
+			ESIndex:            cfg.Storage.Elasticsearch.Index,
+			ESILMRetentionDays: cfg.Storage.Elasticsearch.ILMRetentionDays,
 		}, tracing.DocumentCollection, tracing.DocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("new tracing document store (elasticsearch): %w", err)
@@ -82,11 +83,12 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 
 	if cfg.Storage.Elasticsearch.Enabled() {
 		profileStore, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
-			Driver:      "elasticsearch",
-			ESAddresses: strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
-			ESUsername:  cfg.Storage.Elasticsearch.Username,
-			ESPassword:  cfg.Storage.Elasticsearch.Password,
-			ESIndex:     cfg.Storage.Elasticsearch.Index,
+			Driver:             "elasticsearch",
+			ESAddresses:        strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
+			ESUsername:         cfg.Storage.Elasticsearch.Username,
+			ESPassword:         cfg.Storage.Elasticsearch.Password,
+			ESIndex:            cfg.Storage.Elasticsearch.Index,
+			ESILMRetentionDays: cfg.Storage.Elasticsearch.ILMRetentionDays,
 		}, profiler.MetadataCollection, tracing.ProfileDocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("new profiling document store (elasticsearch): %w", err)

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -170,7 +170,10 @@ idle timeout; 15–60 seconds is typical.
         # Index = "huatuo_bamai"
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
+        # ILMRetentionDays = 0
 ```
+
+Set `ILMRetentionDays` to a positive number to let Elasticsearch create a lifecycle policy, roll the write alias over every day, and delete expired indices. The default `0` leaves index lifecycle management disabled. This option uses Elasticsearch ILM APIs and must remain disabled for OpenSearch; existing installations should also ensure that the configured `Index` name is not already a concrete index before enabling its rollover alias.
 
 - **Address**: ElasticSearch/OpenSearch service address.
 

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -170,7 +170,10 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
         # Index = "huatuo_bamai"
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
+        # ILMRetentionDays = 0
 ```
+
+将 `ILMRetentionDays` 设为正数后，Elasticsearch 会创建生命周期策略，每日滚动写入别名，并删除超过保留天数的索引。默认值 `0` 表示禁用。该选项使用 Elasticsearch ILM API，OpenSearch 必须保持禁用；已有部署启用前还应确认配置的 `Index` 名称尚未被同名实体索引占用。
 
 - **Address**：ElasticSearch/OpenSearch 存储服务地址。 
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -99,6 +99,10 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
         # Index = "huatuo_bamai"
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
+        # Optional Elasticsearch ILM retention. A positive value enables daily
+        # rollover and deletion after this many days. Keep 0 for OpenSearch or
+        # when lifecycle management is handled externally.
+        # ILMRetentionDays = 0
 
     # LocalFile Storage
     #

--- a/internal/config/elasticsearch.go
+++ b/internal/config/elasticsearch.go
@@ -24,10 +24,11 @@ import (
 // ElasticsearchConfig keeps storage opt-in explicit so incomplete credentials
 // cannot silently disable persistence.
 type ElasticsearchConfig struct {
-	Address  string
-	Username string
-	Password string
-	Index    string `default:"huatuo_bamai"`
+	Address          string
+	Username         string
+	Password         string
+	Index            string `default:"huatuo_bamai"`
+	ILMRetentionDays int
 }
 
 // Enabled reports whether all connection fields opt in to Elasticsearch.
@@ -39,6 +40,9 @@ func (c ElasticsearchConfig) Enabled() bool {
 
 // Validate accepts either a complete connection or no connection fields.
 func (c ElasticsearchConfig) Validate() error {
+	if c.ILMRetentionDays < 0 {
+		return errors.New("ILM retention days must not be negative")
+	}
 	fields := []string{c.Address, c.Username, c.Password}
 	configured := 0
 	for _, field := range fields {
@@ -47,6 +51,9 @@ func (c ElasticsearchConfig) Validate() error {
 		}
 	}
 	if configured == 0 {
+		if c.ILMRetentionDays > 0 {
+			return errors.New("ILM retention requires an Elasticsearch connection")
+		}
 		return nil
 	}
 	if configured != len(fields) {

--- a/internal/config/elasticsearch_test.go
+++ b/internal/config/elasticsearch_test.go
@@ -39,6 +39,26 @@ func TestElasticsearchConfigValidate(t *testing.T) {
 			wantEnabled: true,
 		},
 		{
+			name: "enabled with ILM retention",
+			config: ElasticsearchConfig{
+				Address:          "http://127.0.0.1:9200",
+				Username:         "elastic",
+				Password:         "secret",
+				ILMRetentionDays: 14,
+			},
+			wantEnabled: true,
+		},
+		{
+			name:      "ILM without connection",
+			config:    ElasticsearchConfig{ILMRetentionDays: 14},
+			wantError: "ILM retention requires an Elasticsearch connection",
+		},
+		{
+			name:      "negative ILM retention",
+			config:    ElasticsearchConfig{ILMRetentionDays: -1},
+			wantError: "ILM retention days must not be negative",
+		},
+		{
 			name: "multiple addresses",
 			config: ElasticsearchConfig{
 				Address:  "http://es-a:9200, https://es-b:9200",

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -53,10 +53,11 @@ type Config struct {
 	LocalFileRotationSize int
 	LocalFileMaxRotation  int
 
-	ESAddresses []string
-	ESUsername  string
-	ESPassword  string
-	ESIndex     string
+	ESAddresses        []string
+	ESUsername         string
+	ESPassword         string
+	ESIndex            string
+	ESILMRetentionDays int
 }
 
 // Op is a storage query operator.

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -50,10 +50,11 @@ const (
 
 // Config contains Elasticsearch backend settings.
 type Config struct {
-	Addresses []string
-	Username  string
-	Password  string
-	Index     string
+	Addresses        []string
+	Username         string
+	Password         string
+	Index            string
+	ILMRetentionDays int
 }
 
 // Storage stores records in Elasticsearch, OpenSearch, or any compatible backend.
@@ -64,9 +65,10 @@ type Config struct {
 // whole-batch failures (429, 5xx, transport errors) are retried by the client.
 // Call Close on shutdown to flush any pending events.
 type Storage struct {
-	transport esapi.Transport
-	bulk      esutil.BulkIndexer
-	index     string
+	transport        esapi.Transport
+	bulk             esutil.BulkIndexer
+	index            string
+	ilmRetentionDays int
 }
 
 var _ driver.Backend = (*Storage)(nil)
@@ -74,10 +76,11 @@ var _ driver.Backend = (*Storage)(nil)
 func init() {
 	factory := func(cfg *driver.Config) (driver.Backend, error) {
 		return NewBackend(&Config{
-			Addresses: cfg.ESAddresses,
-			Username:  cfg.ESUsername,
-			Password:  cfg.ESPassword,
-			Index:     cfg.ESIndex,
+			Addresses:        cfg.ESAddresses,
+			Username:         cfg.ESUsername,
+			Password:         cfg.ESPassword,
+			Index:            cfg.ESIndex,
+			ILMRetentionDays: cfg.ESILMRetentionDays,
 		})
 	}
 	driver.RegisterBackend("elasticsearch", factory)
@@ -109,7 +112,7 @@ func NewBackend(cfg *Config) (*Storage, error) {
 		return nil, fmt.Errorf("elasticsearch bulk indexer: %w", err)
 	}
 
-	return &Storage{transport: client, bulk: bulk, index: prefix}, nil
+	return &Storage{transport: client, bulk: bulk, index: prefix, ilmRetentionDays: cfg.ILMRetentionDays}, nil
 }
 
 // Close flushes any pending bulk operations and stops the indexer workers.
@@ -121,11 +124,14 @@ func (s *Storage) Close(ctx context.Context) error {
 	return s.bulk.Close(ctx)
 }
 
-func (s *Storage) Init(_ context.Context, _ string, indexes []driver.Index) error {
+func (s *Storage) Init(ctx context.Context, _ string, indexes []driver.Index) error {
 	for _, idx := range indexes {
 		if err := validateFieldName(idx.Field); err != nil {
 			return err
 		}
+	}
+	if s.ilmRetentionDays > 0 {
+		return s.initIndexLifecycle(ctx)
 	}
 	return nil
 }

--- a/internal/storage/elasticsearch/lifecycle.go
+++ b/internal/storage/elasticsearch/lifecycle.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elasticsearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+func (s *Storage) initIndexLifecycle(ctx context.Context) error {
+	policyName := s.index + "-policy"
+	templateName := s.index + "-template"
+	policy := map[string]any{"policy": map[string]any{"phases": map[string]any{
+		"hot":    map[string]any{"actions": map[string]any{"rollover": map[string]any{"max_age": "1d"}}},
+		"delete": map[string]any{"min_age": fmt.Sprintf("%dd", s.ilmRetentionDays), "actions": map[string]any{"delete": map[string]any{}}},
+	}}}
+	if err := s.lifecycleRequest(ctx, http.MethodPut, "/_ilm/policy/"+url.PathEscape(policyName), policy, http.StatusOK); err != nil {
+		return fmt.Errorf("configure ILM policy: %w", err)
+	}
+	template := map[string]any{
+		"index_patterns": []string{s.index + "-*"},
+		"template": map[string]any{"settings": map[string]any{
+			"index.lifecycle.name":           policyName,
+			"index.lifecycle.rollover_alias": s.index,
+		}},
+	}
+	if err := s.lifecycleRequest(ctx, http.MethodPut, "/_index_template/"+url.PathEscape(templateName), template, http.StatusOK); err != nil {
+		return fmt.Errorf("configure ILM index template: %w", err)
+	}
+
+	bootstrap := s.index + "-000001"
+	exists, err := s.lifecycleIndexExists(ctx, bootstrap)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	body := map[string]any{"aliases": map[string]any{s.index: map[string]any{"is_write_index": true}}}
+	if err := s.lifecycleRequest(ctx, http.MethodPut, "/"+url.PathEscape(bootstrap), body, http.StatusOK); err != nil {
+		return fmt.Errorf("create ILM bootstrap index: %w", err)
+	}
+	return nil
+}
+
+func (s *Storage) lifecycleIndexExists(ctx context.Context, index string) (bool, error) {
+	req, err := http.NewRequestWithContext(driver.WithContext(ctx), http.MethodHead, "/"+url.PathEscape(index), http.NoBody)
+	if err != nil {
+		return false, err
+	}
+	res, err := s.transport.Perform(req)
+	if err != nil {
+		return false, fmt.Errorf("check ILM bootstrap index: %w", err)
+	}
+	defer res.Body.Close()
+	_, _ = io.Copy(io.Discard, res.Body)
+	if res.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return false, fmt.Errorf("check ILM bootstrap index: status %d", res.StatusCode)
+	}
+	return true, nil
+}
+
+func (s *Storage) lifecycleRequest(ctx context.Context, method, path string, payload any, expected int) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(driver.WithContext(ctx), method, path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := s.transport.Perform(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != expected {
+		message, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return fmt.Errorf("status %d: %s", res.StatusCode, strings.TrimSpace(string(message)))
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+	return nil
+}

--- a/internal/storage/elasticsearch/lifecycle_test.go
+++ b/internal/storage/elasticsearch/lifecycle_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elasticsearch
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/storage/driver"
+)
+
+type lifecycleTransport func(*http.Request) (*http.Response, error)
+
+func (f lifecycleTransport) Perform(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestInitConfiguresIndexLifecycle(t *testing.T) {
+	type call struct {
+		method, path string
+		body         map[string]any
+	}
+	var calls []call
+	transport := lifecycleTransport(func(req *http.Request) (*http.Response, error) {
+		var body map[string]any
+		if req.Body != nil {
+			_ = json.NewDecoder(req.Body).Decode(&body)
+		}
+		calls = append(calls, call{req.Method, req.URL.Path, body})
+		status := http.StatusOK
+		if req.Method == http.MethodHead {
+			status = http.StatusNotFound
+		}
+		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+	})
+	backend := &Storage{transport: transport, index: "huatuo_bamai", ilmRetentionDays: 14}
+
+	if err := backend.Init(t.Context(), "documents", []driver.Index{{Field: "region"}}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if len(calls) != 4 {
+		t.Fatalf("calls = %d, want 4: %+v", len(calls), calls)
+	}
+	want := []struct{ method, path string }{
+		{http.MethodPut, "/_ilm/policy/huatuo_bamai-policy"},
+		{http.MethodPut, "/_index_template/huatuo_bamai-template"},
+		{http.MethodHead, "/huatuo_bamai-000001"},
+		{http.MethodPut, "/huatuo_bamai-000001"},
+	}
+	for i := range want {
+		if calls[i].method != want[i].method || calls[i].path != want[i].path {
+			t.Errorf("call[%d] = %s %s, want %s %s", i, calls[i].method, calls[i].path, want[i].method, want[i].path)
+		}
+	}
+	policyJSON, _ := json.Marshal(calls[0].body)
+	if !strings.Contains(string(policyJSON), `"min_age":"14d"`) || !strings.Contains(string(policyJSON), `"max_age":"1d"`) {
+		t.Errorf("policy = %s", policyJSON)
+	}
+	bootstrapJSON, _ := json.Marshal(calls[3].body)
+	if !strings.Contains(string(bootstrapJSON), `"is_write_index":true`) {
+		t.Errorf("bootstrap = %s", bootstrapJSON)
+	}
+}
+
+func TestInitSkipsExistingBootstrapIndex(t *testing.T) {
+	var calls int
+	transport := lifecycleTransport(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+	})
+	backend := &Storage{transport: transport, index: "huatuo_bamai", ilmRetentionDays: 7}
+	if err := backend.Init(t.Context(), "documents", nil); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want policy, template, HEAD", calls)
+	}
+}
+
+func TestInitReportsLifecycleAPIError(t *testing.T) {
+	transport := lifecycleTransport(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader(`{"error":"no handler for _ilm"}`))}, nil
+	})
+	backend := &Storage{transport: transport, index: "huatuo_bamai", ilmRetentionDays: 7}
+	err := backend.Init(t.Context(), "documents", nil)
+	if err == nil || !strings.Contains(err.Error(), "no handler for _ilm") {
+		t.Fatalf("Init() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add opt-in Elasticsearch ILM retention configuration
- create a daily rollover policy and composable index template at startup
- bootstrap the first write index and alias idempotently
- keep lifecycle management disabled by default and document the Elasticsearch/OpenSearch compatibility boundary

A positive `ILMRetentionDays` enables the policy; zero preserves the existing single-index behavior.

Fixes #36

## Testing
- `make check`
- `go test ./internal/config ./internal/storage/elasticsearch ./cmd/huatuo-bamai`
- `make unit` (all relevant tests pass; the WSL host cannot run the existing real eBPF attach and cgroup interface tests)