### PR TITLE
fix(storage): guard localfile writerByName against concurrent map read

### DIFF
--- a/internal/storage/localfile/localfile.go
+++ b/internal/storage/localfile/localfile.go
@@ -123,14 +123,9 @@ func (b *Storage) newFileWriter(filename string) io.Writer {
 }
 
 func (b *Storage) writerByName(name string) (io.Writer, error) {
-	if fileWriter, ok := b.files[name]; ok {
-		return fileWriter, nil
-	}
-
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// Double-check after acquiring lock
 	if fileWriter, ok := b.files[name]; ok {
 		return fileWriter, nil
 	}


### PR DESCRIPTION
## Summary

Fixes #597

In `internal/storage/localfile/localfile.go`, `writerByName()` reads the `b.files` map without holding `b.lock` in a fast-path check:

```go
func (b *Storage) writerByName(name string) (io.Writer, error) {
    if fileWriter, ok := b.files[name]; ok {  // ← no lock!
        return fileWriter, nil
    }

    b.lock.Lock()
    defer b.lock.Unlock()

    // Double-check after acquiring lock
    if fileWriter, ok := b.files[name]; ok {
        return fileWriter, nil
    }
    ...
}
```

Meanwhile, `newFileWriter()` writes to the same `b.files` map under `b.lock`. Since `Save()` can be called concurrently by multiple tracer goroutines, one goroutine may write to `b.files` while another reads it in the unlocked fast path, triggering `fatal error: concurrent map read and map write`.

## Fix

Remove the unlocked fast-path map read; perform all map lookups under the lock:

```go
func (b *Storage) writerByName(name string) (io.Writer, error) {
    b.lock.Lock()
    defer b.lock.Unlock()

    if fileWriter, ok := b.files[name]; ok {
        return fileWriter, nil
    }
    ...
}
```

The double-check pattern is no longer needed since there is only one map read under the lock.

## Verification

- `go build ./internal/storage/localfile/` — pass
- `golangci-lint run ./internal/storage/localfile/... --timeout=5m --config .golangci.yaml` — pass, zero warnings
- `go test ./internal/storage/localfile/ -count=1 -v` — all 4 tests pass