### PR TITLE
fix(storage): add stable profile cursor pagination

### DIFF
--- a/build/migrate-profile-storage-id.sh
+++ b/build/migrate-profile-storage-id.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 usage() {
-	cat <<'EOF'
+	cat << 'EOF'
 Usage: migrate-profile-storage-id.sh [--check]
 
 Environment:
@@ -44,11 +44,11 @@ case "${1:-}" in
 	;;
 esac
 
-command -v curl >/dev/null || {
+command -v curl > /dev/null || {
 	echo "curl is required" >&2
 	exit 1
 }
-command -v jq >/dev/null || {
+command -v jq > /dev/null || {
 	echo "jq is required" >&2
 	exit 1
 }
@@ -126,8 +126,8 @@ missing_sort_value_query='{
 index_mapping=$(curl "${curl_options[@]}" \
 	--request GET \
 	"${elasticsearch_url}/${elasticsearch_index}/_mapping")
-resolved_indices=$(jq -r 'keys[]' <<<"${index_mapping}")
-if [[ $(wc -l <<<"${resolved_indices}") -ne 1 || ${resolved_indices} != "${elasticsearch_index}" ]]; then
+resolved_indices=$(jq -r 'keys[]' <<< "${index_mapping}")
+if [[ $(wc -l <<< "${resolved_indices}") -ne 1 || ${resolved_indices} != "${elasticsearch_index}" ]]; then
 	echo "ELASTICSEARCH_INDEX must resolve to one physical index with the same name" >&2
 	echo "Resolved indices: ${resolved_indices//$'\n'/, }" >&2
 	exit 2
@@ -136,11 +136,11 @@ fi
 profile_storage_type=$(jq -r \
 	--arg index "${elasticsearch_index}" \
 	'.[$index].mappings.properties.profile_storage_id.type // ""' \
-	<<<"${index_mapping}")
+	<<< "${index_mapping}")
 profile_storage_keyword_type=$(jq -r \
 	--arg index "${elasticsearch_index}" \
 	'.[$index].mappings.properties.profile_storage_id.fields.keyword.type // ""' \
-	<<<"${index_mapping}")
+	<<< "${index_mapping}")
 
 ensure_profile_storage_mapping() {
 	if [[ ${profile_storage_keyword_type} == "keyword" ]]; then
@@ -168,7 +168,7 @@ ensure_profile_storage_mapping() {
 	curl "${curl_options[@]}" \
 		--request PUT \
 		--data-binary "${mapping}" \
-		"${elasticsearch_url}/${elasticsearch_index}/_mapping" >/dev/null
+		"${elasticsearch_url}/${elasticsearch_index}/_mapping" > /dev/null
 
 	local keyword_mapping
 	keyword_mapping=$(curl "${curl_options[@]}" \
@@ -177,7 +177,7 @@ ensure_profile_storage_mapping() {
 	if ! jq -e \
 		--arg index "${elasticsearch_index}" \
 		'.[$index].mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
-		>/dev/null <<<"${keyword_mapping}"; then
+		> /dev/null <<< "${keyword_mapping}"; then
 		echo "profile_storage_id.keyword mapping was not created" >&2
 		exit 1
 	fi
@@ -187,16 +187,16 @@ count_legacy_profiles() {
 	curl "${curl_options[@]}" \
 		--request POST \
 		--data-binary "${profile_query}" \
-		"${elasticsearch_url}/${elasticsearch_index}/_count" |
-		jq -er '.count'
+		"${elasticsearch_url}/${elasticsearch_index}/_count" \
+		| jq -er '.count'
 }
 
 count_missing_sort_values() {
 	curl "${curl_options[@]}" \
 		--request POST \
 		--data-binary "${missing_sort_value_query}" \
-		"${elasticsearch_url}/${elasticsearch_index}/_count" |
-		jq -er '.count'
+		"${elasticsearch_url}/${elasticsearch_index}/_count" \
+		| jq -er '.count'
 }
 
 pending=$(count_legacy_profiles)
@@ -242,12 +242,12 @@ if [[ ${missing_sort_values} -ne 0 ]]; then
       }
     }' \
 		"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
-	if ! jq -e '.failures | length == 0' >/dev/null <<<"${refresh_response}"; then
+	if ! jq -e '.failures | length == 0' > /dev/null <<< "${refresh_response}"; then
 		echo "profile storage ID sort refresh returned document failures" >&2
-		jq '.failures' <<<"${refresh_response}" >&2
+		jq '.failures' <<< "${refresh_response}" >&2
 		exit 1
 	fi
-	echo "Reindexed existing profile storage IDs: $(jq -er '.updated' <<<"${refresh_response}")"
+	echo "Reindexed existing profile storage IDs: $(jq -er '.updated' <<< "${refresh_response}")"
 fi
 
 if [[ ${pending} -eq 0 ]]; then
@@ -287,13 +287,13 @@ update_response=$(curl "${curl_options[@]}" \
   }' \
 	"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
 
-if ! jq -e '.failures | length == 0' >/dev/null <<<"${update_response}"; then
+if ! jq -e '.failures | length == 0' > /dev/null <<< "${update_response}"; then
 	echo "profile storage ID migration returned document failures" >&2
-	jq '.failures' <<<"${update_response}" >&2
+	jq '.failures' <<< "${update_response}" >&2
 	exit 1
 fi
 
-updated=$(jq -er '.updated' <<<"${update_response}")
+updated=$(jq -er '.updated' <<< "${update_response}")
 remaining=$(count_legacy_profiles)
 remaining_sort_values=$(count_missing_sort_values)
 echo "Updated profile documents: ${updated}"

--- a/build/migrate-profile-storage-id.sh
+++ b/build/migrate-profile-storage-id.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: migrate-profile-storage-id.sh [--check]
+
+Environment:
+  ELASTICSEARCH_URL       Elasticsearch/OpenSearch URL (default: http://127.0.0.1:9200)
+  ELASTICSEARCH_INDEX     Profile index (default: huatuo_bamai)
+  ELASTICSEARCH_USERNAME  Optional basic-auth username
+  ELASTICSEARCH_PASSWORD  Optional basic-auth password
+
+--check reports legacy document count and sortable mapping state without writes.
+EOF
+}
+
+mode="migrate"
+case "${1:-}" in
+"") ;;
+--check) mode="check" ;;
+-h | --help)
+	usage
+	exit 0
+	;;
+*)
+	usage >&2
+	exit 2
+	;;
+esac
+
+command -v curl >/dev/null || {
+	echo "curl is required" >&2
+	exit 1
+}
+command -v jq >/dev/null || {
+	echo "jq is required" >&2
+	exit 1
+}
+
+elasticsearch_url=${ELASTICSEARCH_URL:-http://127.0.0.1:9200}
+elasticsearch_url=${elasticsearch_url%/}
+elasticsearch_index=${ELASTICSEARCH_INDEX:-huatuo_bamai}
+elasticsearch_username=${ELASTICSEARCH_USERNAME:-}
+elasticsearch_password=${ELASTICSEARCH_PASSWORD:-}
+
+if [[ ! ${elasticsearch_index} =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+	echo "ELASTICSEARCH_INDEX must be one explicit lowercase index name" >&2
+	exit 2
+fi
+if [[ -n ${elasticsearch_password} && -z ${elasticsearch_username} ]]; then
+	echo "ELASTICSEARCH_USERNAME is required when ELASTICSEARCH_PASSWORD is set" >&2
+	exit 2
+fi
+
+curl_options=(
+	--fail-with-body
+	--silent
+	--show-error
+	--connect-timeout 5
+	--max-time 1800
+	--header "Content-Type: application/json"
+)
+if [[ -n ${elasticsearch_username} ]]; then
+	curl_options+=(--user "${elasticsearch_username}:${elasticsearch_password}")
+fi
+
+profile_query='{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "bool": {
+            "should": [
+              {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+              {"exists": {"field": "tracer_data.flamedata.profile"}}
+            ],
+            "minimum_should_match": 1
+          }
+        }
+      ],
+      "must_not": [
+        {"exists": {"field": "profile_storage_id"}}
+      ]
+    }
+  }
+}'
+
+missing_sort_value_query='{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "bool": {
+            "should": [
+              {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+              {"exists": {"field": "tracer_data.flamedata.profile"}}
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {"exists": {"field": "profile_storage_id"}}
+      ],
+      "must_not": [
+        {"exists": {"field": "profile_storage_id.keyword"}}
+      ]
+    }
+  }
+}'
+
+index_mapping=$(curl "${curl_options[@]}" \
+	--request GET \
+	"${elasticsearch_url}/${elasticsearch_index}/_mapping")
+resolved_indices=$(jq -r 'keys[]' <<<"${index_mapping}")
+if [[ $(wc -l <<<"${resolved_indices}") -ne 1 || ${resolved_indices} != "${elasticsearch_index}" ]]; then
+	echo "ELASTICSEARCH_INDEX must resolve to one physical index with the same name" >&2
+	echo "Resolved indices: ${resolved_indices//$'\n'/, }" >&2
+	exit 2
+fi
+
+profile_storage_type=$(jq -r \
+	--arg index "${elasticsearch_index}" \
+	'.[$index].mappings.properties.profile_storage_id.type // ""' \
+	<<<"${index_mapping}")
+profile_storage_keyword_type=$(jq -r \
+	--arg index "${elasticsearch_index}" \
+	'.[$index].mappings.properties.profile_storage_id.fields.keyword.type // ""' \
+	<<<"${index_mapping}")
+
+ensure_profile_storage_mapping() {
+	if [[ ${profile_storage_keyword_type} == "keyword" ]]; then
+		return
+	fi
+	if [[ -n ${profile_storage_keyword_type} ]]; then
+		echo "profile_storage_id.keyword must be mapped as keyword" >&2
+		exit 1
+	fi
+	if [[ -n ${profile_storage_type} && ${profile_storage_type} != "text" && ${profile_storage_type} != "keyword" ]]; then
+		echo "profile_storage_id must be text or keyword, got ${profile_storage_type}" >&2
+		exit 1
+	fi
+
+	local root_type=${profile_storage_type:-text}
+	local mapping
+	mapping=$(jq -cn --arg root_type "${root_type}" '{
+      properties: {
+        profile_storage_id: {
+          type: $root_type,
+          fields: {keyword: {type: "keyword", ignore_above: 256}}
+        }
+      }
+    }')
+	curl "${curl_options[@]}" \
+		--request PUT \
+		--data-binary "${mapping}" \
+		"${elasticsearch_url}/${elasticsearch_index}/_mapping" >/dev/null
+
+	local keyword_mapping
+	keyword_mapping=$(curl "${curl_options[@]}" \
+		--request GET \
+		"${elasticsearch_url}/${elasticsearch_index}/_mapping/field/profile_storage_id.keyword")
+	if ! jq -e \
+		--arg index "${elasticsearch_index}" \
+		'.[$index].mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
+		>/dev/null <<<"${keyword_mapping}"; then
+		echo "profile_storage_id.keyword mapping was not created" >&2
+		exit 1
+	fi
+}
+
+count_legacy_profiles() {
+	curl "${curl_options[@]}" \
+		--request POST \
+		--data-binary "${profile_query}" \
+		"${elasticsearch_url}/${elasticsearch_index}/_count" |
+		jq -er '.count'
+}
+
+count_missing_sort_values() {
+	curl "${curl_options[@]}" \
+		--request POST \
+		--data-binary "${missing_sort_value_query}" \
+		"${elasticsearch_url}/${elasticsearch_index}/_count" |
+		jq -er '.count'
+}
+
+pending=$(count_legacy_profiles)
+missing_sort_values=$(count_missing_sort_values)
+echo "Legacy profile documents without profile_storage_id: ${pending}"
+echo "Profile documents without profile_storage_id.keyword value: ${missing_sort_values}"
+if [[ ${mode} == "check" ]]; then
+	mapping_state=missing
+	if [[ ${profile_storage_keyword_type} == "keyword" ]]; then
+		mapping_state=present
+	fi
+	echo "profile_storage_id.keyword mapping: ${mapping_state}"
+	exit 0
+fi
+
+ensure_profile_storage_mapping
+if [[ ${missing_sort_values} -ne 0 ]]; then
+	refresh_response=$(curl "${curl_options[@]}" \
+		--request POST \
+		--data-binary '{
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": [
+                  {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+                  {"exists": {"field": "tracer_data.flamedata.profile"}}
+                ],
+                "minimum_should_match": 1
+              }
+            },
+            {"exists": {"field": "profile_storage_id"}}
+          ],
+          "must_not": [
+            {"exists": {"field": "profile_storage_id.keyword"}}
+          ]
+        }
+      },
+      "script": {
+        "lang": "painless",
+        "source": "ctx._source.profile_storage_id = ctx._source.profile_storage_id"
+      }
+    }' \
+		"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
+	if ! jq -e '.failures | length == 0' >/dev/null <<<"${refresh_response}"; then
+		echo "profile storage ID sort refresh returned document failures" >&2
+		jq '.failures' <<<"${refresh_response}" >&2
+		exit 1
+	fi
+	echo "Reindexed existing profile storage IDs: $(jq -er '.updated' <<<"${refresh_response}")"
+fi
+
+if [[ ${pending} -eq 0 ]]; then
+	remaining_sort_values=$(count_missing_sort_values)
+	if [[ ${remaining_sort_values} -ne 0 ]]; then
+		echo "Migration incomplete: ${remaining_sort_values} profile storage IDs remain unsortable" >&2
+		exit 1
+	fi
+	exit 0
+fi
+
+update_response=$(curl "${curl_options[@]}" \
+	--request POST \
+	--data-binary '{
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "bool": {
+              "should": [
+                {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+                {"exists": {"field": "tracer_data.flamedata.profile"}}
+              ],
+              "minimum_should_match": 1
+            }
+          }
+        ],
+        "must_not": [
+          {"exists": {"field": "profile_storage_id"}}
+        ]
+      }
+    },
+    "script": {
+      "lang": "painless",
+      "source": "ctx._source.profile_storage_id = ctx._id"
+    }
+  }' \
+	"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
+
+if ! jq -e '.failures | length == 0' >/dev/null <<<"${update_response}"; then
+	echo "profile storage ID migration returned document failures" >&2
+	jq '.failures' <<<"${update_response}" >&2
+	exit 1
+fi
+
+updated=$(jq -er '.updated' <<<"${update_response}")
+remaining=$(count_legacy_profiles)
+remaining_sort_values=$(count_missing_sort_values)
+echo "Updated profile documents: ${updated}"
+if [[ ${remaining} -ne 0 ]]; then
+	echo "Migration incomplete: ${remaining} legacy profile documents remain" >&2
+	exit 1
+fi
+if [[ ${remaining_sort_values} -ne 0 ]]; then
+	echo "Migration incomplete: ${remaining_sort_values} profile storage IDs remain unsortable" >&2
+	exit 1
+fi

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -383,6 +383,37 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
+### 10. Migrate Profiles Written Before `profile_storage_id`
+
+Profile documents written before this release do not contain the unique
+`profile_storage_id` sort key. Take an Elasticsearch/OpenSearch snapshot, then
+stop old huatuo-bamai writers that do not persist this field. Deploy the
+new writer and run the idempotent migration once for every physical profile
+index before using long window queries. Aliases and data streams are rejected:
+
+```bash
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh --check
+
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh
+```
+
+The script updates only profiling documents that lack the field and copies
+their existing Elasticsearch `_id`. Existing IDs and non-profiling documents
+are unchanged. It also creates or validates the sortable
+`profile_storage_id.keyword` mapping and reindexes existing IDs when that
+multi-field was added later. It fails if any matching legacy or unsortable
+documents remain, so rerunning it after an interrupted migration is safe. Run
+`--check` again after the old writers are stopped. `_update_by_query` consumes
+cluster I/O; run it during a low-traffic period for large indices.
+
 ## 📖 profiler CLI Overview
 
 `profiler` is HUATUO's standalone performance profiling CLI. It samples host processes or processes inside containers without requiring huatuo-apiserver, Elasticsearch, or Grafana. The tool supports C, C++, Go, Java, and Python processes and writes call stacks as folded stacks or SVG flame graphs.

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -385,6 +385,34 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
+### 10. 迁移缺少 `profile_storage_id` 的历史数据
+
+旧版本写入的 profile 文档没有唯一的 `profile_storage_id` 排序键。使用长时间
+窗口查询前，先为 Elasticsearch/OpenSearch 创建快照，停止仍不会写入该字段的
+旧版 huatuo-bamai，再部署新版 writer，并对每个物理 profile 索引执行一次
+幂等迁移。脚本会拒绝 alias 和 data stream：
+
+```bash
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh --check
+
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh
+```
+
+脚本只更新缺少该字段的 profile 文档，并复制其现有 Elasticsearch `_id`；
+已有 ID 和非 profile 文档不会变化，同时创建或校验可排序的
+`profile_storage_id.keyword` mapping；如果该 multi-field 是后加的，还会重索引
+已有 ID。如果仍存在未迁移或不可排序的文档，脚本会失败，因此中断后可安全
+重试。停止旧 writer 后应再次运行 `--check`。
+`_update_by_query` 会消耗集群 I/O，大索引应在低流量时段执行。
+
 ## 📖 profiler 命令行功能概述
 
 `profiler` 是 HUATUO 提供的独立性能剖析命令行工具。它可以直接对宿主机进程或容器内进程采样，不依赖 huatuo-apiserver、Elasticsearch 或 Grafana。工具支持 C、C++、Go、Java 和 Python 进程，并将调用栈输出为折叠栈或 SVG 火焰图。

--- a/integration/test_profiler_storage_elasticsearch.sh
+++ b/integration/test_profiler_storage_elasticsearch.sh
@@ -22,11 +22,11 @@ source "${ROOT_DIR}/integration/lib_storage.sh"
 # Bash cannot export arrays from the integration runner to this test process.
 CURL_TIMEOUT=(--connect-timeout 2 --max-time 3)
 
-command -v docker > /dev/null || skip "docker command is not installed"
-docker info > /dev/null 2>&1 || skip "docker daemon is unavailable"
-command -v curl > /dev/null || skip "curl command is not installed"
-command -v jq > /dev/null || skip "jq command is not installed"
-command -v go > /dev/null || fatal "go command is not installed"
+command -v docker >/dev/null || skip "docker command is not installed"
+docker info >/dev/null 2>&1 || skip "docker daemon is unavailable"
+command -v curl >/dev/null || skip "curl command is not installed"
+command -v jq >/dev/null || skip "jq command is not installed"
+command -v go >/dev/null || fatal "go command is not installed"
 
 cleanup() {
 	local status=$?
@@ -38,6 +38,124 @@ cleanup() {
 trap cleanup EXIT
 
 elasticsearch_start
+
+test_profile_storage_id_migration() {
+	local index="huatuo-profile-migration-test-${RANDOM}"
+	local alias="${index}-alias"
+	local alias_index="${index}-alias-target"
+	local document
+
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${index}" \
+		-d '{"mappings":{"properties":{"profile_storage_id":{"type":"keyword"}}}}' \
+		>/dev/null
+
+	for document in legacy-a legacy-b; do
+		curl -fsS "${CURL_TIMEOUT[@]}" \
+			-H "Content-Type: application/json" \
+			-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/${document}?refresh=true" \
+			-d "{
+				\"uploaded_time\":\"2026-08-16T02:00:00.000000001Z\",
+				\"tracer_id\":\"trace-shared\",
+				\"tracer_data\":{\"flamedata\":{\"profile\":{\"time_nanos\":1}}}
+			}" >/dev/null
+	done
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/current?refresh=true" \
+		-d '{
+			"profile_storage_id":"preserved-current-id",
+			"tracer_data":{"flamedata":{"profile_type":"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}}
+		}' >/dev/null
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile?refresh=true" \
+		-d '{"tracer_data":{"flamedata":{"cpusys":18}}}' >/dev/null
+	local check_run checked_id
+	check_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${index}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" --check)
+	grep -q 'without profile_storage_id: 2' <<<"${check_run}" ||
+		fatal "profile storage ID check did not report legacy documents"
+	grep -q 'profile_storage_id.keyword mapping: missing' <<<"${check_run}" ||
+		fatal "profile storage ID check did not report the missing mapping"
+	grep -q 'without profile_storage_id.keyword value: 1' <<<"${check_run}" ||
+		fatal "profile storage ID check did not report unsortable current IDs"
+	checked_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/legacy-a" |
+		jq -r '._source.profile_storage_id // "missing"')
+	assert_eq "${checked_id}" "missing" \
+		"check mode does not update profile documents" ||
+		fatal "profile storage ID check changed a document"
+
+	ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${index}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh"
+
+	for document in legacy-a legacy-b; do
+		local migrated_id
+		migrated_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+			"${ELASTICSEARCH_ADDR}/${index}/_doc/${document}" |
+			jq -er '._source.profile_storage_id')
+		assert_eq "${migrated_id}" "${document}" \
+			"legacy profile_storage_id uses Elasticsearch _id" ||
+			fatal "legacy profile storage ID migration failed"
+	done
+
+	local current_id non_profile_id
+	current_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/current" |
+		jq -er '._source.profile_storage_id')
+	assert_eq "${current_id}" "preserved-current-id" \
+		"current profile_storage_id is preserved" ||
+		fatal "current profile storage ID changed"
+	local current_sort
+	current_sort=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X POST "${ELASTICSEARCH_ADDR}/${index}/_search" \
+		-d '{"query":{"ids":{"values":["current"]}},"sort":["profile_storage_id.keyword"]}' |
+		jq -er '.hits.hits[0].sort[0]')
+	assert_eq "${current_sort}" "preserved-current-id" \
+		"current profile_storage_id is backfilled into the sort field" ||
+		fatal "current profile storage ID is not sortable"
+	non_profile_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile" |
+		jq -r '._source.profile_storage_id // "missing"')
+	assert_eq "${non_profile_id}" "missing" \
+		"non-profile document is not migrated" ||
+		fatal "non-profile document was changed"
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_mapping/field/profile_storage_id.keyword" |
+		jq -e 'to_entries[0].value.mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
+			>/dev/null ||
+		fatal "migrated profile_storage_id is not sortable as keyword"
+
+	local second_run
+	second_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${index}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh")
+	grep -q 'without profile_storage_id: 0' <<<"${second_run}" ||
+		fatal "profile storage ID migration is not idempotent"
+
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${alias_index}" >/dev/null
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X POST "${ELASTICSEARCH_ADDR}/_aliases" \
+		-d "{\"actions\":[{\"add\":{\"index\":\"${index}\",\"alias\":\"${alias}\"}},{\"add\":{\"index\":\"${alias_index}\",\"alias\":\"${alias}\"}}]}" \
+		>/dev/null
+	if ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${alias}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" >/dev/null 2>&1; then
+		fatal "profile storage ID migration accepted a multi-index alias"
+	fi
+
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-X DELETE "${ELASTICSEARCH_ADDR}/${index},${alias_index}" >/dev/null
+}
+
+test_profile_storage_id_migration
 
 HUATUO_ES_TEST_ADDR="${ELASTICSEARCH_ADDR}" \
 	go test ./internal/profiler/service \

--- a/integration/test_profiler_storage_elasticsearch.sh
+++ b/integration/test_profiler_storage_elasticsearch.sh
@@ -22,11 +22,11 @@ source "${ROOT_DIR}/integration/lib_storage.sh"
 # Bash cannot export arrays from the integration runner to this test process.
 CURL_TIMEOUT=(--connect-timeout 2 --max-time 3)
 
-command -v docker >/dev/null || skip "docker command is not installed"
-docker info >/dev/null 2>&1 || skip "docker daemon is unavailable"
-command -v curl >/dev/null || skip "curl command is not installed"
-command -v jq >/dev/null || skip "jq command is not installed"
-command -v go >/dev/null || fatal "go command is not installed"
+command -v docker > /dev/null || skip "docker command is not installed"
+docker info > /dev/null 2>&1 || skip "docker daemon is unavailable"
+command -v curl > /dev/null || skip "curl command is not installed"
+command -v jq > /dev/null || skip "jq command is not installed"
+command -v go > /dev/null || fatal "go command is not installed"
 
 cleanup() {
 	local status=$?
@@ -49,7 +49,7 @@ test_profile_storage_id_migration() {
 		-H "Content-Type: application/json" \
 		-X PUT "${ELASTICSEARCH_ADDR}/${index}" \
 		-d '{"mappings":{"properties":{"profile_storage_id":{"type":"keyword"}}}}' \
-		>/dev/null
+		> /dev/null
 
 	for document in legacy-a legacy-b; do
 		curl -fsS "${CURL_TIMEOUT[@]}" \
@@ -59,7 +59,7 @@ test_profile_storage_id_migration() {
 				\"uploaded_time\":\"2026-08-16T02:00:00.000000001Z\",
 				\"tracer_id\":\"trace-shared\",
 				\"tracer_data\":{\"flamedata\":{\"profile\":{\"time_nanos\":1}}}
-			}" >/dev/null
+			}" > /dev/null
 	done
 	curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
@@ -67,27 +67,27 @@ test_profile_storage_id_migration() {
 		-d '{
 			"profile_storage_id":"preserved-current-id",
 			"tracer_data":{"flamedata":{"profile_type":"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}}
-		}' >/dev/null
+		}' > /dev/null
 	curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
 		-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile?refresh=true" \
-		-d '{"tracer_data":{"flamedata":{"cpusys":18}}}' >/dev/null
+		-d '{"tracer_data":{"flamedata":{"cpusys":18}}}' > /dev/null
 	local check_run checked_id
 	check_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${index}" \
 		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" --check)
-	grep -q 'without profile_storage_id: 2' <<<"${check_run}" ||
-		fatal "profile storage ID check did not report legacy documents"
-	grep -q 'profile_storage_id.keyword mapping: missing' <<<"${check_run}" ||
-		fatal "profile storage ID check did not report the missing mapping"
-	grep -q 'without profile_storage_id.keyword value: 1' <<<"${check_run}" ||
-		fatal "profile storage ID check did not report unsortable current IDs"
+	grep -q 'without profile_storage_id: 2' <<< "${check_run}" \
+		|| fatal "profile storage ID check did not report legacy documents"
+	grep -q 'profile_storage_id.keyword mapping: missing' <<< "${check_run}" \
+		|| fatal "profile storage ID check did not report the missing mapping"
+	grep -q 'without profile_storage_id.keyword value: 1' <<< "${check_run}" \
+		|| fatal "profile storage ID check did not report unsortable current IDs"
 	checked_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_doc/legacy-a" |
-		jq -r '._source.profile_storage_id // "missing"')
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/legacy-a" \
+		| jq -r '._source.profile_storage_id // "missing"')
 	assert_eq "${checked_id}" "missing" \
-		"check mode does not update profile documents" ||
-		fatal "profile storage ID check changed a document"
+		"check mode does not update profile documents" \
+		|| fatal "profile storage ID check changed a document"
 
 	ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${index}" \
@@ -96,63 +96,63 @@ test_profile_storage_id_migration() {
 	for document in legacy-a legacy-b; do
 		local migrated_id
 		migrated_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-			"${ELASTICSEARCH_ADDR}/${index}/_doc/${document}" |
-			jq -er '._source.profile_storage_id')
+			"${ELASTICSEARCH_ADDR}/${index}/_doc/${document}" \
+			| jq -er '._source.profile_storage_id')
 		assert_eq "${migrated_id}" "${document}" \
-			"legacy profile_storage_id uses Elasticsearch _id" ||
-			fatal "legacy profile storage ID migration failed"
+			"legacy profile_storage_id uses Elasticsearch _id" \
+			|| fatal "legacy profile storage ID migration failed"
 	done
 
 	local current_id non_profile_id
 	current_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_doc/current" |
-		jq -er '._source.profile_storage_id')
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/current" \
+		| jq -er '._source.profile_storage_id')
 	assert_eq "${current_id}" "preserved-current-id" \
-		"current profile_storage_id is preserved" ||
-		fatal "current profile storage ID changed"
+		"current profile_storage_id is preserved" \
+		|| fatal "current profile storage ID changed"
 	local current_sort
 	current_sort=$(curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
 		-X POST "${ELASTICSEARCH_ADDR}/${index}/_search" \
-		-d '{"query":{"ids":{"values":["current"]}},"sort":["profile_storage_id.keyword"]}' |
-		jq -er '.hits.hits[0].sort[0]')
+		-d '{"query":{"ids":{"values":["current"]}},"sort":["profile_storage_id.keyword"]}' \
+		| jq -er '.hits.hits[0].sort[0]')
 	assert_eq "${current_sort}" "preserved-current-id" \
-		"current profile_storage_id is backfilled into the sort field" ||
-		fatal "current profile storage ID is not sortable"
+		"current profile_storage_id is backfilled into the sort field" \
+		|| fatal "current profile storage ID is not sortable"
 	non_profile_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile" |
-		jq -r '._source.profile_storage_id // "missing"')
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile" \
+		| jq -r '._source.profile_storage_id // "missing"')
 	assert_eq "${non_profile_id}" "missing" \
-		"non-profile document is not migrated" ||
-		fatal "non-profile document was changed"
+		"non-profile document is not migrated" \
+		|| fatal "non-profile document was changed"
 	curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_mapping/field/profile_storage_id.keyword" |
-		jq -e 'to_entries[0].value.mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
-			>/dev/null ||
-		fatal "migrated profile_storage_id is not sortable as keyword"
+		"${ELASTICSEARCH_ADDR}/${index}/_mapping/field/profile_storage_id.keyword" \
+		| jq -e 'to_entries[0].value.mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
+			> /dev/null \
+		|| fatal "migrated profile_storage_id is not sortable as keyword"
 
 	local second_run
 	second_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${index}" \
 		"${ROOT_DIR}/build/migrate-profile-storage-id.sh")
-	grep -q 'without profile_storage_id: 0' <<<"${second_run}" ||
-		fatal "profile storage ID migration is not idempotent"
+	grep -q 'without profile_storage_id: 0' <<< "${second_run}" \
+		|| fatal "profile storage ID migration is not idempotent"
 
 	curl -fsS "${CURL_TIMEOUT[@]}" \
-		-X PUT "${ELASTICSEARCH_ADDR}/${alias_index}" >/dev/null
+		-X PUT "${ELASTICSEARCH_ADDR}/${alias_index}" > /dev/null
 	curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
 		-X POST "${ELASTICSEARCH_ADDR}/_aliases" \
 		-d "{\"actions\":[{\"add\":{\"index\":\"${index}\",\"alias\":\"${alias}\"}},{\"add\":{\"index\":\"${alias_index}\",\"alias\":\"${alias}\"}}]}" \
-		>/dev/null
+		> /dev/null
 	if ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${alias}" \
-		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" >/dev/null 2>&1; then
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" > /dev/null 2>&1; then
 		fatal "profile storage ID migration accepted a multi-index alias"
 	fi
 
 	curl -fsS "${CURL_TIMEOUT[@]}" \
-		-X DELETE "${ELASTICSEARCH_ADDR}/${index},${alias_index}" >/dev/null
+		-X DELETE "${ELASTICSEARCH_ADDR}/${index},${alias_index}" > /dev/null
 }
 
 test_profile_storage_id_migration

--- a/integration/test_profiler_storage_elasticsearch.sh
+++ b/integration/test_profiler_storage_elasticsearch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+source "${ROOT_DIR}/integration/lib_storage.sh"
+
+# Bash cannot export arrays from the integration runner to this test process.
+CURL_TIMEOUT=(--connect-timeout 2 --max-time 3)
+
+command -v docker > /dev/null || skip "docker command is not installed"
+docker info > /dev/null 2>&1 || skip "docker daemon is unavailable"
+command -v curl > /dev/null || skip "curl command is not installed"
+command -v jq > /dev/null || skip "jq command is not installed"
+command -v go > /dev/null || fatal "go command is not installed"
+
+cleanup() {
+	local status=$?
+	if [[ ${status} -ne 0 ]]; then
+		elasticsearch_dump_logs || true
+	fi
+	elasticsearch_stop || true
+}
+trap cleanup EXIT
+
+elasticsearch_start
+
+HUATUO_ES_TEST_ADDR="${ELASTICSEARCH_ADDR}" \
+	go test ./internal/profiler/service \
+	-run '^TestProfileStorageSearchProfilesElasticsearch$' -count=1

--- a/internal/job/storage_store.go
+++ b/internal/job/storage_store.go
@@ -250,7 +250,7 @@ func (storeMapper) Indexes() []driver.Index {
 	return indexes
 }
 
-func toStorageQuery(q *JobQuery) driver.Query {
+func toStorageQuery(q *JobQuery) *driver.Query {
 	if q == nil {
 		q = &JobQuery{}
 	}
@@ -298,7 +298,7 @@ func toStorageQuery(q *JobQuery) driver.Query {
 		field = field[1:]
 	}
 	query.Sorts = []driver.Sort{{Field: field, Desc: desc}, {Field: "id", Desc: desc}}
-	return query
+	return &query
 }
 
 func cloneJob(entity *Job) *Job {

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -149,7 +149,7 @@ func (s *ProfileStorage) Ready(ctx context.Context) error {
 	if s == nil || s.store == nil {
 		return errors.New("profile storage is not initialized")
 	}
-	if _, err := s.store.Count(ctx, driver.Query{Limit: 1}); err != nil {
+	if _, err := s.store.Count(ctx, &driver.Query{Limit: 1}); err != nil {
 		return fmt.Errorf("profile storage readiness: %w", err)
 	}
 	return nil
@@ -179,7 +179,7 @@ func (s *ProfileStorage) SearchProfilesPageContext(
 	query := buildProfileSearchQuery(filter)
 	query.SearchAfter = cursor
 
-	documents, nextCursor, err := s.store.QueryPage(ctx, query)
+	documents, nextCursor, err := s.store.QueryPage(ctx, &query)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,10 +203,11 @@ func (s *ProfileStorage) AggregationsByFieldContext(ctx context.Context, filter 
 		return nil, err
 	}
 
+	query := buildProfileAggregationQuery(filter)
 	terms, err := s.store.Values(
 		ctx,
 		normalizedField,
-		buildProfileAggregationQuery(filter),
+		&query,
 		normalizeProfileSearchLimit(filter),
 	)
 	if err != nil {

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -37,6 +37,7 @@ const (
 	profileFieldRegion            = "region"
 	profileFieldUploadedTime      = "uploaded_time"
 	profileFieldTime              = "time"
+	profileFieldStorageID         = "profile_storage_id"
 	profileFieldContainerID       = "container_id"
 	profileFieldContainerHostname = "container_hostname"
 	profileFieldContainerHostNS   = "container_host_namespace"
@@ -53,9 +54,10 @@ const (
 
 // ProfileDocument defines the document structure used in profiling storage.
 type ProfileDocument struct {
-	Hostname     string    `json:"hostname"`
-	Region       string    `json:"region"`
-	UploadedTime time.Time `json:"uploaded_time"`
+	Hostname         string    `json:"hostname"`
+	Region           string    `json:"region"`
+	UploadedTime     time.Time `json:"uploaded_time"`
+	ProfileStorageID string    `json:"profile_storage_id,omitempty"`
 	// equal to `TracerTime`, supported the old version.
 	Time string `json:"time"`
 
@@ -160,17 +162,29 @@ func (s *ProfileStorage) SearchProfiles(filter *SearchFilter) ([]*ProfileDocumen
 
 // SearchProfilesContext searches profiles with caller-owned cancellation.
 func (s *ProfileStorage) SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error) {
+	documents, _, err := s.SearchProfilesPageContext(ctx, filter, nil)
+	return documents, err
+}
+
+// SearchProfilesPageContext searches one page and returns the backend cursor
+// needed to continue without relying on Elasticsearch's bounded offset window.
+func (s *ProfileStorage) SearchProfilesPageContext(
+	ctx context.Context,
+	filter *SearchFilter,
+	cursor []any,
+) ([]*ProfileDocument, []any, error) {
 	if s == nil || s.store == nil {
-		return nil, errors.New("profile storage is not initialized")
+		return nil, nil, errors.New("profile storage is not initialized")
 	}
 	query := buildProfileSearchQuery(filter)
+	query.SearchAfter = cursor
 
-	documents, err := s.store.Query(ctx, query)
+	documents, nextCursor, err := s.store.QueryPage(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return documents, nil
+	return documents, nextCursor, nil
 }
 
 // AggregationsByField gets aggregations by field.
@@ -203,6 +217,10 @@ func (s *ProfileStorage) AggregationsByFieldContext(ctx context.Context, filter 
 }
 
 func (profileDocumentMapper) ID(document *ProfileDocument) string {
+	if document.ProfileStorageID != "" {
+		return document.ProfileStorageID
+	}
+	// Legacy documents predate profile_storage_id and used tracer_id as their ID.
 	return document.TracerID
 }
 
@@ -224,6 +242,7 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
+		profileFieldStorageID:         document.ProfileStorageID,
 		profileFieldTime:              parseProfileDocumentTime(document.Time, document.UploadedTime),
 		profileFieldContainerID:       document.ContainerID,
 		profileFieldContainerHostname: document.ContainerHostname,
@@ -244,6 +263,7 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
 		{Field: profileFieldUploadedTime},
+		{Field: profileFieldStorageID},
 		{Field: profileFieldTime},
 		{Field: profileFieldContainerID},
 		{Field: profileFieldContainerHostname},
@@ -265,6 +285,10 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	}
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID + ".keyword"},
+		// Older documents lack this field; migrating them or using PIT is required
+		// to make timestamp collisions strictly ordered across historical data.
+		{Field: profileFieldStorageID + ".keyword"},
 	}
 	return query
 }
@@ -354,8 +378,8 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 
 func normalizeProfileAggregationField(field string) (string, error) {
 	switch field {
-	case "id":
-		return profileFieldTracerID, nil
+	case "id", "tracer":
+		return profileFieldTracerID + ".keyword", nil
 	case profileFieldRegion,
 		profileFieldHostname,
 		profileFieldContainerHostname,
@@ -367,7 +391,7 @@ func normalizeProfileAggregationField(field string) (string, error) {
 		profileFieldTracerID,
 		profileFieldTracerType,
 		profileFieldProfileType:
-		return field, nil
+		return field + ".keyword", nil
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -286,8 +286,8 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
 		{Field: profileFieldTracerID + ".keyword"},
-		// Older documents lack this field; migrating them or using PIT is required
-		// to make timestamp collisions strictly ordered across historical data.
+		// The migration script copies legacy Elasticsearch _id values into this
+		// field so historical timestamp collisions remain strictly ordered.
 		{Field: profileFieldStorageID + ".keyword"},
 	}
 	return query

--- a/internal/profiler/service/storage_integration_test.go
+++ b/internal/profiler/service/storage_integration_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const elasticsearchIntegrationAddressEnv = "HUATUO_ES_TEST_ADDR"
+
+func TestProfileStorageSearchProfilesElasticsearch(t *testing.T) {
+	address := strings.TrimRight(os.Getenv(elasticsearchIntegrationAddressEnv), "/")
+	if address == "" {
+		t.Skipf("set %s to run the Elasticsearch integration test", elasticsearchIntegrationAddressEnv)
+	}
+
+	index := fmt.Sprintf("huatuo-profile-storage-test-%d", time.Now().UnixNano())
+	storage, err := NewProfileStorageContext(t.Context(), address, "", "", index)
+	if err != nil {
+		t.Fatalf("NewProfileStorageContext() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := storage.Close(context.Background()); closeErr != nil {
+			t.Errorf("close profile storage: %v", closeErr)
+		}
+	})
+	t.Cleanup(func() {
+		requestElasticsearch(t, context.Background(), http.MethodDelete, address+"/"+index, nil)
+	})
+
+	documents := []struct {
+		storageID  string
+		tracerID   string
+		capturedAt string
+	}{
+		{storageID: "window-a", tracerID: "trace-old", capturedAt: "2026-08-16T01:00:00.000000001Z"},
+		{storageID: "window-b", tracerID: "trace-shared", capturedAt: "2026-08-16T02:00:00.000000001Z"},
+		{storageID: "window-c", tracerID: "trace-shared", capturedAt: "2026-08-16T02:00:00.000000001Z"},
+		{storageID: "window-d", tracerID: "trace-new", capturedAt: "2026-08-16T03:00:00.000000001Z"},
+	}
+	for _, document := range documents {
+		body := fmt.Appendf(nil, `{
+			"hostname":"node-1",
+			"region":"integration",
+			"profile_storage_id":%q,
+			"uploaded_time":%q,
+			"tracer_id":%q,
+			"tracer_time":%q
+		}`, document.storageID, document.capturedAt, document.tracerID, document.capturedAt)
+		requestElasticsearch(
+			t,
+			t.Context(),
+			http.MethodPut,
+			fmt.Sprintf("%s/%s/_doc/%s?refresh=true", address, index, document.storageID),
+			body,
+		)
+	}
+	for _, field := range []string{"id", "tracer"} {
+		values, err := storage.AggregationsByFieldContext(
+			t.Context(),
+			&SearchFilter{Hostname: "node-1", Limit: 10},
+			field,
+		)
+		if err != nil {
+			t.Fatalf("AggregationsByFieldContext(%q) error = %v", field, err)
+		}
+		slices.Sort(values)
+		want := []string{"trace-new", "trace-old", "trace-shared"}
+		if !slices.Equal(values, want) {
+			t.Errorf("AggregationsByFieldContext(%q) = %#v, want %#v", field, values, want)
+		}
+	}
+
+	filter := &SearchFilter{Hostname: "node-1", Limit: 2}
+	firstPage, cursor, err := storage.SearchProfilesPageContext(t.Context(), filter, nil)
+	if err != nil {
+		t.Fatalf("first SearchProfilesPageContext() error = %v", err)
+	}
+	assertProfileOrder(t, firstPage, "trace-new/window-d", "trace-shared/window-b")
+	if len(cursor) != 3 {
+		t.Fatalf("first cursor = %#v, want three sort values", cursor)
+	}
+
+	secondPage, cursor, err := storage.SearchProfilesPageContext(t.Context(), filter, cursor)
+	if err != nil {
+		t.Fatalf("second SearchProfilesPageContext() error = %v", err)
+	}
+	assertProfileOrder(t, secondPage, "trace-shared/window-c", "trace-old/window-a")
+	if len(cursor) != 3 {
+		t.Fatalf("second cursor = %#v, want three sort values", cursor)
+	}
+
+	lastPage, cursor, err := storage.SearchProfilesPageContext(t.Context(), filter, cursor)
+	if err != nil {
+		t.Fatalf("last SearchProfilesPageContext() error = %v", err)
+	}
+	assertProfileOrder(t, lastPage)
+	if cursor != nil {
+		t.Fatalf("last cursor = %#v, want nil", cursor)
+	}
+}
+
+func requestElasticsearch(t *testing.T, ctx context.Context, method, target string, body []byte) {
+	t.Helper()
+
+	request, err := http.NewRequestWithContext(ctx, method, target, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create Elasticsearch %s request: %v", method, err)
+	}
+	if len(body) > 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("Elasticsearch %s %s: %v", method, target, err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read Elasticsearch %s %s response: %v", method, target, err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		t.Fatalf(
+			"Elasticsearch %s %s returned status %d: %s",
+			method,
+			target,
+			response.StatusCode,
+			strings.TrimSpace(string(responseBody)),
+		)
+	}
+}
+
+func assertProfileOrder(t *testing.T, documents []*ProfileDocument, want ...string) {
+	t.Helper()
+
+	if len(documents) != len(want) {
+		t.Fatalf("profile count = %d, want %d", len(documents), len(want))
+	}
+	for i, expected := range want {
+		if documents[i] == nil {
+			t.Fatalf("profile %d = nil, want %q", i, expected)
+		}
+		got := documents[i].TracerID + "/" + documents[i].ProfileStorageID
+		if got != expected {
+			t.Errorf("profile %d = %q, want %q", i, got, expected)
+		}
+	}
+}

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -59,6 +59,53 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 	}
 }
 
+func TestProfileDocumentMapperUsesProfileStorageID(t *testing.T) {
+	mapper := profileDocumentMapper{}
+	document := &ProfileDocument{
+		ProfileStorageID: "window-1",
+		TracerID:         "trace-1",
+	}
+	if got := mapper.ID(document); got != "window-1" {
+		t.Fatalf("ID() = %q, want window-1", got)
+	}
+
+	document.ProfileStorageID = ""
+	if got := mapper.ID(document); got != "trace-1" {
+		t.Fatalf("legacy ID() = %q, want trace-1", got)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldUsesKeywords(t *testing.T) {
+	tests := map[string]string{
+		"id":                    profileFieldTracerID + ".keyword",
+		"tracer":                profileFieldTracerID + ".keyword",
+		profileFieldContainerID: profileFieldContainerID + ".keyword",
+		profileFieldProfileType: profileFieldProfileType + ".keyword",
+	}
+	for input, want := range tests {
+		got, err := normalizeProfileAggregationField(input)
+		if err != nil {
+			t.Fatalf("normalizeProfileAggregationField(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("normalizeProfileAggregationField(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestBuildProfileSearchQueryUsesStablePaginationOrder(t *testing.T) {
+	query := buildProfileSearchQuery(&SearchFilter{Limit: 1000, Offset: 1000})
+	want := []driver.Sort{
+		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID + ".keyword"},
+		{Field: profileFieldStorageID + ".keyword"},
+	}
+
+	if !reflect.DeepEqual(query.Sorts, want) {
+		t.Fatalf("query sorts = %#v, want %#v", query.Sorts, want)
+	}
+}
+
 func TestBuildProfileAggregationQueryFiltersByRegion(t *testing.T) {
 	query := buildProfileAggregationQuery(&SearchFilter{
 		Region:   "cn-beijing",

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -94,17 +94,19 @@ type Sort struct {
 
 // Query describes filters, ordering, and pagination.
 type Query struct {
-	Filters []Filter
-	Sorts   []Sort
-	Limit   int
-	Offset  int
+	Filters     []Filter
+	Sorts       []Sort
+	SearchAfter []any
+	Limit       int
+	Offset      int
 }
 
 // Record is the backend-neutral persisted representation.
 type Record struct {
-	ID     string
-	Data   []byte
-	Fields map[string]any
+	ID         string
+	Data       []byte
+	Fields     map[string]any
+	SortValues []any
 }
 
 // Index declares one queryable field.

--- a/internal/storage/elasticsearch/dsl.go
+++ b/internal/storage/elasticsearch/dsl.go
@@ -64,6 +64,20 @@ func buildSearchRequest(q driver.Query) ([]byte, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return nil, driver.ErrNegativePagination
 	}
+	if len(q.SearchAfter) > 0 && q.Offset > 0 {
+		return nil, fmt.Errorf("%w: search_after cannot be combined with a non-zero offset", driver.ErrInvalidQuery)
+	}
+	if len(q.SearchAfter) > 0 && len(q.Sorts) == 0 {
+		return nil, fmt.Errorf("%w: search_after requires at least one sort field", driver.ErrInvalidQuery)
+	}
+	if len(q.SearchAfter) > 0 && len(q.SearchAfter) != len(q.Sorts) {
+		return nil, fmt.Errorf(
+			"%w: search_after has %d values for %d sort fields",
+			driver.ErrInvalidQuery,
+			len(q.SearchAfter),
+			len(q.Sorts),
+		)
+	}
 
 	query, err := buildQuery(q.Filters)
 	if err != nil {
@@ -81,6 +95,12 @@ func buildSearchRequest(q driver.Query) ([]byte, error) {
 	}
 	if q.Offset > 0 {
 		req.From = &q.Offset
+	}
+	if len(q.SearchAfter) > 0 {
+		req.SearchAfter = make([]types.FieldValue, len(q.SearchAfter))
+		for i, value := range q.SearchAfter {
+			req.SearchAfter[i] = value
+		}
 	}
 	if len(q.Sorts) > 0 {
 		sorts, err := buildSort(q.Sorts)

--- a/internal/storage/elasticsearch/dsl.go
+++ b/internal/storage/elasticsearch/dsl.go
@@ -60,7 +60,7 @@ func validateFieldName(field string) error {
 	return nil
 }
 
-func buildSearchRequest(q driver.Query) ([]byte, error) {
+func buildSearchRequest(q *driver.Query) ([]byte, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return nil, driver.ErrNegativePagination
 	}
@@ -112,7 +112,7 @@ func buildSearchRequest(q driver.Query) ([]byte, error) {
 	return json.Marshal(req)
 }
 
-func buildCountRequest(q driver.Query) ([]byte, error) {
+func buildCountRequest(q *driver.Query) ([]byte, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return nil, driver.ErrNegativePagination
 	}
@@ -124,7 +124,7 @@ func buildCountRequest(q driver.Query) ([]byte, error) {
 	return json.Marshal(escount.Request{Query: query})
 }
 
-func buildValuesRequest(field string, q driver.Query, size int) ([]byte, error) {
+func buildValuesRequest(field string, q *driver.Query, size int) ([]byte, error) {
 	if err := validateFieldName(field); err != nil {
 		return nil, err
 	}

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -201,8 +201,8 @@ func (s *Storage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) {
-	body, err := buildSearchRequest(q)
+func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	body, err := buildSearchRequest(&q)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +242,8 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 	return records, nil
 }
 
-func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
-	body, err := buildCountRequest(q)
+func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	body, err := buildCountRequest(&q)
 	if err != nil {
 		return 0, err
 	}
@@ -266,8 +266,8 @@ func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
 	return payload.Count, nil
 }
 
-func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) {
-	body, err := buildValuesRequest(field, q, size)
+func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	body, err := buildValuesRequest(field, &q, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -229,7 +229,15 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 		if hit.Id_ != nil {
 			id = *hit.Id_
 		}
-		records = append(records, driver.Record{ID: id, Data: driver.CloneBytes(hit.Source_)})
+		sortValues := make([]any, len(hit.Sort))
+		for i, value := range hit.Sort {
+			sortValues[i] = value
+		}
+		records = append(records, driver.Record{
+			ID:         id,
+			Data:       driver.CloneBytes(hit.Source_),
+			SortValues: sortValues,
+		})
 	}
 	return records, nil
 }

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -780,6 +780,64 @@ func TestBuildSearchRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "search-after",
+			query: driver.Query{
+				Sorts: []driver.Sort{
+					{Field: "created_at", Desc: true},
+					{Field: "id.keyword"},
+				},
+				SearchAfter: []any{1720000000000.0, "job-alpha"},
+				Limit:       1000,
+			},
+			validate: func(t *testing.T, got map[string]any, err error) {
+				if err != nil {
+					t.Errorf("buildSearchRequest() error = %v", err)
+					return
+				}
+				if _, found := got["from"]; found {
+					t.Errorf("from = %v, want omitted", got["from"])
+				}
+				cursor := toAnySlice(got["search_after"])
+				if len(cursor) != 2 || cursor[0] != 1720000000000.0 || cursor[1] != "job-alpha" {
+					t.Errorf("search_after = %#v, want [1720000000000 job-alpha]", cursor)
+				}
+			},
+		},
+		{
+			name: "search-after-with-offset",
+			query: driver.Query{
+				Sorts:       []driver.Sort{{Field: "id.keyword"}},
+				SearchAfter: []any{"job-alpha"},
+				Offset:      1,
+			},
+			validate: func(t *testing.T, _ map[string]any, err error) {
+				if !errors.Is(err, driver.ErrInvalidQuery) {
+					t.Errorf("buildSearchRequest() error = %v, want ErrInvalidQuery", err)
+				}
+			},
+		},
+		{
+			name:  "search-after-without-sort",
+			query: driver.Query{SearchAfter: []any{"job-alpha"}},
+			validate: func(t *testing.T, _ map[string]any, err error) {
+				if !errors.Is(err, driver.ErrInvalidQuery) {
+					t.Errorf("buildSearchRequest() error = %v, want ErrInvalidQuery", err)
+				}
+			},
+		},
+		{
+			name: "search-after-sort-count-mismatch",
+			query: driver.Query{
+				Sorts:       []driver.Sort{{Field: "created_at"}, {Field: "id.keyword"}},
+				SearchAfter: []any{"job-alpha"},
+			},
+			validate: func(t *testing.T, _ map[string]any, err error) {
+				if !errors.Is(err, driver.ErrInvalidQuery) {
+					t.Errorf("buildSearchRequest() error = %v, want ErrInvalidQuery", err)
+				}
+			},
+		},
+		{
 			name: "invalid-pagination",
 			query: driver.Query{
 				Limit: -1,

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -852,7 +852,7 @@ func TestBuildSearchRequest(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rawBody, err := buildSearchRequest(tc.query)
+			rawBody, err := buildSearchRequest(&tc.query)
 			body := decodeJSONMap(t, rawBody)
 			tc.validate(t, body, err)
 		})

--- a/internal/storage/sqlite/sql.go
+++ b/internal/storage/sqlite/sql.go
@@ -38,6 +38,9 @@ func buildSelectSQL(collection string, q driver.Query) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}
+	if len(q.SearchAfter) > 0 {
+		return "", nil, fmt.Errorf("%w: sqlite does not support search_after", driver.ErrUnsupportedOp)
+	}
 
 	baseSQL := fmt.Sprintf(`SELECT id, data, fields FROM %s`, quoteIdentifier(collection))
 	whereSQL, args, err := buildWhereSQL(q.Filters)

--- a/internal/storage/sqlite/sql.go
+++ b/internal/storage/sqlite/sql.go
@@ -34,7 +34,7 @@ var binaryOpSQL = map[driver.Op]string{
 	driver.OpLte: "<=",
 }
 
-func buildSelectSQL(collection string, q driver.Query) (string, []any, error) {
+func buildSelectSQL(collection string, q *driver.Query) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}
@@ -78,7 +78,7 @@ func buildSelectSQL(collection string, q driver.Query) (string, []any, error) {
 	return sb.String(), args, nil
 }
 
-func buildCountSQL(collection string, q driver.Query) (string, []any, error) {
+func buildCountSQL(collection string, q *driver.Query) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}
@@ -94,7 +94,7 @@ func buildCountSQL(collection string, q driver.Query) (string, []any, error) {
 	return baseSQL + " WHERE " + whereSQL, args, nil
 }
 
-func buildValuesSQL(collection, field string, q driver.Query, size int) (string, []any, error) {
+func buildValuesSQL(collection, field string, q *driver.Query, size int) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -183,8 +183,8 @@ func (s *Storage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) {
-	querySQL, args, err := buildSelectSQL(s.table, q)
+func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	querySQL, args, err := buildSelectSQL(s.table, &q)
 	if err != nil {
 		return nil, err
 	}
@@ -216,8 +216,8 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 	return records, nil
 }
 
-func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
-	countSQL, args, err := buildCountSQL(s.table, q)
+func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	countSQL, args, err := buildCountSQL(s.table, &q)
 	if err != nil {
 		return 0, err
 	}
@@ -229,12 +229,12 @@ func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
 	return count, nil
 }
 
-func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) {
+func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	if err := validateIdentifier(field); err != nil {
 		return nil, err
 	}
 
-	valuesSQL, args, err := buildValuesSQL(s.table, field, q, size)
+	valuesSQL, args, err := buildValuesSQL(s.table, field, &q, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -247,6 +247,14 @@ func TestSQLiteBackendQuery(t *testing.T) {
 	if err == nil {
 		t.Errorf("backend Query() error = nil for negative limit, want error")
 	}
+
+	_, err = backend.Query(t.Context(), driver.Query{
+		Sorts:       []driver.Sort{{Field: "priority"}},
+		SearchAfter: []any{int64(3)},
+	})
+	if !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("backend Query() search_after error = %v, want ErrUnsupportedOp", err)
+	}
 }
 
 // TestSQLiteBackendTerms covers SQLite backend Terms aggregation: verifies it returns distinct field values matching the filter, skips missing fields, and respects the size limit.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -139,19 +139,19 @@ func (s *Store[T]) Close(ctx context.Context) error {
 }
 
 // Query returns objects matching q; all filter and sort fields must be registered indexes.
-func (s *Store[T]) Query(ctx context.Context, q driver.Query) ([]T, error) {
+func (s *Store[T]) Query(ctx context.Context, q *driver.Query) ([]T, error) {
 	values, _, err := s.QueryPage(ctx, q)
 	return values, err
 }
 
 // QueryPage returns objects matching q and the last record's backend sort
 // values. Passing those values as Query.SearchAfter retrieves the next page.
-func (s *Store[T]) QueryPage(ctx context.Context, q driver.Query) ([]T, []any, error) {
+func (s *Store[T]) QueryPage(ctx context.Context, q *driver.Query) ([]T, []any, error) {
 	if err := s.validateQuery(q); err != nil {
 		return nil, nil, err
 	}
 
-	records, err := s.backend.Query(driver.WithContext(ctx), q)
+	records, err := s.backend.Query(driver.WithContext(ctx), *q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,16 +173,16 @@ func (s *Store[T]) QueryPage(ctx context.Context, q driver.Query) ([]T, []any, e
 }
 
 // Count returns the number of objects matching the given query.
-func (s *Store[T]) Count(ctx context.Context, q driver.Query) (int64, error) {
+func (s *Store[T]) Count(ctx context.Context, q *driver.Query) (int64, error) {
 	if err := s.validateQuery(q); err != nil {
 		return 0, err
 	}
 
-	return s.backend.Count(driver.WithContext(ctx), q)
+	return s.backend.Count(driver.WithContext(ctx), *q)
 }
 
 // Values returns up to size distinct values for field, filtered by q.
-func (s *Store[T]) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) {
+func (s *Store[T]) Values(ctx context.Context, field string, q *driver.Query, size int) ([]string, error) {
 	if size < 0 {
 		return nil, driver.ErrNegativeSize
 	}
@@ -190,11 +190,14 @@ func (s *Store[T]) Values(ctx context.Context, field string, q driver.Query, siz
 		return nil, err
 	}
 
-	return s.backend.Values(driver.WithContext(ctx), field, q, size)
+	return s.backend.Values(driver.WithContext(ctx), field, *q, size)
 }
 
 // validateQuery checks that limit and offset are non-negative.
-func (s *Store[T]) validateQuery(q driver.Query) error {
+func (s *Store[T]) validateQuery(q *driver.Query) error {
+	if q == nil {
+		return fmt.Errorf("%w: query is nil", driver.ErrInvalidQuery)
+	}
 	if q.Limit < 0 || q.Offset < 0 {
 		return driver.ErrNegativePagination
 	}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -140,25 +140,36 @@ func (s *Store[T]) Close(ctx context.Context) error {
 
 // Query returns objects matching q; all filter and sort fields must be registered indexes.
 func (s *Store[T]) Query(ctx context.Context, q driver.Query) ([]T, error) {
+	values, _, err := s.QueryPage(ctx, q)
+	return values, err
+}
+
+// QueryPage returns objects matching q and the last record's backend sort
+// values. Passing those values as Query.SearchAfter retrieves the next page.
+func (s *Store[T]) QueryPage(ctx context.Context, q driver.Query) ([]T, []any, error) {
 	if err := s.validateQuery(q); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	records, err := s.backend.Query(driver.WithContext(ctx), q)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	values := make([]T, 0, len(records))
 	for _, rec := range records {
 		value, decodeErr := s.mapper.Decode(rec.Data)
 		if decodeErr != nil {
-			return nil, fmt.Errorf("%w: %w", driver.ErrDecodeFailed, decodeErr)
+			return nil, nil, fmt.Errorf("%w: %w", driver.ErrDecodeFailed, decodeErr)
 		}
 		values = append(values, value)
 	}
 
-	return values, nil
+	if len(records) == 0 || len(records[len(records)-1].SortValues) == 0 {
+		return values, nil, nil
+	}
+	cursor := append([]any(nil), records[len(records)-1].SortValues...)
+	return values, cursor, nil
 }
 
 // Count returns the number of objects matching the given query.
@@ -186,6 +197,23 @@ func (s *Store[T]) Values(ctx context.Context, field string, q driver.Query, siz
 func (s *Store[T]) validateQuery(q driver.Query) error {
 	if q.Limit < 0 || q.Offset < 0 {
 		return driver.ErrNegativePagination
+	}
+	if len(q.SearchAfter) == 0 {
+		return nil
+	}
+	if q.Offset > 0 {
+		return fmt.Errorf("%w: search_after cannot be combined with a non-zero offset", driver.ErrInvalidQuery)
+	}
+	if len(q.Sorts) == 0 {
+		return fmt.Errorf("%w: search_after requires at least one sort field", driver.ErrInvalidQuery)
+	}
+	if len(q.SearchAfter) != len(q.Sorts) {
+		return fmt.Errorf(
+			"%w: search_after has %d values for %d sort fields",
+			driver.ErrInvalidQuery,
+			len(q.SearchAfter),
+			len(q.Sorts),
+		)
 	}
 
 	return nil

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -137,19 +137,19 @@ func (b *testBackend) Delete(_ context.Context, id string) error {
 	return b.deleteErr
 }
 
-func (b *testBackend) Query(_ context.Context, q driver.Query) ([]driver.Record, error) {
+func (b *testBackend) Query(_ context.Context, q driver.Query) ([]driver.Record, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	b.queryCalls++
 	b.lastQuery = q
 	return b.queryRecords, b.queryErr
 }
 
-func (b *testBackend) Count(_ context.Context, q driver.Query) (int64, error) {
+func (b *testBackend) Count(_ context.Context, q driver.Query) (int64, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	b.countCalls++
 	b.lastQuery = q
 	return b.countValue, b.countErr
 }
 
-func (b *testBackend) Values(_ context.Context, field string, q driver.Query, size int) ([]string, error) {
+func (b *testBackend) Values(_ context.Context, field string, q driver.Query, size int) ([]string, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	b.valuesCalls++
 	b.valuesField = field
 	b.lastQuery = q
@@ -641,7 +641,7 @@ func TestStoreQuery(t *testing.T) {
 				return
 			}
 
-			entities, queryErr := store.Query(t.Context(), tc.query)
+			entities, queryErr := store.Query(t.Context(), &tc.query)
 			tc.validate(t, entities, queryErr, tc.backend)
 		})
 	}
@@ -667,7 +667,7 @@ func TestStoreQueryPageReturnsLastSortValues(t *testing.T) {
 		t.Fatalf("NewStore() error = %v", err)
 	}
 
-	values, cursor, err := store.QueryPage(t.Context(), driver.Query{
+	values, cursor, err := store.QueryPage(t.Context(), &driver.Query{
 		Sorts: []driver.Sort{{Field: "cost", Desc: true}, {Field: "id"}},
 		Limit: 2,
 	})
@@ -711,7 +711,7 @@ func TestStoreRejectsInvalidSearchAfter(t *testing.T) {
 				t.Fatalf("NewStore() error = %v", err)
 			}
 
-			_, _, err = store.QueryPage(t.Context(), query)
+			_, _, err = store.QueryPage(t.Context(), &query)
 			if !errors.Is(err, driver.ErrInvalidQuery) {
 				t.Fatalf("QueryPage() error = %v, want ErrInvalidQuery", err)
 			}
@@ -719,6 +719,21 @@ func TestStoreRejectsInvalidSearchAfter(t *testing.T) {
 				t.Fatalf("backend Query() calls = %d, want 0", backend.queryCalls)
 			}
 		})
+	}
+}
+
+func TestStoreRejectsNilQuery(t *testing.T) {
+	backend := &testBackend{}
+	store, err := NewStore[testEntity](t.Context(), "nil-query", backend, "jobs", newTestMapper())
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	if _, err = store.Query(t.Context(), nil); !errors.Is(err, driver.ErrInvalidQuery) {
+		t.Fatalf("Query() error = %v, want ErrInvalidQuery", err)
+	}
+	if backend.queryCalls != 0 {
+		t.Fatalf("backend Query() calls = %d, want 0", backend.queryCalls)
 	}
 }
 
@@ -798,7 +813,7 @@ func TestStoreCount(t *testing.T) {
 				return
 			}
 
-			count, countErr := store.Count(t.Context(), tc.query)
+			count, countErr := store.Count(t.Context(), &tc.query)
 			tc.validate(t, count, countErr, tc.backend)
 		})
 	}
@@ -891,7 +906,7 @@ func TestStoreTerms(t *testing.T) {
 				return
 			}
 
-			terms, valuesErr := store.Values(t.Context(), tc.field, tc.query, tc.size)
+			terms, valuesErr := store.Values(t.Context(), tc.field, &tc.query, tc.size)
 			tc.validate(t, terms, valuesErr, tc.backend)
 		})
 	}

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -647,6 +647,81 @@ func TestStoreQuery(t *testing.T) {
 	}
 }
 
+func TestStoreQueryPageReturnsLastSortValues(t *testing.T) {
+	backend := &testBackend{
+		queryRecords: []driver.Record{
+			{
+				ID:         "job-first",
+				Data:       mustEncodeEntity(testEntity{ID: "job-first"}),
+				SortValues: []any{2000.0, "job-first"},
+			},
+			{
+				ID:         "job-second",
+				Data:       mustEncodeEntity(testEntity{ID: "job-second"}),
+				SortValues: []any{1000.0, "job-second"},
+			},
+		},
+	}
+	store, err := NewStore[testEntity](t.Context(), "query-page", backend, "jobs", newTestMapper())
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	values, cursor, err := store.QueryPage(t.Context(), driver.Query{
+		Sorts: []driver.Sort{{Field: "cost", Desc: true}, {Field: "id"}},
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("QueryPage() error = %v", err)
+	}
+	if len(values) != 2 {
+		t.Fatalf("QueryPage() values = %d, want 2", len(values))
+	}
+	if len(cursor) != 2 || cursor[0] != 1000.0 || cursor[1] != "job-second" {
+		t.Fatalf("QueryPage() cursor = %#v, want [1000 job-second]", cursor)
+	}
+
+	cursor[1] = "changed"
+	if backend.queryRecords[1].SortValues[1] != "job-second" {
+		t.Fatal("QueryPage() cursor aliases backend sort values")
+	}
+}
+
+func TestStoreRejectsInvalidSearchAfter(t *testing.T) {
+	tests := map[string]driver.Query{
+		"with offset": {
+			Sorts:       []driver.Sort{{Field: "id"}},
+			SearchAfter: []any{"job-first"},
+			Offset:      1,
+		},
+		"without sort": {
+			SearchAfter: []any{"job-first"},
+		},
+		"sort count mismatch": {
+			Sorts:       []driver.Sort{{Field: "cost"}, {Field: "id"}},
+			SearchAfter: []any{"job-first"},
+		},
+	}
+
+	for name, query := range tests {
+		t.Run(name, func(t *testing.T) {
+			backend := &testBackend{}
+			store, err := NewStore[testEntity](t.Context(), name, backend, "jobs", newTestMapper())
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+
+			_, _, err = store.QueryPage(t.Context(), query)
+			if !errors.Is(err, driver.ErrInvalidQuery) {
+				t.Fatalf("QueryPage() error = %v, want ErrInvalidQuery", err)
+			}
+			if backend.queryCalls != 0 {
+				t.Fatalf("backend Query() calls = %d, want 0", backend.queryCalls)
+			}
+		})
+	}
+}
+
 // TestStoreCount covers the Count path: verifies valid queries are forwarded to the backend, invalid pagination is rejected early, and backend errors are propagated.
 func TestStoreCount(t *testing.T) {
 	countErr := errors.New("count failed")

--- a/pkg/tracing/document.go
+++ b/pkg/tracing/document.go
@@ -24,6 +24,8 @@ import (
 	"github.com/rs/xid"
 )
 
+const tracingDocumentTimeLayout = "2006-01-02 15:04:05.000 -0700"
+
 // DocumentCollection is the storage collection name for tracing documents.
 const DocumentCollection = "tracing_documents"
 
@@ -36,8 +38,27 @@ type ProfileDocumentStoreMapper struct {
 }
 
 // ID returns a unique storage ID while tracer_id keeps snapshots queryable as one task.
-func (ProfileDocumentStoreMapper) ID(_ *Document) string {
-	return xid.New().String()
+func (ProfileDocumentStoreMapper) ID(document *Document) string {
+	if document.ProfileStorageID == "" {
+		document.ProfileStorageID = xid.New().String()
+	}
+	return document.ProfileStorageID
+}
+
+func (m ProfileDocumentStoreMapper) Fields(document *Document) (map[string]any, error) {
+	// Regenerate on every save so callers reusing a Document cannot overwrite a window.
+	document.ProfileStorageID = xid.New().String()
+	fields, err := m.DocumentStoreMapper.Fields(document)
+	if err != nil {
+		return nil, err
+	}
+	fields["profile_storage_id"] = document.ProfileStorageID
+	return fields, nil
+}
+
+func (m ProfileDocumentStoreMapper) Indexes() []driver.Index {
+	indexes := m.DocumentStoreMapper.Indexes()
+	return append(indexes, driver.Index{Field: "profile_storage_id"})
 }
 
 func tracingDocumentTimeValue(raw string, fallback time.Time) time.Time {

--- a/pkg/tracing/document_profile_test.go
+++ b/pkg/tracing/document_profile_test.go
@@ -14,13 +14,38 @@
 
 package tracing
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestProfileDocumentStoreMapperUsesUniqueIDs(t *testing.T) {
 	mapper := ProfileDocumentStoreMapper{}
 	document := &Document{TracerID: "profile-task-2026"}
 
+	fields, err := mapper.Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
 	first := mapper.ID(document)
+	if fields["profile_storage_id"] != first {
+		t.Fatalf("profile_storage_id field = %v, want %q", fields["profile_storage_id"], first)
+	}
+	encoded, err := mapper.Encode(document)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	var source Document
+	if err := json.Unmarshal(encoded, &source); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if source.ProfileStorageID != first {
+		t.Fatalf("encoded profile storage ID = %q, want %q", source.ProfileStorageID, first)
+	}
+
+	if _, err := mapper.Fields(document); err != nil {
+		t.Fatalf("second Fields() error = %v", err)
+	}
 	second := mapper.ID(document)
 	if first == "" || second == "" {
 		t.Fatal("ProfileDocumentStoreMapper.ID() returned an empty ID")
@@ -30,5 +55,16 @@ func TestProfileDocumentStoreMapperUsesUniqueIDs(t *testing.T) {
 	}
 	if document.TracerID != "profile-task-2026" {
 		t.Fatalf("ProfileDocumentStoreMapper.ID() changed tracer ID to %q", document.TracerID)
+	}
+
+	foundIndex := false
+	for _, index := range mapper.Indexes() {
+		if index.Field == "profile_storage_id" {
+			foundIndex = true
+			break
+		}
+	}
+	if !foundIndex {
+		t.Fatal("ProfileDocumentStoreMapper.Indexes() is missing profile_storage_id")
 	}
 }

--- a/pkg/tracing/store.go
+++ b/pkg/tracing/store.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	tracingDocumentTimeLayout = "2006-01-02 15:04:05.000 -0700"
-
 	TracerRunTypeTask        = "task"
 	TracerRunTypeAutotracing = "autotracing"
 	TracerRunTypeEvent       = "event"

--- a/pkg/tracing/types.go
+++ b/pkg/tracing/types.go
@@ -18,10 +18,11 @@ import "time"
 
 // Document is the tracing document persisted to and queried from storage backends.
 type Document struct {
-	Hostname     string    `json:"hostname"`
-	Region       string    `json:"region"`
-	UploadedTime time.Time `json:"uploaded_time"`
-	Time         string    `json:"time"`
+	Hostname         string    `json:"hostname"`
+	Region           string    `json:"region"`
+	UploadedTime     time.Time `json:"uploaded_time"`
+	Time             string    `json:"time"`
+	ProfileStorageID string    `json:"profile_storage_id,omitempty"`
 
 	ContainerID            string `json:"container_id,omitempty"`
 	ContainerHostname      string `json:"container_hostname,omitempty"`


### PR DESCRIPTION
## Summary

- sort profile pages by upload time, tracer keyword, and a unique storage ID
- carry Elasticsearch search_after cursors through the storage driver
- add real Elasticsearch coverage for identical tracer and timestamp values
- provide a guarded, idempotent migration for historical profile documents
- reject multi-index aliases and repair missing keyword sort values

## Standalone behavior

PR 2 of 6. This PR is independent and safe to merge by itself. Existing raw
and merged profile queries gain stable cursor pagination; no new display API or
dashboard is introduced.

## Historical data

New documents always receive profile_storage_id. Historical documents should
be migrated with build/migrate-profile-storage-id.sh before relying on strict
long-window cursors. Without migration, the extreme legacy case of the same
tracer and the same nanosecond can still require migration or PIT.

## Dependencies

None. PR 1 and PR 2 can be reviewed, tested, and merged in either order.

## Validation

- go test ./internal/storage/... ./internal/profiler/service ./internal/job -count=1
- Elasticsearch 8.15.5 integration test with cross-page duplicate timestamps
- migration integration coverage for mappings, aliases, idempotence, and non-profile data
- shell syntax, repository shfmt flags, and git diff checks

Split from #463.