### PR TITLE
fix(toolstream): close connection after handshake failure

### DIFF
--- a/internal/toolstream/transport/client.go
+++ b/internal/toolstream/transport/client.go
@@ -139,8 +139,18 @@ func NewClient(path, toolName, version, taskID string) (*Client, error) {
 		return nil, err
 	}
 
+	return newClient(conn, toolName, version, taskID)
+}
+
+func newClient(conn net.Conn, toolName, version, taskID string) (*Client, error) {
 	c := &Client{encoder: capnp.NewEncoder(conn), conn: conn}
 	if err := c.handshake(toolName, version, taskID); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("transport: send connect: %w", err),
+				fmt.Errorf("transport: close failed connection: %w", closeErr),
+			)
+		}
 		return nil, fmt.Errorf("transport: send connect: %w", err)
 	}
 

--- a/internal/toolstream/transport/client_test.go
+++ b/internal/toolstream/transport/client_test.go
@@ -41,6 +41,25 @@ func TestClientEndReturnsSendAndCloseErrors(t *testing.T) {
 	}
 }
 
+func TestNewClientClosesConnectionWhenHandshakeFails(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("write failed")
+	closeErr := errors.New("close failed")
+	conn := &failingConn{writeErr: writeErr, closeErr: closeErr}
+
+	client, err := newClient(conn, "dropwatch", "1.0", "task-1")
+	if client != nil {
+		t.Fatalf("newClient() client = %#v, want nil", client)
+	}
+	if !errors.Is(err, writeErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("newClient() error = %v, want write and close errors", err)
+	}
+	if conn.closeCalls != 1 {
+		t.Fatalf("Close() calls = %d, want 1", conn.closeCalls)
+	}
+}
+
 type failingConn struct {
 	writeErr   error
 	closeErr   error


### PR DESCRIPTION
﻿## What changed

- close the established connection when the initial Toolstream handshake cannot be written
- preserve both the handshake and close errors when cleanup also fails
- add regression coverage for the cleanup path

## Why

`NewClient` returned immediately after a handshake error without closing the connection created by `DialUDS`. Repeated failed connections could leak file descriptors.

## Impact

Failed Toolstream client initialization now releases its socket deterministically and retains actionable error context.

## Validation

- `go test ./internal/toolstream/transport -count=1`
- `go vet ./internal/toolstream/transport`
- `git diff --check`
- full `go test ./...` reached all packages; the only failure was the environment-dependent cgroup v1 test because this WSL host has no `cpuacct.stat`
- `make check` reported zero lint issues before the repository's fixed five-minute golangci-lint timeout
