### PR TITLE
fix(flamegraph): truncate symbols at rune boundaries

### DIFF
--- a/internal/profiler/output/flamegraph/render.go
+++ b/internal/profiler/output/flamegraph/render.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"unicode/utf8"
 )
 
 type frame struct {
@@ -191,11 +192,22 @@ func (r *renderer) fitText(text string, width float32) string {
 		return ""
 	}
 
-	if len(text) < avail {
+	if utf8.RuneCountInString(text) < avail {
 		return html.EscapeString(text)
 	}
 
-	return html.EscapeString(text[:avail-2]) + ".."
+	maxRunes := avail - 2
+	end := len(text)
+	runes := 0
+	for index := range text {
+		if runes == maxRunes {
+			end = index
+			break
+		}
+		runes++
+	}
+
+	return html.EscapeString(text[:end]) + ".."
 }
 
 // RenderStyle writes a flame graph SVG for stacks using the given style.

--- a/internal/profiler/output/flamegraph/render_test.go
+++ b/internal/profiler/output/flamegraph/render_test.go
@@ -16,8 +16,10 @@ package flamegraph
 
 import (
 	"bytes"
+	"encoding/xml"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestRenderStyleKeepsSymbolsOutOfJavaScript(t *testing.T) {
@@ -38,5 +40,23 @@ func TestRenderStyleKeepsSymbolsOutOfJavaScript(t *testing.T) {
 	if !strings.Contains(content, `data-title="`) ||
 		!strings.Contains(content, "&lt;script&gt;alert(2)&lt;/script&gt;") {
 		t.Fatalf("SVG does not preserve the escaped symbol as data: %s", content)
+	}
+}
+
+func TestRenderStyleKeepsTruncatedSymbolsValidUTF8(t *testing.T) {
+	symbol := strings.Repeat("中", 200)
+	var output bytes.Buffer
+	if err := RenderStyle([]Stack{{
+		Names:   []string{"root", symbol},
+		Samples: 1,
+	}}, &output, DefaultStyle); err != nil {
+		t.Fatalf("RenderStyle() error = %v", err)
+	}
+
+	if !utf8.Valid(output.Bytes()) {
+		t.Fatal("RenderStyle() emitted invalid UTF-8 after truncating a symbol")
+	}
+	if err := xml.Unmarshal(output.Bytes(), new(any)); err != nil {
+		t.Fatalf("RenderStyle() emitted invalid XML: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- measure flame graph labels by UTF-8 runes instead of bytes
- truncate labels only at rune boundaries
- verify rendered SVG remains valid UTF-8 and parseable XML for long non-ASCII symbols

## Why

`fitText` used a glyph budget as a byte offset. Long Java, Go, or C++ symbols containing multi-byte characters could therefore be cut in the middle of a rune, making the complete SVG invalid and unreadable by XML/SVG consumers.

## Validation

- `go test ./internal/profiler/output/flamegraph -count=1`
- `go vet ./internal/profiler/output/flamegraph`
- `golangci-lint run --new-from-rev=upstream/main ./internal/profiler/output/flamegraph/...`
- `gofumpt` and `goimports` on the changed files
- `git diff --check`

`make check` is not available on this Windows host because GNU Make is not installed; the equivalent changed-package checks above pass, and the repository CI can run the full Linux check.

Closes #584