### PR TITLE
fix(storage): close backend after initialization failure

### DIFF
--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"huatuo-bamai/internal/storage/driver"
@@ -36,7 +37,15 @@ func NewFromConfig[T any](ctx context.Context, cfg *driver.Config, collection st
 		return nil, err
 	}
 
-	return NewStore(ctx, cfg.Driver, backend, collection, mapper)
+	store, err := NewStore(ctx, cfg.Driver, backend, collection, mapper)
+	if err != nil {
+		if backend == nil {
+			return nil, err
+		}
+		return nil, errors.Join(err, backend.Close(driver.WithContext(ctx)))
+	}
+
+	return store, nil
 }
 
 // NewStore validates that backend and mapper are non-nil, verifies the collection

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -89,6 +89,7 @@ type testBackend struct {
 	queryErr     error
 	countErr     error
 	valuesErr    error
+	closeErr     error
 	getRecord    driver.Record
 	queryRecords []driver.Record
 	countValue   int64
@@ -99,6 +100,7 @@ type testBackend struct {
 	queryCalls   int
 	countCalls   int
 	valuesCalls  int
+	closeCalls   int
 	collection   string
 	indexes      []driver.Index
 	savedRecord  driver.Record
@@ -157,7 +159,34 @@ func (b *testBackend) Values(_ context.Context, field string, q driver.Query, si
 	return b.valuesValue, b.valuesErr
 }
 
-func (b *testBackend) Close(context.Context) error { return nil }
+func (b *testBackend) Close(context.Context) error {
+	b.closeCalls++
+	return b.closeErr
+}
+
+func TestNewFromConfigClosesBackendOnInitializationFailure(t *testing.T) {
+	backend := &testBackend{}
+	driverName := "test-init-cleanup"
+	driver.RegisterBackend(driverName, func(*driver.Config) (driver.Backend, error) {
+		return backend, nil
+	})
+
+	store, err := NewFromConfig[testEntity](
+		t.Context(),
+		&driver.Config{Driver: driverName},
+		"jobs",
+		&testMapper{indexes: []driver.Index{{Field: ""}}},
+	)
+	if err == nil {
+		t.Fatal("NewFromConfig() error = nil, want initialization error")
+	}
+	if store != nil {
+		t.Fatalf("NewFromConfig() store = %#v, want nil", store)
+	}
+	if backend.closeCalls != 1 {
+		t.Fatalf("backend Close() calls = %d, want 1", backend.closeCalls)
+	}
+}
 
 func newTestMapper() *testMapper {
 	return &testMapper{

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -165,7 +165,8 @@ func (b *testBackend) Close(context.Context) error {
 }
 
 func TestNewFromConfigClosesBackendOnInitializationFailure(t *testing.T) {
-	backend := &testBackend{}
+	closeErr := errors.New("backend close failed")
+	backend := &testBackend{closeErr: closeErr}
 	driverName := "test-init-cleanup"
 	driver.RegisterBackend(driverName, func(*driver.Config) (driver.Backend, error) {
 		return backend, nil
@@ -185,6 +186,12 @@ func TestNewFromConfigClosesBackendOnInitializationFailure(t *testing.T) {
 	}
 	if backend.closeCalls != 1 {
 		t.Fatalf("backend Close() calls = %d, want 1", backend.closeCalls)
+	}
+	if !errors.Is(err, driver.ErrInvalidField) {
+		t.Errorf("NewFromConfig() error = %v, want ErrInvalidField", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Errorf("NewFromConfig() error = %v, want close error", err)
 	}
 }
 


### PR DESCRIPTION
﻿## What changed

- close a newly created storage backend when `NewStore` initialization fails
- return initialization and cleanup failures together
- add a regression test that verifies the backend is closed exactly once

## Why

`NewFromConfig` allocated a backend before validating the mapper and initializing the collection. When either step failed, it returned without releasing backend resources such as database connections or worker goroutines.

## Impact

Failed storage construction no longer leaks backend resources, while callers retain the original initialization error and any cleanup error.

## Validation

- `go test ./internal/storage -count=1`
- `go vet ./internal/storage`
- `git diff --check`
- full `go test ./...` reached all packages; the only failure was the environment-dependent cgroup v1 test because this WSL host has no `cpuacct.stat`
- `make check` reported zero lint issues before the repository's fixed five-minute golangci-lint timeout
