### PR TITLE
fix(procfs): guard NetArpCache against scanner.Scan failures and headers index out of range

### DIFF
--- a/internal/procfs/net_arpcache.go
+++ b/internal/procfs/net_arpcache.go
@@ -16,7 +16,6 @@ package procfs
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -40,7 +39,7 @@ func NetArpCache() (*ArpCacheStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("arp_cache: empty file or missing header")
+		return &ArpCacheStats{Stats: make(map[string]uint64)}, scanner.Err()
 	}
 
 	// First string is always a header for stats
@@ -51,7 +50,7 @@ func NetArpCache() (*ArpCacheStats, error) {
 	cache := &ArpCacheStats{Stats: make(map[string]uint64)}
 
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("arp_cache: missing data line")
+		return cache, scanner.Err()
 	}
 	for num, counter := range strings.Fields(scanner.Text()) {
 		if num >= len(headers) {

--- a/internal/procfs/net_arpcache.go
+++ b/internal/procfs/net_arpcache.go
@@ -16,6 +16,7 @@ package procfs
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -38,7 +39,9 @@ func NetArpCache() (*ArpCacheStats, error) {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
-	scanner.Scan()
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("arp_cache: empty file or missing header")
+	}
 
 	// First string is always a header for stats
 	var headers []string
@@ -47,8 +50,13 @@ func NetArpCache() (*ArpCacheStats, error) {
 	// Fast path ...
 	cache := &ArpCacheStats{Stats: make(map[string]uint64)}
 
-	scanner.Scan()
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("arp_cache: missing data line")
+	}
 	for num, counter := range strings.Fields(scanner.Text()) {
+		if num >= len(headers) {
+			break
+		}
 		value, err := strconv.ParseUint(counter, 16, 64)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem

`NetArpCache()` in `internal/procfs/net_arpcache.go` has two unchecked `scanner.Scan()` calls that can cause panics:

1. **Empty file**: If `/proc/net/stat/arp_cache` is empty, both `scanner.Scan()` calls return `false`, and `scanner.Text()` returns empty strings.
2. **Missing data line (single CPU)**: If the file has only a header line, the second `scanner.Scan()` returns `false`, but `scanner.Text()` returns the **previous** scan's text (the header). `strings.Fields` then tries to parse header names as hex values, causing `strconv.ParseUint` errors.
3. **Data fields exceed headers**: If the data line has more fields than the header line, `headers[num]` accesses an index beyond the slice bounds, causing `runtime error: index out of range`.

This is the same class of bug fixed by PR #544 for `parseNetStat` in `net_netstat.go`, but in a different file (`internal/procfs/net_arpcache.go`).

## Fix

1. Check `scanner.Scan()` return values before accessing `scanner.Text()`.
2. Guard `headers[num]` against index overflow.

Fixes #549