### PR TITLE
fix(iotracing): reject non-positive display limits

### DIFF
--- a/cmd/iotracing/cli.go
+++ b/cmd/iotracing/cli.go
@@ -117,10 +117,23 @@ func validateFlags(c *cli.Context) error {
 // filter map is a separate return because it crosses the BPF ABI; keeping
 // it out of ioConfig avoids accidental mutation by the data layer.
 func loadConfig(c *cli.Context) (ioConfig, map[string]any, error) {
+	maxStack, err := positiveDisplayLimit(c, cliFlagMaxStack)
+	if err != nil {
+		return ioConfig{}, nil, err
+	}
+	maxProcess, err := positiveDisplayLimit(c, cliFlagMaxProcess)
+	if err != nil {
+		return ioConfig{}, nil, err
+	}
+	maxFilesPerProcess, err := positiveDisplayLimit(c, cliFlagMaxFilesPerPid)
+	if err != nil {
+		return ioConfig{}, nil, err
+	}
+
 	cfg := ioConfig{
-		maxStack:           c.Uint64(cliFlagMaxStack),
-		maxProcess:         c.Uint64(cliFlagMaxProcess),
-		maxFilesPerProcess: c.Uint64(cliFlagMaxFilesPerPid),
+		maxStack:           maxStack,
+		maxProcess:         maxProcess,
+		maxFilesPerProcess: maxFilesPerProcess,
 		scheduleThreshold:  c.Uint64(cliFlagSchedThreshold),
 		durationSecond:     c.Uint64(cliFlagDuration),
 	}
@@ -151,6 +164,15 @@ func loadConfig(c *cli.Context) (ioConfig, map[string]any, error) {
 	}
 
 	return cfg, filters, nil
+}
+
+func positiveDisplayLimit(c *cli.Context, flagName string) (uint64, error) {
+	value := c.Int(flagName)
+	if value <= 0 {
+		return 0, fmt.Errorf("--%s must be greater than zero", flagName)
+	}
+
+	return uint64(value), nil
 }
 
 // parseDeviceNumbers turns a "major:minor[,major:minor]" string into the

--- a/cmd/iotracing/cli_config_test.go
+++ b/cmd/iotracing/cli_config_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestLoadConfigRejectsNonPositiveDisplayLimits(t *testing.T) {
+	tests := []struct {
+		flagName string
+		value    string
+	}{
+		{flagName: cliFlagMaxStack, value: "0"},
+		{flagName: cliFlagMaxStack, value: "-1"},
+		{flagName: cliFlagMaxProcess, value: "0"},
+		{flagName: cliFlagMaxProcess, value: "-1"},
+		{flagName: cliFlagMaxFilesPerPid, value: "0"},
+		{flagName: cliFlagMaxFilesPerPid, value: "-1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.flagName+"="+test.value, func(t *testing.T) {
+			ctx := newTestCLIContext(t, "--"+test.flagName+"="+test.value)
+			_, _, err := loadConfig(ctx)
+			if err == nil {
+				t.Fatalf("loadConfig() error = nil, want %s validation error", test.flagName)
+			}
+			if !strings.Contains(err.Error(), "--"+test.flagName) {
+				t.Fatalf("loadConfig() error = %q, want flag name %q", err, test.flagName)
+			}
+		})
+	}
+}
+
+func TestLoadConfigAcceptsPositiveDisplayLimits(t *testing.T) {
+	ctx := newTestCLIContext(
+		t,
+		"--"+cliFlagMaxStack+"=1",
+		"--"+cliFlagMaxProcess+"=2",
+		"--"+cliFlagMaxFilesPerPid+"=3",
+	)
+
+	cfg, _, err := loadConfig(ctx)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.maxStack != 1 || cfg.maxProcess != 2 || cfg.maxFilesPerProcess != 3 {
+		t.Fatalf(
+			"display limits = (%d, %d, %d), want (1, 2, 3)",
+			cfg.maxStack,
+			cfg.maxProcess,
+			cfg.maxFilesPerProcess,
+		)
+	}
+}
+
+func newTestCLIContext(t *testing.T, args ...string) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	for _, cliFlag := range appFlags() {
+		if err := cliFlag.Apply(set); err != nil {
+			t.Fatalf("apply flag: %v", err)
+		}
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	return cli.NewContext(cli.NewApp(), set, nil)
+}


### PR DESCRIPTION
## Summary

- read the three `IntFlag` display limits as signed integers
- reject zero and negative values before BPF initialization
- convert only validated values to the unsigned collection configuration
- cover every limit with zero/negative cases and a positive configuration

## Why

`--max-stack`, `--max-process`, and `--max-files-per-process` are registered as signed flags but were read through `Context.Uint64`. Negative input was therefore reduced to zero, and explicit zero was also accepted. The tracer could start successfully while discarding every stack or rendering empty top-N results.

## Validation

- focused CLI configuration tests: 7 cases passed
- focused `go vet` passed
- `gofumpt` and `goimports` on changed files
- `git diff --check`

The complete `cmd/iotracing` package cannot be loaded in this Windows checkout because generated `internal/bpf/abi` files are absent. The focused tests were run against the CLI configuration files with a temporary, uncommitted `ioConfig` test stub; repository CI can exercise the generated Linux build.

Closes #586