### PR TITLE
fix(metrics): guard dcb netlink message against short slice panic

### DIFF
--- a/core/metrics/netdev_dcb.go
+++ b/core/metrics/netdev_dcb.go
@@ -149,6 +149,9 @@ func (dcb *dcbCollector) Update() ([]*metric.Data, error) {
 		}
 
 		for _, m := range msgs {
+			if len(m) < sizeofDcbmsg {
+				return nil, fmt.Errorf("dcb netlink message too short: got %d, want at least %d", len(m), sizeofDcbmsg)
+			}
 			attrs, err := nl.ParseRouteAttr(m[sizeofDcbmsg:])
 			if err != nil {
 				return nil, err

--- a/core/metrics/netdev_dcb.go
+++ b/core/metrics/netdev_dcb.go
@@ -89,7 +89,7 @@ type ieeePfc struct {
 }
 
 func deserializeIEEEPfc(b []byte) (*ieeePfc, error) {
-	size := int(unsafe.Sizeof(ipfc{}))
+	size := int(unsafe.Sizeof(ieeePfc{}))
 	if len(b) < size {
 		return nil, fmt.Errorf("ieee pfc attr too short: got %d, want at least %d", len(b), size)
 	}

--- a/core/metrics/netdev_dcb.go
+++ b/core/metrics/netdev_dcb.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ type ieeePfc struct {
 }
 
 func deserializeIEEEPfc(b []byte) (*ieeePfc, error) {
-	size := int(unsafe.Sizeof(ieeePfc{}))
+	size := int(unsafe.Sizeof(ipfc{}))
 	if len(b) < size {
 		return nil, fmt.Errorf("ieee pfc attr too short: got %d, want at least %d", len(b), size)
 	}


### PR DESCRIPTION
## Summary

Fixes #596

In `core/metrics/netdev_dcb.go`, `dcbCollector.Update()` slices each netlink message with `m[sizeofDcbmsg:]` (where `sizeofDcbmsg = 4`) without checking the message length first. If the kernel returns a DCB netlink message shorter than 4 bytes, this triggers a `runtime error: slice bounds out of range` panic, crashing the entire huatuo-bamai process.

## Root Cause

```go
for _, m := range msgs {
    attrs, err := nl.ParseRouteAttr(m[sizeofDcbmsg:])  // panic if len(m) < 4
```

## Fix

Add a length check before slicing:

```go
if len(m) < sizeofDcbmsg {
    return nil, fmt.Errorf("dcb netlink message too short: got %d, want at least %d", len(m), sizeofDcbmsg)
}
```

## Verification

- `go build ./core/metrics/` — pass
- `golangci-lint run ./core/metrics/... --timeout=5m --config .golangci.yaml` — pass, zero warnings
- `go test ./core/metrics/ -count=1 -v` — all tests pass