### PR TITLE
fix(cgroups): read CPU usage from cpuacct

### DIFF
--- a/internal/cgroups/v1/cgroups.go
+++ b/internal/cgroups/v1/cgroups.go
@@ -90,13 +90,13 @@ func (c *CgroupV1) Procs(path string) ([]int32, error) {
 }
 
 func (c *CgroupV1) CpuUsage(path string) (*stats.CpuUsage, error) {
-	statPath := paths.Path(subsystem.SubsystemCPU, path, "cpuacct.stat")
+	statPath := paths.Path(subsystem.SubsystemCPUAcct, path, "cpuacct.stat")
 	raw, err := parseutil.RawKV(statPath)
 	if err != nil {
 		return nil, err
 	}
 
-	usagePath := paths.Path(subsystem.SubsystemCPU, path, "cpuacct.usage")
+	usagePath := paths.Path(subsystem.SubsystemCPUAcct, path, "cpuacct.usage")
 	usage, err := parseutil.ReadUint(usagePath)
 	if err != nil {
 		return nil, err

--- a/internal/cgroups/v1/cgroups_test.go
+++ b/internal/cgroups/v1/cgroups_test.go
@@ -23,6 +23,28 @@ import (
 	"huatuo-bamai/internal/cgroups/subsystem"
 )
 
+func TestCpuUsageReadsCPUAcctSubsystem(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := paths.RootfsDefaultPath
+	paths.RootfsDefaultPath = root
+	t.Cleanup(func() { paths.RootfsDefaultPath = oldRoot })
+
+	path := filepath.Join("test", "usage")
+	writeCgroupFile(t, paths.Path(subsystem.SubsystemCPUAcct, path, "cpuacct.stat"), "user 100\nsystem 50\n")
+	writeCgroupFile(t, paths.Path(subsystem.SubsystemCPUAcct, path, "cpuacct.usage"), "1500000\n")
+
+	usage, err := (&CgroupV1{}).CpuUsage(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantUser := uint64(100 * microsecondsInSecond / clockTicks)
+	wantSystem := uint64(50 * microsecondsInSecond / clockTicks)
+	if usage.User != wantUser || usage.System != wantSystem || usage.Usage != 1500 {
+		t.Errorf("CpuUsage() = %+v, want User=%d System=%d Usage=1500", usage, wantUser, wantSystem)
+	}
+}
+
 func TestCpuQuotaAndPeriodEffectiveCPUCount(t *testing.T) {
 	root := t.TempDir()
 	oldRoot := paths.RootfsDefaultPath

--- a/internal/cgroups/v1/cgroups_test.go
+++ b/internal/cgroups/v1/cgroups_test.go
@@ -38,8 +38,8 @@ func TestCpuUsageReadsCPUAcctSubsystem(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantUser := uint64(100 * microsecondsInSecond / clockTicks)
-	wantSystem := uint64(50 * microsecondsInSecond / clockTicks)
+	wantUser := 100 * microsecondsInSecond / clockTicks
+	wantSystem := 50 * microsecondsInSecond / clockTicks
 	if usage.User != wantUser || usage.System != wantSystem || usage.Usage != 1500 {
 		t.Errorf("CpuUsage() = %+v, want User=%d System=%d Usage=1500", usage, wantUser, wantSystem)
 	}


### PR DESCRIPTION
## Summary

- resolve `cpuacct.stat` and `cpuacct.usage` through the cgroup v1 cpuacct controller
- leave scheduler and quota files on the CPU controller
- cover a split CPU/cpuacct hierarchy with a regression test

## Root cause

The v1 CPU usage reader constructed both accounting paths with `SubsystemCPU`. That only works when the controllers are co-mounted. On a valid split hierarchy, the files exist under `SubsystemCPUAcct` and collection failed with file-not-found errors.

Closes #603.

## Validation

- `GOOS=linux GOARCH=amd64 go test -c ./internal/cgroups/v1`
- `GOOS=linux GOARCH=amd64 go vet ./internal/cgroups/v1`
- `gofmt -d internal/cgroups/v1/cgroups.go internal/cgroups/v1/cgroups_test.go`
- `git diff --check`
- both changed paths checked against all open PRs targeting `main` (no matches)

The generated Linux test binary was compiled successfully; it cannot execute on the Windows host, so runtime tests are delegated to Linux CI.