### PR TITLE
fix(metrics): propagate host vmstat errors

### DIFF
--- a/core/metrics/memory_vmstat.go
+++ b/core/metrics/memory_vmstat.go
@@ -51,14 +51,21 @@ func newMemoryVmStat() (*tracing.EventTracingAttr, error) {
 }
 
 func (c *memoryVmStat) Update() ([]*metric.Data, error) {
-	container, err := c.containerVmstat()
+	return collectMemoryVmstat(c.containerVmstat, c.hostVmstat)
+}
+
+func collectMemoryVmstat(
+	containerCollector func() ([]*metric.Data, error),
+	hostCollector func() ([]*metric.Data, error),
+) ([]*metric.Data, error) {
+	container, err := containerCollector()
 	if err != nil {
 		return nil, err
 	}
 
-	host, err := c.hostVmstat()
+	host, err := hostCollector()
 	if err != nil {
-		return container, nil
+		return container, err
 	}
 
 	return append(container, host...), nil

--- a/core/metrics/memory_vmstat_test.go
+++ b/core/metrics/memory_vmstat_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"huatuo-bamai/pkg/metric"
+)
+
+func TestCollectMemoryVmstatReturnsPartialMetricsWithHostError(t *testing.T) {
+	wantMetric := &metric.Data{Value: 1}
+	wantErr := errors.New("read host vmstat")
+
+	metrics, err := collectMemoryVmstat(
+		func() ([]*metric.Data, error) {
+			return []*metric.Data{wantMetric}, nil
+		},
+		func() ([]*metric.Data, error) {
+			return nil, wantErr
+		},
+	)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("collectMemoryVmstat() error = %v, want %v", err, wantErr)
+	}
+	if len(metrics) != 1 || metrics[0] != wantMetric {
+		t.Fatalf("collectMemoryVmstat() metrics = %v, want partial container metrics", metrics)
+	}
+}
+
+func TestCollectMemoryVmstatStopsAfterContainerError(t *testing.T) {
+	wantErr := errors.New("read container vmstat")
+	hostCalled := false
+
+	metrics, err := collectMemoryVmstat(
+		func() ([]*metric.Data, error) {
+			return nil, wantErr
+		},
+		func() ([]*metric.Data, error) {
+			hostCalled = true
+			return nil, nil
+		},
+	)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("collectMemoryVmstat() error = %v, want %v", err, wantErr)
+	}
+	if metrics != nil {
+		t.Fatalf("collectMemoryVmstat() metrics = %v, want nil", metrics)
+	}
+	if hostCalled {
+		t.Fatal("collectMemoryVmstat() called host collector after container error")
+	}
+}


### PR DESCRIPTION
## Summary

- preserve container vmstat metrics when host collection fails
- return the host error so scrape success reflects the incomplete result
- cover partial-result and container short-circuit behavior

## Root cause

`memoryVmStat.Update()` returned `container, nil` after any host vmstat failure. This hid `/proc/vmstat` read, parse, and host-filter errors even though the collector contract supports returning partial metrics together with an error.

Closes #592.

## Validation

- `gofmt -d core/metrics/memory_vmstat.go core/metrics/memory_vmstat_test.go`
- `git diff --check`
- both changed paths checked against all open PRs targeting `main` (no matches)

Focused package tests and lint cannot compile in this Windows checkout because the generated `internal/bpf/abi` package is absent and Linux-only procfs/sysfs types are excluded. The new helper tests are isolated from those dependencies and are expected to run in the repository's Linux CI.