### PR TITLE
fix(iotracing): handle BPF info lookup failures

### DIFF
--- a/cmd/iotracing/bpf_attach.go
+++ b/cmd/iotracing/bpf_attach.go
@@ -33,11 +33,11 @@ func attachAndEventPipe(ctx context.Context, b bpf.BPF) (reader bpf.PerfEventRea
 		return nil, fmt.Errorf("get event pipe: %w", err)
 	}
 
-	defer func() {
+	defer func(openReader bpf.PerfEventReader) {
 		if err != nil {
-			reader.Close()
+			openReader.Close()
 		}
-	}()
+	}(reader)
 
 	infos, err := b.Info()
 	if err != nil {

--- a/cmd/iotracing/bpf_attach.go
+++ b/cmd/iotracing/bpf_attach.go
@@ -39,7 +39,10 @@ func attachAndEventPipe(ctx context.Context, b bpf.BPF) (reader bpf.PerfEventRea
 		}
 	}()
 
-	infos, _ := b.Info()
+	infos, err := b.Info()
+	if err != nil {
+		return nil, fmt.Errorf("get BPF info: %w", err)
+	}
 
 	options, err := buildAttachOptions(infos.ProgramsInfo)
 	if err != nil {

--- a/cmd/iotracing/bpf_attach_test.go
+++ b/cmd/iotracing/bpf_attach_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+)
+
+type closeTrackingReader struct {
+	bpf.PerfEventReader
+	closeCalls int
+}
+
+func (r *closeTrackingReader) Close() error {
+	r.closeCalls++
+	return nil
+}
+
+type infoFailingBPF struct {
+	bpf.BPF
+	reader      bpf.PerfEventReader
+	infoErr     error
+	attachCalls int
+}
+
+func (b *infoFailingBPF) EventPipeByName(context.Context, string, uint32) (bpf.PerfEventReader, error) {
+	return b.reader, nil
+}
+
+func (b *infoFailingBPF) Info() (*bpf.Info, error) {
+	return nil, b.infoErr
+}
+
+func (b *infoFailingBPF) AttachWithOptions([]bpf.AttachOption) error {
+	b.attachCalls++
+	return nil
+}
+
+func TestAttachAndEventPipeClosesReaderWhenInfoFails(t *testing.T) {
+	infoErr := errors.New("BPF object closed")
+	reader := &closeTrackingReader{}
+	b := &infoFailingBPF{reader: reader, infoErr: infoErr}
+
+	gotReader, err := attachAndEventPipe(t.Context(), b)
+
+	if !errors.Is(err, infoErr) {
+		t.Fatalf("attachAndEventPipe() error = %v, want wrapped %v", err, infoErr)
+	}
+	if gotReader != nil {
+		t.Fatalf("attachAndEventPipe() reader = %v, want nil", gotReader)
+	}
+	if reader.closeCalls != 1 {
+		t.Fatalf("reader Close() calls = %d, want 1", reader.closeCalls)
+	}
+	if b.attachCalls != 0 {
+		t.Fatalf("AttachWithOptions() calls = %d, want 0", b.attachCalls)
+	}
+}


### PR DESCRIPTION
## What changed

- check the error returned by `b.Info()` before reading `ProgramsInfo`
- return that cause with operation context
- add a regression test that verifies the previously created perf reader is closed and program attachment is not attempted

## Why

`attachAndEventPipe` creates its perf reader before loading BPF metadata. If the BPF object closes between those operations, `Info()` can return `(nil, bpf.ErrClosed)`. Ignoring that error caused a nil dereference and also bypassed the existing reader-cleanup defer because no named error had been set.

The error now follows the same cleanup path as later attach failures, so callers receive the original cause and the reader is not leaked.

## Verification

- `goimports -w -local huatuo-bamai cmd/iotracing/bpf_attach.go cmd/iotracing/bpf_attach_test.go`
- `gofumpt -w cmd/iotracing/bpf_attach.go cmd/iotracing/bpf_attach_test.go`
- `git diff --check`
- `go test ./cmd/iotracing` — blocked before test execution because this checkout does not contain the generated `internal/bpf/abi` package
- `golangci-lint run ./cmd/iotracing --timeout=5m` — blocked by the same missing generated package
- `make check` — unavailable in the Windows environment because GNU Make is not installed

Fixes #611
