### PR TITLE
fix(metrics): guard parseNetStat against empty header line slice panic

### DIFF
--- a/core/metrics/net_netstat.go
+++ b/core/metrics/net_netstat.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -146,7 +146,10 @@ func parseNetStat(fileName string) (map[string]map[string]string, error) {
 		}
 
 		if !scanner.Scan() {
-			break
+			if err := scanner.Err(); err != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("netstat: missing value line after header in %s", fileName)
 		}
 		valueParts := strings.Split(scanner.Text(), " ")
 

--- a/core/metrics/net_netstat.go
+++ b/core/metrics/net_netstat.go
@@ -138,7 +138,16 @@ func parseNetStat(fileName string) (map[string]map[string]string, error) {
 	for scanner.Scan() {
 		nameParts := strings.Split(scanner.Text(), " ")
 
-		scanner.Scan()
+		// Guard against an empty or malformed header line (e.g. trailing
+		// empty line in /proc/net/netstat) to avoid a slice-bounds panic on
+		// nameParts[0][:len(nameParts[0])-1] when nameParts[0] is empty.
+		if len(nameParts) == 0 || nameParts[0] == "" {
+			continue
+		}
+
+		if !scanner.Scan() {
+			break
+		}
 		valueParts := strings.Split(scanner.Text(), " ")
 
 		// remove trailing ":"


### PR DESCRIPTION
## Summary

Fixes #598

In `core/metrics/net_netstat.go`, `parseNetStat()` has two issues that can cause panics:

### 1. Empty header line → slice bounds out of range

When `scanner.Text()` returns an empty string (e.g., a trailing empty line in `/proc/net/netstat`), `strings.Split("", " ")` returns `[""]`. Then `nameParts[0][:len(nameParts[0])-1]` evaluates to `""[:-1]`, triggering `runtime error: slice bounds out of range [:-1]`.

### 2. Unchecked second `scanner.Scan()`

The second `scanner.Scan()` (to read the values line) is not checked. If the file is truncated after the header line, `scanner.Text()` returns `""`, leading to a `valueParts` / `nameParts` length mismatch.

## Fix

```go
// Guard against empty or malformed header line
if len(nameParts) == 0 || nameParts[0] == "" {
    continue
}

// Check second scanner.Scan() return value
if !scanner.Scan() {
    break
}
```

## Note

This addresses a different issue than #544 (which also touches `parseNetStat`). #544 fixes the second `scanner.Scan()` return value check; this PR additionally guards against the first `scanner.Scan()` returning an empty line, which causes the `nameParts[0]` slice to go out of bounds before the second `scanner.Scan()` is even reached.

## Verification

- `go build ./core/metrics/` — pass
- `golangci-lint run ./core/metrics/... --timeout=5m --config .golangci.yaml` — pass, zero warnings
- `go test ./core/metrics/ -count=1 -v` — all tests pass