### PR TITLE
fix(metrics): guard parseTcpMemory against index out of range when tcp_mem has fewer than 3 values

### DIFF
--- a/core/metrics/net_tcp_memory.go
+++ b/core/metrics/net_tcp_memory.go
@@ -62,6 +62,9 @@ func parseTcpMemory() (*tcpMemoryStat, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(values) < 3 {
+		return nil, fmt.Errorf("tcp_mem: expected at least 3 values, got %d", len(values))
+	}
 
 	stat4, err := fs.NetSockstat()
 	if err != nil {

--- a/core/metrics/net_tcp_memory_test.go
+++ b/core/metrics/net_tcp_memory_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025, 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"huatuo-bamai/internal/procfs"
+)
+
+func TestParseTcpMemoryBoundary(t *testing.T) {
+	tempDir := t.TempDir()
+	sysctlDir := filepath.Join(tempDir, "proc", "sys", "net", "ipv4")
+	require.NoError(t, os.MkdirAll(sysctlDir, 0o755))
+
+	tcpMemPath := filepath.Join(sysctlDir, "tcp_mem")
+
+	procfs.RootPrefix(tempDir)
+	defer procfs.RootPrefix("/")
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"empty_file", ""},
+		{"one_value", "100"},
+		{"two_values", "100 200"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := os.WriteFile(tcpMemPath, []byte(tt.content), 0o600)
+			require.NoError(t, err)
+
+			_, err = parseTcpMemory()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "tcp_mem")
+		})
+	}
+}

--- a/core/metrics/net_tcp_memory_test.go
+++ b/core/metrics/net_tcp_memory_test.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,12 +36,18 @@ func TestParseTcpMemoryBoundary(t *testing.T) {
 	defer procfs.RootPrefix("/")
 
 	tests := []struct {
-		name    string
-		content string
+		name      string
+		content   string
+		wantErr   bool
+		wantInErr string
 	}{
-		{"empty_file", ""},
-		{"one_value", "100"},
-		{"two_values", "100 200"},
+		{"empty_file", "", true, "tcp_mem"},
+		{"one_value", "100", true, "tcp_mem"},
+		{"two_values", "100 200", true, "tcp_mem"},
+		// With 3+ values the guard passes; NetSockstat will fail because
+		// no sockstat file exists in the temp procfs, but the error must
+		// NOT be the tcp_mem guard error.
+		{"three_values_passes_guard", "100 200 300", true, ""},
 	}
 
 	for _, tt := range tests {
@@ -50,7 +57,11 @@ func TestParseTcpMemoryBoundary(t *testing.T) {
 
 			_, err = parseTcpMemory()
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "tcp_mem")
+			if tt.wantInErr != "" {
+				require.True(t, strings.Contains(err.Error(), tt.wantInErr))
+			} else {
+				require.False(t, strings.Contains(err.Error(), "tcp_mem"))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`parseTcpMemory()` in `core/metrics/net_tcp_memory.go` accesses `values[2]` without checking the length of the `[]int` slice returned by `fs.SysctlInts("net.ipv4.tcp_mem")`.

```go
// core/metrics/net_tcp_memory.go, line 78-80
values, err := fs.SysctlInts("net.ipv4.tcp_mem")
if err != nil {
    return nil, err
}
// ...
memoryLimit: float64(values[2]), // tcpMemLimit  ← panics if len(values) < 3
```

The `newTcpMemory()` constructor only calls `procfs.RequireFile("sys/net/ipv4/tcp_mem")` which checks file **existence** via `os.Stat`, not content validity. When the file exists but is empty or has fewer than 3 fields (e.g., in a restricted container, chroot, or a corrupted procfs mount), `SysctlInts` returns a slice with length < 3, and `values[2]` triggers:

```
runtime error: index out of range [2] with length 0
```

This is distinct from PR #421 which fixed the `memoryLimit == 0` NaN panic (line 95-97) but did not guard the `values[2]` access.

## Fix

Add a length check before accessing `values[2]`:

```go
if len(values) < 3 {
    return nil, fmt.Errorf("tcp_mem: expected at least 3 values, got %d", len(values))
}
```

Fixes #550