### PR TITLE
feat(profiling): stream Pyroscope display queries

### DIFF
--- a/build/migrate-profile-storage-id.sh
+++ b/build/migrate-profile-storage-id.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 usage() {
-	cat <<'EOF'
+	cat << 'EOF'
 Usage: migrate-profile-storage-id.sh [--check]
 
 Environment:
@@ -44,11 +44,11 @@ case "${1:-}" in
 	;;
 esac
 
-command -v curl >/dev/null || {
+command -v curl > /dev/null || {
 	echo "curl is required" >&2
 	exit 1
 }
-command -v jq >/dev/null || {
+command -v jq > /dev/null || {
 	echo "jq is required" >&2
 	exit 1
 }
@@ -126,8 +126,8 @@ missing_sort_value_query='{
 index_mapping=$(curl "${curl_options[@]}" \
 	--request GET \
 	"${elasticsearch_url}/${elasticsearch_index}/_mapping")
-resolved_indices=$(jq -r 'keys[]' <<<"${index_mapping}")
-if [[ $(wc -l <<<"${resolved_indices}") -ne 1 || ${resolved_indices} != "${elasticsearch_index}" ]]; then
+resolved_indices=$(jq -r 'keys[]' <<< "${index_mapping}")
+if [[ $(wc -l <<< "${resolved_indices}") -ne 1 || ${resolved_indices} != "${elasticsearch_index}" ]]; then
 	echo "ELASTICSEARCH_INDEX must resolve to one physical index with the same name" >&2
 	echo "Resolved indices: ${resolved_indices//$'\n'/, }" >&2
 	exit 2
@@ -136,11 +136,11 @@ fi
 profile_storage_type=$(jq -r \
 	--arg index "${elasticsearch_index}" \
 	'.[$index].mappings.properties.profile_storage_id.type // ""' \
-	<<<"${index_mapping}")
+	<<< "${index_mapping}")
 profile_storage_keyword_type=$(jq -r \
 	--arg index "${elasticsearch_index}" \
 	'.[$index].mappings.properties.profile_storage_id.fields.keyword.type // ""' \
-	<<<"${index_mapping}")
+	<<< "${index_mapping}")
 
 ensure_profile_storage_mapping() {
 	if [[ ${profile_storage_keyword_type} == "keyword" ]]; then
@@ -168,7 +168,7 @@ ensure_profile_storage_mapping() {
 	curl "${curl_options[@]}" \
 		--request PUT \
 		--data-binary "${mapping}" \
-		"${elasticsearch_url}/${elasticsearch_index}/_mapping" >/dev/null
+		"${elasticsearch_url}/${elasticsearch_index}/_mapping" > /dev/null
 
 	local keyword_mapping
 	keyword_mapping=$(curl "${curl_options[@]}" \
@@ -177,7 +177,7 @@ ensure_profile_storage_mapping() {
 	if ! jq -e \
 		--arg index "${elasticsearch_index}" \
 		'.[$index].mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
-		>/dev/null <<<"${keyword_mapping}"; then
+		> /dev/null <<< "${keyword_mapping}"; then
 		echo "profile_storage_id.keyword mapping was not created" >&2
 		exit 1
 	fi
@@ -187,16 +187,16 @@ count_legacy_profiles() {
 	curl "${curl_options[@]}" \
 		--request POST \
 		--data-binary "${profile_query}" \
-		"${elasticsearch_url}/${elasticsearch_index}/_count" |
-		jq -er '.count'
+		"${elasticsearch_url}/${elasticsearch_index}/_count" \
+		| jq -er '.count'
 }
 
 count_missing_sort_values() {
 	curl "${curl_options[@]}" \
 		--request POST \
 		--data-binary "${missing_sort_value_query}" \
-		"${elasticsearch_url}/${elasticsearch_index}/_count" |
-		jq -er '.count'
+		"${elasticsearch_url}/${elasticsearch_index}/_count" \
+		| jq -er '.count'
 }
 
 pending=$(count_legacy_profiles)
@@ -242,12 +242,12 @@ if [[ ${missing_sort_values} -ne 0 ]]; then
       }
     }' \
 		"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
-	if ! jq -e '.failures | length == 0' >/dev/null <<<"${refresh_response}"; then
+	if ! jq -e '.failures | length == 0' > /dev/null <<< "${refresh_response}"; then
 		echo "profile storage ID sort refresh returned document failures" >&2
-		jq '.failures' <<<"${refresh_response}" >&2
+		jq '.failures' <<< "${refresh_response}" >&2
 		exit 1
 	fi
-	echo "Reindexed existing profile storage IDs: $(jq -er '.updated' <<<"${refresh_response}")"
+	echo "Reindexed existing profile storage IDs: $(jq -er '.updated' <<< "${refresh_response}")"
 fi
 
 if [[ ${pending} -eq 0 ]]; then
@@ -287,13 +287,13 @@ update_response=$(curl "${curl_options[@]}" \
   }' \
 	"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
 
-if ! jq -e '.failures | length == 0' >/dev/null <<<"${update_response}"; then
+if ! jq -e '.failures | length == 0' > /dev/null <<< "${update_response}"; then
 	echo "profile storage ID migration returned document failures" >&2
-	jq '.failures' <<<"${update_response}" >&2
+	jq '.failures' <<< "${update_response}" >&2
 	exit 1
 fi
 
-updated=$(jq -er '.updated' <<<"${update_response}")
+updated=$(jq -er '.updated' <<< "${update_response}")
 remaining=$(count_legacy_profiles)
 remaining_sort_values=$(count_missing_sort_values)
 echo "Updated profile documents: ${updated}"

--- a/build/migrate-profile-storage-id.sh
+++ b/build/migrate-profile-storage-id.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: migrate-profile-storage-id.sh [--check]
+
+Environment:
+  ELASTICSEARCH_URL       Elasticsearch/OpenSearch URL (default: http://127.0.0.1:9200)
+  ELASTICSEARCH_INDEX     Profile index (default: huatuo_bamai)
+  ELASTICSEARCH_USERNAME  Optional basic-auth username
+  ELASTICSEARCH_PASSWORD  Optional basic-auth password
+
+--check reports legacy document count and sortable mapping state without writes.
+EOF
+}
+
+mode="migrate"
+case "${1:-}" in
+"") ;;
+--check) mode="check" ;;
+-h | --help)
+	usage
+	exit 0
+	;;
+*)
+	usage >&2
+	exit 2
+	;;
+esac
+
+command -v curl >/dev/null || {
+	echo "curl is required" >&2
+	exit 1
+}
+command -v jq >/dev/null || {
+	echo "jq is required" >&2
+	exit 1
+}
+
+elasticsearch_url=${ELASTICSEARCH_URL:-http://127.0.0.1:9200}
+elasticsearch_url=${elasticsearch_url%/}
+elasticsearch_index=${ELASTICSEARCH_INDEX:-huatuo_bamai}
+elasticsearch_username=${ELASTICSEARCH_USERNAME:-}
+elasticsearch_password=${ELASTICSEARCH_PASSWORD:-}
+
+if [[ ! ${elasticsearch_index} =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+	echo "ELASTICSEARCH_INDEX must be one explicit lowercase index name" >&2
+	exit 2
+fi
+if [[ -n ${elasticsearch_password} && -z ${elasticsearch_username} ]]; then
+	echo "ELASTICSEARCH_USERNAME is required when ELASTICSEARCH_PASSWORD is set" >&2
+	exit 2
+fi
+
+curl_options=(
+	--fail-with-body
+	--silent
+	--show-error
+	--connect-timeout 5
+	--max-time 1800
+	--header "Content-Type: application/json"
+)
+if [[ -n ${elasticsearch_username} ]]; then
+	curl_options+=(--user "${elasticsearch_username}:${elasticsearch_password}")
+fi
+
+profile_query='{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "bool": {
+            "should": [
+              {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+              {"exists": {"field": "tracer_data.flamedata.profile"}}
+            ],
+            "minimum_should_match": 1
+          }
+        }
+      ],
+      "must_not": [
+        {"exists": {"field": "profile_storage_id"}}
+      ]
+    }
+  }
+}'
+
+missing_sort_value_query='{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "bool": {
+            "should": [
+              {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+              {"exists": {"field": "tracer_data.flamedata.profile"}}
+            ],
+            "minimum_should_match": 1
+          }
+        },
+        {"exists": {"field": "profile_storage_id"}}
+      ],
+      "must_not": [
+        {"exists": {"field": "profile_storage_id.keyword"}}
+      ]
+    }
+  }
+}'
+
+index_mapping=$(curl "${curl_options[@]}" \
+	--request GET \
+	"${elasticsearch_url}/${elasticsearch_index}/_mapping")
+resolved_indices=$(jq -r 'keys[]' <<<"${index_mapping}")
+if [[ $(wc -l <<<"${resolved_indices}") -ne 1 || ${resolved_indices} != "${elasticsearch_index}" ]]; then
+	echo "ELASTICSEARCH_INDEX must resolve to one physical index with the same name" >&2
+	echo "Resolved indices: ${resolved_indices//$'\n'/, }" >&2
+	exit 2
+fi
+
+profile_storage_type=$(jq -r \
+	--arg index "${elasticsearch_index}" \
+	'.[$index].mappings.properties.profile_storage_id.type // ""' \
+	<<<"${index_mapping}")
+profile_storage_keyword_type=$(jq -r \
+	--arg index "${elasticsearch_index}" \
+	'.[$index].mappings.properties.profile_storage_id.fields.keyword.type // ""' \
+	<<<"${index_mapping}")
+
+ensure_profile_storage_mapping() {
+	if [[ ${profile_storage_keyword_type} == "keyword" ]]; then
+		return
+	fi
+	if [[ -n ${profile_storage_keyword_type} ]]; then
+		echo "profile_storage_id.keyword must be mapped as keyword" >&2
+		exit 1
+	fi
+	if [[ -n ${profile_storage_type} && ${profile_storage_type} != "text" && ${profile_storage_type} != "keyword" ]]; then
+		echo "profile_storage_id must be text or keyword, got ${profile_storage_type}" >&2
+		exit 1
+	fi
+
+	local root_type=${profile_storage_type:-text}
+	local mapping
+	mapping=$(jq -cn --arg root_type "${root_type}" '{
+      properties: {
+        profile_storage_id: {
+          type: $root_type,
+          fields: {keyword: {type: "keyword", ignore_above: 256}}
+        }
+      }
+    }')
+	curl "${curl_options[@]}" \
+		--request PUT \
+		--data-binary "${mapping}" \
+		"${elasticsearch_url}/${elasticsearch_index}/_mapping" >/dev/null
+
+	local keyword_mapping
+	keyword_mapping=$(curl "${curl_options[@]}" \
+		--request GET \
+		"${elasticsearch_url}/${elasticsearch_index}/_mapping/field/profile_storage_id.keyword")
+	if ! jq -e \
+		--arg index "${elasticsearch_index}" \
+		'.[$index].mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
+		>/dev/null <<<"${keyword_mapping}"; then
+		echo "profile_storage_id.keyword mapping was not created" >&2
+		exit 1
+	fi
+}
+
+count_legacy_profiles() {
+	curl "${curl_options[@]}" \
+		--request POST \
+		--data-binary "${profile_query}" \
+		"${elasticsearch_url}/${elasticsearch_index}/_count" |
+		jq -er '.count'
+}
+
+count_missing_sort_values() {
+	curl "${curl_options[@]}" \
+		--request POST \
+		--data-binary "${missing_sort_value_query}" \
+		"${elasticsearch_url}/${elasticsearch_index}/_count" |
+		jq -er '.count'
+}
+
+pending=$(count_legacy_profiles)
+missing_sort_values=$(count_missing_sort_values)
+echo "Legacy profile documents without profile_storage_id: ${pending}"
+echo "Profile documents without profile_storage_id.keyword value: ${missing_sort_values}"
+if [[ ${mode} == "check" ]]; then
+	mapping_state=missing
+	if [[ ${profile_storage_keyword_type} == "keyword" ]]; then
+		mapping_state=present
+	fi
+	echo "profile_storage_id.keyword mapping: ${mapping_state}"
+	exit 0
+fi
+
+ensure_profile_storage_mapping
+if [[ ${missing_sort_values} -ne 0 ]]; then
+	refresh_response=$(curl "${curl_options[@]}" \
+		--request POST \
+		--data-binary '{
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "bool": {
+                "should": [
+                  {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+                  {"exists": {"field": "tracer_data.flamedata.profile"}}
+                ],
+                "minimum_should_match": 1
+              }
+            },
+            {"exists": {"field": "profile_storage_id"}}
+          ],
+          "must_not": [
+            {"exists": {"field": "profile_storage_id.keyword"}}
+          ]
+        }
+      },
+      "script": {
+        "lang": "painless",
+        "source": "ctx._source.profile_storage_id = ctx._source.profile_storage_id"
+      }
+    }' \
+		"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
+	if ! jq -e '.failures | length == 0' >/dev/null <<<"${refresh_response}"; then
+		echo "profile storage ID sort refresh returned document failures" >&2
+		jq '.failures' <<<"${refresh_response}" >&2
+		exit 1
+	fi
+	echo "Reindexed existing profile storage IDs: $(jq -er '.updated' <<<"${refresh_response}")"
+fi
+
+if [[ ${pending} -eq 0 ]]; then
+	remaining_sort_values=$(count_missing_sort_values)
+	if [[ ${remaining_sort_values} -ne 0 ]]; then
+		echo "Migration incomplete: ${remaining_sort_values} profile storage IDs remain unsortable" >&2
+		exit 1
+	fi
+	exit 0
+fi
+
+update_response=$(curl "${curl_options[@]}" \
+	--request POST \
+	--data-binary '{
+    "query": {
+      "bool": {
+        "filter": [
+          {
+            "bool": {
+              "should": [
+                {"exists": {"field": "tracer_data.flamedata.profile_type"}},
+                {"exists": {"field": "tracer_data.flamedata.profile"}}
+              ],
+              "minimum_should_match": 1
+            }
+          }
+        ],
+        "must_not": [
+          {"exists": {"field": "profile_storage_id"}}
+        ]
+      }
+    },
+    "script": {
+      "lang": "painless",
+      "source": "ctx._source.profile_storage_id = ctx._id"
+    }
+  }' \
+	"${elasticsearch_url}/${elasticsearch_index}/_update_by_query?refresh=true")
+
+if ! jq -e '.failures | length == 0' >/dev/null <<<"${update_response}"; then
+	echo "profile storage ID migration returned document failures" >&2
+	jq '.failures' <<<"${update_response}" >&2
+	exit 1
+fi
+
+updated=$(jq -er '.updated' <<<"${update_response}")
+remaining=$(count_legacy_profiles)
+remaining_sort_values=$(count_missing_sort_values)
+echo "Updated profile documents: ${updated}"
+if [[ ${remaining} -ne 0 ]]; then
+	echo "Migration incomplete: ${remaining} legacy profile documents remain" >&2
+	exit 1
+fi
+if [[ ${remaining_sort_values} -ne 0 ]]; then
+	echo "Migration incomplete: ${remaining_sort_values} profile storage IDs remain unsortable" >&2
+	exit 1
+fi

--- a/cmd/huatuo-apiserver/config/config.go
+++ b/cmd/huatuo-apiserver/config/config.go
@@ -24,7 +24,10 @@ import (
 	internalconfig "huatuo-bamai/internal/config"
 )
 
-const maxAggregationIntervalSeconds = 1200
+const (
+	maxAggregationIntervalSeconds = 1200
+	defaultMaxQueryDocuments      = 100000
+)
 
 // LogConfig controls process logging.
 type LogConfig struct {
@@ -142,6 +145,7 @@ func defaultConfig() Config {
 		Profiling: ProfilingConfig{
 			AggregationIntervalSeconds:     10,
 			MaxConcurrentProfilerProcesses: 10,
+			MaxQueryDocuments:              defaultMaxQueryDocuments,
 		},
 	}
 }

--- a/cmd/huatuo-apiserver/config/config.go
+++ b/cmd/huatuo-apiserver/config/config.go
@@ -35,6 +35,7 @@ type LogConfig struct {
 type ProfilingConfig struct {
 	AggregationIntervalSeconds     int
 	MaxConcurrentProfilerProcesses int
+	MaxQueryDocuments              int64
 	DashboardBaseURL               string
 }
 
@@ -187,6 +188,9 @@ func (c ProfilingConfig) Validate() error {
 	}
 	if c.MaxConcurrentProfilerProcesses < 0 {
 		return errors.New("maximum concurrent profiler processes must not be negative")
+	}
+	if c.MaxQueryDocuments < 0 {
+		return errors.New("maximum profile query documents must not be negative")
 	}
 	if c.DashboardBaseURL == "" {
 		return nil

--- a/cmd/huatuo-apiserver/config/config_test.go
+++ b/cmd/huatuo-apiserver/config/config_test.go
@@ -62,7 +62,7 @@ Admin = true
 	}
 	if cfg.Profiling.AggregationIntervalSeconds != 10 ||
 		cfg.Profiling.MaxConcurrentProfilerProcesses != 10 ||
-		cfg.Profiling.MaxQueryDocuments != 0 ||
+		cfg.Profiling.MaxQueryDocuments != 100000 ||
 		cfg.Profiling.DashboardBaseURL != "" {
 		t.Errorf("Profiling = %+v, want default values", cfg.Profiling)
 	}
@@ -145,6 +145,25 @@ Permissions = ["GET /v1/profiling/**"]
 	}
 	if cfg.Auth.Users[0].ID != "operator" {
 		t.Errorf("user ID = %q, want operator", cfg.Auth.Users[0].ID)
+	}
+}
+
+func TestLoadFileAllowsUnlimitedProfileQueries(t *testing.T) {
+	cfg := loadTestConfig(t, `
+[Profiling]
+MaxQueryDocuments = 0
+
+[[Auth.Users]]
+ID = "admin"
+BearerToken = "secret"
+Admin = true
+`)
+
+	if cfg.Profiling.MaxQueryDocuments != 0 {
+		t.Fatalf(
+			"Profiling.MaxQueryDocuments = %d, want explicit zero",
+			cfg.Profiling.MaxQueryDocuments,
+		)
 	}
 }
 

--- a/cmd/huatuo-apiserver/config/config_test.go
+++ b/cmd/huatuo-apiserver/config/config_test.go
@@ -62,6 +62,7 @@ Admin = true
 	}
 	if cfg.Profiling.AggregationIntervalSeconds != 10 ||
 		cfg.Profiling.MaxConcurrentProfilerProcesses != 10 ||
+		cfg.Profiling.MaxQueryDocuments != 0 ||
 		cfg.Profiling.DashboardBaseURL != "" {
 		t.Errorf("Profiling = %+v, want default values", cfg.Profiling)
 	}
@@ -109,6 +110,7 @@ Index = "profiles"
 [Profiling]
 AggregationIntervalSeconds = 15
 MaxConcurrentProfilerProcesses = 6
+MaxQueryDocuments = 250000
 DashboardBaseURL = "https://grafana.example/d"
 
 [[Auth.Users]]
@@ -137,8 +139,9 @@ Permissions = ["GET /v1/profiling/**"]
 	if !cfg.Elasticsearch.Enabled() || cfg.Elasticsearch.Index != "profiles" {
 		t.Errorf("Elasticsearch = %+v, want enabled overrides", cfg.Elasticsearch)
 	}
-	if cfg.Profiling.DashboardBaseURL != "https://grafana.example/d" {
-		t.Errorf("DashboardBaseURL = %q, want override", cfg.Profiling.DashboardBaseURL)
+	if cfg.Profiling.DashboardBaseURL != "https://grafana.example/d" ||
+		cfg.Profiling.MaxQueryDocuments != 250000 {
+		t.Errorf("Profiling = %+v, want query and dashboard overrides", cfg.Profiling)
 	}
 	if cfg.Auth.Users[0].ID != "operator" {
 		t.Errorf("user ID = %q, want operator", cfg.Auth.Users[0].ID)
@@ -377,6 +380,13 @@ func TestConfigValidation(t *testing.T) {
 				cfg.Profiling.AggregationIntervalSeconds = 1200
 			},
 			wantErr: "less than 1200 seconds",
+		},
+		{
+			name: "invalid profile query limit",
+			mutate: func(cfg *Config) {
+				cfg.Profiling.MaxQueryDocuments = -1
+			},
+			wantErr: "maximum profile query documents",
 		},
 		{
 			name: "invalid dashboard URL",

--- a/cmd/huatuo-apiserver/handlers/profiling/handler.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/handler.go
@@ -43,6 +43,8 @@ type Config struct {
 // ProfileQueryService defines profile query operations consumed by the handler.
 type ProfileQueryService interface {
 	SelectMergeStacktraces(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*querierv1.SelectMergeStacktracesResponse, error)
+	SelectSeries(ctx context.Context, req *querierv1.SelectSeriesRequest) (*querierv1.SelectSeriesResponse, error)
+	MarshalPprof(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) ([]byte, error)
 	ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesRequest) (*querierv1.ProfileTypesResponse, error)
 	LabelNames(ctx context.Context, req *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error)
 	LabelValues(ctx context.Context, req *typesv1.LabelValuesRequest) (*typesv1.LabelValuesResponse, error)
@@ -83,6 +85,11 @@ func NewHandler(
 			h.Handlers,
 			server.Handle{Typ: server.HttpGet, Uri: "/:id/raw", Handle: h.getRawData},
 			server.Handle{
+				Typ:    server.HttpGet,
+				Uri:    "/flamegraph/export/pprof",
+				Handle: h.displayPprofExport,
+			},
+			server.Handle{
 				Typ:    server.HttpPost,
 				Uri:    "/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces",
 				Handle: h.displaySelectMergeStacktraces,
@@ -91,6 +98,11 @@ func NewHandler(
 				Typ:    server.HttpPost,
 				Uri:    "/flamegraph/querier.v1.QuerierService/ProfileTypes",
 				Handle: h.displayProfileTypes,
+			},
+			server.Handle{
+				Typ:    server.HttpPost,
+				Uri:    "/flamegraph/querier.v1.QuerierService/SelectSeries",
+				Handle: h.displaySelectSeries,
 			},
 			server.Handle{
 				Typ:    server.HttpPost,

--- a/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/profiling_test.go
@@ -45,8 +45,10 @@ func TestNewHandlerRegistersStorageRoutesWhenEnabled(t *testing.T) {
 
 	want := []string{
 		"/:id/raw",
+		"/flamegraph/export/pprof",
 		"/flamegraph/querier.v1.QuerierService/SelectMergeStacktraces",
 		"/flamegraph/querier.v1.QuerierService/ProfileTypes",
+		"/flamegraph/querier.v1.QuerierService/SelectSeries",
 		"/flamegraph/querier.v1.QuerierService/LabelNames",
 		"/flamegraph/querier.v1.QuerierService/LabelValues",
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/querier.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier.go
@@ -17,13 +17,17 @@ package profiling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"huatuo-bamai/internal/log"
 	profileService "huatuo-bamai/internal/profiler/service"
 	"huatuo-bamai/internal/server"
 
 	"github.com/gin-gonic/gin/binding"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 )
 
 func handleProto[Request, Response any](
@@ -39,22 +43,30 @@ func handleProto[Request, Response any](
 
 	resp, err := invoke(ctx.Request().Context(), req)
 	if err != nil {
-		if errors.Is(err, profileService.ErrInvalidQuery) {
-			ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
-			return nil
+		status, message := profileQueryHTTPError(err)
+		if status == http.StatusInternalServerError {
+			log.WithError(err).WithField("operation", operation).Error("profile query failed")
 		}
-		if errors.Is(err, profileService.ErrProfilesAbsent) {
-			ctx.JSON(http.StatusNotFound, map[string]any{"message": "profiles not found"})
-			return nil
-		}
-		log.WithError(err).WithField("operation", operation).Error("profile query failed")
-		ctx.JSON(http.StatusInternalServerError, map[string]any{"message": "internal error"})
+		ctx.JSON(status, map[string]any{"message": message})
 		return nil
 	}
 
 	ctx.Header("Content-Type", "application/proto")
 	ctx.ProtoBuf(http.StatusOK, resp)
 	return nil
+}
+
+func profileQueryHTTPError(err error) (int, string) {
+	switch {
+	case errors.Is(err, profileService.ErrInvalidQuery):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, profileService.ErrProfilesAbsent):
+		return http.StatusNotFound, "profiles not found"
+	case errors.Is(err, profileService.ErrProfileQueryLimitExceeded):
+		return http.StatusUnprocessableEntity, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal error"
+	}
 }
 
 func (h *Handler) displaySelectMergeStacktraces(ctx *server.Context) error {
@@ -65,10 +77,73 @@ func (h *Handler) displayProfileTypes(ctx *server.Context) error {
 	return handleProto(ctx, "profile_types", h.profileService.ProfileTypes)
 }
 
+func (h *Handler) displaySelectSeries(ctx *server.Context) error {
+	return handleProto(ctx, "select_series", h.profileService.SelectSeries)
+}
+
 func (h *Handler) displayLabelNames(ctx *server.Context) error {
 	return handleProto(ctx, "label_names", h.profileService.LabelNames)
 }
 
 func (h *Handler) displayLabelValues(ctx *server.Context) error {
 	return handleProto(ctx, "label_values", h.profileService.LabelValues)
+}
+
+func profileExportRequest(
+	query func(string) string,
+) (*querierv1.SelectMergeStacktracesRequest, error) {
+	profileType := strings.TrimSpace(query("profile_type"))
+	if profileType == "" {
+		return nil, errors.New("profile_type is required")
+	}
+	selector := strings.TrimSpace(query("selector"))
+	if selector == "" {
+		return nil, errors.New("selector is required")
+	}
+	start, err := strconv.ParseInt(query("start"), 10, 64)
+	if err != nil {
+		return nil, errors.New("start must be a Unix timestamp in milliseconds")
+	}
+	end, err := strconv.ParseInt(query("end"), 10, 64)
+	if err != nil {
+		return nil, errors.New("end must be a Unix timestamp in milliseconds")
+	}
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profileType,
+		LabelSelector: selector,
+		Start:         start,
+		End:           end,
+	}, nil
+}
+
+func writeProfileServiceError(ctx *server.Context, operation string, err error) {
+	status, message := profileQueryHTTPError(err)
+	if status == http.StatusInternalServerError {
+		log.WithError(err).WithField("operation", operation).Error("profile query failed")
+	}
+	ctx.JSON(status, map[string]any{"message": message})
+}
+
+func (h *Handler) displayPprofExport(ctx *server.Context) error {
+	req, err := profileExportRequest(ctx.Query)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, map[string]any{"message": err.Error()})
+		return nil
+	}
+	payload, err := h.profileService.MarshalPprof(ctx.Request().Context(), req)
+	if err != nil {
+		writeProfileServiceError(ctx, "export_pprof", err)
+		return nil
+	}
+	ctx.Header("Content-Type", "application/octet-stream")
+	ctx.Header(
+		"Content-Disposition",
+		`attachment; filename="huatuo-profile.pb.gz"`,
+	)
+	ctx.Header("X-Content-Type-Options", "nosniff")
+	ctx.Writer().WriteHeader(http.StatusOK)
+	if _, err := ctx.Writer().Write(payload); err != nil {
+		return fmt.Errorf("write pprof export: %w", err)
+	}
+	return nil
 }

--- a/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/querier_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiling
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	profileService "huatuo-bamai/internal/profiler/service"
+)
+
+func TestProfileQueryHTTPError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name:        "invalid query",
+			err:         errors.Join(profileService.ErrInvalidQuery, errors.New("bad selector")),
+			wantStatus:  http.StatusBadRequest,
+			wantMessage: "bad selector",
+		},
+		{
+			name:        "not found",
+			err:         profileService.ErrProfilesAbsent,
+			wantStatus:  http.StatusNotFound,
+			wantMessage: "profiles not found",
+		},
+		{
+			name: "selection too large",
+			err: errors.Join(
+				profileService.ErrProfileQueryLimitExceeded,
+				errors.New("10001 documents"),
+			),
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: "10001 documents",
+		},
+		{
+			name:        "internal",
+			err:         errors.New("elasticsearch unavailable"),
+			wantStatus:  http.StatusInternalServerError,
+			wantMessage: "internal error",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := profileQueryHTTPError(test.err)
+			if status != test.wantStatus {
+				t.Fatalf("status = %d, want %d", status, test.wantStatus)
+			}
+			if !strings.Contains(message, test.wantMessage) {
+				t.Fatalf("message = %q, want it to contain %q", message, test.wantMessage)
+			}
+		})
+	}
+}
+
+func TestProfileExportRequest(t *testing.T) {
+	values := map[string]string{
+		"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		"selector":     `{hostname="node-a"}`,
+		"start":        "1784944800000",
+		"end":          "1784944860000",
+	}
+	req, err := profileExportRequest(func(name string) string {
+		return values[name]
+	})
+	if err != nil {
+		t.Fatalf("profileExportRequest() error = %v", err)
+	}
+	if req.ProfileTypeID != values["profile_type"] ||
+		req.LabelSelector != values["selector"] ||
+		req.Start != 1784944800000 ||
+		req.End != 1784944860000 {
+		t.Fatalf("profileExportRequest() = %#v, want query values", req)
+	}
+}
+
+func TestProfileExportRequestRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values map[string]string
+		want   string
+	}{
+		{
+			name:   "profile type",
+			values: map[string]string{},
+			want:   "profile_type is required",
+		},
+		{
+			name: "selector",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+			},
+			want: "selector is required",
+		},
+		{
+			name: "start",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "yesterday",
+			},
+			want: "start must be a Unix timestamp in milliseconds",
+		},
+		{
+			name: "end",
+			values: map[string]string{
+				"profile_type": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				"selector":     `{hostname="node-a"}`,
+				"start":        "1784944800000",
+				"end":          "tomorrow",
+			},
+			want: "end must be a Unix timestamp in milliseconds",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := profileExportRequest(func(name string) string {
+				return test.values[name]
+			})
+			if err == nil || err.Error() != test.want {
+				t.Fatalf(
+					"profileExportRequest() error = %v, want %q",
+					err,
+					test.want,
+				)
+			}
+		})
+	}
+}

--- a/cmd/huatuo-apiserver/profiling.go
+++ b/cmd/huatuo-apiserver/profiling.go
@@ -29,10 +29,11 @@ func setupProfileFlamegraph(ctx context.Context, d *Daemon) (func(context.Contex
 	}
 
 	esConfig := &service.ElasticSearchConfig{
-		Address:  d.opts.Config.Elasticsearch.Address,
-		Username: d.opts.Config.Elasticsearch.Username,
-		Password: d.opts.Config.Elasticsearch.Password,
-		Index:    d.opts.Config.Elasticsearch.Index,
+		Address:           d.opts.Config.Elasticsearch.Address,
+		Username:          d.opts.Config.Elasticsearch.Username,
+		Password:          d.opts.Config.Elasticsearch.Password,
+		Index:             d.opts.Config.Elasticsearch.Index,
+		MaxQueryDocuments: d.opts.Config.Profiling.MaxQueryDocuments,
 	}
 	profileService, err := service.NewService(ctx, esConfig)
 	if err != nil {

--- a/docs/configuration/huatuo-apiserver-configuration_en.md
+++ b/docs/configuration/huatuo-apiserver-configuration_en.md
@@ -238,7 +238,7 @@ change job ownership because tokens are never used as principal IDs.
 ### 7. Profiling
 
 ```toml
-# Profiling subprocess configuration.
+# Profiling and profile query configuration.
 [Profiling]
     # - AggregationIntervalSeconds
     # Aggregation interval in seconds. Must be greater than 0 and less than
@@ -250,18 +250,27 @@ change job ownership because tokens are never used as principal IDs.
     # this process limit.
     # Default: 10
     #
+    # - MaxQueryDocuments
+    # Maximum profile documents processed by one display query. A value of 0
+    # disables this query limit. Documents are processed in bounded pages.
+    # Default: 0
+    #
     # - DashboardBaseURL
     # Optional dashboard base URL. Result URLs are omitted when empty.
     # Default: empty
     #
     # AggregationIntervalSeconds = 10
     # MaxConcurrentProfilerProcesses = 10
+    # MaxQueryDocuments = 0
     # DashboardBaseURL = "https://grafana.example.com/d"
 ```
 
 - `AggregationIntervalSeconds` must be greater than zero and less than 1200.
 - `MaxConcurrentProfilerProcesses` limits third-party profiler subprocesses.
   Zero disables this process limit; negative values are invalid.
+- `MaxQueryDocuments` limits how many stored profiles one flame graph, diff,
+  series, or pprof export query may process. Zero disables the limit; negative
+  values are invalid.
 - `DashboardBaseURL` is optional and must use HTTP or HTTPS when configured.
   Completed jobs omit a result URL when it is empty.
 

--- a/docs/configuration/huatuo-apiserver-configuration_en.md
+++ b/docs/configuration/huatuo-apiserver-configuration_en.md
@@ -253,7 +253,7 @@ change job ownership because tokens are never used as principal IDs.
     # - MaxQueryDocuments
     # Maximum profile documents processed by one display query. A value of 0
     # disables this query limit. Documents are processed in bounded pages.
-    # Default: 0
+    # Default: 100000
     #
     # - DashboardBaseURL
     # Optional dashboard base URL. Result URLs are omitted when empty.
@@ -261,7 +261,7 @@ change job ownership because tokens are never used as principal IDs.
     #
     # AggregationIntervalSeconds = 10
     # MaxConcurrentProfilerProcesses = 10
-    # MaxQueryDocuments = 0
+    # MaxQueryDocuments = 100000
     # DashboardBaseURL = "https://grafana.example.com/d"
 ```
 
@@ -269,8 +269,8 @@ change job ownership because tokens are never used as principal IDs.
 - `MaxConcurrentProfilerProcesses` limits third-party profiler subprocesses.
   Zero disables this process limit; negative values are invalid.
 - `MaxQueryDocuments` limits how many stored profiles one flame graph, diff,
-  series, or pprof export query may process. Zero disables the limit; negative
-  values are invalid.
+  series, or pprof export query may process. The default is 100000. Zero
+  explicitly disables the limit; negative values are invalid.
 - `DashboardBaseURL` is optional and must use HTTP or HTTPS when configured.
   Completed jobs omit a result URL when it is empty.
 

--- a/docs/configuration/huatuo-apiserver-configuration_zh.md
+++ b/docs/configuration/huatuo-apiserver-configuration_zh.md
@@ -230,7 +230,7 @@ API 服务实例会恢复持久化的 `pending` 或 `running` 状态并继续监
 ### 7. 性能剖析
 
 ```toml
-# Profiling subprocess configuration.
+# Profiling and profile query configuration.
 [Profiling]
     # - AggregationIntervalSeconds
     # Aggregation interval in seconds. Must be greater than 0 and less than
@@ -242,18 +242,26 @@ API 服务实例会恢复持久化的 `pending` 或 `running` 状态并继续监
     # this process limit.
     # Default: 10
     #
+    # - MaxQueryDocuments
+    # 单次展示查询最多处理的 profile 文档数。配置为 0 表示不限制。文档按
+    # 固定大小分页处理。
+    # Default: 0
+    #
     # - DashboardBaseURL
     # Optional dashboard base URL. Result URLs are omitted when empty.
     # Default: empty
     #
     # AggregationIntervalSeconds = 10
     # MaxConcurrentProfilerProcesses = 10
+    # MaxQueryDocuments = 0
     # DashboardBaseURL = "https://grafana.example.com/d"
 ```
 
 - `AggregationIntervalSeconds` 必须大于零且小于 1200。
 - `MaxConcurrentProfilerProcesses` 限制第三方 profiler 子进程并发数。
   配置为零表示禁用该进程数限制，负数无效。
+- `MaxQueryDocuments` 限制单次火焰图、diff、时序或 pprof 导出查询可处理的
+  profile 文档数。配置为零表示不限制，负数无效。
 - `DashboardBaseURL` 可选；配置时必须使用 HTTP 或 HTTPS。为空时，已完成
   任务不生成结果 URL。
 

--- a/docs/configuration/huatuo-apiserver-configuration_zh.md
+++ b/docs/configuration/huatuo-apiserver-configuration_zh.md
@@ -245,7 +245,7 @@ API 服务实例会恢复持久化的 `pending` 或 `running` 状态并继续监
     # - MaxQueryDocuments
     # 单次展示查询最多处理的 profile 文档数。配置为 0 表示不限制。文档按
     # 固定大小分页处理。
-    # Default: 0
+    # Default: 100000
     #
     # - DashboardBaseURL
     # Optional dashboard base URL. Result URLs are omitted when empty.
@@ -253,7 +253,7 @@ API 服务实例会恢复持久化的 `pending` 或 `running` 状态并继续监
     #
     # AggregationIntervalSeconds = 10
     # MaxConcurrentProfilerProcesses = 10
-    # MaxQueryDocuments = 0
+    # MaxQueryDocuments = 100000
     # DashboardBaseURL = "https://grafana.example.com/d"
 ```
 
@@ -261,7 +261,7 @@ API 服务实例会恢复持久化的 `pending` 或 `running` 状态并继续监
 - `MaxConcurrentProfilerProcesses` 限制第三方 profiler 子进程并发数。
   配置为零表示禁用该进程数限制，负数无效。
 - `MaxQueryDocuments` 限制单次火焰图、diff、时序或 pprof 导出查询可处理的
-  profile 文档数。配置为零表示不限制，负数无效。
+  profile 文档数。默认值为 100000；显式配置为零表示不限制，负数无效。
 - `DashboardBaseURL` 可选；配置时必须使用 HTTP 或 HTTPS。为空时，已完成
   任务不生成结果 URL。
 

--- a/docs/key-feature/continuous-profiling_en.md
+++ b/docs/key-feature/continuous-profiling_en.md
@@ -383,6 +383,37 @@ curl -sS -i \
 
 A successful deletion returns `204 No Content` with no response body. If the job is still active, the endpoint returns `409 Conflict`.
 
+### 10. Migrate Profiles Written Before `profile_storage_id`
+
+Profile documents written before this release do not contain the unique
+`profile_storage_id` sort key. Take an Elasticsearch/OpenSearch snapshot, then
+stop old huatuo-bamai writers that do not persist this field. Deploy the
+new writer and run the idempotent migration once for every physical profile
+index before using long window queries. Aliases and data streams are rejected:
+
+```bash
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh --check
+
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh
+```
+
+The script updates only profiling documents that lack the field and copies
+their existing Elasticsearch `_id`. Existing IDs and non-profiling documents
+are unchanged. It also creates or validates the sortable
+`profile_storage_id.keyword` mapping and reindexes existing IDs when that
+multi-field was added later. It fails if any matching legacy or unsortable
+documents remain, so rerunning it after an interrupted migration is safe. Run
+`--check` again after the old writers are stopped. `_update_by_query` consumes
+cluster I/O; run it during a low-traffic period for large indices.
+
 ## 📖 profiler CLI Overview
 
 `profiler` is HUATUO's standalone performance profiling CLI. It samples host processes or processes inside containers without requiring huatuo-apiserver, Elasticsearch, or Grafana. The tool supports C, C++, Go, Java, and Python processes and writes call stacks as folded stacks or SVG flame graphs.

--- a/docs/key-feature/continuous-profiling_zh.md
+++ b/docs/key-feature/continuous-profiling_zh.md
@@ -385,6 +385,34 @@ curl -sS -i \
 
 删除成功返回 `204 No Content`，不包含响应体。任务仍在运行时返回 `409 Conflict`。
 
+### 10. 迁移缺少 `profile_storage_id` 的历史数据
+
+旧版本写入的 profile 文档没有唯一的 `profile_storage_id` 排序键。使用长时间
+窗口查询前，先为 Elasticsearch/OpenSearch 创建快照，停止仍不会写入该字段的
+旧版 huatuo-bamai，再部署新版 writer，并对每个物理 profile 索引执行一次
+幂等迁移。脚本会拒绝 alias 和 data stream：
+
+```bash
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh --check
+
+ELASTICSEARCH_URL="http://localhost:9200" \
+ELASTICSEARCH_INDEX="huatuo_bamai" \
+ELASTICSEARCH_USERNAME="elastic" \
+ELASTICSEARCH_PASSWORD="REPLACE_WITH_PASSWORD" \
+./build/migrate-profile-storage-id.sh
+```
+
+脚本只更新缺少该字段的 profile 文档，并复制其现有 Elasticsearch `_id`；
+已有 ID 和非 profile 文档不会变化，同时创建或校验可排序的
+`profile_storage_id.keyword` mapping；如果该 multi-field 是后加的，还会重索引
+已有 ID。如果仍存在未迁移或不可排序的文档，脚本会失败，因此中断后可安全
+重试。停止旧 writer 后应再次运行 `--check`。
+`_update_by_query` 会消耗集群 I/O，大索引应在低流量时段执行。
+
 ## 📖 profiler 命令行功能概述
 
 `profiler` 是 HUATUO 提供的独立性能剖析命令行工具。它可以直接对宿主机进程或容器内进程采样，不依赖 huatuo-apiserver、Elasticsearch 或 Grafana。工具支持 C、C++、Go、Java 和 Python 进程，并将调用栈输出为折叠栈或 SVG 火焰图。

--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -154,7 +154,7 @@
     #         "GET /v1/profiles/**",
     #     ]
 
-# Profiling subprocess configuration.
+# Profiling and profile query configuration.
 [Profiling]
     # - AggregationIntervalSeconds
     # Aggregation interval in seconds. Must be greater than 0 and less than
@@ -166,10 +166,16 @@
     # this process limit.
     # Default: 10
     #
+    # - MaxQueryDocuments
+    # Maximum profile documents processed by one display query. A value of 0
+    # disables this query limit. Documents are processed in bounded pages.
+    # Default: 0
+    #
     # - DashboardBaseURL
     # Optional dashboard base URL. Result URLs are omitted when empty.
     # Default: empty
     #
     # AggregationIntervalSeconds = 10
     # MaxConcurrentProfilerProcesses = 10
+    # MaxQueryDocuments = 0
     # DashboardBaseURL = "http://localhost:8006/d"

--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -169,7 +169,7 @@
     # - MaxQueryDocuments
     # Maximum profile documents processed by one display query. A value of 0
     # disables this query limit. Documents are processed in bounded pages.
-    # Default: 0
+    # Default: 100000
     #
     # - DashboardBaseURL
     # Optional dashboard base URL. Result URLs are omitted when empty.
@@ -177,5 +177,5 @@
     #
     # AggregationIntervalSeconds = 10
     # MaxConcurrentProfilerProcesses = 10
-    # MaxQueryDocuments = 0
+    # MaxQueryDocuments = 100000
     # DashboardBaseURL = "http://localhost:8006/d"

--- a/integration/test_profiler_storage_elasticsearch.sh
+++ b/integration/test_profiler_storage_elasticsearch.sh
@@ -22,11 +22,11 @@ source "${ROOT_DIR}/integration/lib_storage.sh"
 # Bash cannot export arrays from the integration runner to this test process.
 CURL_TIMEOUT=(--connect-timeout 2 --max-time 3)
 
-command -v docker > /dev/null || skip "docker command is not installed"
-docker info > /dev/null 2>&1 || skip "docker daemon is unavailable"
-command -v curl > /dev/null || skip "curl command is not installed"
-command -v jq > /dev/null || skip "jq command is not installed"
-command -v go > /dev/null || fatal "go command is not installed"
+command -v docker >/dev/null || skip "docker command is not installed"
+docker info >/dev/null 2>&1 || skip "docker daemon is unavailable"
+command -v curl >/dev/null || skip "curl command is not installed"
+command -v jq >/dev/null || skip "jq command is not installed"
+command -v go >/dev/null || fatal "go command is not installed"
 
 cleanup() {
 	local status=$?
@@ -38,6 +38,124 @@ cleanup() {
 trap cleanup EXIT
 
 elasticsearch_start
+
+test_profile_storage_id_migration() {
+	local index="huatuo-profile-migration-test-${RANDOM}"
+	local alias="${index}-alias"
+	local alias_index="${index}-alias-target"
+	local document
+
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${index}" \
+		-d '{"mappings":{"properties":{"profile_storage_id":{"type":"keyword"}}}}' \
+		>/dev/null
+
+	for document in legacy-a legacy-b; do
+		curl -fsS "${CURL_TIMEOUT[@]}" \
+			-H "Content-Type: application/json" \
+			-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/${document}?refresh=true" \
+			-d "{
+				\"uploaded_time\":\"2026-08-16T02:00:00.000000001Z\",
+				\"tracer_id\":\"trace-shared\",
+				\"tracer_data\":{\"flamedata\":{\"profile\":{\"time_nanos\":1}}}
+			}" >/dev/null
+	done
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/current?refresh=true" \
+		-d '{
+			"profile_storage_id":"preserved-current-id",
+			"tracer_data":{"flamedata":{"profile_type":"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}}
+		}' >/dev/null
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile?refresh=true" \
+		-d '{"tracer_data":{"flamedata":{"cpusys":18}}}' >/dev/null
+	local check_run checked_id
+	check_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${index}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" --check)
+	grep -q 'without profile_storage_id: 2' <<<"${check_run}" ||
+		fatal "profile storage ID check did not report legacy documents"
+	grep -q 'profile_storage_id.keyword mapping: missing' <<<"${check_run}" ||
+		fatal "profile storage ID check did not report the missing mapping"
+	grep -q 'without profile_storage_id.keyword value: 1' <<<"${check_run}" ||
+		fatal "profile storage ID check did not report unsortable current IDs"
+	checked_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/legacy-a" |
+		jq -r '._source.profile_storage_id // "missing"')
+	assert_eq "${checked_id}" "missing" \
+		"check mode does not update profile documents" ||
+		fatal "profile storage ID check changed a document"
+
+	ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${index}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh"
+
+	for document in legacy-a legacy-b; do
+		local migrated_id
+		migrated_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+			"${ELASTICSEARCH_ADDR}/${index}/_doc/${document}" |
+			jq -er '._source.profile_storage_id')
+		assert_eq "${migrated_id}" "${document}" \
+			"legacy profile_storage_id uses Elasticsearch _id" ||
+			fatal "legacy profile storage ID migration failed"
+	done
+
+	local current_id non_profile_id
+	current_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/current" |
+		jq -er '._source.profile_storage_id')
+	assert_eq "${current_id}" "preserved-current-id" \
+		"current profile_storage_id is preserved" ||
+		fatal "current profile storage ID changed"
+	local current_sort
+	current_sort=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X POST "${ELASTICSEARCH_ADDR}/${index}/_search" \
+		-d '{"query":{"ids":{"values":["current"]}},"sort":["profile_storage_id.keyword"]}' |
+		jq -er '.hits.hits[0].sort[0]')
+	assert_eq "${current_sort}" "preserved-current-id" \
+		"current profile_storage_id is backfilled into the sort field" ||
+		fatal "current profile storage ID is not sortable"
+	non_profile_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile" |
+		jq -r '._source.profile_storage_id // "missing"')
+	assert_eq "${non_profile_id}" "missing" \
+		"non-profile document is not migrated" ||
+		fatal "non-profile document was changed"
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		"${ELASTICSEARCH_ADDR}/${index}/_mapping/field/profile_storage_id.keyword" |
+		jq -e 'to_entries[0].value.mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
+			>/dev/null ||
+		fatal "migrated profile_storage_id is not sortable as keyword"
+
+	local second_run
+	second_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${index}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh")
+	grep -q 'without profile_storage_id: 0' <<<"${second_run}" ||
+		fatal "profile storage ID migration is not idempotent"
+
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-X PUT "${ELASTICSEARCH_ADDR}/${alias_index}" >/dev/null
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-H "Content-Type: application/json" \
+		-X POST "${ELASTICSEARCH_ADDR}/_aliases" \
+		-d "{\"actions\":[{\"add\":{\"index\":\"${index}\",\"alias\":\"${alias}\"}},{\"add\":{\"index\":\"${alias_index}\",\"alias\":\"${alias}\"}}]}" \
+		>/dev/null
+	if ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
+		ELASTICSEARCH_INDEX="${alias}" \
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" >/dev/null 2>&1; then
+		fatal "profile storage ID migration accepted a multi-index alias"
+	fi
+
+	curl -fsS "${CURL_TIMEOUT[@]}" \
+		-X DELETE "${ELASTICSEARCH_ADDR}/${index},${alias_index}" >/dev/null
+}
+
+test_profile_storage_id_migration
 
 HUATUO_ES_TEST_ADDR="${ELASTICSEARCH_ADDR}" \
 	go test ./internal/profiler/service \

--- a/integration/test_profiler_storage_elasticsearch.sh
+++ b/integration/test_profiler_storage_elasticsearch.sh
@@ -22,11 +22,11 @@ source "${ROOT_DIR}/integration/lib_storage.sh"
 # Bash cannot export arrays from the integration runner to this test process.
 CURL_TIMEOUT=(--connect-timeout 2 --max-time 3)
 
-command -v docker >/dev/null || skip "docker command is not installed"
-docker info >/dev/null 2>&1 || skip "docker daemon is unavailable"
-command -v curl >/dev/null || skip "curl command is not installed"
-command -v jq >/dev/null || skip "jq command is not installed"
-command -v go >/dev/null || fatal "go command is not installed"
+command -v docker > /dev/null || skip "docker command is not installed"
+docker info > /dev/null 2>&1 || skip "docker daemon is unavailable"
+command -v curl > /dev/null || skip "curl command is not installed"
+command -v jq > /dev/null || skip "jq command is not installed"
+command -v go > /dev/null || fatal "go command is not installed"
 
 cleanup() {
 	local status=$?
@@ -49,7 +49,7 @@ test_profile_storage_id_migration() {
 		-H "Content-Type: application/json" \
 		-X PUT "${ELASTICSEARCH_ADDR}/${index}" \
 		-d '{"mappings":{"properties":{"profile_storage_id":{"type":"keyword"}}}}' \
-		>/dev/null
+		> /dev/null
 
 	for document in legacy-a legacy-b; do
 		curl -fsS "${CURL_TIMEOUT[@]}" \
@@ -59,7 +59,7 @@ test_profile_storage_id_migration() {
 				\"uploaded_time\":\"2026-08-16T02:00:00.000000001Z\",
 				\"tracer_id\":\"trace-shared\",
 				\"tracer_data\":{\"flamedata\":{\"profile\":{\"time_nanos\":1}}}
-			}" >/dev/null
+			}" > /dev/null
 	done
 	curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
@@ -67,27 +67,27 @@ test_profile_storage_id_migration() {
 		-d '{
 			"profile_storage_id":"preserved-current-id",
 			"tracer_data":{"flamedata":{"profile_type":"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}}
-		}' >/dev/null
+		}' > /dev/null
 	curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
 		-X PUT "${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile?refresh=true" \
-		-d '{"tracer_data":{"flamedata":{"cpusys":18}}}' >/dev/null
+		-d '{"tracer_data":{"flamedata":{"cpusys":18}}}' > /dev/null
 	local check_run checked_id
 	check_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${index}" \
 		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" --check)
-	grep -q 'without profile_storage_id: 2' <<<"${check_run}" ||
-		fatal "profile storage ID check did not report legacy documents"
-	grep -q 'profile_storage_id.keyword mapping: missing' <<<"${check_run}" ||
-		fatal "profile storage ID check did not report the missing mapping"
-	grep -q 'without profile_storage_id.keyword value: 1' <<<"${check_run}" ||
-		fatal "profile storage ID check did not report unsortable current IDs"
+	grep -q 'without profile_storage_id: 2' <<< "${check_run}" \
+		|| fatal "profile storage ID check did not report legacy documents"
+	grep -q 'profile_storage_id.keyword mapping: missing' <<< "${check_run}" \
+		|| fatal "profile storage ID check did not report the missing mapping"
+	grep -q 'without profile_storage_id.keyword value: 1' <<< "${check_run}" \
+		|| fatal "profile storage ID check did not report unsortable current IDs"
 	checked_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_doc/legacy-a" |
-		jq -r '._source.profile_storage_id // "missing"')
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/legacy-a" \
+		| jq -r '._source.profile_storage_id // "missing"')
 	assert_eq "${checked_id}" "missing" \
-		"check mode does not update profile documents" ||
-		fatal "profile storage ID check changed a document"
+		"check mode does not update profile documents" \
+		|| fatal "profile storage ID check changed a document"
 
 	ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${index}" \
@@ -96,63 +96,63 @@ test_profile_storage_id_migration() {
 	for document in legacy-a legacy-b; do
 		local migrated_id
 		migrated_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-			"${ELASTICSEARCH_ADDR}/${index}/_doc/${document}" |
-			jq -er '._source.profile_storage_id')
+			"${ELASTICSEARCH_ADDR}/${index}/_doc/${document}" \
+			| jq -er '._source.profile_storage_id')
 		assert_eq "${migrated_id}" "${document}" \
-			"legacy profile_storage_id uses Elasticsearch _id" ||
-			fatal "legacy profile storage ID migration failed"
+			"legacy profile_storage_id uses Elasticsearch _id" \
+			|| fatal "legacy profile storage ID migration failed"
 	done
 
 	local current_id non_profile_id
 	current_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_doc/current" |
-		jq -er '._source.profile_storage_id')
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/current" \
+		| jq -er '._source.profile_storage_id')
 	assert_eq "${current_id}" "preserved-current-id" \
-		"current profile_storage_id is preserved" ||
-		fatal "current profile storage ID changed"
+		"current profile_storage_id is preserved" \
+		|| fatal "current profile storage ID changed"
 	local current_sort
 	current_sort=$(curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
 		-X POST "${ELASTICSEARCH_ADDR}/${index}/_search" \
-		-d '{"query":{"ids":{"values":["current"]}},"sort":["profile_storage_id.keyword"]}' |
-		jq -er '.hits.hits[0].sort[0]')
+		-d '{"query":{"ids":{"values":["current"]}},"sort":["profile_storage_id.keyword"]}' \
+		| jq -er '.hits.hits[0].sort[0]')
 	assert_eq "${current_sort}" "preserved-current-id" \
-		"current profile_storage_id is backfilled into the sort field" ||
-		fatal "current profile storage ID is not sortable"
+		"current profile_storage_id is backfilled into the sort field" \
+		|| fatal "current profile storage ID is not sortable"
 	non_profile_id=$(curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile" |
-		jq -r '._source.profile_storage_id // "missing"')
+		"${ELASTICSEARCH_ADDR}/${index}/_doc/non-profile" \
+		| jq -r '._source.profile_storage_id // "missing"')
 	assert_eq "${non_profile_id}" "missing" \
-		"non-profile document is not migrated" ||
-		fatal "non-profile document was changed"
+		"non-profile document is not migrated" \
+		|| fatal "non-profile document was changed"
 	curl -fsS "${CURL_TIMEOUT[@]}" \
-		"${ELASTICSEARCH_ADDR}/${index}/_mapping/field/profile_storage_id.keyword" |
-		jq -e 'to_entries[0].value.mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
-			>/dev/null ||
-		fatal "migrated profile_storage_id is not sortable as keyword"
+		"${ELASTICSEARCH_ADDR}/${index}/_mapping/field/profile_storage_id.keyword" \
+		| jq -e 'to_entries[0].value.mappings["profile_storage_id.keyword"].mapping.keyword.type == "keyword"' \
+			> /dev/null \
+		|| fatal "migrated profile_storage_id is not sortable as keyword"
 
 	local second_run
 	second_run=$(ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${index}" \
 		"${ROOT_DIR}/build/migrate-profile-storage-id.sh")
-	grep -q 'without profile_storage_id: 0' <<<"${second_run}" ||
-		fatal "profile storage ID migration is not idempotent"
+	grep -q 'without profile_storage_id: 0' <<< "${second_run}" \
+		|| fatal "profile storage ID migration is not idempotent"
 
 	curl -fsS "${CURL_TIMEOUT[@]}" \
-		-X PUT "${ELASTICSEARCH_ADDR}/${alias_index}" >/dev/null
+		-X PUT "${ELASTICSEARCH_ADDR}/${alias_index}" > /dev/null
 	curl -fsS "${CURL_TIMEOUT[@]}" \
 		-H "Content-Type: application/json" \
 		-X POST "${ELASTICSEARCH_ADDR}/_aliases" \
 		-d "{\"actions\":[{\"add\":{\"index\":\"${index}\",\"alias\":\"${alias}\"}},{\"add\":{\"index\":\"${alias_index}\",\"alias\":\"${alias}\"}}]}" \
-		>/dev/null
+		> /dev/null
 	if ELASTICSEARCH_URL="${ELASTICSEARCH_ADDR}" \
 		ELASTICSEARCH_INDEX="${alias}" \
-		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" >/dev/null 2>&1; then
+		"${ROOT_DIR}/build/migrate-profile-storage-id.sh" > /dev/null 2>&1; then
 		fatal "profile storage ID migration accepted a multi-index alias"
 	fi
 
 	curl -fsS "${CURL_TIMEOUT[@]}" \
-		-X DELETE "${ELASTICSEARCH_ADDR}/${index},${alias_index}" >/dev/null
+		-X DELETE "${ELASTICSEARCH_ADDR}/${index},${alias_index}" > /dev/null
 }
 
 test_profile_storage_id_migration

--- a/integration/test_profiler_storage_elasticsearch.sh
+++ b/integration/test_profiler_storage_elasticsearch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+source "${ROOT_DIR}/integration/lib_storage.sh"
+
+# Bash cannot export arrays from the integration runner to this test process.
+CURL_TIMEOUT=(--connect-timeout 2 --max-time 3)
+
+command -v docker > /dev/null || skip "docker command is not installed"
+docker info > /dev/null 2>&1 || skip "docker daemon is unavailable"
+command -v curl > /dev/null || skip "curl command is not installed"
+command -v jq > /dev/null || skip "jq command is not installed"
+command -v go > /dev/null || fatal "go command is not installed"
+
+cleanup() {
+	local status=$?
+	if [[ ${status} -ne 0 ]]; then
+		elasticsearch_dump_logs || true
+	fi
+	elasticsearch_stop || true
+}
+trap cleanup EXIT
+
+elasticsearch_start
+
+HUATUO_ES_TEST_ADDR="${ELASTICSEARCH_ADDR}" \
+	go test ./internal/profiler/service \
+	-run '^TestProfileStorageSearchProfilesElasticsearch$' -count=1

--- a/internal/job/storage_store.go
+++ b/internal/job/storage_store.go
@@ -250,7 +250,7 @@ func (storeMapper) Indexes() []driver.Index {
 	return indexes
 }
 
-func toStorageQuery(q *JobQuery) driver.Query {
+func toStorageQuery(q *JobQuery) *driver.Query {
 	if q == nil {
 		q = &JobQuery{}
 	}
@@ -298,7 +298,7 @@ func toStorageQuery(q *JobQuery) driver.Query {
 		field = field[1:]
 	}
 	query.Sorts = []driver.Sort{{Field: field, Desc: desc}, {Field: "id", Desc: desc}}
-	return query
+	return &query
 }
 
 func cloneJob(entity *Job) *Job {

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -17,6 +17,9 @@ package aggregator
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"huatuo-bamai/core/autotracing"
@@ -37,6 +40,7 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	if !ok {
 		return fmt.Errorf("invalid pprof data for uploading: %T", data)
 	}
+	setProfileCollectionLabels(flameData, p.pctx)
 
 	tracerData := &profctx.TracerData{
 		MetricData: newMetrics(int(p.overflowCount.Load())),
@@ -60,4 +64,71 @@ func (p *Pipeline) saveProfilingDocument(_ context.Context, data any) error {
 	log.WithField("tracer_id", p.tracerID).Infof("profiling event sent via toolstream")
 
 	return nil
+}
+
+func setProfileCollectionLabels(
+	data *profiler.ProfileData,
+	pctx *profctx.ProfilerContext,
+) {
+	if data.Labels == nil {
+		data.Labels = make(map[string]string)
+	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		delete(data.Labels, name)
+	}
+	for name, value := range profileCollectionLabels(pctx) {
+		data.Labels[name] = value
+	}
+}
+
+func profileCollectionLabels(pctx *profctx.ProfilerContext) map[string]string {
+	labels := map[string]string{
+		profiler.LabelProfilingScope: profileCollectionScope(pctx),
+	}
+	if cpu := formatProfileLabelIDs(pctx.CPUIDs); cpu != "" {
+		labels[profiler.LabelCPU] = cpu
+	}
+	if pctx.ThreadGroup {
+		if tgid := formatProfileLabelIDs(pctx.PIDs); tgid != "" {
+			labels[profiler.LabelTGID] = tgid
+		}
+	} else if pid := formatProfileLabelIDs(pctx.PIDs); pid != "" {
+		labels[profiler.LabelPID] = pid
+	}
+	if pctx.ContainerID != "" {
+		labels[profiler.LabelContainerID] = pctx.ContainerID
+	}
+	return labels
+}
+
+func profileCollectionScope(pctx *profctx.ProfilerContext) string {
+	switch {
+	case pctx.ContainerID != "":
+		return "container"
+	case pctx.ThreadGroup:
+		return "thread_group"
+	case len(pctx.PIDs) != 0:
+		return "pid"
+	case len(pctx.CPUIDs) != 0:
+		return "cpu"
+	default:
+		return "host"
+	}
+}
+
+func formatProfileLabelIDs(ids []int) string {
+	if len(ids) == 0 {
+		return ""
+	}
+
+	sorted := append([]int(nil), ids...)
+	sort.Ints(sorted)
+	values := make([]string, 0, len(sorted))
+	for index, id := range sorted {
+		if index > 0 && id == sorted[index-1] {
+			continue
+		}
+		values = append(values, strconv.Itoa(id))
+	}
+	return strings.Join(values, ",")
 }

--- a/internal/profiler/aggregator/save.go
+++ b/internal/profiler/aggregator/save.go
@@ -105,7 +105,7 @@ func profileCollectionScope(pctx *profctx.ProfilerContext) string {
 	switch {
 	case pctx.ContainerID != "":
 		return "container"
-	case pctx.ThreadGroup:
+	case pctx.ThreadGroup && len(pctx.PIDs) != 0:
 		return "thread_group"
 	case len(pctx.PIDs) != 0:
 		return "pid"

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -71,6 +71,24 @@ func TestProfileCollectionLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "thread group without PID falls back to host",
+			pctx: &profctx.ProfilerContext{ThreadGroup: true},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "host",
+			},
+		},
+		{
+			name: "thread group without PID preserves CPU scope",
+			pctx: &profctx.ProfilerContext{
+				CPUIDs:      []int{6, 2, 6},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "cpu",
+				profiler.LabelCPU:            "2,6",
+			},
+		},
+		{
 			name: "container takes scope precedence",
 			pctx: &profctx.ProfilerContext{
 				ContainerID: "container-a",

--- a/internal/profiler/aggregator/save_test.go
+++ b/internal/profiler/aggregator/save_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/toolstream"
+)
+
+func TestProfileCollectionLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		pctx *profctx.ProfilerContext
+		want map[string]string
+	}{
+		{
+			name: "host",
+			pctx: &profctx.ProfilerContext{},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "host",
+			},
+		},
+		{
+			name: "CPU",
+			pctx: &profctx.ProfilerContext{CPUIDs: []int{6, 2, 6}},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "cpu",
+				profiler.LabelCPU:            "2,6",
+			},
+		},
+		{
+			name: "PID with CPU restriction",
+			pctx: &profctx.ProfilerContext{
+				PIDs:   []int{42, 7, 42},
+				CPUIDs: []int{5, 3},
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "pid",
+				profiler.LabelCPU:            "3,5",
+				profiler.LabelPID:            "7,42",
+			},
+		},
+		{
+			name: "thread group uses TGID",
+			pctx: &profctx.ProfilerContext{
+				PIDs:        []int{42, 7},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "thread_group",
+				profiler.LabelTGID:           "7,42",
+			},
+		},
+		{
+			name: "container takes scope precedence",
+			pctx: &profctx.ProfilerContext{
+				ContainerID: "container-a",
+				PIDs:        []int{42, 7},
+				CPUIDs:      []int{5, 3},
+				ThreadGroup: true,
+			},
+			want: map[string]string{
+				profiler.LabelProfilingScope: "container",
+				profiler.LabelContainerID:    "container-a",
+				profiler.LabelCPU:            "3,5",
+				profiler.LabelTGID:           "7,42",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := profileCollectionLabels(test.pctx)
+			if !maps.Equal(got, test.want) {
+				t.Fatalf("profileCollectionLabels() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSetProfileCollectionLabelsRebuildsManagedDimensions(t *testing.T) {
+	data := &profiler.ProfileData{Labels: map[string]string{
+		"custom":                     "retained",
+		profiler.LabelProfilingScope: "stale",
+		profiler.LabelCPU:            "stale",
+		profiler.LabelPID:            "stale",
+		profiler.LabelTGID:           "stale",
+		profiler.LabelContainerID:    "stale",
+	}}
+	pids := []int{42, 7, 42}
+	cpus := []int{6, 2, 6}
+	pctx := &profctx.ProfilerContext{
+		PIDs:        pids,
+		CPUIDs:      cpus,
+		ThreadGroup: true,
+	}
+
+	setProfileCollectionLabels(data, pctx)
+
+	want := map[string]string{
+		"custom":                     "retained",
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelCPU:            "2,6",
+		profiler.LabelTGID:           "7,42",
+	}
+	if !maps.Equal(data.Labels, want) {
+		t.Fatalf("ProfileData.Labels = %v, want %v", data.Labels, want)
+	}
+	if !slices.Equal(pctx.PIDs, []int{42, 7, 42}) ||
+		!slices.Equal(pctx.CPUIDs, []int{6, 2, 6}) {
+		t.Fatalf("context ID order mutated: PIDs=%v CPUIDs=%v", pctx.PIDs, pctx.CPUIDs)
+	}
+}
+
+type savedProfileEvent struct {
+	TracerData struct {
+		FlameData *profiler.ProfileData `json:"flamedata"`
+	} `json:"tracer_data"`
+}
+
+func TestSaveProfilingDocumentInjectsLabelsAtUploadBoundary(t *testing.T) {
+	sockPath := t.TempDir() + "/toolstream.sock"
+	server, err := toolstream.NewServer(sockPath)
+	if err != nil {
+		t.Fatalf("toolstream.NewServer() error = %v", err)
+	}
+	received := make(chan *savedProfileEvent, 1)
+	toolstream.Register(
+		server,
+		profilerTracerName,
+		func(_ *toolstream.Session, event *savedProfileEvent) error {
+			received <- event
+			return nil
+		},
+	)
+	if err := server.Start(); err != nil {
+		t.Fatalf("toolstream server start: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+
+	client, err := toolstream.NewClient(toolstream.ClientOptions{
+		SockPath: sockPath,
+		ToolName: profilerTracerName,
+		Version:  "1",
+		TaskID:   "trace-a",
+	})
+	if err != nil {
+		t.Fatalf("toolstream.NewClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	pctx := &profctx.ProfilerContext{
+		PIDs:             []int{42, 7},
+		CPUIDs:           []int{6, 2},
+		ThreadGroup:      true,
+		ToolstreamClient: client,
+	}
+	pipeline := &Pipeline{pctx: pctx, tracerID: "trace-a"}
+	data := &profiler.ProfileData{Labels: map[string]string{"custom": "retained"}}
+	if err := pipeline.saveProfilingDocument(context.Background(), data); err != nil {
+		t.Fatalf("saveProfilingDocument() error = %v", err)
+	}
+
+	select {
+	case event := <-received:
+		want := map[string]string{
+			"custom":                     "retained",
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelCPU:            "2,6",
+			profiler.LabelTGID:           "7,42",
+		}
+		if event == nil || event.TracerData.FlameData == nil {
+			t.Fatal("received profile event without flame data")
+		}
+		if got := event.TracerData.FlameData.Labels; !maps.Equal(got, want) {
+			t.Fatalf("uploaded labels = %v, want %v", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for uploaded profile event")
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+const (
+	// LabelProfilingScope identifies the target selector used for collection.
+	LabelProfilingScope = "profiling_scope"
+	// LabelCPU identifies the CPUs selected for native CPU collection.
+	LabelCPU = "cpu"
+	// LabelPID identifies exact process or thread targets.
+	LabelPID = "pid"
+	// LabelTGID identifies a target thread group.
+	LabelTGID = "tgid"
+	// LabelContainerID identifies a target through the common container selector.
+	LabelContainerID = "container_id"
+)
+
+var collectionDimensionLabels = [...]string{
+	LabelProfilingScope,
+	LabelCPU,
+	LabelPID,
+	LabelTGID,
+	LabelContainerID,
+}
+
+// CollectionDimensionLabelNames returns labels managed by collection filters.
+func CollectionDimensionLabelNames() []string {
+	names := make([]string, len(collectionDimensionLabels))
+	copy(names, collectionDimensionLabels[:])
+	return names
+}
+
+// IsCollectionDimensionLabel reports whether name is a supported display dimension.
+func IsCollectionDimensionLabel(name string) bool {
+	switch name {
+	case LabelProfilingScope, LabelCPU, LabelPID, LabelTGID, LabelContainerID:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/profiler/labels.go
+++ b/internal/profiler/labels.go
@@ -15,6 +15,10 @@
 package profiler
 
 const (
+	// LabelProfileID identifies a stored profile through the Profiles API job ID.
+	LabelProfileID = "id"
+	// LabelTracer identifies a stored profile through the Pyroscope-compatible alias.
+	LabelTracer = "tracer"
 	// LabelProfilingScope identifies the target selector used for collection.
 	LabelProfilingScope = "profiling_scope"
 	// LabelCPU identifies the CPUs selected for native CPU collection.
@@ -27,12 +31,24 @@ const (
 	LabelContainerID = "container_id"
 )
 
+var profileIdentifierLabels = [...]string{
+	LabelProfileID,
+	LabelTracer,
+}
+
 var collectionDimensionLabels = [...]string{
 	LabelProfilingScope,
 	LabelCPU,
 	LabelPID,
 	LabelTGID,
 	LabelContainerID,
+}
+
+// ProfileIdentifierLabelNames returns aliases for the stored profile identifier.
+func ProfileIdentifierLabelNames() []string {
+	names := make([]string, len(profileIdentifierLabels))
+	copy(names, profileIdentifierLabels[:])
+	return names
 }
 
 // CollectionDimensionLabelNames returns labels managed by collection filters.

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -16,6 +16,19 @@ package profiler
 
 import "testing"
 
+func TestProfileIdentifierLabelNamesReturnsCopy(t *testing.T) {
+	names := ProfileIdentifierLabelNames()
+	names[0] = "changed"
+
+	want := []string{LabelProfileID, LabelTracer}
+	got := ProfileIdentifierLabelNames()
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("profile identifier labels = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
 	names := CollectionDimensionLabelNames()
 	names[0] = "changed"

--- a/internal/profiler/labels_test.go
+++ b/internal/profiler/labels_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiler
+
+import "testing"
+
+func TestCollectionDimensionLabelNamesReturnsCopy(t *testing.T) {
+	names := CollectionDimensionLabelNames()
+	names[0] = "changed"
+
+	if got := CollectionDimensionLabelNames()[0]; got != LabelProfilingScope {
+		t.Fatalf("first collection label = %q, want %q", got, LabelProfilingScope)
+	}
+}
+
+func TestIsCollectionDimensionLabel(t *testing.T) {
+	for _, name := range CollectionDimensionLabelNames() {
+		if !IsCollectionDimensionLabel(name) {
+			t.Errorf("IsCollectionDimensionLabel(%q) = false", name)
+		}
+	}
+	if IsCollectionDimensionLabel("arbitrary") {
+		t.Fatal("IsCollectionDimensionLabel(arbitrary) = true")
+	}
+}

--- a/internal/profiler/service/display_query.go
+++ b/internal/profiler/service/display_query.go
@@ -1,0 +1,558 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	profileQueryPageSize = 1000
+	profileSeriesLimit   = 10
+	// DefaultProfileMaxNodes is the flame graph node limit used when omitted.
+	DefaultProfileMaxNodes int64 = 5000
+	// MaxProfileNodes is the largest accepted flame graph node limit.
+	MaxProfileNodes int64 = 10000
+)
+
+type profileSelection struct {
+	filter     *SearchFilter
+	sampleType string
+}
+
+func buildProfileSelection(profileType, selector string, start, end int64) (*profileSelection, error) {
+	profileTypeParts := strings.Split(profileType, ":")
+	if len(profileTypeParts) != 5 {
+		return nil, invalidProfileQueryf("invalid profile type %q", profileType)
+	}
+	if end < start {
+		return nil, invalidProfileQueryf("end time precedes start time")
+	}
+
+	matchers, err := parser.ParseMetricSelector(selector)
+	if err != nil {
+		return nil, invalidProfileQueryf("parse matchers: %v", err)
+	}
+	filter := &SearchFilter{
+		StartTime:   time.UnixMilli(start),
+		EndTime:     time.UnixMilli(end),
+		ProfileType: profileType,
+	}
+	for _, matcher := range matchers {
+		if matcher == nil {
+			continue
+		}
+		if matcher.Name == "__profile_type__" && matcher.Value != profileType {
+			return nil, invalidProfileQueryf(
+				"profile type matcher %q does not match request %q",
+				matcher.Value,
+				profileType,
+			)
+		}
+		if err := applyProfileMatcher(filter, matcher); err != nil {
+			return nil, err
+		}
+	}
+	if filter.ID != "" && filter.TracerID != "" && filter.ID != filter.TracerID {
+		return nil, invalidProfileQueryf("id and tracer select different profiles")
+	}
+	if !hasExactProfileTarget(filter) {
+		return nil, invalidProfileQueryf(
+			"id, hostname, container_id, container_hostname, tracer, or a " +
+				"collection dimension must be specified",
+		)
+	}
+	return &profileSelection{filter: filter, sampleType: profileTypeParts[1]}, nil
+}
+
+func invalidProfileQueryf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrInvalidQuery, fmt.Sprintf(format, args...))
+}
+
+func hasExactProfileTarget(filter *SearchFilter) bool {
+	if filter == nil {
+		return false
+	}
+	if filter.ID != "" ||
+		filter.Hostname != "" ||
+		filter.ContainerID != "" ||
+		filter.ContainerHostname != "" ||
+		filter.TracerID != "" {
+		return true
+	}
+	for _, value := range filter.Labels {
+		if value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) visitProfileDocuments(
+	ctx context.Context,
+	selection *profileSelection,
+	visit func(*ProfileDocument) error,
+) (int64, error) {
+	if s == nil || s.profileStorage == nil {
+		return 0, errorsProfileStorageNotInitialized()
+	}
+	if s.maxQueryDocuments > 0 {
+		count, err := s.profileStorage.CountProfilesContext(ctx, selection.filter)
+		if err != nil {
+			return 0, fmt.Errorf("count profiles: %w", err)
+		}
+		if count < 0 {
+			return 0, fmt.Errorf("count profiles: storage returned negative count %d", count)
+		}
+		if count > s.maxQueryDocuments {
+			return 0, fmt.Errorf(
+				"%w: matched %d documents; narrow the time range or selector to at most %d",
+				ErrProfileQueryLimitExceeded,
+				count,
+				s.maxQueryDocuments,
+			)
+		}
+	}
+
+	var visited int64
+	var cursor []any
+	for {
+		pageFilter := *selection.filter
+		pageFilter.Limit = profileQueryPageSize
+		if s.maxQueryDocuments > 0 {
+			remaining := s.maxQueryDocuments - visited
+			if remaining == 0 {
+				// Probe once past an exact full limit to avoid rejecting a query
+				// whose result contains exactly the configured maximum.
+				pageFilter.Limit = 1
+			} else {
+				pageFilter.Limit = int(min(int64(profileQueryPageSize), remaining))
+			}
+		}
+		pageFilter.Offset = 0
+		page, nextCursor, err := s.profileStorage.SearchProfilesPageContext(
+			ctx,
+			&pageFilter,
+			cursor,
+		)
+		if err != nil {
+			return visited, fmt.Errorf("search profiles after %d documents: %w", visited, err)
+		}
+		if len(page) > pageFilter.Limit {
+			return visited, fmt.Errorf(
+				"search profiles after %d documents: storage returned %d documents, limit is %d",
+				visited,
+				len(page),
+				pageFilter.Limit,
+			)
+		}
+		if s.maxQueryDocuments > 0 && visited == s.maxQueryDocuments && len(page) > 0 {
+			return visited, fmt.Errorf(
+				"%w: more than %d documents matched while paging; narrow the time range or selector",
+				ErrProfileQueryLimitExceeded,
+				s.maxQueryDocuments,
+			)
+		}
+		for index, document := range page {
+			if document == nil {
+				return visited, fmt.Errorf(
+					"search profiles after %d documents: storage returned nil document at page index %d",
+					visited,
+					index,
+				)
+			}
+			if err := visit(document); err != nil {
+				return visited, fmt.Errorf(
+					"process profile after %d documents at page index %d: %w",
+					visited,
+					index,
+					err,
+				)
+			}
+			visited++
+		}
+		// Short pages tolerate retention and indicate that the cursor is
+		// exhausted without relying on a separate count result.
+		if len(page) < pageFilter.Limit || len(nextCursor) == 0 {
+			break
+		}
+		cursor = nextCursor
+	}
+	return visited, nil
+}
+
+func errorsProfileStorageNotInitialized() error {
+	return fmt.Errorf("profile storage is not initialized")
+}
+
+func (s *Service) selectProfileTree(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+	allowEmpty bool,
+) (*phlaremodel.Tree, bool, error) {
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	tree := new(phlaremodel.Tree)
+	hasSamples := false
+	_, err = s.visitProfileDocuments(ctx, selection, func(document *ProfileDocument) error {
+		if addProfileDocumentToTree(tree, document, selection.sampleType) {
+			hasSamples = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if !hasSamples && !allowEmpty {
+		return nil, false, ErrProfilesAbsent
+	}
+	return tree, hasSamples, nil
+}
+
+func addProfileDocumentToTree(
+	tree *phlaremodel.Tree,
+	document *ProfileDocument,
+	sampleType string,
+) bool {
+	profile := &document.TracerData.Flamedata.Profile
+	sampleTypeIndex, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return false
+	}
+
+	locations := make(map[uint64]*profilev1.Location, len(profile.Location))
+	for _, location := range profile.Location {
+		if location != nil {
+			locations[location.Id] = location
+		}
+	}
+	functions := make(map[uint64]*profilev1.Function, len(profile.Function))
+	for _, function := range profile.Function {
+		if function != nil {
+			functions[function.Id] = function
+		}
+	}
+	inserted := false
+	for _, sample := range profile.Sample {
+		if sample == nil || sampleTypeIndex >= len(sample.Value) {
+			continue
+		}
+		stack := profileSampleStack(profile, locations, functions, sample.LocationId)
+		if len(stack) > 0 {
+			tree.InsertStack(sample.Value[sampleTypeIndex], stack...)
+			inserted = true
+		}
+	}
+	return inserted
+}
+
+func profileSampleTypeIndex(profile *profilev1.Profile, sampleType string) (int, bool) {
+	for i, valueType := range profile.SampleType {
+		if valueType == nil {
+			continue
+		}
+		if name, ok := profileString(profile.StringTable, valueType.Type); ok && name == sampleType {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func profileSampleStack(
+	profile *profilev1.Profile,
+	locations map[uint64]*profilev1.Location,
+	functions map[uint64]*profilev1.Function,
+	locationIDs []uint64,
+) []string {
+	stack := make([]string, 0, len(locationIDs))
+	for _, locationID := range locationIDs {
+		location := locations[locationID]
+		if location == nil {
+			continue
+		}
+		for _, line := range location.Line {
+			if line == nil {
+				continue
+			}
+			function := functions[line.FunctionId]
+			if function == nil {
+				continue
+			}
+			name, ok := profileString(profile.StringTable, function.Name)
+			if ok {
+				stack = append(stack, name)
+			}
+		}
+	}
+	for left, right := 0, len(stack)-1; left < right; left, right = left+1, right-1 {
+		stack[left], stack[right] = stack[right], stack[left]
+	}
+	return stack
+}
+
+func normalizeProfileMaxNodes(maxNodes int64) (int64, error) {
+	if maxNodes == 0 {
+		return DefaultProfileMaxNodes, nil
+	}
+	if maxNodes < 0 || maxNodes > MaxProfileNodes {
+		return 0, invalidProfileQueryf(
+			"max nodes must be between 0 and %d",
+			MaxProfileNodes,
+		)
+	}
+	return maxNodes, nil
+}
+
+// SelectSeries returns sample totals bucketed by time and exact profile labels.
+func (s *Service) SelectSeries(
+	ctx context.Context,
+	req *querierv1.SelectSeriesRequest,
+) (*querierv1.SelectSeriesResponse, error) {
+	if req == nil {
+		return nil, invalidProfileQueryf("request is required")
+	}
+	stepMillis, err := seriesStepMillis(req.Step)
+	if err != nil {
+		return nil, err
+	}
+	aggregation := typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM
+	if req.Aggregation != nil {
+		aggregation = *req.Aggregation
+	}
+	if aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM &&
+		aggregation != typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+		return nil, invalidProfileQueryf(
+			"unsupported time series aggregation %q",
+			aggregation.String(),
+		)
+	}
+	groupBy, err := normalizeProfileGroupBy(req.GroupBy)
+	if err != nil {
+		return nil, err
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, err
+	}
+	type bucketValue struct {
+		sum   float64
+		count int64
+	}
+	type groupedSeries struct {
+		labels  []*typesv1.LabelPair
+		buckets map[int64]*bucketValue
+	}
+	groups := make(map[string]*groupedSeries)
+	_, err = s.visitProfileDocuments(ctx, selection, func(document *ProfileDocument) error {
+		value, found := profileDocumentSampleTotal(document, selection.sampleType)
+		if !found {
+			return nil
+		}
+		seriesLabels, key := profileSeriesLabels(document, groupBy)
+		group := groups[key]
+		if group == nil {
+			group = &groupedSeries{
+				labels:  seriesLabels,
+				buckets: make(map[int64]*bucketValue),
+			}
+			groups[key] = group
+		}
+		timestamp := profileDocumentTimestamp(document).UnixMilli()
+		bucketTimestamp := req.Start + ((timestamp-req.Start)/stepMillis)*stepMillis
+		bucket := group.buckets[bucketTimestamp]
+		if bucket == nil {
+			bucket = &bucketValue{}
+			group.buckets[bucketTimestamp] = bucket
+		}
+		bucket.sum += value
+		bucket.count++
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	series := make([]*typesv1.Series, 0, len(groups))
+	for _, group := range groups {
+		points := make([]*typesv1.Point, 0, len(group.buckets))
+		for timestamp, value := range group.buckets {
+			pointValue := value.sum
+			if aggregation ==
+				typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_AVERAGE {
+				pointValue /= float64(value.count)
+			}
+			points = append(points, &typesv1.Point{
+				Value:     pointValue,
+				Timestamp: timestamp,
+			})
+		}
+		sort.Slice(points, func(i, j int) bool {
+			return points[i].Timestamp < points[j].Timestamp
+		})
+		series = append(series, &typesv1.Series{
+			Labels: group.labels,
+			Points: points,
+		})
+	}
+	sort.Slice(series, func(i, j int) bool {
+		left, right := profileSeriesValue(series[i]), profileSeriesValue(series[j])
+		if left != right {
+			return left > right
+		}
+		return phlaremodel.CompareLabelPairs(series[i].Labels, series[j].Labels) < 0
+	})
+	if len(series) > profileSeriesLimit {
+		series = series[:profileSeriesLimit]
+	}
+	return &querierv1.SelectSeriesResponse{Series: series}, nil
+}
+
+func seriesStepMillis(step float64) (int64, error) {
+	if math.IsNaN(step) ||
+		math.IsInf(step, 0) ||
+		step <= 0 ||
+		step > float64(math.MaxInt64)/1000 {
+		return 0, invalidProfileQueryf(
+			"step must be a finite positive number of seconds",
+		)
+	}
+	milliseconds := int64(math.Round(step * 1000))
+	if milliseconds < 1 {
+		return 1, nil
+	}
+	return milliseconds, nil
+}
+
+func normalizeProfileGroupBy(groupBy []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(groupBy))
+	result := make([]string, 0, len(groupBy))
+	for _, name := range groupBy {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		switch name {
+		case profiler.LabelProfileID,
+			"hostname",
+			"container_id",
+			"container_hostname",
+			profiler.LabelTracer:
+		default:
+			if !profiler.IsCollectionDimensionLabel(name) {
+				return nil, invalidProfileQueryf("invalid group-by label %q", name)
+			}
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func profileDocumentSampleTotal(
+	document *ProfileDocument,
+	sampleType string,
+) (float64, bool) {
+	profile := &document.TracerData.Flamedata.Profile
+	index, ok := profileSampleTypeIndex(profile, sampleType)
+	if !ok {
+		return 0, false
+	}
+	var total float64
+	var found bool
+	for _, sample := range profile.Sample {
+		if sample == nil || index >= len(sample.Value) {
+			continue
+		}
+		total += float64(sample.Value[index])
+		found = true
+	}
+	return total, found
+}
+
+func profileSeriesLabels(
+	document *ProfileDocument,
+	groupBy []string,
+) ([]*typesv1.LabelPair, string) {
+	pairs := make([]*typesv1.LabelPair, 0, len(groupBy))
+	var key strings.Builder
+	for _, name := range groupBy {
+		value := profileDocumentLabelValue(document, name)
+		pairs = append(pairs, &typesv1.LabelPair{Name: name, Value: value})
+		_, _ = fmt.Fprintf(&key, "%d:%s=%d:%s;", len(name), name, len(value), value)
+	}
+	return pairs, key.String()
+}
+
+func profileDocumentLabelValue(document *ProfileDocument, name string) string {
+	switch name {
+	case profiler.LabelProfileID, profiler.LabelTracer:
+		return document.TracerID
+	case "hostname":
+		return document.Hostname
+	case "container_id":
+		return document.ContainerID
+	case "container_hostname":
+		return document.ContainerHostname
+	default:
+		if profiler.IsCollectionDimensionLabel(name) {
+			return document.TracerData.Flamedata.Labels[name]
+		}
+		return ""
+	}
+}
+
+func profileDocumentTimestamp(document *ProfileDocument) time.Time {
+	if !document.UploadedTime.IsZero() {
+		return document.UploadedTime
+	}
+	return parseProfileDocumentTime(document.TracerTime, time.Unix(0, 0))
+}
+
+func profileSeriesValue(series *typesv1.Series) float64 {
+	var total float64
+	for _, point := range series.GetPoints() {
+		total += point.GetValue()
+	}
+	return total
+}

--- a/internal/profiler/service/display_query_test.go
+++ b/internal/profiler/service/display_query_test.go
@@ -1,0 +1,806 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+type fakeProfileQueryStorage struct {
+	documents   []*ProfileDocument
+	count       int64
+	countErr    error
+	searchErr   error
+	searchCalls []SearchFilter
+	searchAfter [][]any
+	pages       map[int][]*ProfileDocument
+}
+
+func (*fakeProfileQueryStorage) Close(context.Context) error { return nil }
+func (*fakeProfileQueryStorage) Ready(context.Context) error { return nil }
+
+func (s *fakeProfileQueryStorage) SearchProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) ([]*ProfileDocument, error) {
+	documents, _, err := s.SearchProfilesPageContext(context.Background(), filter, nil)
+	return documents, err
+}
+
+func (s *fakeProfileQueryStorage) SearchProfilesPageContext(
+	_ context.Context,
+	filter *SearchFilter,
+	cursor []any,
+) ([]*ProfileDocument, []any, error) {
+	if s.searchErr != nil {
+		return nil, nil, s.searchErr
+	}
+	s.searchCalls = append(s.searchCalls, *filter)
+	s.searchAfter = append(s.searchAfter, append([]any(nil), cursor...))
+	offset := filter.Offset
+	if len(cursor) > 0 {
+		offset = cursor[0].(int)
+	}
+	if s.pages != nil {
+		page := s.pages[offset]
+		return page, fakeProfilePageCursor(offset, page), nil
+	}
+	documents := s.matchingDocuments(filter)
+	if offset >= len(documents) {
+		return nil, nil, nil
+	}
+	end := min(offset+filter.Limit, len(documents))
+	page := documents[offset:end]
+	return page, fakeProfilePageCursor(offset, page), nil
+}
+
+func fakeProfilePageCursor(offset int, page []*ProfileDocument) []any {
+	if len(page) == 0 {
+		return nil
+	}
+	return []any{offset + len(page)}
+}
+
+func (s *fakeProfileQueryStorage) CountProfilesContext(
+	_ context.Context,
+	filter *SearchFilter,
+) (int64, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	if s.count != 0 {
+		return s.count, nil
+	}
+	return int64(len(s.matchingDocuments(filter))), nil
+}
+
+func (*fakeProfileQueryStorage) AggregationsByFieldContext(
+	context.Context,
+	*SearchFilter,
+	string,
+) ([]string, error) {
+	return nil, nil
+}
+
+func (s *fakeProfileQueryStorage) matchingDocuments(filter *SearchFilter) []*ProfileDocument {
+	documents := make([]*ProfileDocument, 0, len(s.documents))
+documentLoop:
+	for _, document := range s.documents {
+		if document == nil {
+			continue
+		}
+		timestamp := profileDocumentTimestamp(document)
+		if !filter.StartTime.IsZero() && timestamp.Before(filter.StartTime) {
+			continue
+		}
+		if !filter.EndTime.IsZero() && timestamp.After(filter.EndTime) {
+			continue
+		}
+		if filter.ProfileType != "" &&
+			filter.ProfileType != document.TracerData.Flamedata.ProfileType {
+			continue
+		}
+		tracerID := filter.TracerID
+		if tracerID == "" {
+			tracerID = filter.ID
+		}
+		if tracerID != "" && tracerID != document.TracerID {
+			continue
+		}
+		if filter.Hostname != "" &&
+			(filter.Hostname != document.Hostname || document.ContainerHostname != "") {
+			continue
+		}
+		if filter.ContainerID != "" && filter.ContainerID != document.ContainerID {
+			continue
+		}
+		if filter.ContainerHostname != "" &&
+			filter.ContainerHostname != document.ContainerHostname {
+			continue
+		}
+		for name, value := range filter.Labels {
+			if value != "" &&
+				document.TracerData.Flamedata.Labels[name] != value {
+				continue documentLoop
+			}
+		}
+		documents = append(documents, document)
+	}
+	return documents
+}
+
+func newTestProfileService(storage *fakeProfileQueryStorage) *Service {
+	return &Service{profileStorage: storage}
+}
+
+func testProfileDocument(
+	timestamp time.Time,
+	tracerID string,
+	value int64,
+	stack ...string,
+) *ProfileDocument {
+	stringTable := []string{"", "cpu", "nanoseconds"}
+	functions := make([]*profilev1.Function, len(stack))
+	locations := make([]*profilev1.Location, len(stack))
+	locationIDs := make([]uint64, len(stack))
+	for i, name := range stack {
+		stringTable = append(stringTable, name)
+		id := uint64(i + 1)
+		functions[i] = &profilev1.Function{
+			Id:   id,
+			Name: int64(len(stringTable) - 1),
+		}
+		locations[i] = &profilev1.Location{
+			Id:   id,
+			Line: []*profilev1.Line{{FunctionId: id}},
+		}
+		locationIDs[len(stack)-1-i] = id
+	}
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: timestamp,
+		TracerID:     tracerID,
+		TracerTime:   timestamp.Format(profileTimeLayout),
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	document.TracerData.Flamedata.Profile = profilev1.Profile{
+		StringTable: stringTable,
+		SampleType: []*profilev1.ValueType{{
+			Type: 1,
+			Unit: 2,
+		}},
+		Function: functions,
+		Location: locations,
+		Sample: []*profilev1.Sample{{
+			LocationId: locationIDs,
+			Value:      []int64{value},
+		}},
+	}
+	return document
+}
+
+func TestVisitProfileDocumentsPaginatesWithoutAccumulating(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	documents := make([]*ProfileDocument, 1001)
+	for i := range documents {
+		documents[i] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{hostname="node-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	var got int
+	visited, err := service.visitProfileDocuments(
+		t.Context(),
+		selection,
+		func(*ProfileDocument) error {
+			got++
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("visitProfileDocuments() error = %v", err)
+	}
+	if got != len(documents) || visited != int64(len(documents)) {
+		t.Fatalf("visited documents = (%d, %d), want %d", got, visited, len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	if storage.searchCalls[0].Limit != 1000 ||
+		storage.searchCalls[0].Offset != 0 ||
+		storage.searchCalls[1].Limit != 1000 ||
+		storage.searchCalls[1].Offset != 0 ||
+		len(storage.searchAfter[0]) != 0 ||
+		!reflect.DeepEqual(storage.searchAfter[1], []any{1000}) {
+		t.Fatalf(
+			"search pages = %#v after %#v, want limit 1000 and cursor 1000",
+			storage.searchCalls,
+			storage.searchAfter,
+		)
+	}
+}
+
+func TestVisitProfileDocumentsAllowsUnlimitedLongQuery(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	documents := make([]*ProfileDocument, 10001)
+	for i := range documents {
+		documents[i] = document
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{documents: documents})
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{hostname="node-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	visited, err := service.visitProfileDocuments(
+		t.Context(),
+		selection,
+		func(*ProfileDocument) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("visitProfileDocuments() error = %v", err)
+	}
+	if visited != int64(len(documents)) {
+		t.Fatalf("visited documents = %d, want %d", visited, len(documents))
+	}
+}
+
+func TestVisitProfileDocumentsEnforcesConfiguredLimit(t *testing.T) {
+	storage := &fakeProfileQueryStorage{count: 10001}
+	service := newTestProfileService(storage)
+	service.maxQueryDocuments = 10000
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	_, err = service.visitProfileDocuments(
+		t.Context(),
+		selection,
+		func(*ProfileDocument) error { return nil },
+	)
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf("visitProfileDocuments() error = %v, want query limit error", err)
+	}
+	if len(storage.searchCalls) != 0 {
+		t.Fatalf("search calls = %d, want 0", len(storage.searchCalls))
+	}
+}
+
+func TestVisitProfileDocumentsRejectsInvalidStorageResults(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	tests := []struct {
+		name    string
+		storage *fakeProfileQueryStorage
+	}{
+		{
+			name:    "negative count",
+			storage: &fakeProfileQueryStorage{count: -1},
+		},
+		{
+			name: "oversized page",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {document, document, document}},
+			},
+		},
+		{
+			name: "nil document",
+			storage: &fakeProfileQueryStorage{
+				count: 1,
+				pages: map[int][]*ProfileDocument{0: {nil}},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTestProfileService(test.storage)
+			service.maxQueryDocuments = 1
+			selection, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				`{id="trace-a"}`,
+				0,
+				time.Now().Add(time.Hour).UnixMilli(),
+			)
+			if err != nil {
+				t.Fatalf("buildProfileSelection() error = %v", err)
+			}
+
+			_, err = service.visitProfileDocuments(
+				t.Context(),
+				selection,
+				func(*ProfileDocument) error { return nil },
+			)
+			if err == nil {
+				t.Fatal("visitProfileDocuments() error = nil, want storage contract error")
+			}
+			if errors.Is(err, ErrInvalidQuery) ||
+				errors.Is(err, ErrProfilesAbsent) ||
+				errors.Is(err, ErrProfileQueryLimitExceeded) {
+				t.Fatalf("storage contract error = %v, want internal error", err)
+			}
+		})
+	}
+}
+
+func TestVisitProfileDocumentsToleratesCountDrift(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	storage := &fakeProfileQueryStorage{
+		count: 2,
+		pages: map[int][]*ProfileDocument{0: {document}},
+	}
+	service := newTestProfileService(storage)
+	service.maxQueryDocuments = 100
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	visited, err := service.visitProfileDocuments(
+		t.Context(),
+		selection,
+		func(*ProfileDocument) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("visitProfileDocuments() error = %v", err)
+	}
+	if visited != 1 {
+		t.Fatalf("visited documents = %d, want 1", visited)
+	}
+}
+
+func TestVisitProfileDocumentsDetectsGrowthPastConfiguredLimit(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	storage := &fakeProfileQueryStorage{
+		count: 2,
+		documents: []*ProfileDocument{
+			document,
+			document,
+			document,
+		},
+	}
+	service := newTestProfileService(storage)
+	service.maxQueryDocuments = 2
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	var visited int
+	_, err = service.visitProfileDocuments(
+		t.Context(),
+		selection,
+		func(*ProfileDocument) error {
+			visited++
+			return nil
+		},
+	)
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf("visitProfileDocuments() error = %v, want query limit error", err)
+	}
+	if visited != 2 {
+		t.Fatalf("callback visits = %d, want 2 before overflow probe", visited)
+	}
+	if len(storage.searchCalls) != 2 ||
+		storage.searchCalls[0].Limit != 2 ||
+		storage.searchCalls[1].Limit != 1 {
+		t.Fatalf("search calls = %#v, want two-document page and one probe", storage.searchCalls)
+	}
+}
+
+func TestVisitProfileDocumentsAcceptsExactConfiguredLimit(t *testing.T) {
+	document := testProfileDocument(time.Now(), "trace-a", 1, "root", "leaf")
+	storage := &fakeProfileQueryStorage{
+		count:     2,
+		documents: []*ProfileDocument{document, document},
+	}
+	service := newTestProfileService(storage)
+	service.maxQueryDocuments = 2
+	selection, err := buildProfileSelection(
+		profiler.ProfileTypeCpuSample,
+		`{id="trace-a"}`,
+		0,
+		time.Now().Add(time.Hour).UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("buildProfileSelection() error = %v", err)
+	}
+
+	visited, err := service.visitProfileDocuments(
+		t.Context(),
+		selection,
+		func(*ProfileDocument) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("visitProfileDocuments() error = %v", err)
+	}
+	if visited != 2 {
+		t.Fatalf("visited documents = %d, want 2", visited)
+	}
+	if len(storage.searchCalls) != 2 || storage.searchCalls[1].Limit != 1 {
+		t.Fatalf("search calls = %#v, want one overflow probe", storage.searchCalls)
+	}
+}
+
+func TestBuildProfileSelectionRejectsBroadMatchers(t *testing.T) {
+	for _, selector := range []string{
+		`{hostname=~"node-.*"}`,
+		`{region="ap-guangzhou"}`,
+		`{arbitrary_label="value"}`,
+		`{id="trace-a",tracer="trace-b"}`,
+		`{pid=""}`,
+	} {
+		t.Run(selector, func(t *testing.T) {
+			_, err := buildProfileSelection(
+				profiler.ProfileTypeCpuSample,
+				selector,
+				0,
+				1,
+			)
+			if !errors.Is(err, ErrInvalidQuery) {
+				t.Fatalf("buildProfileSelection() error = %v, want invalid query", err)
+			}
+		})
+	}
+}
+
+func TestSelectSeriesBucketsAndGroups(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{documents: []*ProfileDocument{
+		testProfileDocument(start.Add(100*time.Millisecond), "trace-a", 10, "root", "hot"),
+		testProfileDocument(start.Add(1500*time.Millisecond), "trace-a", 20, "root", "hot"),
+		testProfileDocument(start.Add(500*time.Millisecond), "trace-b", 7, "root", "worker"),
+	}}
+	service := newTestProfileService(storage)
+
+	response, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(4 * time.Second).UnixMilli(),
+		GroupBy:       []string{"tracer"},
+		Step:          2,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 2 {
+		t.Fatalf("series = %#v, want two tracer groups", response.Series)
+	}
+	if got := response.Series[0].Labels[0].Value; got != "trace-a" {
+		t.Fatalf("first series tracer = %q, want trace-a", got)
+	}
+	wantPoints := []*typesv1.Point{{
+		Value:     30,
+		Timestamp: start.UnixMilli(),
+	}}
+	if got := response.Series[0].Points; !reflect.DeepEqual(got, wantPoints) {
+		t.Fatalf("trace-a points = %#v, want %#v", got, wantPoints)
+	}
+}
+
+func TestSelectSeriesReturnsTopTenGroups(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 15, 0, 0, time.UTC)
+	documents := make([]*ProfileDocument, 12)
+	for i := range documents {
+		documents[i] = testProfileDocument(
+			start,
+			fmt.Sprintf("trace-%02d", i+1),
+			int64(i+1),
+			"root",
+			"worker",
+		)
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{documents: documents})
+
+	response, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		GroupBy:       []string{profiler.LabelTracer},
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != profileSeriesLimit {
+		t.Fatalf("series = %d, want %d", len(response.Series), profileSeriesLimit)
+	}
+	if got := response.Series[0].Labels[0].Value; got != "trace-12" {
+		t.Fatalf("first series tracer = %q, want trace-12", got)
+	}
+	if got := response.Series[9].Labels[0].Value; got != "trace-03" {
+		t.Fatalf("last series tracer = %q, want trace-03", got)
+	}
+}
+
+func TestCollectionDimensionsFilterAndGroupFixtureProfiles(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 30, 0, 0, time.UTC)
+	matching := testProfileDocument(
+		start.Add(time.Second),
+		"trace-pid-4242",
+		25,
+		"root",
+		"hot",
+	)
+	matching.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "pid",
+		profiler.LabelCPU:            "2,4,5,6,7",
+		profiler.LabelPID:            "4242",
+	}
+	matching.TracerData.Flamedata.Profile.StringTable = append(
+		matching.TracerData.Flamedata.Profile.StringTable,
+		profiler.LabelProfilingScope,
+		"pid",
+		"2,4,5,6,7",
+		"4242",
+	)
+	matching.TracerData.Flamedata.Profile.Sample[0].Label = []*profilev1.Label{
+		{Key: 5, Str: 6},
+		{Key: 1, Str: 7},
+		{Key: 6, Str: 8},
+	}
+	other := testProfileDocument(
+		start.Add(2*time.Second),
+		"trace-pid-9000",
+		100,
+		"root",
+		"cold",
+	)
+	other.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "pid",
+		profiler.LabelCPU:            "3",
+		profiler.LabelPID:            "9000",
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{matching, other},
+	})
+
+	response, err := service.SelectSeries(
+		t.Context(),
+		&querierv1.SelectSeriesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{profiling_scope="pid",cpu="2,4,5,6,7"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+			GroupBy:       []string{profiler.LabelPID},
+			Step:          10,
+		},
+	)
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(response.Series) != 1 ||
+		len(response.Series[0].Labels) != 1 ||
+		response.Series[0].Labels[0].Name != profiler.LabelPID ||
+		response.Series[0].Labels[0].Value != "4242" ||
+		len(response.Series[0].Points) != 1 ||
+		response.Series[0].Points[0].Value != 25 {
+		t.Fatalf("dimensioned series = %#v", response.Series)
+	}
+
+	flamegraph, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{pid="4242"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("SelectMergeStacktraces() error = %v", err)
+	}
+	if flamegraph.GetFlamegraph().GetTotal() != 25 {
+		t.Fatalf(
+			"dimensioned flame graph total = %d, want 25",
+			flamegraph.GetFlamegraph().GetTotal(),
+		)
+	}
+
+	payload, err := service.MarshalPprof(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{pid="4242"}`,
+			Start:         start.UnixMilli(),
+			End:           start.Add(time.Minute).UnixMilli(),
+		},
+	)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	exported, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("decode exported pprof: %v", err)
+	}
+	if len(exported.Sample) != 1 || len(exported.Sample[0].Label) != 3 {
+		t.Fatalf("exported managed sample labels = %#v", exported.Sample)
+	}
+	exportedLabels := make(map[string]string, len(exported.Sample[0].Label))
+	for _, label := range exported.Sample[0].Label {
+		name, nameOK := profileString(exported.StringTable, label.Key)
+		value, valueOK := profileString(exported.StringTable, label.Str)
+		if nameOK && valueOK {
+			exportedLabels[name] = value
+		}
+	}
+	if !reflect.DeepEqual(
+		exportedLabels,
+		matching.TracerData.Flamedata.Labels,
+	) {
+		t.Fatalf(
+			"exported labels = %#v, want %#v",
+			exportedLabels,
+			matching.TracerData.Flamedata.Labels,
+		)
+	}
+}
+
+func TestProfileNodeLimits(t *testing.T) {
+	if got, err := normalizeProfileMaxNodes(0); err != nil ||
+		got != DefaultProfileMaxNodes {
+		t.Fatalf("normalizeProfileMaxNodes(0) = (%d, %v)", got, err)
+	}
+	for _, value := range []int64{-1, MaxProfileNodes + 1} {
+		if _, err := normalizeProfileMaxNodes(value); !errors.Is(
+			err,
+			ErrInvalidQuery,
+		) {
+			t.Fatalf(
+				"normalizeProfileMaxNodes(%d) error = %v, want invalid query",
+				value,
+				err,
+			)
+		}
+	}
+}
+
+func TestEmptyStoredProfileHasNoUsableSamples(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 0, 0, 0, time.UTC)
+	document := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	document.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	_, err := service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="empty-profile"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="empty-profile"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+}
+
+func TestSamplesWithoutValuesAreSkipped(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 13, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "no-values", 1, "root", "leaf")
+	document.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{
+		nil,
+		{LocationId: []uint64{2, 1}},
+	}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{document},
+	})
+
+	series, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="no-values"}`,
+		Start:         start.Add(-time.Second).UnixMilli(),
+		End:           start.Add(time.Second).UnixMilli(),
+		Step:          1,
+	})
+	if err != nil {
+		t.Fatalf("SelectSeries() error = %v", err)
+	}
+	if len(series.Series) != 0 {
+		t.Fatalf("SelectSeries() series = %#v, want empty", series.Series)
+	}
+
+	_, err = service.SelectMergeStacktraces(
+		t.Context(),
+		&querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: profiler.ProfileTypeCpuSample,
+			LabelSelector: `{id="no-values"}`,
+			Start:         start.Add(-time.Second).UnixMilli(),
+			End:           start.Add(time.Second).UnixMilli(),
+		},
+	)
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf("SelectMergeStacktraces() error = %v, want profiles absent", err)
+	}
+}
+
+func TestProfileQueryStorageErrorsRemainInternal(t *testing.T) {
+	sentinel := fmt.Errorf("backend unavailable")
+	service := newTestProfileService(&fakeProfileQueryStorage{countErr: sentinel})
+	service.maxQueryDocuments = 100
+	_, err := service.SelectSeries(t.Context(), &querierv1.SelectSeriesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{id="trace-a"}`,
+		Start:         0,
+		End:           1,
+		Step:          1,
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("SelectSeries() error = %v, want wrapped backend error", err)
+	}
+}

--- a/internal/profiler/service/errors.go
+++ b/internal/profiler/service/errors.go
@@ -17,6 +17,7 @@ package service
 import "errors"
 
 var (
-	ErrInvalidQuery   = errors.New("invalid profile query")
-	ErrProfilesAbsent = errors.New("profiles not found")
+	ErrInvalidQuery              = errors.New("invalid profile query")
+	ErrProfilesAbsent            = errors.New("profiles not found")
+	ErrProfileQueryLimitExceeded = errors.New("profile query limit exceeded")
 )

--- a/internal/profiler/service/export.go
+++ b/internal/profiler/service/export.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+// SelectMergePprof returns the standard pprof profile for an exact target
+// selection. Broad and unsupported label queries are rejected before storage
+// access.
+func (s *Service) SelectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, error) {
+	profile, _, err := s.selectMergePprof(ctx, req)
+	return profile, err
+}
+
+func (s *Service) selectMergePprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, string, error) {
+	if req == nil {
+		return nil, "", invalidProfileQueryf("request is required")
+	}
+	selection, err := buildProfileSelection(
+		req.ProfileTypeID,
+		req.LabelSelector,
+		req.Start,
+		req.End,
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	var merged pprof.ProfileMerge
+	mergedProfiles := 0
+	_, err = s.visitProfileDocuments(ctx, selection, func(document *ProfileDocument) error {
+		if _, found := profileDocumentSampleTotal(
+			document,
+			selection.sampleType,
+		); !found {
+			return nil
+		}
+		profile := document.TracerData.Flamedata.Profile.CloneVT()
+		if profile == nil {
+			return nil
+		}
+		// Pyroscope's merge helper requires a value even though pprof makes it
+		// optional.
+		if profile.PeriodType == nil {
+			profile.PeriodType = &profilev1.ValueType{}
+		}
+		if err := merged.Merge(profile); err != nil {
+			return fmt.Errorf("merge profile: %w", err)
+		}
+		mergedProfiles++
+		return nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	if mergedProfiles == 0 {
+		return nil, "", ErrProfilesAbsent
+	}
+	profile := merged.Profile()
+	if profile == nil {
+		return nil, "", ErrProfilesAbsent
+	}
+	return profile, selection.sampleType, nil
+}
+
+// MarshalPprof serializes a selected profile as gzip-compressed pprof data.
+func (s *Service) MarshalPprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) ([]byte, error) {
+	profile, err := s.SelectMergePprof(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := pprof.Marshal(profile, true)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pprof: %w", err)
+	}
+	return payload, nil
+}

--- a/internal/profiler/service/export_test.go
+++ b/internal/profiler/service/export_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
+)
+
+func exportTestRequest(start time.Time) *querierv1.SelectMergeStacktracesRequest {
+	return &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: profiler.ProfileTypeCpuSample,
+		LabelSelector: `{hostname="node-a"}`,
+		Start:         start.UnixMilli(),
+		End:           start.Add(time.Minute).UnixMilli(),
+	}
+}
+
+func TestSelectMergePprofStreamsProfilePages(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 10, 0, 0, 0, time.UTC)
+	document := testProfileDocument(start, "trace-a", 1, "root", "worker")
+	documents := make([]*ProfileDocument, profileQueryPageSize+1)
+	for index := range documents {
+		documents[index] = document
+	}
+	storage := &fakeProfileQueryStorage{documents: documents}
+	service := newTestProfileService(storage)
+
+	profile, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if err != nil {
+		t.Fatalf("SelectMergePprof() error = %v", err)
+	}
+	var total int64
+	for _, sample := range profile.Sample {
+		if sample != nil && len(sample.Value) > 0 {
+			total += sample.Value[0]
+		}
+	}
+	if total != int64(len(documents)) {
+		t.Fatalf("merged sample total = %d, want %d", total, len(documents))
+	}
+	if len(storage.searchCalls) != 2 {
+		t.Fatalf("search calls = %d, want 2", len(storage.searchCalls))
+	}
+	first, second := storage.searchCalls[0], storage.searchCalls[1]
+	if first.Offset != 0 ||
+		first.Limit != profileQueryPageSize ||
+		second.Offset != 0 ||
+		second.Limit != profileQueryPageSize ||
+		len(storage.searchAfter[0]) != 0 ||
+		!reflect.DeepEqual(storage.searchAfter[1], []any{profileQueryPageSize}) {
+		t.Fatalf(
+			"search pages = (%d,%d),(%d,%d) after %#v, want cursor pagination",
+			first.Offset,
+			first.Limit,
+			second.Offset,
+			second.Limit,
+			storage.searchAfter,
+		)
+	}
+}
+
+func TestSelectMergePprofEnforcesConfiguredSelectionLimit(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 11, 0, 0, 0, time.UTC)
+	storage := &fakeProfileQueryStorage{count: 10001}
+	service := newTestProfileService(storage)
+	service.maxQueryDocuments = 10000
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfileQueryLimitExceeded) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfileQueryLimitExceeded",
+			err,
+		)
+	}
+	if len(storage.searchCalls) != 0 {
+		t.Fatalf("search calls = %d, want 0", len(storage.searchCalls))
+	}
+}
+
+func TestSelectMergePprofRejectsEmptyStoredProfilesWithoutPanicking(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 12, 30, 0, 0, time.UTC)
+	empty := &ProfileDocument{
+		Hostname:     "node-a",
+		UploadedTime: start,
+		TracerID:     "empty-profile",
+	}
+	empty.TracerData.Flamedata.ProfileType = profiler.ProfileTypeCpuSample
+	empty.TracerData.Flamedata.Profile.Sample = []*profilev1.Sample{nil}
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{empty},
+	})
+
+	_, err := service.SelectMergePprof(t.Context(), exportTestRequest(start))
+	if !errors.Is(err, ErrProfilesAbsent) {
+		t.Fatalf(
+			"SelectMergePprof() error = %v, want ErrProfilesAbsent",
+			err,
+		)
+	}
+}
+
+func TestMarshalPprof(t *testing.T) {
+	start := time.Date(2026, time.July, 25, 14, 0, 0, 0, time.UTC)
+	service := newTestProfileService(&fakeProfileQueryStorage{
+		documents: []*ProfileDocument{
+			testProfileDocument(start, "trace-a", 10, "root", "hot"),
+		},
+	})
+	req := exportTestRequest(start)
+
+	payload, err := service.MarshalPprof(t.Context(), req)
+	if err != nil {
+		t.Fatalf("MarshalPprof() error = %v", err)
+	}
+	decoded, err := pprof.RawFromBytes(payload)
+	if err != nil {
+		t.Fatalf("RawFromBytes() error = %v", err)
+	}
+	if len(decoded.Sample) != 1 || decoded.Sample[0].Value[0] != 10 {
+		t.Fatalf("pprof samples = %#v, want value 10", decoded.Sample)
+	}
+}

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -22,27 +22,51 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 
-	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
-	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
 type ElasticSearchConfig struct {
 	Address, Username, Password, Index string
+	MaxQueryDocuments                  int64
+}
+
+type profileQueryStorage interface {
+	Close(ctx context.Context) error
+	Ready(ctx context.Context) error
+	SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error)
+	SearchProfilesPageContext(
+		ctx context.Context,
+		filter *SearchFilter,
+		cursor []any,
+	) ([]*ProfileDocument, []any, error)
+	CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error)
+	AggregationsByFieldContext(
+		ctx context.Context,
+		filter *SearchFilter,
+		field string,
+	) ([]string, error)
 }
 
 // Service provides profile query operations.
 type Service struct {
-	profileStorage *ProfileStorage
+	profileStorage    profileQueryStorage
+	maxQueryDocuments int64
 }
 
 // NewService initializes a profile query service.
 func NewService(ctx context.Context, esConfig *ElasticSearchConfig) (*Service, error) {
+	if esConfig == nil {
+		return nil, errors.New("Elasticsearch config is required")
+	}
+	if esConfig.MaxQueryDocuments < 0 {
+		return nil, errors.New("maximum profile query documents must not be negative")
+	}
 	profileStorage, err := NewProfileStorageContext(
 		ctx,
 		esConfig.Address,
@@ -53,7 +77,10 @@ func NewService(ctx context.Context, esConfig *ElasticSearchConfig) (*Service, e
 	if err != nil {
 		return nil, err
 	}
-	return &Service{profileStorage: profileStorage}, nil
+	return &Service{
+		profileStorage:    profileStorage,
+		maxQueryDocuments: esConfig.MaxQueryDocuments,
+	}, nil
 }
 
 // Close releases profile query resources.
@@ -77,152 +104,17 @@ func (s *Service) SelectMergeStacktraces(ctx context.Context, req *querierv1.Sel
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidQuery)
 	}
-	if req.End < req.Start {
-		return nil, fmt.Errorf("%w: end time precedes start time", ErrInvalidQuery)
-	}
-	filter := &SearchFilter{
-		StartTime:   time.UnixMilli(req.Start),
-		EndTime:     time.UnixMilli(req.End),
-		ProfileType: req.ProfileTypeID,
-		Limit:       100,
-	}
-
 	log.Debugf("SelectMergeStacktracesRequest: %+v", req)
-
-	profileTypes := strings.Split(filter.ProfileType, ":")
-	if len(profileTypes) != 5 {
-		return nil, fmt.Errorf("%w: invalid profile type %q", ErrInvalidQuery, filter.ProfileType)
-	}
-
-	// labels
-	labels, err := parser.ParseMetricSelector(req.LabelSelector)
+	maxNodes, err := normalizeProfileMaxNodes(req.GetMaxNodes())
 	if err != nil {
-		return nil, errors.Join(ErrInvalidQuery, fmt.Errorf("parse matchers: %w", err))
+		return nil, err
 	}
-
-	for _, label := range labels {
-		// skip empty or "All"
-		if label.Value == "" || label.Value == "all" || label.Value == "All" || label.Value == "*" {
-			continue
-		}
-
-		if err := applyProfileMatcher(filter, label); err != nil {
-			return nil, err
-		}
-	}
-
-	if filter.ID == "" && filter.Hostname == "" && filter.ContainerID == "" && filter.ContainerHostname == "" {
-		return nil, fmt.Errorf("%w: id, hostname, or container must be specified", ErrInvalidQuery)
-	}
-
-	// search
-	profileDocs, err := s.profileStorage.SearchProfilesContext(ctx, filter)
+	tree, _, err := s.selectProfileTree(ctx, req, false)
 	if err != nil {
-		return nil, fmt.Errorf("search profiles: %w", err)
+		return nil, err
 	}
-	if len(profileDocs) == 0 {
-		return nil, ErrProfilesAbsent
-	}
-
-	// merge profileDocs
-	var profilesMerge pprof.ProfileMerge
-	for _, profileDoc := range profileDocs {
-		profile := &profileDoc.TracerData.Flamedata.Profile
-		if err := profilesMerge.Merge(profile); err != nil {
-			return nil, fmt.Errorf("merge profile: %w", err)
-		}
-	}
-	profile := profilesMerge.Profile()
-	if profile == nil {
-		return nil, ErrProfilesAbsent
-	}
-	sampleType := profileTypes[1]
-
-	// convert profilev1.Profile to phlaremodel.Tree
-	phlaremodelTree := new(phlaremodel.Tree)
-
-	// Find the index of the sample type we're interested in
-	sampleTypeIndex := -1
-	for i, st := range profile.SampleType {
-		if st == nil {
-			continue
-		}
-		if value, ok := profileString(profile.StringTable, st.Type); ok && value == sampleType {
-			sampleTypeIndex = i
-			break
-		}
-	}
-	if sampleTypeIndex == -1 {
-		return nil, fmt.Errorf("%w: sample type %q not found", ErrInvalidQuery, sampleType)
-	}
-
-	// Create a map for quick location lookup
-	locationMap := make(map[uint64]*googlev1.Location, len(profile.Location))
-	for _, loc := range profile.Location {
-		if loc == nil {
-			continue
-		}
-		locationMap[loc.Id] = loc
-	}
-
-	// Create a map for quick function lookup
-	functionMap := make(map[uint64]*googlev1.Function, len(profile.Function))
-	for _, fn := range profile.Function {
-		if fn == nil {
-			continue
-		}
-		functionMap[fn.Id] = fn
-	}
-
-	// Process each sample
-	for _, sample := range profile.Sample {
-		if sample == nil {
-			continue
-		}
-		// Get the value for our sample type
-		if len(sample.Value) <= sampleTypeIndex {
-			continue
-		}
-		value := sample.Value[sampleTypeIndex]
-
-		// Build stack trace string from location ids
-		stack := make([]string, 0, len(sample.LocationId))
-		for _, locId := range sample.LocationId {
-			loc, exists := locationMap[locId]
-			if !exists || len(loc.Line) == 0 {
-				continue
-			}
-
-			// Get the first line entry (primary function)
-			line := loc.Line[0]
-			if line == nil {
-				continue
-			}
-			fn, exists := functionMap[line.FunctionId]
-			if !exists {
-				continue
-			}
-
-			// Get function name from string table
-			funcName, ok := profileString(profile.StringTable, fn.Name)
-			if !ok {
-				continue
-			}
-			stack = append(stack, funcName)
-		}
-
-		// Insert stack into tree (leaf is at stack[0], so we need to reverse for phlaremodel.Tree)
-		if len(stack) > 0 {
-			for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
-				stack[i], stack[j] = stack[j], stack[i]
-			}
-			phlaremodelTree.InsertStack(value, stack...)
-		}
-	}
-
-	// convert phlaremodel.Tree to FlameGraph
 	return &querierv1.SelectMergeStacktracesResponse{
-		Flamegraph: phlaremodel.NewFlameGraph(phlaremodelTree, -1),
+		Flamegraph: phlaremodel.NewFlameGraph(tree, maxNodes),
 	}, nil
 }
 
@@ -231,7 +123,7 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 		return fmt.Errorf("%w: label %q only supports equality", ErrInvalidQuery, matcher.Name)
 	}
 	switch matcher.Name {
-	case "id":
+	case profiler.LabelProfileID:
 		filter.ID = matcher.Value
 	case "region":
 		filter.Region = matcher.Value
@@ -241,10 +133,18 @@ func applyProfileMatcher(filter *SearchFilter, matcher *labels.Matcher) error {
 		filter.ContainerID = matcher.Value
 	case "container_hostname":
 		filter.ContainerHostname = matcher.Value
+	case profiler.LabelTracer:
+		filter.TracerID = matcher.Value
 	case "__profile_type__":
 		filter.ProfileType = matcher.Value
 	default:
-		return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		if !profiler.IsCollectionDimensionLabel(matcher.Name) {
+			return fmt.Errorf("%w: invalid label %q", ErrInvalidQuery, matcher.Name)
+		}
+		if filter.Labels == nil {
+			filter.Labels = make(map[string]string)
+		}
+		filter.Labels[matcher.Name] = matcher.Value
 	}
 	return nil
 }
@@ -302,8 +202,21 @@ func (s *Service) ProfileTypes(ctx context.Context, req *querierv1.ProfileTypesR
 //	request: typesv1.LabelNamesRequest
 //	response: typesv1.LabelNamesResponse
 func (s *Service) LabelNames(context.Context, *typesv1.LabelNamesRequest) (*typesv1.LabelNamesResponse, error) {
+	names := profiler.ProfileIdentifierLabelNames()
+	names = append(names,
+		"region",
+		"hostname",
+		"container_id",
+		"container_hostname",
+		"container_host_namespace",
+	)
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name != profiler.LabelContainerID {
+			names = append(names, name)
+		}
+	}
 	response := &typesv1.LabelNamesResponse{
-		Names: []string{"region", "hostname", "container_id", "container_hostname", "container_host_namespace"},
+		Names: names,
 	}
 	return response, nil
 }

--- a/internal/profiler/service/flamegraph_test.go
+++ b/internal/profiler/service/flamegraph_test.go
@@ -15,11 +15,53 @@
 package service
 
 import (
+	"context"
+	"reflect"
 	"strings"
 	"testing"
 
+	"huatuo-bamai/internal/profiler"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/prometheus/prometheus/model/labels"
 )
+
+type labelValuesStorage struct {
+	aggregationField string
+}
+
+func (*labelValuesStorage) Close(context.Context) error { return nil }
+func (*labelValuesStorage) Ready(context.Context) error { return nil }
+func (*labelValuesStorage) SearchProfilesContext(
+	context.Context,
+	*SearchFilter,
+) ([]*ProfileDocument, error) {
+	return nil, nil
+}
+
+func (*labelValuesStorage) SearchProfilesPageContext(
+	context.Context,
+	*SearchFilter,
+	[]any,
+) ([]*ProfileDocument, []any, error) {
+	return nil, nil, nil
+}
+
+func (*labelValuesStorage) CountProfilesContext(
+	context.Context,
+	*SearchFilter,
+) (int64, error) {
+	return 0, nil
+}
+
+func (s *labelValuesStorage) AggregationsByFieldContext(
+	_ context.Context,
+	_ *SearchFilter,
+	field string,
+) ([]string, error) {
+	s.aggregationField = field
+	return []string{"profile-a"}, nil
+}
 
 func TestServiceReadyRejectsUninitializedStorage(t *testing.T) {
 	err := (*Service)(nil).Ready(t.Context())
@@ -46,6 +88,61 @@ func TestApplyProfileMatcherRejectsUnknownLabel(t *testing.T) {
 
 	if err := applyProfileMatcher(filter, matcher); err == nil {
 		t.Fatal("applyProfileMatcher() error = nil, want error for unknown label")
+	}
+}
+
+func TestLabelNamesIncludesProfileIdentifierAliases(t *testing.T) {
+	response, err := (&Service{}).LabelNames(
+		t.Context(),
+		&typesv1.LabelNamesRequest{},
+	)
+	if err != nil {
+		t.Fatalf("LabelNames() error = %v", err)
+	}
+
+	want := []string{
+		profiler.LabelProfileID,
+		profiler.LabelTracer,
+		"region",
+		"hostname",
+		"container_id",
+		"container_hostname",
+		"container_host_namespace",
+		profiler.LabelProfilingScope,
+		profiler.LabelCPU,
+		profiler.LabelPID,
+		profiler.LabelTGID,
+	}
+	if !reflect.DeepEqual(response.Names, want) {
+		t.Fatalf("LabelNames() = %v, want %v", response.Names, want)
+	}
+}
+
+func TestLabelValuesAcceptsProfileIdentifierAliases(t *testing.T) {
+	for _, name := range profiler.ProfileIdentifierLabelNames() {
+		t.Run(name, func(t *testing.T) {
+			storage := &labelValuesStorage{}
+			service := &Service{profileStorage: storage}
+			response, err := service.LabelValues(t.Context(), &typesv1.LabelValuesRequest{
+				Name: name,
+				Matchers: []string{
+					`{__profile_type__="process_cpu:cpu:nanoseconds:cpu:nanoseconds"}`,
+				},
+			})
+			if err != nil {
+				t.Fatalf("LabelValues(%q) error = %v", name, err)
+			}
+			if storage.aggregationField != name {
+				t.Fatalf(
+					"aggregation field = %q, want %q",
+					storage.aggregationField,
+					name,
+				)
+			}
+			if !reflect.DeepEqual(response.Names, []string{"profile-a"}) {
+				t.Fatalf("LabelValues(%q) = %v", name, response.Names)
+			}
+		})
 	}
 }
 

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -149,7 +149,7 @@ func (s *ProfileStorage) Ready(ctx context.Context) error {
 	if s == nil || s.store == nil {
 		return errors.New("profile storage is not initialized")
 	}
-	if _, err := s.store.Count(ctx, driver.Query{Limit: 1}); err != nil {
+	if _, err := s.store.Count(ctx, &driver.Query{Limit: 1}); err != nil {
 		return fmt.Errorf("profile storage readiness: %w", err)
 	}
 	return nil
@@ -179,7 +179,7 @@ func (s *ProfileStorage) SearchProfilesPageContext(
 	query := buildProfileSearchQuery(filter)
 	query.SearchAfter = cursor
 
-	documents, nextCursor, err := s.store.QueryPage(ctx, query)
+	documents, nextCursor, err := s.store.QueryPage(ctx, &query)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,10 +203,11 @@ func (s *ProfileStorage) AggregationsByFieldContext(ctx context.Context, filter 
 		return nil, err
 	}
 
+	query := buildProfileAggregationQuery(filter)
 	terms, err := s.store.Values(
 		ctx,
 		normalizedField,
-		buildProfileAggregationQuery(filter),
+		&query,
 		normalizeProfileSearchLimit(filter),
 	)
 	if err != nil {

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -37,6 +37,7 @@ const (
 	profileFieldRegion            = "region"
 	profileFieldUploadedTime      = "uploaded_time"
 	profileFieldTime              = "time"
+	profileFieldStorageID         = "profile_storage_id"
 	profileFieldContainerID       = "container_id"
 	profileFieldContainerHostname = "container_hostname"
 	profileFieldContainerHostNS   = "container_host_namespace"
@@ -53,9 +54,10 @@ const (
 
 // ProfileDocument defines the document structure used in profiling storage.
 type ProfileDocument struct {
-	Hostname     string    `json:"hostname"`
-	Region       string    `json:"region"`
-	UploadedTime time.Time `json:"uploaded_time"`
+	Hostname         string    `json:"hostname"`
+	Region           string    `json:"region"`
+	UploadedTime     time.Time `json:"uploaded_time"`
+	ProfileStorageID string    `json:"profile_storage_id,omitempty"`
 	// equal to `TracerTime`, supported the old version.
 	Time string `json:"time"`
 
@@ -160,17 +162,29 @@ func (s *ProfileStorage) SearchProfiles(filter *SearchFilter) ([]*ProfileDocumen
 
 // SearchProfilesContext searches profiles with caller-owned cancellation.
 func (s *ProfileStorage) SearchProfilesContext(ctx context.Context, filter *SearchFilter) ([]*ProfileDocument, error) {
+	documents, _, err := s.SearchProfilesPageContext(ctx, filter, nil)
+	return documents, err
+}
+
+// SearchProfilesPageContext searches one page and returns the backend cursor
+// needed to continue without relying on Elasticsearch's bounded offset window.
+func (s *ProfileStorage) SearchProfilesPageContext(
+	ctx context.Context,
+	filter *SearchFilter,
+	cursor []any,
+) ([]*ProfileDocument, []any, error) {
 	if s == nil || s.store == nil {
-		return nil, errors.New("profile storage is not initialized")
+		return nil, nil, errors.New("profile storage is not initialized")
 	}
 	query := buildProfileSearchQuery(filter)
+	query.SearchAfter = cursor
 
-	documents, err := s.store.Query(ctx, query)
+	documents, nextCursor, err := s.store.QueryPage(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return documents, nil
+	return documents, nextCursor, nil
 }
 
 // AggregationsByField gets aggregations by field.
@@ -203,6 +217,10 @@ func (s *ProfileStorage) AggregationsByFieldContext(ctx context.Context, filter 
 }
 
 func (profileDocumentMapper) ID(document *ProfileDocument) string {
+	if document.ProfileStorageID != "" {
+		return document.ProfileStorageID
+	}
+	// Legacy documents predate profile_storage_id and used tracer_id as their ID.
 	return document.TracerID
 }
 
@@ -224,6 +242,7 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
+		profileFieldStorageID:         document.ProfileStorageID,
 		profileFieldTime:              parseProfileDocumentTime(document.Time, document.UploadedTime),
 		profileFieldContainerID:       document.ContainerID,
 		profileFieldContainerHostname: document.ContainerHostname,
@@ -244,6 +263,7 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
 		{Field: profileFieldUploadedTime},
+		{Field: profileFieldStorageID},
 		{Field: profileFieldTime},
 		{Field: profileFieldContainerID},
 		{Field: profileFieldContainerHostname},
@@ -265,6 +285,10 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	}
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID + ".keyword"},
+		// Older documents lack this field; migrating them or using PIT is required
+		// to make timestamp collisions strictly ordered across historical data.
+		{Field: profileFieldStorageID + ".keyword"},
 	}
 	return query
 }
@@ -354,8 +378,8 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 
 func normalizeProfileAggregationField(field string) (string, error) {
 	switch field {
-	case "id":
-		return profileFieldTracerID, nil
+	case "id", "tracer":
+		return profileFieldTracerID + ".keyword", nil
 	case profileFieldRegion,
 		profileFieldHostname,
 		profileFieldContainerHostname,
@@ -367,7 +391,7 @@ func normalizeProfileAggregationField(field string) (string, error) {
 		profileFieldTracerID,
 		profileFieldTracerType,
 		profileFieldProfileType:
-		return field, nil
+		return field + ".keyword", nil
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -286,8 +286,8 @@ func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
 	query.Sorts = []driver.Sort{
 		{Field: profileFieldUploadedTime, Desc: true},
 		{Field: profileFieldTracerID + ".keyword"},
-		// Older documents lack this field; migrating them or using PIT is required
-		// to make timestamp collisions strictly ordered across historical data.
+		// The migration script copies legacy Elasticsearch _id values into this
+		// field so historical timestamp collisions remain strictly ordered.
 		{Field: profileFieldStorageID + ".keyword"},
 	}
 	return query

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/profiler/timeutil"
 	"huatuo-bamai/internal/storage"
 	"huatuo-bamai/internal/storage/driver"
@@ -76,6 +77,7 @@ type ProfileDocument struct {
 	TracerData struct {
 		Flamedata struct {
 			ProfileType string            `json:"profile_type,omitempty"`
+			Labels      map[string]string `json:"labels,omitempty"`
 			Profile     profilev1.Profile `json:"profile,omitempty"`
 		} `json:"flamedata,omitempty"`
 		// others
@@ -98,6 +100,7 @@ type SearchFilter struct {
 	StartTime         time.Time
 	EndTime           time.Time
 	ProfileType       string
+	Labels            map[string]string
 	Limit             int
 	Offset            int
 }
@@ -187,6 +190,15 @@ func (s *ProfileStorage) SearchProfilesPageContext(
 	return documents, nextCursor, nil
 }
 
+// CountProfilesContext counts profiles matching a filter.
+func (s *ProfileStorage) CountProfilesContext(ctx context.Context, filter *SearchFilter) (int64, error) {
+	if s == nil || s.store == nil {
+		return 0, errors.New("profile storage is not initialized")
+	}
+	query := buildProfileAggregationQuery(filter)
+	return s.store.Count(ctx, &query)
+}
+
 // AggregationsByField gets aggregations by field.
 func (s *ProfileStorage) AggregationsByField(filter *SearchFilter, field string) ([]string, error) {
 	return s.AggregationsByFieldContext(context.Background(), filter, field)
@@ -239,7 +251,7 @@ func (profileDocumentMapper) Decode(data []byte) (*ProfileDocument, error) {
 }
 
 func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, error) {
-	return map[string]any{
+	fields := map[string]any{
 		profileFieldHostname:          document.Hostname,
 		profileFieldRegion:            document.Region,
 		profileFieldUploadedTime:      document.UploadedTime,
@@ -255,11 +267,20 @@ func (profileDocumentMapper) Fields(document *ProfileDocument) (map[string]any, 
 		profileFieldTracerTime:        parseProfileDocumentTime(document.TracerTime, document.UploadedTime),
 		profileFieldTracerType:        document.TracerRunType,
 		profileFieldProfileType:       document.TracerData.Flamedata.ProfileType,
-	}, nil
+	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label == profiler.LabelContainerID {
+			continue
+		}
+		if value := document.TracerData.Flamedata.Labels[label]; value != "" {
+			fields[profileLabelField(label)] = value
+		}
+	}
+	return fields, nil
 }
 
 func (profileDocumentMapper) Indexes() []driver.Index {
-	return []driver.Index{
+	indexes := []driver.Index{
 		{Field: profileFieldTracerID},
 		{Field: profileFieldHostname},
 		{Field: profileFieldRegion},
@@ -276,6 +297,12 @@ func (profileDocumentMapper) Indexes() []driver.Index {
 		{Field: profileFieldTracerType},
 		{Field: profileFieldProfileType},
 	}
+	for _, label := range profiler.CollectionDimensionLabelNames() {
+		if label != profiler.LabelContainerID {
+			indexes = append(indexes, driver.Index{Field: profileLabelField(label)})
+		}
+	}
+	return indexes
 }
 
 func buildProfileSearchQuery(filter *SearchFilter) driver.Query {
@@ -373,13 +400,31 @@ func buildProfileAggregationQuery(filter *SearchFilter) driver.Query {
 			Value: filter.ProfileType,
 		})
 	}
+	for _, name := range profiler.CollectionDimensionLabelNames() {
+		if name == profiler.LabelContainerID {
+			continue
+		}
+		if value := filter.Labels[name]; value != "" {
+			query.Filters = append(query.Filters, driver.Filter{
+				Field: profileLabelKeywordField(name),
+				Op:    driver.OpEq,
+				Value: value,
+			})
+		}
+	}
 
 	return query
 }
 
 func normalizeProfileAggregationField(field string) (string, error) {
+	if profiler.IsCollectionDimensionLabel(field) {
+		if field == profiler.LabelContainerID {
+			return profileFieldContainerID + ".keyword", nil
+		}
+		return profileLabelKeywordField(field), nil
+	}
 	switch field {
-	case "id", "tracer":
+	case profiler.LabelProfileID, profiler.LabelTracer:
 		return profileFieldTracerID + ".keyword", nil
 	case profileFieldRegion,
 		profileFieldHostname,
@@ -396,6 +441,14 @@ func normalizeProfileAggregationField(field string) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid aggregation field: %q", field)
 	}
+}
+
+func profileLabelField(name string) string {
+	return "tracer_data.flamedata.labels." + name
+}
+
+func profileLabelKeywordField(name string) string {
+	return profileLabelField(name) + ".keyword"
 }
 
 func normalizeProfileSearchLimit(filter *SearchFilter) int {

--- a/internal/profiler/service/storage_integration_test.go
+++ b/internal/profiler/service/storage_integration_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+const elasticsearchIntegrationAddressEnv = "HUATUO_ES_TEST_ADDR"
+
+func TestProfileStorageSearchProfilesElasticsearch(t *testing.T) {
+	address := strings.TrimRight(os.Getenv(elasticsearchIntegrationAddressEnv), "/")
+	if address == "" {
+		t.Skipf("set %s to run the Elasticsearch integration test", elasticsearchIntegrationAddressEnv)
+	}
+
+	index := fmt.Sprintf("huatuo-profile-storage-test-%d", time.Now().UnixNano())
+	storage, err := NewProfileStorageContext(t.Context(), address, "", "", index)
+	if err != nil {
+		t.Fatalf("NewProfileStorageContext() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := storage.Close(context.Background()); closeErr != nil {
+			t.Errorf("close profile storage: %v", closeErr)
+		}
+	})
+	t.Cleanup(func() {
+		requestElasticsearch(t, context.Background(), http.MethodDelete, address+"/"+index, nil)
+	})
+
+	documents := []struct {
+		storageID  string
+		tracerID   string
+		capturedAt string
+	}{
+		{storageID: "window-a", tracerID: "trace-old", capturedAt: "2026-08-16T01:00:00.000000001Z"},
+		{storageID: "window-b", tracerID: "trace-shared", capturedAt: "2026-08-16T02:00:00.000000001Z"},
+		{storageID: "window-c", tracerID: "trace-shared", capturedAt: "2026-08-16T02:00:00.000000001Z"},
+		{storageID: "window-d", tracerID: "trace-new", capturedAt: "2026-08-16T03:00:00.000000001Z"},
+	}
+	for _, document := range documents {
+		body := fmt.Appendf(nil, `{
+			"hostname":"node-1",
+			"region":"integration",
+			"profile_storage_id":%q,
+			"uploaded_time":%q,
+			"tracer_id":%q,
+			"tracer_time":%q
+		}`, document.storageID, document.capturedAt, document.tracerID, document.capturedAt)
+		requestElasticsearch(
+			t,
+			t.Context(),
+			http.MethodPut,
+			fmt.Sprintf("%s/%s/_doc/%s?refresh=true", address, index, document.storageID),
+			body,
+		)
+	}
+	for _, field := range []string{"id", "tracer"} {
+		values, err := storage.AggregationsByFieldContext(
+			t.Context(),
+			&SearchFilter{Hostname: "node-1", Limit: 10},
+			field,
+		)
+		if err != nil {
+			t.Fatalf("AggregationsByFieldContext(%q) error = %v", field, err)
+		}
+		slices.Sort(values)
+		want := []string{"trace-new", "trace-old", "trace-shared"}
+		if !slices.Equal(values, want) {
+			t.Errorf("AggregationsByFieldContext(%q) = %#v, want %#v", field, values, want)
+		}
+	}
+
+	filter := &SearchFilter{Hostname: "node-1", Limit: 2}
+	firstPage, cursor, err := storage.SearchProfilesPageContext(t.Context(), filter, nil)
+	if err != nil {
+		t.Fatalf("first SearchProfilesPageContext() error = %v", err)
+	}
+	assertProfileOrder(t, firstPage, "trace-new/window-d", "trace-shared/window-b")
+	if len(cursor) != 3 {
+		t.Fatalf("first cursor = %#v, want three sort values", cursor)
+	}
+
+	secondPage, cursor, err := storage.SearchProfilesPageContext(t.Context(), filter, cursor)
+	if err != nil {
+		t.Fatalf("second SearchProfilesPageContext() error = %v", err)
+	}
+	assertProfileOrder(t, secondPage, "trace-shared/window-c", "trace-old/window-a")
+	if len(cursor) != 3 {
+		t.Fatalf("second cursor = %#v, want three sort values", cursor)
+	}
+
+	lastPage, cursor, err := storage.SearchProfilesPageContext(t.Context(), filter, cursor)
+	if err != nil {
+		t.Fatalf("last SearchProfilesPageContext() error = %v", err)
+	}
+	assertProfileOrder(t, lastPage)
+	if cursor != nil {
+		t.Fatalf("last cursor = %#v, want nil", cursor)
+	}
+}
+
+func requestElasticsearch(t *testing.T, ctx context.Context, method, target string, body []byte) {
+	t.Helper()
+
+	request, err := http.NewRequestWithContext(ctx, method, target, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create Elasticsearch %s request: %v", method, err)
+	}
+	if len(body) > 0 {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("Elasticsearch %s %s: %v", method, target, err)
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read Elasticsearch %s %s response: %v", method, target, err)
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		t.Fatalf(
+			"Elasticsearch %s %s returned status %d: %s",
+			method,
+			target,
+			response.StatusCode,
+			strings.TrimSpace(string(responseBody)),
+		)
+	}
+}
+
+func assertProfileOrder(t *testing.T, documents []*ProfileDocument, want ...string) {
+	t.Helper()
+
+	if len(documents) != len(want) {
+		t.Fatalf("profile count = %d, want %d", len(documents), len(want))
+	}
+	for i, expected := range want {
+		if documents[i] == nil {
+			t.Fatalf("profile %d = nil, want %q", i, expected)
+		}
+		got := documents[i].TracerID + "/" + documents[i].ProfileStorageID
+		if got != expected {
+			t.Errorf("profile %d = %q, want %q", i, got, expected)
+		}
+	}
+}

--- a/internal/profiler/service/storage_integration_test.go
+++ b/internal/profiler/service/storage_integration_test.go
@@ -66,7 +66,8 @@ func TestProfileStorageSearchProfilesElasticsearch(t *testing.T) {
 			"profile_storage_id":%q,
 			"uploaded_time":%q,
 			"tracer_id":%q,
-			"tracer_time":%q
+			"tracer_time":%q,
+			"tracer_data":{"flamedata":{"profile_type":"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}}
 		}`, document.storageID, document.capturedAt, document.tracerID, document.capturedAt)
 		requestElasticsearch(
 			t,
@@ -90,6 +91,18 @@ func TestProfileStorageSearchProfilesElasticsearch(t *testing.T) {
 		if !slices.Equal(values, want) {
 			t.Errorf("AggregationsByFieldContext(%q) = %#v, want %#v", field, values, want)
 		}
+	}
+	profileTypes, err := storage.AggregationsByFieldContext(
+		t.Context(),
+		&SearchFilter{Hostname: "node-1", Limit: 10},
+		profileFieldProfileType,
+	)
+	if err != nil {
+		t.Fatalf("profile type aggregation error = %v", err)
+	}
+	wantProfileTypes := []string{"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	if !slices.Equal(profileTypes, wantProfileTypes) {
+		t.Errorf("profile type aggregation = %#v, want %#v", profileTypes, wantProfileTypes)
 	}
 
 	filter := &SearchFilter{Hostname: "node-1", Limit: 2}

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"huatuo-bamai/internal/profiler"
 	"huatuo-bamai/internal/storage/driver"
 )
 
@@ -75,12 +76,70 @@ func TestProfileDocumentMapperUsesProfileStorageID(t *testing.T) {
 	}
 }
 
-func TestNormalizeProfileAggregationFieldUsesKeywords(t *testing.T) {
+func TestProfileDocumentMapperIndexesCollectionDimensions(t *testing.T) {
+	document := &ProfileDocument{}
+	document.ContainerID = "containerd://abc"
+	document.TracerData.Flamedata.Labels = map[string]string{
+		profiler.LabelProfilingScope: "thread_group",
+		profiler.LabelTGID:           "4242",
+		profiler.LabelContainerID:    document.ContainerID,
+	}
+
+	fields, err := (profileDocumentMapper{}).Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
+	if got := fields[profileLabelField(profiler.LabelProfilingScope)]; got != "thread_group" {
+		t.Fatalf("profiling_scope field = %v, want thread_group", got)
+	}
+	if got := fields[profileLabelField(profiler.LabelTGID)]; got != "4242" {
+		t.Fatalf("tgid field = %v, want 4242", got)
+	}
+	if _, duplicated := fields[profileLabelField(profiler.LabelContainerID)]; duplicated {
+		t.Fatal("container_id duplicated under profile labels")
+	}
+}
+
+func TestBuildProfileAggregationQueryAddsDimensionMatchers(t *testing.T) {
+	query := buildProfileAggregationQuery(&SearchFilter{
+		ContainerID: "containerd://abc",
+		Labels: map[string]string{
+			profiler.LabelProfilingScope: "thread_group",
+			profiler.LabelTGID:           "4242",
+			"unmanaged":                  "ignored",
+		},
+	})
+	want := []driver.Filter{
+		{
+			Field: profileFieldContainerID + ".keyword",
+			Op:    driver.OpEq,
+			Value: "containerd://abc",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelProfilingScope),
+			Op:    driver.OpEq,
+			Value: "thread_group",
+		},
+		{
+			Field: profileLabelKeywordField(profiler.LabelTGID),
+			Op:    driver.OpEq,
+			Value: "4242",
+		},
+	}
+
+	if !reflect.DeepEqual(query.Filters, want) {
+		t.Fatalf("query filters = %#v, want %#v", query.Filters, want)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldSupportsDimensionsAndAliases(t *testing.T) {
 	tests := map[string]string{
-		"id":                    profileFieldTracerID + ".keyword",
-		"tracer":                profileFieldTracerID + ".keyword",
-		profileFieldContainerID: profileFieldContainerID + ".keyword",
-		profileFieldProfileType: profileFieldProfileType + ".keyword",
+		profiler.LabelProfileID:   profileFieldTracerID + ".keyword",
+		profiler.LabelTracer:      profileFieldTracerID + ".keyword",
+		profiler.LabelPID:         profileLabelKeywordField(profiler.LabelPID),
+		profiler.LabelTGID:        profileLabelKeywordField(profiler.LabelTGID),
+		profiler.LabelContainerID: profileFieldContainerID + ".keyword",
+		profileFieldProfileType:   profileFieldProfileType + ".keyword",
 	}
 	for input, want := range tests {
 		got, err := normalizeProfileAggregationField(input)

--- a/internal/profiler/service/storage_test.go
+++ b/internal/profiler/service/storage_test.go
@@ -59,6 +59,53 @@ func TestBuildProfileAggregationQueryAddsTracerIDOnce(t *testing.T) {
 	}
 }
 
+func TestProfileDocumentMapperUsesProfileStorageID(t *testing.T) {
+	mapper := profileDocumentMapper{}
+	document := &ProfileDocument{
+		ProfileStorageID: "window-1",
+		TracerID:         "trace-1",
+	}
+	if got := mapper.ID(document); got != "window-1" {
+		t.Fatalf("ID() = %q, want window-1", got)
+	}
+
+	document.ProfileStorageID = ""
+	if got := mapper.ID(document); got != "trace-1" {
+		t.Fatalf("legacy ID() = %q, want trace-1", got)
+	}
+}
+
+func TestNormalizeProfileAggregationFieldUsesKeywords(t *testing.T) {
+	tests := map[string]string{
+		"id":                    profileFieldTracerID + ".keyword",
+		"tracer":                profileFieldTracerID + ".keyword",
+		profileFieldContainerID: profileFieldContainerID + ".keyword",
+		profileFieldProfileType: profileFieldProfileType + ".keyword",
+	}
+	for input, want := range tests {
+		got, err := normalizeProfileAggregationField(input)
+		if err != nil {
+			t.Fatalf("normalizeProfileAggregationField(%q) error = %v", input, err)
+		}
+		if got != want {
+			t.Errorf("normalizeProfileAggregationField(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestBuildProfileSearchQueryUsesStablePaginationOrder(t *testing.T) {
+	query := buildProfileSearchQuery(&SearchFilter{Limit: 1000, Offset: 1000})
+	want := []driver.Sort{
+		{Field: profileFieldUploadedTime, Desc: true},
+		{Field: profileFieldTracerID + ".keyword"},
+		{Field: profileFieldStorageID + ".keyword"},
+	}
+
+	if !reflect.DeepEqual(query.Sorts, want) {
+		t.Fatalf("query sorts = %#v, want %#v", query.Sorts, want)
+	}
+}
+
 func TestBuildProfileAggregationQueryFiltersByRegion(t *testing.T) {
 	query := buildProfileAggregationQuery(&SearchFilter{
 		Region:   "cn-beijing",

--- a/internal/profiler/types.go
+++ b/internal/profiler/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ const MetadataCollection = "profiling_metadata"
 // ProfileData is the data saved by the profiler.
 type ProfileData struct {
 	ProfileType string `json:"profile_type,omitempty"`
+	// Labels expose indexed dimensions to profile display backends.
+	Labels map[string]string `json:"labels,omitempty"`
 	// Please note:
 	//
 	//	In pyroscope 1.13.0, use profilev1.Profile instead of ptree.Profile, but it depends

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -94,17 +94,19 @@ type Sort struct {
 
 // Query describes filters, ordering, and pagination.
 type Query struct {
-	Filters []Filter
-	Sorts   []Sort
-	Limit   int
-	Offset  int
+	Filters     []Filter
+	Sorts       []Sort
+	SearchAfter []any
+	Limit       int
+	Offset      int
 }
 
 // Record is the backend-neutral persisted representation.
 type Record struct {
-	ID     string
-	Data   []byte
-	Fields map[string]any
+	ID         string
+	Data       []byte
+	Fields     map[string]any
+	SortValues []any
 }
 
 // Index declares one queryable field.

--- a/internal/storage/elasticsearch/dsl.go
+++ b/internal/storage/elasticsearch/dsl.go
@@ -64,6 +64,20 @@ func buildSearchRequest(q driver.Query) ([]byte, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return nil, driver.ErrNegativePagination
 	}
+	if len(q.SearchAfter) > 0 && q.Offset > 0 {
+		return nil, fmt.Errorf("%w: search_after cannot be combined with a non-zero offset", driver.ErrInvalidQuery)
+	}
+	if len(q.SearchAfter) > 0 && len(q.Sorts) == 0 {
+		return nil, fmt.Errorf("%w: search_after requires at least one sort field", driver.ErrInvalidQuery)
+	}
+	if len(q.SearchAfter) > 0 && len(q.SearchAfter) != len(q.Sorts) {
+		return nil, fmt.Errorf(
+			"%w: search_after has %d values for %d sort fields",
+			driver.ErrInvalidQuery,
+			len(q.SearchAfter),
+			len(q.Sorts),
+		)
+	}
 
 	query, err := buildQuery(q.Filters)
 	if err != nil {
@@ -81,6 +95,12 @@ func buildSearchRequest(q driver.Query) ([]byte, error) {
 	}
 	if q.Offset > 0 {
 		req.From = &q.Offset
+	}
+	if len(q.SearchAfter) > 0 {
+		req.SearchAfter = make([]types.FieldValue, len(q.SearchAfter))
+		for i, value := range q.SearchAfter {
+			req.SearchAfter[i] = value
+		}
 	}
 	if len(q.Sorts) > 0 {
 		sorts, err := buildSort(q.Sorts)

--- a/internal/storage/elasticsearch/dsl.go
+++ b/internal/storage/elasticsearch/dsl.go
@@ -60,7 +60,7 @@ func validateFieldName(field string) error {
 	return nil
 }
 
-func buildSearchRequest(q driver.Query) ([]byte, error) {
+func buildSearchRequest(q *driver.Query) ([]byte, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return nil, driver.ErrNegativePagination
 	}
@@ -112,7 +112,7 @@ func buildSearchRequest(q driver.Query) ([]byte, error) {
 	return json.Marshal(req)
 }
 
-func buildCountRequest(q driver.Query) ([]byte, error) {
+func buildCountRequest(q *driver.Query) ([]byte, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return nil, driver.ErrNegativePagination
 	}
@@ -124,7 +124,7 @@ func buildCountRequest(q driver.Query) ([]byte, error) {
 	return json.Marshal(escount.Request{Query: query})
 }
 
-func buildValuesRequest(field string, q driver.Query, size int) ([]byte, error) {
+func buildValuesRequest(field string, q *driver.Query, size int) ([]byte, error) {
 	if err := validateFieldName(field); err != nil {
 		return nil, err
 	}

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -201,8 +201,8 @@ func (s *Storage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) {
-	body, err := buildSearchRequest(q)
+func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	body, err := buildSearchRequest(&q)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +242,8 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 	return records, nil
 }
 
-func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
-	body, err := buildCountRequest(q)
+func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	body, err := buildCountRequest(&q)
 	if err != nil {
 		return 0, err
 	}
@@ -266,8 +266,8 @@ func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
 	return payload.Count, nil
 }
 
-func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) {
-	body, err := buildValuesRequest(field, q, size)
+func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	body, err := buildValuesRequest(field, &q, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -229,7 +229,15 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 		if hit.Id_ != nil {
 			id = *hit.Id_
 		}
-		records = append(records, driver.Record{ID: id, Data: driver.CloneBytes(hit.Source_)})
+		sortValues := make([]any, len(hit.Sort))
+		for i, value := range hit.Sort {
+			sortValues[i] = value
+		}
+		records = append(records, driver.Record{
+			ID:         id,
+			Data:       driver.CloneBytes(hit.Source_),
+			SortValues: sortValues,
+		})
 	}
 	return records, nil
 }

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -780,6 +780,64 @@ func TestBuildSearchRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "search-after",
+			query: driver.Query{
+				Sorts: []driver.Sort{
+					{Field: "created_at", Desc: true},
+					{Field: "id.keyword"},
+				},
+				SearchAfter: []any{1720000000000.0, "job-alpha"},
+				Limit:       1000,
+			},
+			validate: func(t *testing.T, got map[string]any, err error) {
+				if err != nil {
+					t.Errorf("buildSearchRequest() error = %v", err)
+					return
+				}
+				if _, found := got["from"]; found {
+					t.Errorf("from = %v, want omitted", got["from"])
+				}
+				cursor := toAnySlice(got["search_after"])
+				if len(cursor) != 2 || cursor[0] != 1720000000000.0 || cursor[1] != "job-alpha" {
+					t.Errorf("search_after = %#v, want [1720000000000 job-alpha]", cursor)
+				}
+			},
+		},
+		{
+			name: "search-after-with-offset",
+			query: driver.Query{
+				Sorts:       []driver.Sort{{Field: "id.keyword"}},
+				SearchAfter: []any{"job-alpha"},
+				Offset:      1,
+			},
+			validate: func(t *testing.T, _ map[string]any, err error) {
+				if !errors.Is(err, driver.ErrInvalidQuery) {
+					t.Errorf("buildSearchRequest() error = %v, want ErrInvalidQuery", err)
+				}
+			},
+		},
+		{
+			name:  "search-after-without-sort",
+			query: driver.Query{SearchAfter: []any{"job-alpha"}},
+			validate: func(t *testing.T, _ map[string]any, err error) {
+				if !errors.Is(err, driver.ErrInvalidQuery) {
+					t.Errorf("buildSearchRequest() error = %v, want ErrInvalidQuery", err)
+				}
+			},
+		},
+		{
+			name: "search-after-sort-count-mismatch",
+			query: driver.Query{
+				Sorts:       []driver.Sort{{Field: "created_at"}, {Field: "id.keyword"}},
+				SearchAfter: []any{"job-alpha"},
+			},
+			validate: func(t *testing.T, _ map[string]any, err error) {
+				if !errors.Is(err, driver.ErrInvalidQuery) {
+					t.Errorf("buildSearchRequest() error = %v, want ErrInvalidQuery", err)
+				}
+			},
+		},
+		{
 			name: "invalid-pagination",
 			query: driver.Query{
 				Limit: -1,

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -852,7 +852,7 @@ func TestBuildSearchRequest(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rawBody, err := buildSearchRequest(tc.query)
+			rawBody, err := buildSearchRequest(&tc.query)
 			body := decodeJSONMap(t, rawBody)
 			tc.validate(t, body, err)
 		})

--- a/internal/storage/sqlite/sql.go
+++ b/internal/storage/sqlite/sql.go
@@ -38,6 +38,9 @@ func buildSelectSQL(collection string, q driver.Query) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}
+	if len(q.SearchAfter) > 0 {
+		return "", nil, fmt.Errorf("%w: sqlite does not support search_after", driver.ErrUnsupportedOp)
+	}
 
 	baseSQL := fmt.Sprintf(`SELECT id, data, fields FROM %s`, quoteIdentifier(collection))
 	whereSQL, args, err := buildWhereSQL(q.Filters)

--- a/internal/storage/sqlite/sql.go
+++ b/internal/storage/sqlite/sql.go
@@ -34,7 +34,7 @@ var binaryOpSQL = map[driver.Op]string{
 	driver.OpLte: "<=",
 }
 
-func buildSelectSQL(collection string, q driver.Query) (string, []any, error) {
+func buildSelectSQL(collection string, q *driver.Query) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}
@@ -78,7 +78,7 @@ func buildSelectSQL(collection string, q driver.Query) (string, []any, error) {
 	return sb.String(), args, nil
 }
 
-func buildCountSQL(collection string, q driver.Query) (string, []any, error) {
+func buildCountSQL(collection string, q *driver.Query) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}
@@ -94,7 +94,7 @@ func buildCountSQL(collection string, q driver.Query) (string, []any, error) {
 	return baseSQL + " WHERE " + whereSQL, args, nil
 }
 
-func buildValuesSQL(collection, field string, q driver.Query, size int) (string, []any, error) {
+func buildValuesSQL(collection, field string, q *driver.Query, size int) (string, []any, error) {
 	if q.Limit < 0 || q.Offset < 0 {
 		return "", nil, driver.ErrNegativePagination
 	}

--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -183,8 +183,8 @@ func (s *Storage) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) {
-	querySQL, args, err := buildSelectSQL(s.table, q)
+func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	querySQL, args, err := buildSelectSQL(s.table, &q)
 	if err != nil {
 		return nil, err
 	}
@@ -216,8 +216,8 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 	return records, nil
 }
 
-func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
-	countSQL, args, err := buildCountSQL(s.table, q)
+func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) { //nolint:gocritic // driver.Storage requires Query by value.
+	countSQL, args, err := buildCountSQL(s.table, &q)
 	if err != nil {
 		return 0, err
 	}
@@ -229,12 +229,12 @@ func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
 	return count, nil
 }
 
-func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) {
+func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	if err := validateIdentifier(field); err != nil {
 		return nil, err
 	}
 
-	valuesSQL, args, err := buildValuesSQL(s.table, field, q, size)
+	valuesSQL, args, err := buildValuesSQL(s.table, field, &q, size)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -247,6 +247,14 @@ func TestSQLiteBackendQuery(t *testing.T) {
 	if err == nil {
 		t.Errorf("backend Query() error = nil for negative limit, want error")
 	}
+
+	_, err = backend.Query(t.Context(), driver.Query{
+		Sorts:       []driver.Sort{{Field: "priority"}},
+		SearchAfter: []any{int64(3)},
+	})
+	if !errors.Is(err, driver.ErrUnsupportedOp) {
+		t.Errorf("backend Query() search_after error = %v, want ErrUnsupportedOp", err)
+	}
 }
 
 // TestSQLiteBackendTerms covers SQLite backend Terms aggregation: verifies it returns distinct field values matching the filter, skips missing fields, and respects the size limit.

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -139,19 +139,19 @@ func (s *Store[T]) Close(ctx context.Context) error {
 }
 
 // Query returns objects matching q; all filter and sort fields must be registered indexes.
-func (s *Store[T]) Query(ctx context.Context, q driver.Query) ([]T, error) {
+func (s *Store[T]) Query(ctx context.Context, q *driver.Query) ([]T, error) {
 	values, _, err := s.QueryPage(ctx, q)
 	return values, err
 }
 
 // QueryPage returns objects matching q and the last record's backend sort
 // values. Passing those values as Query.SearchAfter retrieves the next page.
-func (s *Store[T]) QueryPage(ctx context.Context, q driver.Query) ([]T, []any, error) {
+func (s *Store[T]) QueryPage(ctx context.Context, q *driver.Query) ([]T, []any, error) {
 	if err := s.validateQuery(q); err != nil {
 		return nil, nil, err
 	}
 
-	records, err := s.backend.Query(driver.WithContext(ctx), q)
+	records, err := s.backend.Query(driver.WithContext(ctx), *q)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,16 +173,16 @@ func (s *Store[T]) QueryPage(ctx context.Context, q driver.Query) ([]T, []any, e
 }
 
 // Count returns the number of objects matching the given query.
-func (s *Store[T]) Count(ctx context.Context, q driver.Query) (int64, error) {
+func (s *Store[T]) Count(ctx context.Context, q *driver.Query) (int64, error) {
 	if err := s.validateQuery(q); err != nil {
 		return 0, err
 	}
 
-	return s.backend.Count(driver.WithContext(ctx), q)
+	return s.backend.Count(driver.WithContext(ctx), *q)
 }
 
 // Values returns up to size distinct values for field, filtered by q.
-func (s *Store[T]) Values(ctx context.Context, field string, q driver.Query, size int) ([]string, error) {
+func (s *Store[T]) Values(ctx context.Context, field string, q *driver.Query, size int) ([]string, error) {
 	if size < 0 {
 		return nil, driver.ErrNegativeSize
 	}
@@ -190,11 +190,14 @@ func (s *Store[T]) Values(ctx context.Context, field string, q driver.Query, siz
 		return nil, err
 	}
 
-	return s.backend.Values(driver.WithContext(ctx), field, q, size)
+	return s.backend.Values(driver.WithContext(ctx), field, *q, size)
 }
 
 // validateQuery checks that limit and offset are non-negative.
-func (s *Store[T]) validateQuery(q driver.Query) error {
+func (s *Store[T]) validateQuery(q *driver.Query) error {
+	if q == nil {
+		return fmt.Errorf("%w: query is nil", driver.ErrInvalidQuery)
+	}
 	if q.Limit < 0 || q.Offset < 0 {
 		return driver.ErrNegativePagination
 	}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -140,25 +140,36 @@ func (s *Store[T]) Close(ctx context.Context) error {
 
 // Query returns objects matching q; all filter and sort fields must be registered indexes.
 func (s *Store[T]) Query(ctx context.Context, q driver.Query) ([]T, error) {
+	values, _, err := s.QueryPage(ctx, q)
+	return values, err
+}
+
+// QueryPage returns objects matching q and the last record's backend sort
+// values. Passing those values as Query.SearchAfter retrieves the next page.
+func (s *Store[T]) QueryPage(ctx context.Context, q driver.Query) ([]T, []any, error) {
 	if err := s.validateQuery(q); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	records, err := s.backend.Query(driver.WithContext(ctx), q)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	values := make([]T, 0, len(records))
 	for _, rec := range records {
 		value, decodeErr := s.mapper.Decode(rec.Data)
 		if decodeErr != nil {
-			return nil, fmt.Errorf("%w: %w", driver.ErrDecodeFailed, decodeErr)
+			return nil, nil, fmt.Errorf("%w: %w", driver.ErrDecodeFailed, decodeErr)
 		}
 		values = append(values, value)
 	}
 
-	return values, nil
+	if len(records) == 0 || len(records[len(records)-1].SortValues) == 0 {
+		return values, nil, nil
+	}
+	cursor := append([]any(nil), records[len(records)-1].SortValues...)
+	return values, cursor, nil
 }
 
 // Count returns the number of objects matching the given query.
@@ -186,6 +197,23 @@ func (s *Store[T]) Values(ctx context.Context, field string, q driver.Query, siz
 func (s *Store[T]) validateQuery(q driver.Query) error {
 	if q.Limit < 0 || q.Offset < 0 {
 		return driver.ErrNegativePagination
+	}
+	if len(q.SearchAfter) == 0 {
+		return nil
+	}
+	if q.Offset > 0 {
+		return fmt.Errorf("%w: search_after cannot be combined with a non-zero offset", driver.ErrInvalidQuery)
+	}
+	if len(q.Sorts) == 0 {
+		return fmt.Errorf("%w: search_after requires at least one sort field", driver.ErrInvalidQuery)
+	}
+	if len(q.SearchAfter) != len(q.Sorts) {
+		return fmt.Errorf(
+			"%w: search_after has %d values for %d sort fields",
+			driver.ErrInvalidQuery,
+			len(q.SearchAfter),
+			len(q.Sorts),
+		)
 	}
 
 	return nil

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -137,19 +137,19 @@ func (b *testBackend) Delete(_ context.Context, id string) error {
 	return b.deleteErr
 }
 
-func (b *testBackend) Query(_ context.Context, q driver.Query) ([]driver.Record, error) {
+func (b *testBackend) Query(_ context.Context, q driver.Query) ([]driver.Record, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	b.queryCalls++
 	b.lastQuery = q
 	return b.queryRecords, b.queryErr
 }
 
-func (b *testBackend) Count(_ context.Context, q driver.Query) (int64, error) {
+func (b *testBackend) Count(_ context.Context, q driver.Query) (int64, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	b.countCalls++
 	b.lastQuery = q
 	return b.countValue, b.countErr
 }
 
-func (b *testBackend) Values(_ context.Context, field string, q driver.Query, size int) ([]string, error) {
+func (b *testBackend) Values(_ context.Context, field string, q driver.Query, size int) ([]string, error) { //nolint:gocritic // driver.Storage requires Query by value.
 	b.valuesCalls++
 	b.valuesField = field
 	b.lastQuery = q
@@ -641,7 +641,7 @@ func TestStoreQuery(t *testing.T) {
 				return
 			}
 
-			entities, queryErr := store.Query(t.Context(), tc.query)
+			entities, queryErr := store.Query(t.Context(), &tc.query)
 			tc.validate(t, entities, queryErr, tc.backend)
 		})
 	}
@@ -667,7 +667,7 @@ func TestStoreQueryPageReturnsLastSortValues(t *testing.T) {
 		t.Fatalf("NewStore() error = %v", err)
 	}
 
-	values, cursor, err := store.QueryPage(t.Context(), driver.Query{
+	values, cursor, err := store.QueryPage(t.Context(), &driver.Query{
 		Sorts: []driver.Sort{{Field: "cost", Desc: true}, {Field: "id"}},
 		Limit: 2,
 	})
@@ -711,7 +711,7 @@ func TestStoreRejectsInvalidSearchAfter(t *testing.T) {
 				t.Fatalf("NewStore() error = %v", err)
 			}
 
-			_, _, err = store.QueryPage(t.Context(), query)
+			_, _, err = store.QueryPage(t.Context(), &query)
 			if !errors.Is(err, driver.ErrInvalidQuery) {
 				t.Fatalf("QueryPage() error = %v, want ErrInvalidQuery", err)
 			}
@@ -719,6 +719,21 @@ func TestStoreRejectsInvalidSearchAfter(t *testing.T) {
 				t.Fatalf("backend Query() calls = %d, want 0", backend.queryCalls)
 			}
 		})
+	}
+}
+
+func TestStoreRejectsNilQuery(t *testing.T) {
+	backend := &testBackend{}
+	store, err := NewStore[testEntity](t.Context(), "nil-query", backend, "jobs", newTestMapper())
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	if _, err = store.Query(t.Context(), nil); !errors.Is(err, driver.ErrInvalidQuery) {
+		t.Fatalf("Query() error = %v, want ErrInvalidQuery", err)
+	}
+	if backend.queryCalls != 0 {
+		t.Fatalf("backend Query() calls = %d, want 0", backend.queryCalls)
 	}
 }
 
@@ -798,7 +813,7 @@ func TestStoreCount(t *testing.T) {
 				return
 			}
 
-			count, countErr := store.Count(t.Context(), tc.query)
+			count, countErr := store.Count(t.Context(), &tc.query)
 			tc.validate(t, count, countErr, tc.backend)
 		})
 	}
@@ -891,7 +906,7 @@ func TestStoreTerms(t *testing.T) {
 				return
 			}
 
-			terms, valuesErr := store.Values(t.Context(), tc.field, tc.query, tc.size)
+			terms, valuesErr := store.Values(t.Context(), tc.field, &tc.query, tc.size)
 			tc.validate(t, terms, valuesErr, tc.backend)
 		})
 	}

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -647,6 +647,81 @@ func TestStoreQuery(t *testing.T) {
 	}
 }
 
+func TestStoreQueryPageReturnsLastSortValues(t *testing.T) {
+	backend := &testBackend{
+		queryRecords: []driver.Record{
+			{
+				ID:         "job-first",
+				Data:       mustEncodeEntity(testEntity{ID: "job-first"}),
+				SortValues: []any{2000.0, "job-first"},
+			},
+			{
+				ID:         "job-second",
+				Data:       mustEncodeEntity(testEntity{ID: "job-second"}),
+				SortValues: []any{1000.0, "job-second"},
+			},
+		},
+	}
+	store, err := NewStore[testEntity](t.Context(), "query-page", backend, "jobs", newTestMapper())
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	values, cursor, err := store.QueryPage(t.Context(), driver.Query{
+		Sorts: []driver.Sort{{Field: "cost", Desc: true}, {Field: "id"}},
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("QueryPage() error = %v", err)
+	}
+	if len(values) != 2 {
+		t.Fatalf("QueryPage() values = %d, want 2", len(values))
+	}
+	if len(cursor) != 2 || cursor[0] != 1000.0 || cursor[1] != "job-second" {
+		t.Fatalf("QueryPage() cursor = %#v, want [1000 job-second]", cursor)
+	}
+
+	cursor[1] = "changed"
+	if backend.queryRecords[1].SortValues[1] != "job-second" {
+		t.Fatal("QueryPage() cursor aliases backend sort values")
+	}
+}
+
+func TestStoreRejectsInvalidSearchAfter(t *testing.T) {
+	tests := map[string]driver.Query{
+		"with offset": {
+			Sorts:       []driver.Sort{{Field: "id"}},
+			SearchAfter: []any{"job-first"},
+			Offset:      1,
+		},
+		"without sort": {
+			SearchAfter: []any{"job-first"},
+		},
+		"sort count mismatch": {
+			Sorts:       []driver.Sort{{Field: "cost"}, {Field: "id"}},
+			SearchAfter: []any{"job-first"},
+		},
+	}
+
+	for name, query := range tests {
+		t.Run(name, func(t *testing.T) {
+			backend := &testBackend{}
+			store, err := NewStore[testEntity](t.Context(), name, backend, "jobs", newTestMapper())
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+
+			_, _, err = store.QueryPage(t.Context(), query)
+			if !errors.Is(err, driver.ErrInvalidQuery) {
+				t.Fatalf("QueryPage() error = %v, want ErrInvalidQuery", err)
+			}
+			if backend.queryCalls != 0 {
+				t.Fatalf("backend Query() calls = %d, want 0", backend.queryCalls)
+			}
+		})
+	}
+}
+
 // TestStoreCount covers the Count path: verifies valid queries are forwarded to the backend, invalid pagination is rejected early, and backend errors are propagated.
 func TestStoreCount(t *testing.T) {
 	countErr := errors.New("count failed")

--- a/pkg/tracing/document.go
+++ b/pkg/tracing/document.go
@@ -24,6 +24,8 @@ import (
 	"github.com/rs/xid"
 )
 
+const tracingDocumentTimeLayout = "2006-01-02 15:04:05.000 -0700"
+
 // DocumentCollection is the storage collection name for tracing documents.
 const DocumentCollection = "tracing_documents"
 
@@ -36,8 +38,27 @@ type ProfileDocumentStoreMapper struct {
 }
 
 // ID returns a unique storage ID while tracer_id keeps snapshots queryable as one task.
-func (ProfileDocumentStoreMapper) ID(_ *Document) string {
-	return xid.New().String()
+func (ProfileDocumentStoreMapper) ID(document *Document) string {
+	if document.ProfileStorageID == "" {
+		document.ProfileStorageID = xid.New().String()
+	}
+	return document.ProfileStorageID
+}
+
+func (m ProfileDocumentStoreMapper) Fields(document *Document) (map[string]any, error) {
+	// Regenerate on every save so callers reusing a Document cannot overwrite a window.
+	document.ProfileStorageID = xid.New().String()
+	fields, err := m.DocumentStoreMapper.Fields(document)
+	if err != nil {
+		return nil, err
+	}
+	fields["profile_storage_id"] = document.ProfileStorageID
+	return fields, nil
+}
+
+func (m ProfileDocumentStoreMapper) Indexes() []driver.Index {
+	indexes := m.DocumentStoreMapper.Indexes()
+	return append(indexes, driver.Index{Field: "profile_storage_id"})
 }
 
 func tracingDocumentTimeValue(raw string, fallback time.Time) time.Time {

--- a/pkg/tracing/document_profile_test.go
+++ b/pkg/tracing/document_profile_test.go
@@ -14,13 +14,38 @@
 
 package tracing
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestProfileDocumentStoreMapperUsesUniqueIDs(t *testing.T) {
 	mapper := ProfileDocumentStoreMapper{}
 	document := &Document{TracerID: "profile-task-2026"}
 
+	fields, err := mapper.Fields(document)
+	if err != nil {
+		t.Fatalf("Fields() error = %v", err)
+	}
 	first := mapper.ID(document)
+	if fields["profile_storage_id"] != first {
+		t.Fatalf("profile_storage_id field = %v, want %q", fields["profile_storage_id"], first)
+	}
+	encoded, err := mapper.Encode(document)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	var source Document
+	if err := json.Unmarshal(encoded, &source); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if source.ProfileStorageID != first {
+		t.Fatalf("encoded profile storage ID = %q, want %q", source.ProfileStorageID, first)
+	}
+
+	if _, err := mapper.Fields(document); err != nil {
+		t.Fatalf("second Fields() error = %v", err)
+	}
 	second := mapper.ID(document)
 	if first == "" || second == "" {
 		t.Fatal("ProfileDocumentStoreMapper.ID() returned an empty ID")
@@ -30,5 +55,16 @@ func TestProfileDocumentStoreMapperUsesUniqueIDs(t *testing.T) {
 	}
 	if document.TracerID != "profile-task-2026" {
 		t.Fatalf("ProfileDocumentStoreMapper.ID() changed tracer ID to %q", document.TracerID)
+	}
+
+	foundIndex := false
+	for _, index := range mapper.Indexes() {
+		if index.Field == "profile_storage_id" {
+			foundIndex = true
+			break
+		}
+	}
+	if !foundIndex {
+		t.Fatal("ProfileDocumentStoreMapper.Indexes() is missing profile_storage_id")
 	}
 }

--- a/pkg/tracing/store.go
+++ b/pkg/tracing/store.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	tracingDocumentTimeLayout = "2006-01-02 15:04:05.000 -0700"
-
 	TracerRunTypeTask        = "task"
 	TracerRunTypeAutotracing = "autotracing"
 	TracerRunTypeEvent       = "event"

--- a/pkg/tracing/types.go
+++ b/pkg/tracing/types.go
@@ -18,10 +18,11 @@ import "time"
 
 // Document is the tracing document persisted to and queried from storage backends.
 type Document struct {
-	Hostname     string    `json:"hostname"`
-	Region       string    `json:"region"`
-	UploadedTime time.Time `json:"uploaded_time"`
-	Time         string    `json:"time"`
+	Hostname         string    `json:"hostname"`
+	Region           string    `json:"region"`
+	UploadedTime     time.Time `json:"uploaded_time"`
+	Time             string    `json:"time"`
+	ProfileStorageID string    `json:"profile_storage_id,omitempty"`
 
 	ContainerID            string `json:"container_id,omitempty"`
 	ContainerHostname      string `json:"container_hostname,omitempty"`


### PR DESCRIPTION
## Summary

- stream profile documents page by page for merge, series, and pprof export
- remove the fixed 10k document failure for normal long-window queries
- expose Pyroscope-compatible SelectSeries and profile label aliases
- normalize text-backed aggregation fields to keyword fields
- make the optional total document limit configurable, with zero meaning unlimited
- tolerate count and pagination drift without turning retention races into 500s

## Functional boundary

PR 3 of 6. After its dependencies merge, this PR is complete and usable on its
own: SelectMergeStacktraces, SelectSeries, LabelNames/Values, raw profiles, and
portable pprof export work without PR 4 or PR 5. Diff APIs and Grafana
dashboards are intentionally left to the next layers.

## Dependencies

Depends on #614 and #615. Merge both before this PR.

This source branch includes the PR 1 and PR 2 commits so the branch can compile
and pass CI as a complete unit. After #614 and #615 merge, GitHub will remove
those already-merged changes from this PR diff automatically.

## Validation

- Linux Go 1.24 tests for profiler, aggregator, service, storage, job, config, and handlers
- long-window streaming and query-limit service tests
- real Elasticsearch keyword aggregation and stable cursor coverage
- git diff checks

Split from #463.