### PR TITLE
fix(ci): skip web sync for fork pull requests

### DIFF
--- a/.github/workflows/sync-web-on-change.yml
+++ b/.github/workflows/sync-web-on-change.yml
@@ -19,6 +19,9 @@ on:
 
 jobs:
   sync:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: checkout huatuo


### PR DESCRIPTION
## Summary

- skip the web sync job for pull requests from forks
- avoid checkout failures when repository secrets are unavailable

## Independence

PR 0 of 6. This change is completely independent and can merge immediately.
The remaining profiling PRs do not depend on it.

## Validation

- workflow YAML syntax parsed successfully
- branch contains one commit and one workflow file

Split from #463.