### PR TITLE
fix(profiler): parse Java long classpath option

### DIFF
--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -319,17 +319,31 @@ func extractJavaMainClassFromPid(pid int) (string, error) {
 		return "", err
 	}
 
+	res := javaMainClass(cmdlineSlice)
+
+	if strings.HasPrefix(res, "-") || res == "" {
+		parts := strings.Fields(cmdlineStr)
+		if len(parts) > 0 {
+			return parts[len(parts)-1], nil
+		}
+		return "", fmt.Errorf("couldn't get java thread name")
+	}
+
+	return res, nil
+}
+
+func javaMainClass(cmdline []string) string {
 	skipNext := false
-	var res string
-	for i := 1; i < len(cmdlineSlice); i++ {
-		arg := cmdlineSlice[i]
+	for i := 1; i < len(cmdline); i++ {
+		arg := cmdline[i]
 
 		if skipNext {
 			skipNext = false
 			continue
 		}
 
-		if arg == "-cp" || arg == "-classpath" || arg == "--module-path" || arg == "-p" || arg == "--add-opens" {
+		if arg == "-cp" || arg == "-classpath" || arg == "--class-path" ||
+			arg == "--module-path" || arg == "-p" || arg == "--add-opens" {
 			skipNext = true
 			continue
 		}
@@ -342,26 +356,13 @@ func extractJavaMainClassFromPid(pid int) (string, error) {
 			continue
 		}
 
-		if arg == "-jar" && i+1 < len(cmdlineSlice) {
-			res = cmdlineSlice[i+1]
-		} else if res == "" {
-			res = arg
+		if arg == "-jar" && i+1 < len(cmdline) {
+			return cmdline[i+1]
 		}
-
-		if res != "" {
-			break
-		}
+		return arg
 	}
 
-	if strings.HasPrefix(res, "-") || res == "" {
-		parts := strings.Fields(cmdlineStr)
-		if len(parts) > 0 {
-			return parts[len(parts)-1], nil
-		}
-		return "", fmt.Errorf("couldn't get java thread name")
-	}
-
-	return res, nil
+	return ""
 }
 
 func extractPythonThreadNameFromPid(pid int) (string, error) {

--- a/internal/profiler/profiler_test.go
+++ b/internal/profiler/profiler_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import "testing"
+
+func TestJavaMainClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline []string
+		want    string
+	}{
+		{name: "long class path", cmdline: []string{"java", "--class-path", "libs/*", "com.example.Main"}, want: "com.example.Main"},
+		{name: "short class path", cmdline: []string{"java", "-cp", "libs/*", "com.example.Main"}, want: "com.example.Main"},
+		{name: "legacy class path", cmdline: []string{"java", "-classpath", "libs/*", "com.example.Main"}, want: "com.example.Main"},
+		{name: "jar", cmdline: []string{"java", "-jar", "app.jar", "arg"}, want: "app.jar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := javaMainClass(tt.cmdline); got != tt.want {
+				t.Errorf("javaMainClass() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- treat Java `--class-path` as a launcher option with an operand
- keep existing `-cp`, `-classpath`, and `-jar` parsing behavior
- extract the command-line parser into a focused, table-tested helper

## Root cause

The profiler skipped operands for the short classpath options but not Java's standard `--class-path` form. It therefore selected the classpath value as the main class, producing incorrect process headers and aggregation keys.

Closes #607.

## Validation

- `go test ./internal/profiler -count=1`
- `go vet ./internal/profiler`
- `golangci-lint run --new-from-rev=upstream/main`
- `gofmt -d internal/profiler/profiler.go internal/profiler/profiler_test.go`
- `git diff --check`
- both changed paths checked against all open PRs targeting `main` (no matches)