### PR TITLE
fix(ras): bound ACPI payload extraction

### DIFF
--- a/core/events/ras.go
+++ b/core/events/ras.go
@@ -176,6 +176,21 @@ func cstring(buf []byte, rawOffset, base uint32) string {
 	return string(buf[off:])
 }
 
+func bytesField(buf []byte, rawOffset, base, length uint32) []byte {
+	absOff := rawOffset & 0xffff
+	if absOff < base || length == 0 {
+		return nil
+	}
+
+	off := uint64(absOff - base)
+	if off >= uint64(len(buf)) {
+		return nil
+	}
+
+	end := min(off+uint64(length), uint64(len(buf)))
+	return bytes.Clone(buf[off:end])
+}
+
 // Bank's MCi_STATUS MSR
 //
 // #define MCI_STATUS_DEFERRED     BIT_ULL(44)  /* uncorrected error, deferred exception */
@@ -487,11 +502,10 @@ func buildRasAcpiTracerData(data *rasEvent) (*RasTracingData, error) {
 	const nonStandardBase uint32 = 56
 	fru := cstring(payload.Msg[:], payload.FRUTxtOffset, nonStandardBase)
 
-	// Extract raw bytes at the FRU text location for the hex dump.
-	var rawData []byte
-	if absOff := payload.FRUTxtOffset & 0xffff; absOff >= nonStandardBase {
-		rawData = bytes.Clone(payload.Msg[absOff-nonStandardBase : absOff-nonStandardBase+payload.Len])
-	}
+	// Extract the raw bytes described by the buf offset for the hex dump.
+	// The kernel stores it as a __data_loc field: low 16 bits are the offset
+	// into the trace entry, and REC->len bytes follow.
+	rawData := bytesField(payload.Msg[:], payload.BufOffset, nonStandardBase, payload.Len)
 
 	return newRasTracingData(data, "ACPI", "NON_STANDARD", acpiErrType(payload.Sev), struct {
 		Severity uint8  `json:"severity"`

--- a/core/events/ras_test.go
+++ b/core/events/ras_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBytesFieldBounds(t *testing.T) {
+	buf := []byte{0, 1, 2, 3, 4}
+	tests := []struct {
+		name      string
+		rawOffset uint32
+		base      uint32
+		length    uint32
+		want      []byte
+	}{
+		{name: "before base", rawOffset: 9, base: 10, length: 2},
+		{name: "at end", rawOffset: 15, base: 10, length: 1},
+		{name: "zero length", rawOffset: 11, base: 10},
+		{name: "within bounds", rawOffset: 11, base: 10, length: 2, want: []byte{1, 2}},
+		{name: "truncated at end", rawOffset: 13, base: 10, length: 10, want: []byte{3, 4}},
+		{name: "huge length", rawOffset: 11, base: 10, length: 1 << 20, want: []byte{1, 2, 3, 4}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bytesField(buf, tt.rawOffset, tt.base, tt.length)
+			if !bytes.Equal(got, tt.want) {
+				t.Fatalf("bytesField() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// acpiEvent encodes a non_standard_event trace entry the way the kernel lays it
+// out, using the layout reported by
+// /sys/kernel/tracing/events/ras/non_standard_event/format.
+func acpiEvent(t *testing.T, fruTxtOffset, bufOffset, length uint32, msg []byte) rasEvent {
+	t.Helper()
+
+	type acpiPayload struct {
+		Pad          uint64
+		SecType      [16]uint8
+		FRUID        [16]uint8
+		FRUTxtOffset uint32
+		Sev          uint8
+		Pattern      [3]uint8
+		Len          uint32
+		BufOffset    uint32
+		Msg          [DETAIL_INFO_SIZE_ACPI]byte
+	}
+
+	payload := acpiPayload{
+		FRUTxtOffset: fruTxtOffset,
+		BufOffset:    bufOffset,
+		Len:          length,
+	}
+	copy(payload.Msg[:], msg)
+
+	var encoded bytes.Buffer
+	if err := binary.Write(&encoded, binary.LittleEndian, payload); err != nil {
+		t.Fatal(err)
+	}
+
+	var event rasEvent
+	copy(event.Info[:], encoded.Bytes())
+	return event
+}
+
+func TestBuildRasAcpiTracerDataRawData(t *testing.T) {
+	tests := []struct {
+		name         string
+		fruTxtOffset uint32
+		bufOffset    uint32
+		length       uint32
+		msg          []byte
+		wantFRU      string
+		wantRaw      string
+	}{
+		{
+			name:         "reads the buffer at buf_offset",
+			fruTxtOffset: 56,
+			bufOffset:    60,
+			length:       3,
+			msg:          []byte("fru\x00\xde\xad\xbe"),
+			wantFRU:      "fru",
+			wantRaw:      "de ad be",
+		},
+		{
+			// The kernel-provided length is not trustworthy: it can run past
+			// the end of the payload and must be clamped, not sliced blindly.
+			name:         "length past the payload is clamped",
+			fruTxtOffset: 56,
+			bufOffset:    60,
+			length:       1 << 20,
+			msg:          []byte("fru\x00\xde\xad\xbe"),
+			wantFRU:      "fru",
+			wantRaw:      "de ad be" + strings.Repeat(" 00", DETAIL_INFO_SIZE_ACPI-4-3),
+		},
+		{
+			name:         "buf_offset past the payload yields no raw data",
+			fruTxtOffset: 56,
+			bufOffset:    0xffff,
+			length:       3,
+			msg:          []byte("fru\x00"),
+			wantFRU:      "fru",
+		},
+		{
+			name:         "zero length yields no raw data",
+			fruTxtOffset: 56,
+			bufOffset:    60,
+			length:       0,
+			msg:          []byte("fru\x00"),
+			wantFRU:      "fru",
+		},
+		{
+			name:         "empty fru_text",
+			fruTxtOffset: 0,
+			bufOffset:    60,
+			length:       3,
+			msg:          []byte("fru\x00\xde\xad\xbe"),
+			wantRaw:      "de ad be",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := acpiEvent(t, tt.fruTxtOffset, tt.bufOffset, tt.length, tt.msg)
+
+			data, err := buildRasAcpiTracerData(&event)
+			if err != nil {
+				t.Fatalf("buildRasAcpiTracerData() error = %v", err)
+			}
+
+			var info struct {
+				FruText string `json:"fru_text"`
+				RawData string `json:"raw_data"`
+			}
+			if err := json.Unmarshal([]byte(data.Info), &info); err != nil {
+				t.Fatalf("unmarshal info: %v", err)
+			}
+			if info.FruText != tt.wantFRU {
+				t.Errorf("fru_text = %q, want %q", info.FruText, tt.wantFRU)
+			}
+			if info.RawData != tt.wantRaw {
+				t.Errorf("raw_data = %q, want %q", info.RawData, tt.wantRaw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- extract ACPI non-standard raw data from the tracepoint buffer offset
- reject offsets outside the captured payload
- clamp declared lengths to the bytes actually captured
- cover invalid, valid, and truncated dynamic fields

## Root cause

The decoder used `FruTxtOffset` for both the FRU string and raw event bytes, although the tracepoint provides a separate `BufOffset`. It then sliced the fixed BPF capture buffer using the declared event length without checking either boundary, so a malformed or truncated event could panic the agent.

Closes #595.

## Validation

- `gofmt -d core/events/ras.go core/events/ras_test.go`
- `git diff --check`
- both changed paths checked against all open PRs targeting `main` (no matches)

Focused package tests and lint cannot type-check in this Windows checkout because the generated `internal/bpf/abi` package is absent and Linux-only syscall symbols are excluded. The new regression tests will run in the repository's Linux CI.