### PR TITLE
feat(symbol): resolve stripped Go ELF via gopclntab

### DIFF
--- a/internal/symbol/symbols.go
+++ b/internal/symbol/symbols.go
@@ -17,6 +17,7 @@ package symbol
 import (
 	"bufio"
 	"debug/elf"
+	"debug/gosym"
 	"fmt"
 	"io"
 	"os"
@@ -242,7 +243,46 @@ func elfSymbols(f *elf.File) symbols {
 		log.Infof("symbol: %s extracted %d func symbols", s.name, len(syms)-before)
 	}
 	syms.sort()
+	if len(syms) == 0 {
+		goSyms, err := elfGoPCLNTABSymbols(f)
+		if err != nil {
+			log.Infof("symbol: gopclntab not available in %s: %v", f.FileHeader.Type, err)
+		} else {
+			syms = goSyms
+			log.Infof("symbol: gopclntab extracted %d func symbols", len(syms))
+		}
+	}
 	return syms
+}
+
+// elfGoPCLNTABSymbols extracts function metadata from a stripped Go ELF.
+// Go binaries retain .gopclntab after -s -w, while the ELF symbol tables are
+// removed. The text section address anchors gosym's PC ranges to ELF VAs.
+func elfGoPCLNTABSymbols(f *elf.File) (symbols, error) {
+	pclntabSection := f.Section(".gopclntab")
+	textSection := f.Section(".text")
+	if pclntabSection == nil || textSection == nil {
+		return nil, fmt.Errorf("missing .gopclntab or .text section")
+	}
+	pclntab, err := pclntabSection.Data()
+	if err != nil {
+		return nil, fmt.Errorf("read .gopclntab: %w", err)
+	}
+	lineTable := gosym.NewLineTable(pclntab, textSection.Addr)
+	table, err := gosym.NewTable(nil, lineTable)
+	if err != nil {
+		return nil, fmt.Errorf("decode .gopclntab: %w", err)
+	}
+
+	syms := make(symbols, 0, len(table.Funcs))
+	for _, fn := range table.Funcs {
+		if fn.Name == "" || fn.End <= fn.Entry {
+			continue
+		}
+		syms = append(syms, &symbol{Addr: fn.Entry, Size: fn.End - fn.Entry, Name: fn.Name})
+	}
+	syms.sort()
+	return syms, nil
 }
 
 // backedPaths is the set of pseudo-paths in /proc/<pid>/maps with no ELF symbols.

--- a/internal/symbol/symbols_test.go
+++ b/internal/symbol/symbols_test.go
@@ -18,7 +18,9 @@ import (
 	"debug/elf"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -481,6 +483,35 @@ func TestElfSymbols(t *testing.T) {
 			t.Errorf("elfSymbols sort order: got[%d]=0x%x > got[%d]=0x%x", index-1, got[index-1].Addr, index, got[index].Addr)
 		}
 	}
+}
+
+func TestElfSymbolsFromGoPCLNTAB(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("stripped Go ELF fixture requires Linux")
+	}
+
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "main.go")
+	outputPath := filepath.Join(dir, "fixture")
+	mustWriteFile(t, sourcePath, "package main\n\n//go:noinline\nfunc target() int { return 42 }\nfunc main() { _ = target() }\n")
+	cmd := exec.Command("go", "build", "-ldflags=-s -w", "-o", outputPath, sourcePath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build stripped Go ELF: %v\n%s", err, output)
+	}
+
+	elfFile, err := elf.Open(outputPath)
+	if err != nil {
+		t.Fatalf("elf.Open(%q): %v", outputPath, err)
+	}
+	defer elfFile.Close()
+
+	got := elfSymbols(elfFile)
+	for _, sym := range got {
+		if sym.Name == "main.target" {
+			return
+		}
+	}
+	t.Fatalf("elfSymbols(%q): did not recover main.target from .gopclntab", outputPath)
 }
 
 func TestIsLibPath(t *testing.T) {


### PR DESCRIPTION
## 背景

被 `-s -w` 剥离的 Go ELF 通常没有 `.dynsym`/`.symtab` 函数符号，但仍保留 `.gopclntab`，导致用户态栈解析只能返回 unknown。

## 改动

- 使用标准库 `debug/gosym` 从 `.gopclntab` 恢复函数入口、范围和名称。
- 仅在常规 ELF 函数符号为空时启用回退，避免改变已有 ELF 符号优先级。
- 增加真实 `go build -ldflags="-s -w"` stripped ELF 回归测试。

## 验证

- Linux: `go test ./internal/symbol -run TestElfSymbolsFromGoPCLNTAB -count=1` 通过。
- 上游默认分支当前存在既有 ABI 命名不一致（`RatelimitEvent`/`BPFRatelimitEvent`），导致完整 `internal/symbol` 包编译被阻塞；该问题未包含在本 PR。

该 PR 对应维护者在 #500 评论中邀请的独立 gopclntab 支持工作。
