### PR TITLE
fix(pidfile): preserve owner PID on lock contention

### DIFF
--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -45,7 +45,7 @@ type Handle struct {
 func Lock(name string) (*Handle, error) {
 	p := path(name)
 
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +61,19 @@ func Lock(name string) (*Handle, error) {
 			return nil, fmt.Errorf("already running: %s pid=%s", p, bytes.TrimSpace(pid))
 		}
 
+		return nil, err
+	}
+
+	// Truncate only after acquiring the flock. Opening with O_TRUNC would let
+	// a rejected second instance erase the PID recorded by the lock owner.
+	if err := f.Truncate(0); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, err
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
 		return nil, err
 	}
 

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -67,25 +67,29 @@ func Lock(name string) (*Handle, error) {
 	// Truncate only after acquiring the flock. Opening with O_TRUNC would let
 	// a rejected second instance erase the PID recorded by the lock owner.
 	if err := f.Truncate(0); err != nil {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
+		cleanupFailedLock(f, p)
 		return nil, err
 	}
 	if _, err := f.Seek(0, 0); err != nil {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
+		cleanupFailedLock(f, p)
 		return nil, err
 	}
 
 	if _, err := fmt.Fprintf(f, "%d", os.Getpid()); err != nil {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
-		_ = os.Remove(p)
+		cleanupFailedLock(f, p)
 
 		return nil, err
 	}
 
 	return &Handle{file: f, path: p}, nil
+}
+
+// Remove the locked path before releasing the flock so a replacement file
+// created by another process cannot be removed by this failed lock attempt.
+func cleanupFailedLock(f *os.File, path string) {
+	_ = os.Remove(path)
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = f.Close()
 }
 
 // Unlock unlocks, closes, and removes the pid file. Calling Unlock more

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -79,6 +79,11 @@ func TestLock_AlreadyLocked(t *testing.T) {
 	_, err = Lock(name)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already running")
+	assert.Contains(t, err.Error(), strconv.Itoa(os.Getpid()))
+
+	data, readErr := os.ReadFile(path(name))
+	require.NoError(t, readErr)
+	assert.Equal(t, strconv.Itoa(os.Getpid()), string(data))
 }
 
 func TestUnlock_RemovesFile(t *testing.T) {

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -108,6 +109,25 @@ func TestUnlock_Idempotent(t *testing.T) {
 
 	lk.Unlock()
 	lk.Unlock()
+}
+
+func TestCleanupFailedLockRemovesFileAndReleasesFlock(t *testing.T) {
+	redirectPidDir(t)
+
+	p := path("failed")
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	require.NoError(t, syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
+
+	cleanupFailedLock(f, p)
+
+	_, err = os.Stat(p)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	replacement, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = replacement.Close() })
+	require.NoError(t, syscall.Flock(int(replacement.Fd()), syscall.LOCK_EX|syscall.LOCK_NB))
 }
 
 // TestLock_HandleKeepsFlockAlive guards the bug that motivated the


### PR DESCRIPTION
﻿## What changed

- open the PID file without truncating it
- truncate and rewind only after the exclusive flock succeeds
- verify that a rejected second lock still reports and preserves the owner's PID

## Why

Opening the PID file with `O_TRUNC` happened before lock acquisition. A second process could therefore erase the live process's PID even though its flock attempt was rejected.

## Impact

Concurrent startup attempts no longer corrupt the PID file, and the rejection error continues to identify the running process.

## Validation

- `go test ./internal/pidfile -count=1`
- `go vet ./internal/pidfile`
- `git diff --check`
- full `go test ./...` reached all packages; the only failure was the environment-dependent cgroup v1 test because this WSL host has no `cpuacct.stat`
- `make check` reported zero lint issues before the repository's fixed five-minute golangci-lint timeout
