### PR TITLE
feat(profiler): persist multidimensional profile labels

### DIFF
--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -17,6 +17,9 @@ package aggregator
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"huatuo-bamai/core/autotracing"
@@ -37,6 +40,7 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	if !ok {
 		return fmt.Errorf("invalid pprof data for uploading: %T", data)
 	}
+	setProfileCollectionLabels(flameData, p.pctx)
 
 	tracerData := &profctx.TracerData{
 		MetricData: newMetrics(int(p.overflowCount.Load())),
@@ -60,4 +64,71 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	log.WithField("tracer_id", p.tracerID).Infof("profiling event sent via toolstream")
 
 	return nil
+}
+
+func setProfileCollectionLabels(
+	data *profiler.ProfileData,
+	pctx *profctx.ProfilerContext,
+) {
+	if data.Labels == nil {
+		data.Labels = make(map[string]string)
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		delete(data.Labels, name)
+	}
+	for name, value := range profileCollectionLabels(pctx) {
+		data.Labels[name] = value
+	}
+}
+
+func profileCollectionLabels(pctx *profctx.ProfilerContext) map[string]string {
+	labels := map[string]string{
+		profiler.LabelProfilingScope: profileCollectionScope(pctx),
+	}
+	if cpu := formatProfileLabelIDs(pctx.CPUIDs); cpu != "" {
+		labels[profiler.LabelCPU] = cpu
+	}
+	if pctx.ThreadGroup {
+		if tgid := formatProfileLabelIDs(pctx.PIDs); tgid != "" {
+			labels[profiler.LabelTGID] = tgid
+		}
+	} else if pid := formatProfileLabelIDs(pctx.PIDs); pid != "" {
+		labels[profiler.LabelPID] = pid
+	}
+	if pctx.ContainerID != "" {
+		labels[profiler.LabelContainerID] = pctx.ContainerID
+	}
+	return labels
+}
+
+func profileCollectionScope(pctx *profctx.ProfilerContext) string {
+	switch {
+	case pctx.ContainerID != "":
+		return "container"
+	case pctx.ThreadGroup:
+		return "thread_group"
+	case len(pctx.PIDs) != 0:
+		return "pid"
+	case len(pctx.CPUIDs) != 0:
+		return "cpu"
+	default:
+		return "host"
+	}
+}
+
+func formatProfileLabelIDs(ids []int) string {
+	if len(ids) == 0 {
+		return ""
+	}
+
+	sorted := append([]int(nil), ids...)
+	sort.Ints(sorted)
+	values := make([]string, 0, len(sorted))
+	for index, id := range sorted {
+		if index > 0 && id == sorted[index-1] {
+			continue
+		}
+		values = append(values, strconv.Itoa(id))
+	}
+	return strings.Join(values, ",")
 }

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -105,7 +105,7 @@ func profileCollectionScope(pctx *profctx.ProfilerContext) string {
 	switch {
 	case pctx.ContainerID != "":
 		return "container"
-	case pctx.ThreadGroup:
+	case pctx.ThreadGroup && len(pctx.PIDs) != 0:
 		return "thread_group"
 	case len(pctx.PIDs) != 0:
 		return "pid"

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -71,6 +71,24 @@ func TestProfileCollectionLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "thread group without PID falls back to host",
+			pctx: &profctx.ProfilerContext{ThreadGroup: true},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "host",
+			},
+		},
+		{
+			name: "thread group without PID preserves CPU scope",
+			pctx: &profctx.ProfilerContext{
+				CPUIDs:      []int{6, 2, 6},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "cpu",
+				profiler.LabelCPU:            "2,6",
+			},
+		},
+		{
 			name: "container takes scope precedence",
 			pctx: &profctx.ProfilerContext{
 				ContainerID: "container-a",

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/toolstream"
+)
+
+func TestProfileCollectionLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		pctx *profctx.ProfilerContext
+		want map[string]string
+	}{
+		{
+			name: "host",
+			pctx: &profctx.ProfilerContext{},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "host",
+			},
+		},
+		{
+			name: "CPU",
+			pctx: &profctx.ProfilerContext{CPUIDs: []int{6, 2, 6}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "cpu",
+				profiler.LabelCPU:            "2,6",
+			},
+		},
+		{
+			name: "PID with CPU restriction",
+			pctx: &profctx.ProfilerContext{
+				PIDs:   []int{42, 7, 42},
+				CPUIDs: []int{5, 3},
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "pid",
+				profiler.LabelCPU:            "3,5",
+				profiler.LabelPID:            "7,42",
+			},
+		},
+		{
+			name: "thread group uses TGID",
+			pctx: &profctx.ProfilerContext{
+				PIDs:        []int{42, 7},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "thread_group",
+				profiler.LabelTGID:           "7,42",
+			},
+		},
+		{
+			name: "container takes scope precedence",
+			pctx: &profctx.ProfilerContext{
+				ContainerID: "container-a",
+				PIDs:        []int{42, 7},
+				CPUIDs:      []int{5, 3},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "container",
+				profiler.LabelContainerID:    "container-a",
+				profiler.LabelCPU:            "3,5",
+				profiler.LabelTGID:           "7,42",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := profileCollectionLabels(test.pctx)
+			if !maps.Equal(got, test.want) {
+				t.Fatalf("profileCollectionLabels() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSetProfileCollectionLabelsRebuildsManagedDimensions(t *testing.T) {
+	data := &profiler.ProfileData{Labels: map[string]string{
+		"custom":                     "retained",
+		profiler.LabelProfilingScope: "stale",
+		profiler.LabelCPU:            "stale",
+		profiler.LabelPID:            "stale",
+		profiler.LabelTGID:           "stale",
+		profiler.LabelContainerID:    "stale",
+	}}
+	pids := []int{42, 7, 42}
+	cpus := []int{6, 2, 6}
+	pctx := &profctx.ProfilerContext{
+		PIDs:        pids,
+		CPUIDs:      cpus,
+		ThreadGroup: true,
+	}
+
+	setProfileCollectionLabels(data, pctx)
+
+	want := map[string]string{
+		"custom":                     "retained",
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelCPU:            "2,6",
+		profiler.LabelTGID:           "7,42",
+	}
+	if !maps.Equal(data.Labels, want) {
+		t.Fatalf("ProfileData.Labels = %v, want %v", data.Labels, want)
+	}
+	if !slices.Equal(pctx.PIDs, []int{42, 7, 42}) ||
+		!slices.Equal(pctx.CPUIDs, []int{6, 2, 6}) {
+		t.Fatalf("context ID order mutated: PIDs=%v CPUIDs=%v", pctx.PIDs, pctx.CPUIDs)
+	}
+}
+
+type savedProfileEvent struct {
+	TracerData struct {
+		FlameData *profiler.ProfileData `json:"flamedata"`
+	} `json:"tracer_data"`
+}
+
+func TestSaveProfilingDocumentInjectsLabelsAtUploadBoundary(t *testing.T) {
+	sockPath := t.TempDir() + "/toolstream.sock"
+	server, err := toolstream.NewServer(sockPath)
+	if err != nil {
+		t.Fatalf("toolstream.NewServer() error = %v", err)
+	}
+	received := make(chan *savedProfileEvent, 1)
+	toolstream.Register(
+		server,
+		profilerTracerName,
+		func(_ *toolstream.Session, event *savedProfileEvent) error {
+			received <- event
+			return nil
+		},
+	)
+	if err := server.Start(); err != nil {
+		t.Fatalf("toolstream server start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	client, err := toolstream.NewClient(toolstream.ClientOptions{
+		SockPath: sockPath,
+		ToolName: profilerTracerName,
+		Version:  "1",
+		TaskID:   "trace-a",
+	})
+	if err != nil {
+		t.Fatalf("toolstream.NewClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	pctx := &profctx.ProfilerContext{
+		PIDs:             []int{42, 7},
+		CPUIDs:           []int{6, 2},
+		ThreadGroup:      true,
+		ToolstreamClient: client,
+	}
+	pipeline := &Pipeline{pctx: pctx, tracerID: "trace-a"}
+	data := &profiler.ProfileData{Labels: map[string]string{"custom": "retained"}}
+	if err := pipeline.saveProfilingDocument(context.Background(), data); err != nil {
+		t.Fatalf("saveProfilingDocument() error = %v", err)
+	}
+
+	select {
+	case event := <-received:
+		want := map[string]string{
+			"custom":                     "retained",
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelCPU:            "2,6",
+			profiler.LabelTGID:           "7,42",
+		}
+		if event == nil || event.TracerData.FlameData == nil {
+			t.Fatal("received profile event without flame data")
+		}
+		if got := event.TracerData.FlameData.Labels; !maps.Equal(got, want) {
+			t.Fatalf("uploaded labels = %v, want %v", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for uploaded profile event")
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var collectionDimensionLabels = [...]string{
+	LabelProfilingScope,
+	LabelCPU,
+	LabelPID,
+	LabelTGID,
+	LabelContainerID,
+}
+
+// CollectionDimensionLabelNames returns labels managed by collection filters.
+func CollectionDimensionLabelNames() []string {
+	names := make([]string, len(collectionDimensionLabels))
+	copy(names, collectionDimensionLabels[:])
+	return names
+}
+
+// IsCollectionDimensionLabel reports whether name is a supported display dimension.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import "testing"
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	names := CollectionDimensionLabelNames()
+	names[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}
+
+func TestIsCollectionDimensionLabel(t *testing.T) {
+	for _, name := range CollectionDimensionLabelNames() {
+		if !IsCollectionDimensionLabel(name) {
+			t.Errorf("IsCollectionDimensionLabel(%q) = false", name)
+		}
+	}
+	if IsCollectionDimensionLabel("arbitrary") {
+		t.Fatal("IsCollectionDimensionLabel(arbitrary) = true")
+	}
+}

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels expose indexed dimensions to profile display backends.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends


### PR DESCRIPTION
## Summary

- define managed profiling dimensions for scope, CPU, PID, TGID, and container ID
- derive labels once at the common profile upload boundary
- rebuild managed labels from collector context while preserving custom labels
- cover host, CPU, process, thread-group, and container collection paths

## Standalone behavior

PR 1 of 6. This PR is independent and safe to merge by itself. Once merged,
new profile documents persist multidimensional labels while all existing query
and raw-profile APIs continue to work unchanged. It intentionally adds no new
dashboard or query endpoint.

## Dependencies

None. PR 1 and PR 2 can be reviewed, tested, and merged in either order.

## Validation

- go test ./internal/profiler -count=1
- Linux Go 1.24: go test ./internal/profiler/aggregator -count=1
- git diff --check

Split from #463.