### PR TITLE
test(transport): cover UDS data exchange

### DIFF
--- a/internal/toolstream/transport/uds_test.go
+++ b/internal/toolstream/transport/uds_test.go
@@ -15,6 +15,8 @@
 package transport
 
 import (
+	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -97,5 +99,57 @@ func TestListenUDSRejectsNonSocketPath(t *testing.T) {
 	}
 	if string(got) != "keep" {
 		t.Fatalf("regular file content = %q, want keep", got)
+	}
+}
+
+func TestListenAndDialUDSExchangesData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "toolstream.sock")
+	listener, err := ListenUDS(path)
+	if err != nil {
+		t.Fatalf("ListenUDS: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+
+		payload := make([]byte, 4)
+		if _, err := io.ReadFull(conn, payload); err != nil {
+			serverDone <- err
+			return
+		}
+		if string(payload) != "ping" {
+			serverDone <- fmt.Errorf("unexpected client payload %q", payload)
+			return
+		}
+		_, err = conn.Write([]byte("pong"))
+		serverDone <- err
+	}()
+
+	client, err := DialUDS(path)
+	if err != nil {
+		t.Fatalf("DialUDS: %v", err)
+	}
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	response := make([]byte, 4)
+	if _, err := io.ReadFull(client, response); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("client close: %v", err)
+	}
+	if string(response) != "pong" {
+		t.Fatalf("response = %q, want pong", response)
+	}
+	if err := <-serverDone; err != nil {
+		t.Fatalf("server: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds an end-to-end Unix-domain socket exchange test for the transport layer.

## Why

The test verifies that the listener and dialer interoperate, complementing lifecycle and stale-socket coverage.

## Validation

- `gofmt`
- Target package needs generated Cap'n Proto bindings absent from this local checkout; validation is delegated to CI.
