### PR TITLE
fix(tracing): confine task executables to tool directory

### DIFF
--- a/pkg/tracing/task.go
+++ b/pkg/tracing/task.go
@@ -93,6 +93,8 @@ var (
 	ErrTaskCanceled = errors.New("task canceled")
 	// ErrTaskLimitExceeded is returned when a new task would exceed the active limit.
 	ErrTaskLimitExceeded = errors.New("too many running tasks")
+	// ErrInvalidTaskExecutable is returned when a task executable could escape TaskBinDir.
+	ErrInvalidTaskExecutable = errors.New("invalid task executable")
 )
 
 func init() {
@@ -182,6 +184,9 @@ func NewTaskWithIDLimit(
 	defer taskCreateMu.Unlock()
 	if _, loaded := taskLifeTmpCache.Load(taskID); loaded {
 		return taskID, nil
+	}
+	if execBinary == "" || execBinary == "." || execBinary == ".." || path.Base(execBinary) != execBinary {
+		return "", fmt.Errorf("%w: %q", ErrInvalidTaskExecutable, execBinary)
 	}
 	if maxActive > 0 && activeTaskCount() >= maxActive {
 		return "", ErrTaskLimitExceeded

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -86,7 +86,7 @@ func TestNewTaskWithIDIsIdempotent(t *testing.T) {
 	if !ok {
 		t.Fatal("first NewTaskWithID() did not store task")
 	}
-	if _, err := NewTaskWithID(taskID, "different-profiler", time.Second, TaskStorageStdout, nil); err != nil {
+	if _, err := NewTaskWithID(taskID, "../different-profiler", time.Second, TaskStorageStdout, nil); err != nil {
 		t.Fatalf("second NewTaskWithID() error=%v", err)
 	}
 	second, ok := taskLifeTmpCache.Load(taskID)
@@ -113,6 +113,30 @@ func TestNewTaskWithIDLimitAllowsRetryButRejectsNewTask(t *testing.T) {
 		"new-2026", "profiler", time.Second, TaskStorageStdout, nil, 1,
 	); !errors.Is(err, ErrTaskLimitExceeded) {
 		t.Fatalf("new task error=%v, want ErrTaskLimitExceeded", err)
+	}
+}
+
+func TestNewTaskWithIDRejectsExecutablePathTraversal(t *testing.T) {
+	clearTaskCache()
+	t.Cleanup(clearTaskCache)
+
+	for _, executable := range []string{
+		"",
+		".",
+		"..",
+		"../profiler",
+		"tools/profiler",
+		"/usr/bin/id",
+	} {
+		t.Run(executable, func(t *testing.T) {
+			taskID := "invalid-executable-" + strings.ReplaceAll(executable, "/", "-")
+			if _, err := NewTaskWithID(taskID, executable, time.Second, TaskStorageStdout, nil); !errors.Is(err, ErrInvalidTaskExecutable) {
+				t.Fatalf("NewTaskWithID() error=%v, want ErrInvalidTaskExecutable", err)
+			}
+			if _, ok := taskLifeTmpCache.Load(taskID); ok {
+				t.Fatal("invalid executable was stored as a task")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Reject new task executable names that are empty, dot paths, absolute paths, or contain path separators before joining them with `TaskBinDir`.

Preserve task creation idempotency by returning an already-cached task before validating a retry's executable value.

## Why

`tracer_name` reaches task execution as the executable name. Allowing values such as `../profiler` lets `path.Join(TaskBinDir, execBinary)` escape the configured tool directory and execute a binary outside it.

## Tests

- `make check`
- `go test ./pkg/tracing -count=1 -timeout=90s`
- `make unit` (all relevant packages pass; the full run is blocked in this WSL environment by the existing cgroup v1 fixture expecting `/sys/fs/cgroup/cpu/.../cpuacct.stat`)