### PR TITLE
fix(toolstream): preserve replaced socket paths on close

### DIFF
--- a/internal/toolstream/transport/uds.go
+++ b/internal/toolstream/transport/uds.go
@@ -25,12 +25,16 @@ import (
 
 type udsListener struct {
 	net.Listener
-	path string
+	path     string
+	fileInfo os.FileInfo
 }
 
 func (l *udsListener) Close() error {
 	err := l.Listener.Close()
-	_ = os.Remove(l.path)
+	info, statErr := os.Lstat(l.path)
+	if statErr == nil && os.SameFile(l.fileInfo, info) {
+		_ = os.Remove(l.path)
+	}
 	return err
 }
 
@@ -44,6 +48,11 @@ func ListenUDS(path string) (net.Listener, error) {
 	if err != nil {
 		return nil, fmt.Errorf("transport: listen %s: %w", path, err)
 	}
+	if unixListener, ok := l.(*net.UnixListener); ok {
+		// Own unlinking below so Close cannot delete a path that has been
+		// replaced since this listener was bound.
+		unixListener.SetUnlinkOnClose(false)
+	}
 
 	// chmod is the security boundary for who can connect; if it fails the socket
 	// would silently keep the umask-derived permissions, so refuse to expose it.
@@ -53,7 +62,14 @@ func ListenUDS(path string) (net.Listener, error) {
 		return nil, fmt.Errorf("transport: chmod %s: %w", path, err)
 	}
 
-	return &udsListener{Listener: l, path: path}, nil
+	info, err := os.Lstat(path)
+	if err != nil {
+		_ = l.Close()
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("transport: inspect bound socket %s: %w", path, err)
+	}
+
+	return &udsListener{Listener: l, path: path, fileInfo: info}, nil
 }
 
 func prepareSocketPath(path string) error {

--- a/internal/toolstream/transport/uds_test.go
+++ b/internal/toolstream/transport/uds_test.go
@@ -99,3 +99,29 @@ func TestListenUDSRejectsNonSocketPath(t *testing.T) {
 		t.Fatalf("regular file content = %q, want keep", got)
 	}
 }
+
+func TestListenerClosePreservesReplacedPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "toolstream.sock")
+	listener, err := ListenUDS(path)
+	if err != nil {
+		t.Fatalf("ListenUDS: %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove socket path: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("replacement"), 0o600); err != nil {
+		t.Fatalf("create replacement path: %v", err)
+	}
+
+	if err := listener.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement path: %v", err)
+	}
+	if string(data) != "replacement" {
+		t.Fatalf("replacement content = %q, want replacement", data)
+	}
+}


### PR DESCRIPTION
﻿## What changed

- disable the standard Unix listener's unconditional unlink-on-close behavior
- remember the socket identity created by `ListenUDS`
- remove the path during close only when it still refers to that socket
- add regression coverage for a socket path replaced by a regular file

## Why

The listener previously removed its configured path unconditionally. If another actor replaced that pathname while the listener remained open, shutdown deleted the replacement rather than only cleaning up the socket it owned.

## Impact

Toolstream shutdown still removes its own socket, but preserves files or sockets that replaced the original pathname.

## Validation

- `go test ./internal/toolstream/transport -count=1`
- `go vet ./internal/toolstream/transport`
- `git diff --check`
- full `go test ./...` reached all packages; the only failure was the environment-dependent cgroup v1 test because this WSL host has no `cpuacct.stat`
- `make check` reported zero lint issues before the repository's fixed five-minute golangci-lint timeout
