### PR TITLE
fix(job): reject nil agent task requests

### DIFF
--- a/internal/job/errors.go
+++ b/internal/job/errors.go
@@ -27,5 +27,6 @@ var (
 	ErrUnsupportedJobType     = errors.New("unsupported job type")
 	ErrPersistence            = errors.New("job persistence failed")
 	ErrInvalidQuery           = errors.New("invalid job query")
+	ErrInvalidAgentRequest    = errors.New("invalid agent task request")
 	ErrAgentDispatchUncertain = errors.New("agent dispatch result is uncertain")
 )

--- a/internal/job/node_agent.go
+++ b/internal/job/node_agent.go
@@ -116,6 +116,9 @@ func (c *HTTPNodeAgent) StartTaskContext(
 ) (taskID string, returnedErr error) {
 	startedAt := time.Now()
 	defer func() { c.observeRequest("start", startedAt, returnedErr) }()
+	if args == nil {
+		return "", fmt.Errorf("%w: request must not be nil", ErrInvalidAgentRequest)
+	}
 	taskArgs := *args
 	taskArgs.ContainerID = container
 	if taskArgs.TracerName == "profiler" && !hasNonEmptyFlag(taskArgs.TracerArgs, "--tracer-id") {

--- a/internal/job/node_agent_test.go
+++ b/internal/job/node_agent_test.go
@@ -147,6 +147,21 @@ func TestHTTPNodeAgentReturnsBodyReadError(t *testing.T) {
 
 // TestHTTPNodeAgentStartTask tests HTTPNodeAgent.StartTask request and response handling, including successful task dispatch, writing container name to request body, agent returning non-200, and error handling for unparseable response body.
 func TestHTTPNodeAgentStartTask(t *testing.T) {
+	t.Run("nil request", func(t *testing.T) {
+		agent := newHTTPNodeAgentWithTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("HTTP request sent for a nil task request")
+			return nil, nil
+		}))
+
+		taskID, err := agent.StartTask("huatuo-dev", "payment-worker", nil)
+		if !errors.Is(err, ErrInvalidAgentRequest) {
+			t.Fatalf("StartTask() error=%v, want ErrInvalidAgentRequest", err)
+		}
+		if taskID != "" {
+			t.Fatalf("StartTask() taskID=%q, want empty", taskID)
+		}
+	})
+
 	t.Run("success", func(t *testing.T) {
 		var requestBody string
 		agent := newHTTPNodeAgentWithTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- return a defined job error when `StartTaskContext` receives a nil request
- avoid dereferencing the request before validation
- cover the nil-request path with a regression test

## Testing

- `go test ./internal/job -run TestHTTPNodeAgentStartTask -count=1`

The full `internal/job` package run also reached an existing Windows SQLite file-lock failure in an integration test; the focused regression passes.
