### PR TITLE
fix(executil): bound canceled process shutdown

### DIFF
--- a/internal/utils/executil/exec.go
+++ b/internal/utils/executil/exec.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/procfs"
@@ -40,6 +41,8 @@ type CmdResult struct {
 	Success bool
 	CmdErr  error
 }
+
+const processTerminateGracePeriod = 500 * time.Millisecond
 
 // ExecCmd executes one command, captures its output, and terminates its
 // process group when the context is canceled.
@@ -76,7 +79,17 @@ func ExecCmd(ctx context.Context, pid int, binPath string, args ...string) CmdRe
 		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 			log.Warnf("kill process group %d: %v", cmd.Process.Pid, err)
 		}
-		<-done
+
+		graceTimer := time.NewTimer(processTerminateGracePeriod)
+		select {
+		case <-done:
+			graceTimer.Stop()
+		case <-graceTimer.C:
+			if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				log.Warnf("force kill process group %d: %v", cmd.Process.Pid, err)
+			}
+			<-done
+		}
 		cmdErr := ctx.Err()
 		log.Debugf("command stopped: command=%q error=%v", cmdArgs, cmdErr)
 		return CmdResult{

--- a/internal/utils/executil/exec_test.go
+++ b/internal/utils/executil/exec_test.go
@@ -16,6 +16,7 @@ package executil
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -24,11 +25,35 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"huatuo-bamai/internal/procfs"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestExecCmdCancellationKillsTermIgnoringProcessGroup(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("process-group signals require Linux")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	startedAt := time.Now()
+	result := ExecCmd(ctx, 0, "/bin/sh", "-c", "trap '' TERM; while :; do sleep 10; done")
+	elapsed := time.Since(startedAt)
+
+	if result.Success {
+		t.Fatal("ExecCmd() Success=true after context cancellation")
+	}
+	if !errors.Is(result.CmdErr, context.DeadlineExceeded) {
+		t.Fatalf("ExecCmd() error=%v, want context deadline exceeded", result.CmdErr)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("ExecCmd() returned after %v, want forced termination within 3s", elapsed)
+	}
+}
 
 func withProcRoot(t *testing.T, root string) {
 	originalPrefix := filepath.Dir(procfs.DefaultPath())


### PR DESCRIPTION
## What

After context cancellation, keep the existing process-group `SIGTERM`, wait for a 500 ms grace period, then send `SIGKILL` to the process group if it has not exited.

Add a regression test using a shell process group that ignores `SIGTERM`.

## Why

The previous cancellation path waited on `cmd.Wait()` forever after sending only `SIGTERM`. A command or child process that ignores the signal could make task cancellation hang indefinitely.

## Tests

- `make check`
- `go test ./internal/utils/executil -count=1 -timeout=60s`
- `make unit` (the changed package passes; the full run is blocked in this WSL environment by the existing cgroup v1 fixture expecting `/sys/fs/cgroup/cpu/.../cpuacct.stat`)