### PR TITLE
fix(autotracing): require requested meminfo counters

### DIFF
--- a/core/autotracing/memburst.go
+++ b/core/autotracing/memburst.go
@@ -14,12 +14,8 @@
 package autotracing
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"huatuo-bamai/internal/log"
@@ -44,39 +40,6 @@ type (
 		TopMemoryUsage []*processMemInfo `json:"top_memory_usage"`
 	}
 )
-
-// pass required keys and readMemInfo will return their values according to /proc/meminfo
-func readMemInfo(requiredKeys map[string]bool) (map[string]int, error) {
-	file, err := os.Open("/proc/meminfo")
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	results := make(map[string]int)
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		key := strings.Trim(fields[0], ":")
-		if _, ok := requiredKeys[key]; ok {
-			value, err := strconv.Atoi(strings.Trim(fields[1], " kB"))
-			if err != nil {
-				return nil, err
-			}
-			results[key] = value
-			if len(results) == len(requiredKeys) {
-				break
-			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return results, nil
-}
 
 func checkAndRecordMemoryUsage(currentIndex *int, isHistoryFull *bool,
 	memTotal int, history []int, historyWindowLength, topNProcesses int,

--- a/core/autotracing/memburst_test.go
+++ b/core/autotracing/memburst_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadMemInfoFromRequiresEveryRequestedKey(t *testing.T) {
+	required := map[string]bool{
+		"Active(anon)":   true,
+		"Inactive(anon)": true,
+	}
+
+	values, err := readMemInfoFrom(strings.NewReader(
+		"Inactive(anon): 23 kB\nMemFree: 99 kB\nActive(anon): 17 kB\n",
+	), required)
+	if err != nil {
+		t.Fatalf("readMemInfoFrom() error = %v", err)
+	}
+	if values["Active(anon)"] != 17 || values["Inactive(anon)"] != 23 {
+		t.Fatalf("readMemInfoFrom() = %v, want requested values", values)
+	}
+
+	_, err = readMemInfoFrom(strings.NewReader("Active(anon): 17 kB\n"), required)
+	if err == nil || !strings.Contains(err.Error(), "Inactive(anon)") {
+		t.Fatalf("readMemInfoFrom() error = %v, want missing-key error", err)
+	}
+}
+
+func TestReadMemInfoFromRejectsMalformedRequestedValue(t *testing.T) {
+	_, err := readMemInfoFrom(
+		strings.NewReader("MemTotal: unknown kB\n"),
+		map[string]bool{"MemTotal": true},
+	)
+	if err == nil || !strings.Contains(err.Error(), "parse MemTotal") {
+		t.Fatalf("readMemInfoFrom() error = %v, want parse error", err)
+	}
+}

--- a/core/autotracing/meminfo.go
+++ b/core/autotracing/meminfo.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autotracing
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// readMemInfo returns the requested values from /proc/meminfo.
+func readMemInfo(requiredKeys map[string]bool) (map[string]int, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return readMemInfoFrom(file, requiredKeys)
+}
+
+func readMemInfoFrom(reader io.Reader, requiredKeys map[string]bool) (map[string]int, error) {
+	results := make(map[string]int)
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSuffix(fields[0], ":")
+		if _, ok := requiredKeys[key]; !ok {
+			continue
+		}
+		value, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", key, err)
+		}
+		results[key] = value
+		if len(results) == len(requiredKeys) {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(results) != len(requiredKeys) {
+		missing := make([]string, 0, len(requiredKeys)-len(results))
+		for key := range requiredKeys {
+			if _, ok := results[key]; !ok {
+				missing = append(missing, key)
+			}
+		}
+		sort.Strings(missing)
+		return nil, fmt.Errorf("missing required memory info keys: %s", strings.Join(missing, ", "))
+	}
+	return results, nil
+}


### PR DESCRIPTION
## Summary

- move `/proc/meminfo` parsing into a small reader-based helper
- require every counter used by memburst detection instead of silently treating missing counters as zero
- return field-specific errors for missing or malformed values
- cover complete, reordered, missing, and malformed input

## Testing

- `go test core/autotracing/meminfo.go core/autotracing/memburst_test.go`

The complete package cannot be compiled on Windows because the generated Linux BPF ABI is not available; the isolated parser regression passes.
