### PR TITLE
fix(storage): synchronize local writer cache

### DIFF
--- a/internal/storage/localfile/localfile.go
+++ b/internal/storage/localfile/localfile.go
@@ -34,6 +34,7 @@ import (
 type Storage struct {
 	lock         sync.Mutex
 	files        map[string]io.Writer
+	writerCache  sync.Map
 	path         string
 	rotationSize int
 	maxRotation  int
@@ -110,7 +111,14 @@ func (b *Storage) Close(_ context.Context) error {
 
 func (b *Storage) newFileWriter(filename string) io.Writer {
 	fp := path.Join(b.path, filename)
-	b.files[filename] = filerotate.NewFileRotator(fp, b.maxRotation, b.rotationSize)
+
+	fileWriter, ok := b.writerCache.Load(fp)
+	if !ok {
+		fileWriter = filerotate.NewFileRotator(fp, b.maxRotation, b.rotationSize)
+		b.writerCache.Store(fp, fileWriter)
+	}
+
+	b.files[filename] = fileWriter.(io.Writer)
 	return b.files[filename]
 }
 

--- a/internal/storage/localfile/localfile.go
+++ b/internal/storage/localfile/localfile.go
@@ -34,7 +34,6 @@ import (
 type Storage struct {
 	lock         sync.Mutex
 	files        map[string]io.Writer
-	writerCache  sync.Map
 	path         string
 	rotationSize int
 	maxRotation  int
@@ -111,26 +110,14 @@ func (b *Storage) Close(_ context.Context) error {
 
 func (b *Storage) newFileWriter(filename string) io.Writer {
 	fp := path.Join(b.path, filename)
-
-	fileWriter, ok := b.writerCache.Load(fp)
-	if !ok {
-		fileWriter = filerotate.NewFileRotator(fp, b.maxRotation, b.rotationSize)
-		b.writerCache.Store(fp, fileWriter)
-	}
-
-	b.files[filename] = fileWriter.(io.Writer)
+	b.files[filename] = filerotate.NewFileRotator(fp, b.maxRotation, b.rotationSize)
 	return b.files[filename]
 }
 
 func (b *Storage) writerByName(name string) (io.Writer, error) {
-	if fileWriter, ok := b.files[name]; ok {
-		return fileWriter, nil
-	}
-
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// Double-check after acquiring lock
 	if fileWriter, ok := b.files[name]; ok {
 		return fileWriter, nil
 	}

--- a/internal/storage/localfile/localfile_test.go
+++ b/internal/storage/localfile/localfile_test.go
@@ -17,13 +17,67 @@ package localfile
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"huatuo-bamai/internal/storage/driver"
 )
+
+func TestWriterByNameSynchronizesCachedReads(t *testing.T) {
+	backend := NewBackend(t.TempDir(), 1024, 3)
+	backend.files["existing"] = io.Discard
+
+	backend.lock.Lock()
+	returned := make(chan struct{})
+	go func() {
+		_, _ = backend.writerByName("existing")
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		backend.lock.Unlock()
+		t.Fatal("writerByName read the files map without acquiring the lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+	backend.lock.Unlock()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("writerByName did not return after the lock was released")
+	}
+}
+
+func TestBackendConcurrentSave(t *testing.T) {
+	backend := NewBackend(t.TempDir(), 1024, 3)
+
+	const writers = 64
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			name := fmt.Sprintf("concurrent-%d", i)
+			if err := backend.Save(t.Context(), driver.Record{
+				ID:   name,
+				Data: []byte(`{"ok":true}`),
+				Fields: map[string]any{
+					"tracer_name": name,
+				},
+			}); err != nil {
+				t.Errorf("Save(%q): %v", name, err)
+			}
+		}()
+	}
+	wg.Wait()
+}
 
 // TestBackendSave covers the localfile backend save behavior: verifies that fields.tracer_name is used as the filename and JSON content is pretty-printed before writing.
 func TestBackendSave(t *testing.T) {


### PR DESCRIPTION
## What

Protect every access to the local-file backend's `files` map with its mutex and remove the redundant secondary writer cache.

Add a synchronization regression test and concurrent-save coverage.

## Why

`writerByName` previously read `files` before acquiring the mutex while another goroutine could add a writer under the mutex. Concurrent saves for different tracer names could therefore race and trigger Go's concurrent map read/write failure.

## Tests

- `make check`
- `go test -race ./internal/storage/localfile -count=1 -timeout=90s`
- `make unit` (the changed package passes; the full run is blocked in this WSL environment by the existing cgroup v1 fixture expecting `/sys/fs/cgroup/cpu/.../cpuacct.stat`)