### PR TITLE
test(bytesutil): cover fixed array encoding

### DIFF
--- a/internal/utils/bytesutil/struct_test.go
+++ b/internal/utils/bytesutil/struct_test.go
@@ -48,3 +48,11 @@ func TestToBytesUsesLittleEndianLayout(t *testing.T) {
 		})
 	}
 }
+
+func TestToBytesEncodesFixedArrays(t *testing.T) {
+	value := [2]uint32{1, 0x01020304}
+	want := []byte{1, 0, 0, 0, 4, 3, 2, 1}
+	if got := ToBytes(value); !bytes.Equal(got, want) {
+		t.Errorf("ToBytes(%#v) = %x, want %x", value, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds fixed-array coverage for little-endian byte encoding.

## Why

The test extends the binary layout contract beyond scalar and struct inputs.

## Validation

- `gofmt`
- `go test -count=1 ./internal/utils/bytesutil`
