### PR TITLE
fix(pod): classify sidecar containers by exact name match

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	golang.org/x/time v0.9.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	k8s.io/api v0.31.3
+	k8s.io/apimachinery v0.31.3
 	k8s.io/cri-client v0.31.3
 	modernc.org/sqlite v1.44.0
 	sigs.k8s.io/yaml v1.5.0
@@ -212,7 +213,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
-	k8s.io/apimachinery v0.31.3 // indirect
 	k8s.io/client-go v0.31.3 // indirect
 	k8s.io/component-base v0.31.3 // indirect
 	k8s.io/cri-api v0.31.3 // indirect

--- a/internal/pod/container_type_default.go
+++ b/internal/pod/container_type_default.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/pod/container_type_default.go
+++ b/internal/pod/container_type_default.go
@@ -17,12 +17,13 @@
 package pod
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
-var sidecarModules = "istio-proxy"
+// sidecarModules lists the container names that should be classified as
+// sidecars. Names are compared exactly so partial matches (e.g. "proxy",
+// "istio") are not misclassified.
+var sidecarModules = []string{"istio-proxy"}
 
 func parseContainerType(container *corev1.Container, pod *corev1.Pod) (ContainerType, error) {
 	// List of objects depended by this object. If ALL objects in the list have
@@ -42,8 +43,10 @@ func parseContainerType(container *corev1.Container, pod *corev1.Pod) (Container
 		return ContainerTypeDaemonSet, nil
 	}
 
-	if strings.Contains(sidecarModules, container.Name) {
-		return ContainerTypeSidecar, nil
+	for _, name := range sidecarModules {
+		if container.Name == name {
+			return ContainerTypeSidecar, nil
+		}
 	}
 
 	// kind:

--- a/internal/pod/container_type_test.go
+++ b/internal/pod/container_type_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func deploymentPod(containerName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet"},
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func TestParseContainerTypeExactSidecarMatch(t *testing.T) {
+	pod := deploymentPod("istio-proxy")
+	container := &corev1.Container{Name: "istio-proxy"}
+
+	got, err := parseContainerType(container, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ContainerTypeSidecar {
+		t.Fatalf("expected ContainerTypeSidecar, got %v", got)
+	}
+}
+
+func TestParseContainerTypePartialNamesRemainNormal(t *testing.T) {
+	cases := []string{"proxy", "istio", "istio-pro", "istio-proxy-envoy", "p"}
+	for _, name := range cases {
+		pod := deploymentPod(name)
+		container := &corev1.Container{Name: name}
+
+		got, err := parseContainerType(container, pod)
+		if err != nil {
+			t.Fatalf("container %q: unexpected error: %v", name, err)
+		}
+		if got != ContainerTypeNormal {
+			t.Errorf("container %q: expected ContainerTypeNormal, got %v", name, got)
+		}
+	}
+}
+
+func TestParseContainerTypeDaemonSet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	container := &corev1.Container{Name: "istio-proxy"}
+
+	got, err := parseContainerType(container, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ContainerTypeDaemonSet {
+		t.Fatalf("expected ContainerTypeDaemonSet, got %v", got)
+	}
+}
+
+func TestParseContainerTypeNoOwnerRunningIsNormal(t *testing.T) {
+	pod := &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodRunning}}
+	container := &corev1.Container{Name: "anything"}
+
+	got, err := parseContainerType(container, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ContainerTypeNormal {
+		t.Fatalf("expected ContainerTypeNormal, got %v", got)
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix #562.

parseContainerType classified a container as a sidecar with strings.Contains(sidecarModules, container.Name), which had the arguments reversed: it tested whether "istio-proxy" contained the container name. Any container whose name was a substring of "istio-proxy" (proxy, istio, istio-pro, or even a single character) was misclassified as a sidecar, while names like istio-proxy-envoy were not.

## Brief changelog

- container_type_default.go: compare sidecar container names exactly instead of via substring
- add container_type_test.go covering the exact match and substring non-matches

## How was this patch verified

- go test ./internal/pod/ -run TestParseContainerType
- gofmt clean
