### PR TITLE
fix(storage): reject nil backend config

### DIFF
--- a/internal/storage/driver/registry.go
+++ b/internal/storage/driver/registry.go
@@ -36,6 +36,9 @@ func RegisterBackend(name string, factory BackendFactory) {
 
 // NewBackend creates a backend from Config.
 func NewBackend(cfg *Config) (Backend, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("storage: backend config is nil")
+	}
 	if cfg.Driver == "" {
 		return nil, fmt.Errorf("storage: backend driver is empty")
 	}

--- a/internal/storage/driver/registry_nil_config_test.go
+++ b/internal/storage/driver/registry_nil_config_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package driver
+
+import "testing"
+
+func TestNewBackendRejectsNilConfig(t *testing.T) {
+	backend, err := NewBackend(nil)
+	if backend != nil {
+		t.Fatalf("NewBackend(nil) backend = %#v, want nil", backend)
+	}
+	if err == nil {
+		t.Fatal("NewBackend(nil) error = nil, want error")
+	}
+
+	const want = "storage: backend config is nil"
+	if err.Error() != want {
+		t.Fatalf("NewBackend(nil) error = %q, want %q", err, want)
+	}
+}


### PR DESCRIPTION
## Summary

- reject a nil backend configuration before reading its driver
- return a nil backend and a clear configuration error
- cover the nil construction boundary with a regression test

## Root cause

`NewBackend` accessed `cfg.Driver` before validating the configuration pointer. A missing backend configuration therefore panicked even though the construction API is designed to return validation errors.

Closes #605.

## Validation

- `go test ./internal/storage/driver -count=1`
- `go vet ./internal/storage/driver`
- `gofumpt -extra` and `goimports` on changed files
- `golangci-lint run --new-from-rev=upstream/main`
- `git diff --check`
- both changed paths checked against all open PRs targeting `main` (no matches)