### PR TITLE
fix(pod): match sidecar container names exactly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/time v0.9.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	k8s.io/api v0.31.3
+	k8s.io/apimachinery v0.31.3
 	k8s.io/cri-client v0.31.3
 	modernc.org/sqlite v1.44.0
 	sigs.k8s.io/yaml v1.5.0
@@ -212,7 +213,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
-	k8s.io/apimachinery v0.31.3 // indirect
 	k8s.io/client-go v0.31.3 // indirect
 	k8s.io/component-base v0.31.3 // indirect
 	k8s.io/cri-api v0.31.3 // indirect

--- a/internal/pod/container_type_default.go
+++ b/internal/pod/container_type_default.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,13 +16,11 @@
 
 package pod
 
-import (
-	"strings"
+import corev1 "k8s.io/api/core/v1"
 
-	corev1 "k8s.io/api/core/v1"
-)
-
-var sidecarModules = "istio-proxy"
+var sidecarModules = map[string]struct{}{
+	"istio-proxy": {},
+}
 
 func parseContainerType(container *corev1.Container, pod *corev1.Pod) (ContainerType, error) {
 	// List of objects depended by this object. If ALL objects in the list have
@@ -42,7 +40,7 @@ func parseContainerType(container *corev1.Container, pod *corev1.Pod) (Container
 		return ContainerTypeDaemonSet, nil
 	}
 
-	if strings.Contains(sidecarModules, container.Name) {
+	if _, ok := sidecarModules[container.Name]; ok {
 		return ContainerTypeSidecar, nil
 	}
 

--- a/internal/pod/container_type_default_test.go
+++ b/internal/pod/container_type_default_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !didi
+
+package pod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseContainerTypeSidecarName(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet"}},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		containerName string
+		want          ContainerType
+	}{
+		{
+			name:          "exact sidecar name",
+			containerName: "istio-proxy",
+			want:          ContainerTypeSidecar,
+		},
+		{
+			name:          "sidecar name suffix",
+			containerName: "proxy",
+			want:          ContainerTypeNormal,
+		},
+		{
+			name:          "sidecar name prefix",
+			containerName: "istio",
+			want:          ContainerTypeNormal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerType, err := parseContainerType(
+				&corev1.Container{Name: tt.containerName}, pod,
+			)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, containerType)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- replace substring-based sidecar detection with exact-name membership
- keep `istio-proxy` classified as a sidecar
- cover partial-name containers such as `proxy` and `istio`

## Root cause

`strings.Contains("istio-proxy", container.Name)` tested whether the container
name was a substring of the configured sidecar name. This classified unrelated
application containers with partial names as sidecars.

## Impact

Normal containers are no longer omitted from normal-container queries or
reported under the sidecar type merely because their names overlap with
`istio-proxy`.

## Verification

Run remotely on `WZU_4080_Tail`:

- `go test ./internal/pod -count=1`
- `make check`

The full unit suite was also run. All packages passed except the existing
`internal/bpf` lifecycle test, which requires BPF privileges unavailable to the
remote user (`operation not permitted`).

Fixes #562
