### PR TITLE
fix(pod): validate container life resource types without panicking

### DIFF
--- a/internal/pod/container_life_resources.go
+++ b/internal/pod/container_life_resources.go
@@ -32,7 +32,7 @@ var lifeResourcesTpl sync.Map
 //	data := map[string]int{"acct": 0, "usage": 0}
 //	RegisterContainerLifeResources("cpu", reflect.TypeOf(data))
 func RegisterContainerLifeResources(key string, anythingType reflect.Type) error {
-	if anythingType.Kind() != reflect.Pointer && anythingType.Elem().Kind() != reflect.Struct {
+	if anythingType.Kind() != reflect.Pointer || anythingType.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("invalid anythingType: %v, only support pointer of struct", anythingType)
 	}
 

--- a/internal/pod/container_life_resources.go
+++ b/internal/pod/container_life_resources.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ var lifeResourcesTpl sync.Map
 //	data := map[string]int{"acct": 0, "usage": 0}
 //	RegisterContainerLifeResources("cpu", reflect.TypeOf(data))
 func RegisterContainerLifeResources(key string, anythingType reflect.Type) error {
-	if anythingType.Kind() != reflect.Pointer || anythingType.Elem().Kind() != reflect.Struct {
+	if anythingType == nil || anythingType.Kind() != reflect.Pointer ||
+		anythingType.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("invalid anythingType: %v, only support pointer of struct", anythingType)
 	}
 

--- a/internal/pod/container_life_resources_test.go
+++ b/internal/pod/container_life_resources_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"reflect"
+	"testing"
+)
+
+type lifeResourceStruct struct {
+	Acct  int
+	Usage int
+}
+
+func TestRegisterContainerLifeResourcesAcceptsPointerOfStruct(t *testing.T) {
+	if err := RegisterContainerLifeResources("cpu-ok", reflect.TypeOf(&lifeResourceStruct{})); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRegisterContainerLifeResourcesRejectsNonPointer(t *testing.T) {
+	err := RegisterContainerLifeResources("cpu-value", reflect.TypeOf(lifeResourceStruct{}))
+	if err == nil {
+		t.Fatal("expected an error for a non-pointer type")
+	}
+}
+
+func TestRegisterContainerLifeResourcesRejectsPointerToNonStruct(t *testing.T) {
+	err := RegisterContainerLifeResources("cpu-int", reflect.TypeOf(new(int)))
+	if err == nil {
+		t.Fatal("expected an error for a pointer to a non-struct type")
+	}
+}
+
+func TestRegisterContainerLifeResourcesRejectsDuplicateKey(t *testing.T) {
+	if err := RegisterContainerLifeResources("cpu-dup", reflect.TypeOf(&lifeResourceStruct{})); err != nil {
+		t.Fatalf("first registration should succeed: %v", err)
+	}
+	if err := RegisterContainerLifeResources("cpu-dup", reflect.TypeOf(&lifeResourceStruct{})); err == nil {
+		t.Fatal("expected an error for a duplicate key")
+	}
+}

--- a/internal/pod/container_life_resources_test.go
+++ b/internal/pod/container_life_resources_test.go
@@ -37,6 +37,13 @@ func TestRegisterContainerLifeResourcesRejectsNonPointer(t *testing.T) {
 	}
 }
 
+func TestRegisterContainerLifeResourcesRejectsNilType(t *testing.T) {
+	err := RegisterContainerLifeResources("cpu-nil", nil)
+	if err == nil {
+		t.Fatal("expected an error for a nil type")
+	}
+}
+
 func TestRegisterContainerLifeResourcesRejectsPointerToNonStruct(t *testing.T) {
 	err := RegisterContainerLifeResources("cpu-int", reflect.TypeOf(new(int)))
 	if err == nil {


### PR DESCRIPTION
## What is the purpose of the change

Fix #581.

RegisterContainerLifeResources validated its type argument with Kind() != Pointer && Elem().Kind() != Struct. The && should be ||: pointers to non-struct types (e.g. *int) passed validation, and passing a non-pointer type caused reflect.Type.Elem() to panic instead of returning an error.

## Brief changelog

- container_life_resources.go: use || so any type that is not a pointer to a struct returns an error without panicking
- add container_life_resources_test.go covering pointer-to-struct, non-pointer, pointer-to-non-struct and duplicate key cases

## How was this patch verified

- go test ./internal/pod/ -run TestRegisterContainerLifeResources
- gofmt clean
