### PR TITLE
refactor(cgroup): disable cgroup qouta by default

### DIFF
--- a/build/charts/values.yaml
+++ b/build/charts/values.yaml
@@ -29,11 +29,11 @@ securityContext:
 
 resources:
   limits:
-    cpu: "1"
+    cpu: "2"
     memory: 2Gi
   requests:
-    cpu: 500m
-    memory: 512Mi
+    cpu: "2"
+    memory: 2Gi
 
 nodeSelector: {}
 

--- a/build/huatuo-daemonset.minimal.yaml
+++ b/build/huatuo-daemonset.minimal.yaml
@@ -24,11 +24,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: '1'
+            cpu: '2'
             memory: 2Gi
           requests:
-            cpu: 500m
-            memory: 512Mi
+            cpu: '2'
+            memory: 2Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/build/rpm/huatuo-bamai.service
+++ b/build/rpm/huatuo-bamai.service
@@ -26,14 +26,14 @@ ProtectHome=true
 
 # Resource limits
 LimitNOFILE=65536
-LimitNPROC=32768
 
-# Disable cgroup resource management
-Delegate=yes
-MemoryAccounting=false
-CPUAccounting=false
-BlockIOAccounting=false
-TasksAccounting=false
+CPUAccounting=yes
+CPUQuota=200%
+MemoryAccounting=yes
+MemoryMax=2G
+TasksAccounting=yes
+TasksMax=32768
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target

--- a/cmd/huatuo-apiserver/cgroup.go
+++ b/cmd/huatuo-apiserver/cgroup.go
@@ -23,7 +23,7 @@ import (
 )
 
 func setupCgroup(_ context.Context, d *Daemon) (func(context.Context) error, error) {
-	if d.opts.DisableCgroup {
+	if !d.opts.EnableCgroup {
 		return nil, nil
 	}
 	cgroup, err := cgroups.NewManager()

--- a/cmd/huatuo-apiserver/cgroup_test.go
+++ b/cmd/huatuo-apiserver/cgroup_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestSetupCgroupDisabledByDefault(t *testing.T) {
+	cleanup, err := setupCgroup(t.Context(), &Daemon{opts: &Options{}})
+	if err != nil {
+		t.Fatalf("setupCgroup() error = %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("setupCgroup() returned a cleanup function while disabled")
+	}
+}

--- a/cmd/huatuo-apiserver/cli.go
+++ b/cmd/huatuo-apiserver/cli.go
@@ -28,22 +28,22 @@ import (
 )
 
 const (
-	cliFlagConfig        = "config"
-	cliFlagConfigDir     = "config-dir"
-	cliFlagEnablePProf   = "enable-pprof"
-	cliFlagDisableCgroup = "disable-cgroup"
-	cliFlagLogDebug      = "log-debug"
+	cliFlagConfig       = "config"
+	cliFlagConfigDir    = "config-dir"
+	cliFlagEnablePProf  = "enable-pprof"
+	cliFlagEnableCgroup = "enable-cgroup"
+	cliFlagLogDebug     = "log-debug"
 )
 
 // Options holds CLI-derived configuration independently of urfave/cli.
 type Options struct {
-	ConfigFile    string
-	ConfigDir     string
-	EnablePProf   bool
-	DisableCgroup bool
-	LogDebug      bool
-	VersionInfo   version.Info
-	Config        *config.Config
+	ConfigFile   string
+	ConfigDir    string
+	EnablePProf  bool
+	EnableCgroup bool
+	LogDebug     bool
+	VersionInfo  version.Info
+	Config       *config.Config
 }
 
 func buildCommand(seed version.Seed) *cli.App {
@@ -89,8 +89,8 @@ func (o *Options) AddFlags(app *cli.App) {
 			Usage: "package pprof serves via its HTTP server runtime profiling data, default(false)",
 		},
 		&cli.BoolFlag{
-			Name:  cliFlagDisableCgroup,
-			Usage: "disable self cgroup resource limit",
+			Name:  cliFlagEnableCgroup,
+			Usage: "enable self cgroup resource limit",
 		},
 		&cli.BoolFlag{
 			Name:  cliFlagLogDebug,
@@ -103,7 +103,7 @@ func (o *Options) AddFlags(app *cli.App) {
 func (o *Options) FromContext(ctx *cli.Context) error {
 	o.ConfigFile = ctx.String(cliFlagConfig)
 	o.EnablePProf = ctx.Bool(cliFlagEnablePProf)
-	o.DisableCgroup = ctx.Bool(cliFlagDisableCgroup)
+	o.EnableCgroup = ctx.Bool(cliFlagEnableCgroup)
 	o.LogDebug = ctx.Bool(cliFlagLogDebug)
 
 	var err error

--- a/cmd/huatuo-apiserver/cli_test.go
+++ b/cmd/huatuo-apiserver/cli_test.go
@@ -38,7 +38,7 @@ func TestOptionsFromContextPreservesExplicitRelativeConfigDir(t *testing.T) {
 	if err := flags.Parse([]string{
 		"--config-dir", "relative-conf",
 		"--enable-pprof",
-		"--disable-cgroup",
+		"--enable-cgroup",
 		"--log-debug",
 	}); err != nil {
 		t.Fatalf("parse flags: %v", err)
@@ -53,8 +53,8 @@ func TestOptionsFromContextPreservesExplicitRelativeConfigDir(t *testing.T) {
 	if !opts.EnablePProf {
 		t.Error("EnablePProf = false, want true")
 	}
-	if !opts.DisableCgroup {
-		t.Error("DisableCgroup = false, want true")
+	if !opts.EnableCgroup {
+		t.Error("EnableCgroup = false, want true")
 	}
 	if !opts.LogDebug {
 		t.Error("LogDebug = false, want true")

--- a/cmd/huatuo-bamai/cgroup.go
+++ b/cmd/huatuo-bamai/cgroup.go
@@ -27,8 +27,8 @@ import (
 const bytesPerMiB = 1024 * 1024
 
 func setupCgroup(d *Daemon) (func(context.Context) error, error) {
-	if d.opts.DisableCgroup {
-		log.Infof("self cgroup resource limit disabled by --disable-cgroup")
+	if !d.opts.EnableCgroup {
+		log.Infof("self cgroup resource limit disabled by default")
 		return nil, nil
 	}
 

--- a/cmd/huatuo-bamai/cgroup_test.go
+++ b/cmd/huatuo-bamai/cgroup_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestSetupCgroupDisabledByDefault(t *testing.T) {
+	cleanup, err := setupCgroup(&Daemon{opts: &Options{}})
+	if err != nil {
+		t.Fatalf("setupCgroup() error = %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("setupCgroup() returned a cleanup function while disabled")
+	}
+}

--- a/cmd/huatuo-bamai/cli.go
+++ b/cmd/huatuo-bamai/cli.go
@@ -36,9 +36,9 @@ const (
 	cliFlagBPFObjDir      = "bpf-dir"
 	cliFlagToolBinDir     = "tools-bin-dir"
 	cliFlagRegion         = "region"
+	cliFlagEnableCgroup   = "enable-cgroup"
 	cliFlagDisableKubelet = "disable-kubelet"
 	cliFlagDisableStorage = "disable-storage"
-	cliFlagDisableCgroup  = "disable-cgroup"
 	cliFlagDisableTracing = "disable-tracing"
 	cliFlagLogDebug       = "log-debug"
 	cliFlagDryRun         = "dry-run"
@@ -54,9 +54,9 @@ type Options struct {
 	BPFObjDir      string
 	ToolBinDir     string
 	Region         string
+	EnableCgroup   bool
 	DisableKubelet bool
 	DisableStorage bool
-	DisableCgroup  bool
 	DisableTracing []string
 	LogDebug       bool
 	DryRun         bool
@@ -128,9 +128,8 @@ func (o *Options) AddFlags(app *cli.App) {
 			Usage: "disable storage backends(testing only). Not recommended for production use.",
 		},
 		&cli.BoolFlag{
-			Name:  cliFlagDisableCgroup,
-			Value: false,
-			Usage: "disable self cgroup resource limit",
+			Name:  cliFlagEnableCgroup,
+			Usage: "enable self cgroup resource limit",
 		},
 		&cli.StringSliceFlag{
 			Name:  cliFlagDisableTracing,
@@ -157,7 +156,7 @@ func (o *Options) FromContext(ctx *cli.Context) error {
 	o.Region = ctx.String(cliFlagRegion)
 	o.DisableKubelet = ctx.Bool(cliFlagDisableKubelet)
 	o.DisableStorage = ctx.Bool(cliFlagDisableStorage)
-	o.DisableCgroup = ctx.Bool(cliFlagDisableCgroup)
+	o.EnableCgroup = ctx.Bool(cliFlagEnableCgroup)
 	o.DisableTracing = ctx.StringSlice(cliFlagDisableTracing)
 	o.LogDebug = ctx.Bool(cliFlagLogDebug)
 	o.DryRun = ctx.Bool(cliFlagDryRun)

--- a/cmd/huatuo-bamai/cli_test.go
+++ b/cmd/huatuo-bamai/cli_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestOptionsFromContextEnablesCgroup(t *testing.T) {
+	app := cli.NewApp()
+	opts := &Options{}
+	opts.AddFlags(app)
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	for _, cliFlag := range app.Flags {
+		if err := cliFlag.Apply(flags); err != nil {
+			t.Fatalf("apply flag: %v", err)
+		}
+	}
+	if err := flags.Parse([]string{"--region", "test", "--enable-cgroup"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	if err := opts.FromContext(cli.NewContext(app, flags, nil)); err != nil {
+		t.Fatalf("FromContext() error = %v", err)
+	}
+	if !opts.EnableCgroup {
+		t.Fatal("EnableCgroup = false, want true")
+	}
+}

--- a/docs/configuration/huatuo-apiserver-configuration_en.md
+++ b/docs/configuration/huatuo-apiserver-configuration_en.md
@@ -15,6 +15,10 @@ defaults shown below.
 
 ### 2. Logging and Runtime Limits
 
+huatuo-apiserver does not create its own cgroup by default. The `[Runtime]` section
+applies only when `--enable-cgroup` is explicitly passed; Kubernetes and systemd
+deployments should use their native resource controls.
+
 ```toml
 # Log Configuration
 [Log]

--- a/docs/configuration/huatuo-apiserver-configuration_zh.md
+++ b/docs/configuration/huatuo-apiserver-configuration_zh.md
@@ -14,6 +14,9 @@ weight: 5
 
 ### 2. 日志与运行时资源限制
 
+默认不创建 huatuo-apiserver 自身 cgroup。只有显式传入 `--enable-cgroup` 时，
+本节 `[Runtime]` 配置才会生效；Kubernetes 和 systemd 部署应使用各自的资源管理配置。
+
 ```toml
 # Log Configuration
 [Log]

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -60,6 +60,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
 
 ### 4. Runtime Resource Limits
 
+Huatuo does not create its own cgroup by default. This section applies only when `--enable-cgroup` is passed; Kubernetes and systemd deployments should use their native resource controls.
+
 ```bash
 # Runtime limits for the huatuo-bamai process.
 [Runtime]
@@ -1073,7 +1075,7 @@ huatuo-bamai --region <region> [options]
 | `--region` | Deployment region (required) | - |
 | `--disable-kubelet` | Disable kubelet Pod fetching | `false` |
 | `--disable-storage` | Disable storage backends | `false` |
-| `--disable-cgroup` | Disable self cgroup resource limits | `false` |
+| `--enable-cgroup` | Enable self cgroup resource limits (disabled by default) | `false` |
 | `--disable-tracing` | Disable specified tracing modules (may be repeated) | - |
 | `--log-debug` | Force log level to Debug | `false` |
 | `--dry-run` | Load-only test; exit gracefully after startup | `false` |
@@ -1094,12 +1096,13 @@ Specific rules:
 
 2. **Tracing blacklist**: `--disable-tracing` is merged with the configuration file `BlackList` (they complement each other rather than override).
 
-3. **Other boolean switches** (`--disable-kubelet`, `--disable-storage`, `--disable-cgroup`): When explicitly set on the command line, they override the configuration file.
+3. **Other boolean switches** (`--disable-kubelet`, `--disable-storage`): When explicitly set on the command line, they override the configuration file.
 
 ### 13. Best Practices and Important Notes
 
-- **Resource Control**: In production, tune CPU and memory limits under
-  `[Runtime]` to avoid impacting business containers.
+- **Resource Control**: Kubernetes uses Pod resources and systemd uses service limits.
+  Use `--enable-cgroup` and `[Runtime]` only for direct execution without an
+  external manager.
 - **Storage Choice**: For small-scale deployments, prefer [Storage.LocalFile] for local troubleshooting. For large clusters, configure Elasticsearch for centralized storage and querying.
 - **AutoTracing Tuning**: Adjust thresholds based on workload characteristics. Thresholds that are too low cause frequent triggering; thresholds that are too high may miss issues. Validate gradually in a test environment.
 - **Security**: Use strong passwords for ES configuration and consider enabling HTTPS. Avoid hard-coding sensitive information in the configuration file.

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -64,6 +64,8 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
 
 ### 4. 运行时资源限制
 
+默认不创建 Huatuo 自身 cgroup。只有显式传入 `--enable-cgroup` 时，本节配置才会生效；Kubernetes 和 systemd 部署应使用各自的资源管理配置。
+
 ```bash
 # Runtime limits for the huatuo-bamai process.
 [Runtime]
@@ -1090,7 +1092,7 @@ huatuo-bamai --region <region> [选项]
 | `--region` | 部署区域（必填） | - |
 | `--disable-kubelet` | 禁用 kubelet Pod 获取 | `false` |
 | `--disable-storage` | 禁用存储后端 | `false` |
-| `--disable-cgroup` | 禁用自身 cgroup 资源限制 | `false` |
+| `--enable-cgroup` | 启用自身 cgroup 资源限制（默认关闭） | `false` |
 | `--disable-tracing` | 禁用指定追踪模块（可多次指定） | - |
 | `--log-debug` | 强制设置日志级别为 Debug | `false` |
 | `--dry-run` | 仅加载测试，启动后优雅退出 | `false` |
@@ -1111,11 +1113,11 @@ huatuo-bamai --region <region> [选项]
 
 2. **追踪黑名单**：`--disable-tracing` 与配置文件 `BlackList` 合并（两者互补，非覆盖）
 
-3. **其他布尔开关**（`--disable-kubelet`、`--disable-storage`、`--disable-cgroup`）：命令行显式设置时覆盖配置文件
+3. **其他布尔开关**（`--disable-kubelet`、`--disable-storage`）：命令行显式设置时覆盖配置文件
 
 ### 13. 配置最佳实践与注意事项
 
-- **资源控制**：生产环境优先调整 `[Runtime]` 中的 CPU 和内存限制，避免影响业务容器。
+- **资源控制**：Kubernetes 使用 Pod resources，systemd 使用 service 的资源限制。只有直接运行且没有外部管理器时，才使用 `--enable-cgroup` 和 [Runtime]。
 - **存储选择**：小规模部署可优先使用 LocalFile 进行本地排查；大规模集群推荐配置 Elasticsearch 实现集中存储与查询。
 - **自动追踪调优**：根据业务负载特征调整阈值，过低阈值会导致频繁触发，过高则可能遗漏问题。建议在测试环境逐步验证。
 - **安全性**：ES 配置中请使用强密码，并考虑启用 HTTPS；避免在配置文件中硬编码敏感信息。

--- a/docs/deployment/docker_en.md
+++ b/docs/deployment/docker_en.md
@@ -22,7 +22,7 @@ docker run --detach \
   --cgroupns=host \
   --network=host \
   --cpus=2 \
-  --memory=4g \
+  --memory=2g \
   --volume /sys:/sys \
   --volume /proc:/proc \
   --volume /run:/run \
@@ -32,8 +32,8 @@ docker run --detach \
 > Note: The built-in default configuration does not connect to kubelet or Elasticsearch.
 
 Limit CPU and memory in production to isolate abnormal collection workloads.
-The `4 GiB` container limit leaves runtime headroom above the default `2048 MiB`
-process limit, reducing OOM risk.
+Docker manages the container cgroup; Huatuo does not create its own cgroup by default,
+so do not pass `--enable-cgroup` in a Docker deployment.
 
 Verify that the limits are active and observe actual usage:
 

--- a/docs/deployment/docker_zh.md
+++ b/docs/deployment/docker_zh.md
@@ -21,7 +21,7 @@ docker run --detach \
   --cgroupns=host \
   --network=host \
   --cpus=2 \
-  --memory=4g \
+  --memory=2g \
   --volume /sys:/sys \
   --volume /proc:/proc \
   --volume /run:/run \
@@ -30,8 +30,9 @@ docker run --detach \
 
 > 注意：容器内置的默认配置不会连接 kubelet 和 Elasticsearch。
 
-生产环境应限制 CPU 和内存，避免异常采集任务影响宿主机业务。`4 GiB` 容器
-内存上限为默认的 `2048 MiB` 进程上限预留运行时空间，降低 OOM 风险。
+生产环境应限制 CPU 和内存，避免异常采集任务影响宿主机业务。Docker 的容器 cgroup
+负责资源限制；Huatuo 默认不创建自身 cgroup，也不要在 Docker 部署中传入
+`--enable-cgroup`。
 
 通过以下命令确认限制已经生效，并观察实际使用量：
 

--- a/docs/deployment/kubernetes_en.md
+++ b/docs/deployment/kubernetes_en.md
@@ -47,10 +47,10 @@ initial baseline:
 resources:
   limits:
     cpu: "2"
-    memory: 4Gi
+    memory: 2Gi
   requests:
-    cpu: "1"
-    memory: 1Gi
+    cpu: "2"
+    memory: 2Gi
 ```
 
 Apply the modified manifest:
@@ -59,13 +59,14 @@ Apply the modified manifest:
 kubectl apply -f ./huatuo-daemonset.yaml
 ```
 
-`requests` provide scheduling guarantees, while `limits` isolate abnormal jobs
-from the node. The `4 GiB` container limit leaves runtime headroom above the
-default `2048 MiB` process limit, reducing OOM risk.
+`requests` provide scheduling guarantees, while `limits` are enforced by the
+Pod cgroup managed by kubelet. Huatuo does not create its own cgroup by default,
+so it remains under `kubepods` and can be reclaimed normally after containerd
+restart or Pod deletion.
 
-These values are an initial baseline. Adjust them based on node capacity,
-collection jobs, and observed resource peaks. Container limits must not be lower
-than the `[Runtime]` process limits in `huatuo-bamai.conf`.
+These values are an initial baseline with matching requests and limits, so the
+Pod has Guaranteed QoS. `[Runtime]` applies only when `--enable-cgroup` is
+explicitly passed; do not pass that flag in Kubernetes.
 
 ### 1.5 Verify the deployment
 
@@ -124,10 +125,10 @@ image:
 resources:
   limits:
     cpu: "2"
-    memory: 4Gi
+    memory: 2Gi
   requests:
-    cpu: "1"
-    memory: 1Gi
+    cpu: "2"
+    memory: 2Gi
 
 nodeSelector:
   kubernetes.io/os: linux

--- a/docs/deployment/kubernetes_zh.md
+++ b/docs/deployment/kubernetes_zh.md
@@ -46,10 +46,10 @@ curl -L -o huatuo-daemonset.yaml \
 resources:
   limits:
     cpu: "2"
-    memory: 4Gi
+    memory: 2Gi
   requests:
-    cpu: "1"
-    memory: 1Gi
+    cpu: "2"
+    memory: 2Gi
 ```
 
 应用修改后的清单：
@@ -58,11 +58,13 @@ resources:
 kubectl apply -f ./huatuo-daemonset.yaml
 ```
 
-`requests` 提供调度保障，`limits` 限制异常任务对节点的影响。`4 GiB` 容器内存
-上限为默认的 `2048 MiB` 进程上限预留运行时空间，降低 OOM 风险。
+`requests` 提供调度保障，`limits` 由 kubelet 写入 Pod cgroup，负责限制
+Huatuo 的 CPU 和内存。Huatuo 默认不创建自身 cgroup，因此不会把进程移出
+`kubepods` 层级，containerd 重启和 Pod 删除时可以正常回收进程。
 
-示例值为初始基线，应根据节点规格、采集任务和资源峰值调整。容器上限不得低于
-`huatuo-bamai.conf` 中的 `[Runtime]` 进程上限。
+示例值为初始基线，requests 与 limits 相同，因此 Pod 为 Guaranteed QoS。
+只有显式传入 `--enable-cgroup` 时 `[Runtime]` 才生效；Kubernetes 部署不要传入
+该参数。
 
 ### 1.5 验证部署
 
@@ -121,10 +123,10 @@ image:
 resources:
   limits:
     cpu: "2"
-    memory: 4Gi
+    memory: 2Gi
   requests:
-    cpu: "1"
-    memory: 1Gi
+    cpu: "2"
+    memory: 2Gi
 
 nodeSelector:
   kubernetes.io/os: linux

--- a/docs/deployment/systemd_en.md
+++ b/docs/deployment/systemd_en.md
@@ -9,34 +9,22 @@ weight: 3
 
 ## Production resource limits
 
-Set explicit collector resource limits in `huatuo-bamai.conf`:
+systemd owns resource limits and process lifecycle for `huatuo-bamai.service`. The service unit disables Huatuo self-managed cgroups and uses native controls:
 
-```toml
-[Runtime]
-StartupCPULimitCores = 0.5
-CPULimitCores = 2.0
-MemoryLimitMiB = 2048
+```ini
+[Service]
+CPUAccounting=yes
+CPUQuota=200%
+MemoryAccounting=yes
+MemoryMax=2G
+TasksAccounting=yes
+TasksMax=32768
+KillMode=control-group
 ```
 
-Binary installations use
-`/opt/huatuo-bamai/conf/huatuo-bamai.conf`; RPM installations use
-`/etc/huatuo-bamai/huatuo-bamai.conf`. Configure the limits before the first
-start. After changing them for a running service, restart the collector:
+`CPUQuota=200%` allows up to 2 CPU cores and `MemoryMax=2G` caps service memory. Adjust these values for the host, collection jobs, and observed peaks. Do not pass `--enable-cgroup` in a systemd deployment; it would move the process out of the service cgroup.
 
-```bash
-sudo systemctl restart huatuo-bamai
-```
-
-The `0.5` core startup limit reduces initialization spikes. The `2` core runtime
-limit preserves collection capacity, while the `2048 MiB` memory limit prevents
-abnormal growth from exhausting host memory. Adjust these values based on host
-capacity, collection jobs, and observed resource peaks.
-
-The provided `huatuo-bamai.service` uses `Delegate=yes`, allowing the collector
-to manage its delegated cgroup. Do not add `CPUQuota` or `MemoryMax`; a lower
-stacked limit can cause startup failures or unexpected throttling.
-
-After starting the service, check its status and delegated cgroup:
+After starting the service, check its status and cgroup:
 
 ```bash
 systemctl status huatuo-bamai --no-pager
@@ -102,8 +90,7 @@ sudo wget -O /etc/systemd/system/huatuo-apiserver.service "https://raw.githubuse
 
 Edit `/opt/huatuo-bamai/conf/huatuo-bamai.conf` and `/opt/huatuo-bamai/conf/huatuo-apiserver.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](/docs/configuration/huatuo-bamai-configuration_en.md) and [`huatuo-apiserver` configuration](/docs/configuration/huatuo-apiserver-configuration_en.md).
 
-Set `[Runtime]` in `huatuo-bamai.conf` as described in "Production resource
-limits."
+Set `CPUQuota`, `MemoryMax`, and `TasksMax` in the service unit. Configure `[Runtime]` only for direct execution with `--enable-cgroup`.
 
 ### 5. Register the HUATUO services
 
@@ -159,7 +146,7 @@ sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 
 Edit `/etc/huatuo-bamai/huatuo-bamai.conf` to match the deployment environment. For detailed configuration options, see the [`huatuo-bamai` configuration](/docs/configuration/huatuo-bamai-configuration_en.md).
 
-Set `[Runtime]` as described in "Production resource limits."
+Set `CPUQuota`, `MemoryMax`, and `TasksMax` in the service unit. Configure `[Runtime]` only for direct execution with `--enable-cgroup`.
 
 ### 4. Start the HUATUO service
 

--- a/docs/deployment/systemd_zh.md
+++ b/docs/deployment/systemd_zh.md
@@ -9,32 +9,22 @@ weight: 3
 
 ## 生产环境资源限制
 
-在 `huatuo-bamai.conf` 中显式配置采集器资源上限：
+`huatuo-bamai.service` 由 systemd 负责资源限制和进程生命周期。服务单元默认不启用 Huatuo 自身 cgroup，使用以下原生配置：
 
-```toml
-[Runtime]
-StartupCPULimitCores = 0.5
-CPULimitCores = 2.0
-MemoryLimitMiB = 2048
+```ini
+[Service]
+CPUAccounting=yes
+CPUQuota=200%
+MemoryAccounting=yes
+MemoryMax=2G
+TasksAccounting=yes
+TasksMax=32768
+KillMode=control-group
 ```
 
-二进制安装使用 `/opt/huatuo-bamai/conf/huatuo-bamai.conf`，RPM 安装使用
-`/etc/huatuo-bamai/huatuo-bamai.conf`。应在首次启动前完成配置；运行中的服务
-修改配置后需要执行：
+`CPUQuota=200%` 表示最多使用 2 个 CPU 核，`MemoryMax=2G` 限制服务内存。根据主机规格、采集任务和资源峰值调整这些值。systemd 部署不要传入 `--enable-cgroup`，否则进程会脱离 service cgroup。
 
-```bash
-sudo systemctl restart huatuo-bamai
-```
-
-启动阶段限制为 `0.5` 核，降低初始化 CPU 峰值；启动后限制为 `2` 核，保障持续
-采集。`2048 MiB` 内存上限可防止异常增长耗尽宿主机内存。示例值应根据主机
-规格、采集任务和资源峰值调整。
-
-提供的 `huatuo-bamai.service` 使用 `Delegate=yes`，由采集器在委派的 cgroup 中
-管理资源。不要叠加 `CPUQuota` 或 `MemoryMax`，否则较小的限制可能导致启动失败
-或意外限流。
-
-服务启动后，检查运行状态和委派的 cgroup：
+服务启动后，检查状态和 cgroup：
 
 ```bash
 systemctl status huatuo-bamai --no-pager
@@ -100,7 +90,7 @@ sudo wget -O /etc/systemd/system/huatuo-apiserver.service "https://raw.githubuse
 
 根据实际部署环境编辑 `/opt/huatuo-bamai/conf/huatuo-bamai.conf` 和 `/opt/huatuo-bamai/conf/huatuo-apiserver.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](/docs/configuration/huatuo-bamai-configuration_zh.md) 和 [`huatuo-apiserver` 配置](/docs/configuration/huatuo-apiserver-configuration_zh.md)。
 
-按照“生产环境资源限制”一节设置 `huatuo-bamai.conf` 中的 `[Runtime]`。
+根据 service unit 中的 `CPUQuota`、`MemoryMax` 和 `TasksMax` 设置资源上限。只有直接运行且传入 `--enable-cgroup` 时才配置 `[Runtime]`。
 
 ### 5. 注册 HUATUO 服务
 
@@ -156,7 +146,7 @@ sudo dnf install ./huatuo-bamai-2.1.0-2.oc9.aarch64.rpm
 
 根据实际部署环境编辑 `/etc/huatuo-bamai/huatuo-bamai.conf`。详细配置项说明请参见 [`huatuo-bamai` 配置](/docs/configuration/huatuo-bamai-configuration_zh.md)。
 
-按照“生产环境资源限制”一节设置 `[Runtime]`。
+根据 service unit 中的 `CPUQuota`、`MemoryMax` 和 `TasksMax` 设置资源上限。只有直接运行且传入 `--enable-cgroup` 时才配置 `[Runtime]`。
 
 ### 4. 启动 HUATUO 服务
 

--- a/docs/quick-start_en.md
+++ b/docs/quick-start_en.md
@@ -114,8 +114,8 @@ $ docker build --network host -t huatuo/huatuo-bamai:latest .
 
 - Resource Limits
 
-    To ensure host stability, configure startup and steady-state limits:
-    ```yaml
+    Kubernetes and systemd deployments let kubelet or systemd manage Huatuo cgroups by default, so Huatuo does not migrate its own PID. For direct execution without an external manager, pass `--enable-cgroup` and configure:
+    ```toml
     [Runtime]
         StartupCPULimitCores = 0.5
         CPULimitCores = 2.0

--- a/docs/quick-start_zh.md
+++ b/docs/quick-start_zh.md
@@ -115,8 +115,8 @@ $ ./huatuo-bamai --region example --config huatuo-bamai.conf
     所有的内核事件采集 Events 和 AutoTracing 都可以配置触发阈值。默认的阈值都是在实际生产环境反复验证后的经验数据，你可以根据自身需求，在 huatuo-bamai.conf 中修改阈值。
 
 4. 资源限制
-    为保障物理机稳定性，可分别配置启动阶段和常态运行资源限制：
-    ```yaml
+    Kubernetes 和 systemd 部署默认由 kubelet 或 systemd 管理 Huatuo 的 cgroup，Huatuo 不会迁移自身 PID。只有直接运行且没有外部管理器时，才使用 `--enable-cgroup` 并配置：
+    ```toml
     [Runtime]
         StartupCPULimitCores = 0.5
         CPULimitCores = 2.0

--- a/integration/lib.sh
+++ b/integration/lib.sh
@@ -391,7 +391,6 @@ integration_huatuo_bamai_start() {
 			"--procfs-prefix" "${HUATUO_BAMAI_TEST_FIXTURES}"
 			"--disable-storage"
 			"--disable-kubelet"
-			"--disable-cgroup"
 			"--log-debug"
 		)
 	fi

--- a/integration/test_apiserver_health_metrics.sh
+++ b/integration/test_apiserver_health_metrics.sh
@@ -92,7 +92,6 @@ assert_metrics_endpoint() {
 }
 
 integration_huatuo_apiserver_start write_apiserver_apis_config \
-	--disable-cgroup \
 	--log-debug
 assert_endpoints
 assert_metrics_endpoint

--- a/integration/test_apiserver_job_recovery.sh
+++ b/integration/test_apiserver_job_recovery.sh
@@ -100,8 +100,6 @@ assert_shutdown_log() {
 		|| fatal "shutdown log did not include job ID ${PROFILE_ID}"
 }
 
-continuous_profiling_start_stack --disable-cgroup
-
 continuous_profiling_start_native_cpu_fixture TARGET_PID
 continuous_profile_create_cpu "${PROFILE_CREATE_RESPONSE}" "${PROFILE_DURATION}"
 PROFILE_ID=$(jq -er '.data.id' "${PROFILE_CREATE_RESPONSE}") \
@@ -119,8 +117,7 @@ agent_task_status_is running \
 	|| fatal "graceful apiserver shutdown stopped the Agent task"
 
 integration_huatuo_apiserver_start \
-	write_continuous_profiling_apiserver_config \
-	--disable-cgroup
+	write_continuous_profiling_apiserver_config
 wait_until 10 1 recovered_job_metric_is_one \
 	|| fatal "replacement apiserver did not report one recovered job"
 wait_until 10 1 continuous_profile_status_is \

--- a/integration/test_apiserver_profile_capabilities.sh
+++ b/integration/test_apiserver_profile_capabilities.sh
@@ -117,7 +117,6 @@ assert_profile_capabilities() {
 }
 
 integration_huatuo_apiserver_start write_apiserver_profile_capabilities_config \
-	--disable-cgroup \
 	--log-debug
 assert_profile_capabilities_authentication
 assert_profile_capabilities

--- a/integration/test_autotracing_cpusys.sh
+++ b/integration/test_autotracing_cpusys.sh
@@ -85,7 +85,6 @@ integration_huatuo_bamai_start \
 	--procfs-prefix "${CPUSYS_FIXTURE_ROOT}" \
 	--tools-bin-dir "${CPUSYS_FIXTURE_ROOT}/tools" \
 	--disable-kubelet \
-	--disable-cgroup \
 	--log-debug
 
 # Sample 2: total=1100 and system=110. The 10/100 delta establishes a 10%

--- a/integration/test_autotracing_iotracing.sh
+++ b/integration/test_autotracing_iotracing.sh
@@ -82,7 +82,6 @@ integration_huatuo_bamai_start \
 	--region dev \
 	--procfs-prefix "${IOTRACING_FIXTURE_ROOT}" \
 	--disable-kubelet \
-	--disable-cgroup \
 	--log-debug
 
 # Hold each counter value across a five-second sampling tick. Two consecutive


### PR DESCRIPTION
## 关联 Issue

Closes #506 ，Huatuo RuntimeCgroup 默认会在宿主机创建独立 cgroup，并将 Huatuo 进程迁移进去。在 systemd、Kubernetes 或 Docker 场景下，这可能使进程脱离上层管理器分配的 cgroup，导致资源限制和进程生命周期管理不一致。

## 修改

1. 关闭 RuntimeCgroup 默认创建，由外部管理器负责资源限制和进程生命周期：
- systemd：使用 systemd service unit 的 cgroup 配置；
- k8s：使用 Pod/Container cgroup，由 kubelet 和容器运行时管理；
- Docker：使用 Docker 容器 cgroup 配置；
- 裸进程直接启动且没有外部资源管理器时，可通过显式配置 `enable-cgroup` 开启 Huatuo 自身的 cgroup 管控；

2. 统一资源配置和文档

将文档针对 huatuo-bamai 进程的资源进行统一，之前发现有很多前后不一致的情况，现在默认均修改为 2g2g，同步修正文档中 k8s（修改为 guaranteed）、systemd 和 Docker 部署示例中的资源配置，实际部署根据实际环境调整。