### PR TITLE
fix(perf): preserve flamegraph stack order

### DIFF
--- a/cmd/perf/parsedata.go
+++ b/cmd/perf/parsedata.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025-2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ type eventdata struct {
 
 // CgDumpTrace is an interface for dump stacks in cgusage case
 func CgDumpTrace(addrs []uint64) string {
-	stacks := symbol.KsymStackStrsReversed(addrs, perfStackDepth)
+	stacks := symbol.KsymStackStrs(addrs, perfStackDepth)
 	return strings.Join(stacks, "\n")
 }
 
@@ -142,7 +142,7 @@ func buildFlameData(b bpf.BPF) ([]flamegraph.FrameData, error) {
 		}
 
 		if kv.Key.UstackSize > 0 {
-			frames := u.UsymStackStrsReversed(kv.Key.Pid, kv.Key.Ustack[:], int(kv.Key.UstackSize))
+			frames := u.UsymStackStrs(kv.Key.Pid, kv.Key.Ustack[:], int(kv.Key.UstackSize))
 			for _, frame := range frames {
 				if frame != "" {
 					index, functionNames = findOrAdd(frame, functionNames)


### PR DESCRIPTION
## 变更

修复 perf 火焰图中用户栈和内核栈方向反转的问题。

- `CgDumpTrace` 使用保持 BPF 原始方向的 `KsymStackStrs`
- 用户栈使用保持原始方向的 `UsymStackStrs`
- 保持现有拼接顺序：内核栈 → 用户栈 → 线程名
- 更新修改文件版权年份至 2026

## 验证

- `git diff --check`：通过
- 本地 Windows 环境无法编译该 Linux/eBPF 包：项目依赖 Linux 专用 syscall，且本机磁盘空间不足以完成完整构建
- 需要维护者在 Linux/CI 环境验证 perf 火焰图方向

这是根据 PR #500 维护者建议拆出的独立 PR，和 ELF 限制修复无关。