### PR TITLE
test(kernaddr): cover maximum address parsing

### DIFF
--- a/internal/utils/kernaddr/kernaddr_test.go
+++ b/internal/utils/kernaddr/kernaddr_test.go
@@ -94,3 +94,10 @@ func TestFormatParseRoundTrip(t *testing.T) {
 		t.Fatalf("Parse(Format(%#x)) = %#x, want %#x", addr, got, addr)
 	}
 }
+
+func TestParseAcceptsMaximumUint64(t *testing.T) {
+	const address = ^uint64(0)
+	if got, ok := Parse(Format(address)); !ok || got != address {
+		t.Fatalf("Parse(Format(%#x)) = (%#x, %t), want (%#x, true)", address, got, ok, address)
+	}
+}


### PR DESCRIPTION
## Summary

Adds maximum `uint64` kernel-address parsing coverage.

## Why

Kernel pointers may use the complete 64-bit range; this test guards the encoding boundary.

## Validation

- `gofmt`
- `go test -count=1 ./internal/utils/kernaddr`
