### PR TITLE
fix(pod): preserve container enums in JSON

### DIFF
--- a/docs/best-practice/events-watch_en.md
+++ b/docs/best-practice/events-watch_en.md
@@ -112,7 +112,7 @@ The `data` field contains the standard HUATUO event record:
     "container_hostname": "app-pod",
     "container_host_namespace": "prod",
     "container_type": "docker",
-    "container_qos": "Guaranteed"
+    "container_qos": "guaranteed"
   }
 }
 ```
@@ -131,7 +131,7 @@ The `data` field contains the standard HUATUO event record:
 | `container_hostname` | string | Container hostname |
 | `container_host_namespace` | string | Namespace of the container |
 | `container_type` | string | Container runtime type (docker, containerd, etc.) |
-| `container_qos` | string | Container QoS class |
+| `container_qos` | string | Container QoS class (`unknown`, `guaranteed`, `burstable`, or `besteffort`) |
 
 ---
 

--- a/docs/best-practice/events-watch_zh.md
+++ b/docs/best-practice/events-watch_zh.md
@@ -112,7 +112,7 @@ HUATUO（华佗）是由滴滴开源并依托 CCF（中国计算机学会）孵�
     "container_hostname": "app-pod",
     "container_host_namespace": "prod",
     "container_type": "docker",
-    "container_qos": "Guaranteed"
+    "container_qos": "guaranteed"
   }
 }
 ```

--- a/internal/pod/container_json_test.go
+++ b/internal/pod/container_json_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestContainerTypeJSONRoundTrip(t *testing.T) {
+	types := []ContainerType{
+		ContainerTypeSidecar,
+		ContainerTypeDaemonSet,
+		ContainerTypeNode,
+		ContainerTypeStatic,
+		ContainerTypeNormal,
+		ContainerTypeUnknown,
+	}
+
+	for _, want := range types {
+		t.Run(want.String(), func(t *testing.T) {
+			data, err := json.Marshal(want)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			var got ContainerType
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", data, err)
+			}
+			if got != want {
+				t.Errorf("round trip = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestContainerQosJSONRoundTrip(t *testing.T) {
+	levels := []ContainerQos{
+		containerQosUnknown,
+		containerQosGuaranteed,
+		containerQosBurstable,
+		containerQosBestEffort,
+	}
+
+	for _, want := range levels {
+		t.Run(want.String(), func(t *testing.T) {
+			data, err := json.Marshal(want)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			var got ContainerQos
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", data, err)
+			}
+			if got != want {
+				t.Errorf("round trip = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestContainerQosUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want ContainerQos
+	}{
+		{name: "lowercase", data: `"guaranteed"`, want: containerQosGuaranteed},
+		{name: "Kubernetes", data: `"Guaranteed"`, want: containerQosGuaranteed},
+		{name: "uppercase", data: `"GUARANTEED"`, want: containerQosUnknown},
+		{name: "invalid", data: `"invalid"`, want: containerQosUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ContainerQos
+			if err := json.Unmarshal([]byte(tt.data), &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error = %v", tt.data, err)
+			}
+			if got != tt.want {
+				t.Errorf("Unmarshal(%s) = %v, want %v", tt.data, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainerQosUnmarshalJSONRejectsNonString(t *testing.T) {
+	var qos ContainerQos
+	if err := json.Unmarshal([]byte(`1`), &qos); err == nil {
+		t.Fatal("Unmarshal(non-string) error = nil")
+	}
+}
+
+func TestContainerQosStringInvalid(t *testing.T) {
+	for _, qos := range []ContainerQos{-1, containerQosMax} {
+		if got := qos.String(); got != "unknown" {
+			t.Errorf("ContainerQos(%d).String() = %q, want unknown", qos, got)
+		}
+	}
+}
+
+func TestParseContainerQos(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Status.QOSClass = corev1.PodQOSBestEffort
+
+	got, err := parseContainerQos(ContainerTypeUnknown, pod)
+	if err != nil {
+		t.Fatalf("parseContainerQos() error = %v", err)
+	}
+	if got != containerQosBestEffort {
+		t.Errorf("parseContainerQos() = %v, want %v", got, containerQosBestEffort)
+	}
+}
+
+func TestContainerJSONUnknownValues(t *testing.T) {
+	var typ ContainerType
+	if err := json.Unmarshal([]byte(`"future"`), &typ); err != nil {
+		t.Fatalf("Unmarshal(container type) error = %v", err)
+	}
+	if typ != ContainerTypeUnknown {
+		t.Errorf("container type = %v, want unknown", typ)
+	}
+
+	var qos ContainerQos
+	if err := json.Unmarshal([]byte(`"future"`), &qos); err != nil {
+		t.Fatalf("Unmarshal(container qos) error = %v", err)
+	}
+	if qos != containerQosUnknown {
+		t.Errorf("container qos = %v, want unknown", qos)
+	}
+}

--- a/internal/pod/container_level_default.go
+++ b/internal/pod/container_level_default.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package pod
 
 import (
 	"encoding/json"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -54,11 +53,11 @@ func parseContainerQos(typ ContainerType, pod *corev1.Pod) (ContainerQos, error)
 func (p ContainerQos) String() string {
 	switch p {
 	case containerQosBurstable:
-		return strings.ToLower(string(corev1.PodQOSBurstable))
+		return "burstable"
 	case containerQosBestEffort:
-		return strings.ToLower(string(corev1.PodQOSBestEffort))
+		return "besteffort"
 	case containerQosGuaranteed:
-		return strings.ToLower(string(corev1.PodQOSGuaranteed))
+		return "guaranteed"
 	default:
 		return "unknown"
 	}
@@ -77,11 +76,11 @@ func (p *ContainerQos) UnmarshalJSON(data []byte) error {
 	}
 
 	switch s {
-	case string(corev1.PodQOSBurstable):
+	case "burstable", string(corev1.PodQOSBurstable):
 		*p = containerQosBurstable
-	case string(corev1.PodQOSBestEffort):
+	case "besteffort", string(corev1.PodQOSBestEffort):
 		*p = containerQosBestEffort
-	case string(corev1.PodQOSGuaranteed):
+	case "guaranteed", string(corev1.PodQOSGuaranteed):
 		*p = containerQosGuaranteed
 	default:
 		*p = containerQosUnknown

--- a/internal/pod/container_level_default.go
+++ b/internal/pod/container_level_default.go
@@ -37,30 +37,34 @@ const (
 // ContainerQosLevelMin is the minimum priority.
 const ContainerQosLevelMin = containerQosUnknown
 
-func parseContainerQos(typ ContainerType, pod *corev1.Pod) (ContainerQos, error) {
-	switch pod.Status.QOSClass {
-	case corev1.PodQOSBurstable:
-		return containerQosBurstable, nil
-	case corev1.PodQOSBestEffort:
-		return containerQosBestEffort, nil
-	case corev1.PodQOSGuaranteed:
-		return containerQosGuaranteed, nil
-	default:
-		return containerQosUnknown, nil
-	}
+var containerQosStrings = [...]string{
+	containerQosUnknown:    "unknown",
+	containerQosGuaranteed: "guaranteed",
+	containerQosBurstable:  "burstable",
+	containerQosBestEffort: "besteffort",
+}
+
+var containerQosByString = map[string]ContainerQos{
+	"unknown":    containerQosUnknown,
+	"guaranteed": containerQosGuaranteed,
+	"burstable":  containerQosBurstable,
+	"besteffort": containerQosBestEffort,
+
+	string(corev1.PodQOSGuaranteed): containerQosGuaranteed,
+	string(corev1.PodQOSBurstable):  containerQosBurstable,
+	string(corev1.PodQOSBestEffort): containerQosBestEffort,
+}
+
+func parseContainerQos(_ ContainerType, pod *corev1.Pod) (ContainerQos, error) {
+	return containerQosByString[string(pod.Status.QOSClass)], nil
 }
 
 func (p ContainerQos) String() string {
-	switch p {
-	case containerQosBurstable:
-		return "burstable"
-	case containerQosBestEffort:
-		return "besteffort"
-	case containerQosGuaranteed:
-		return "guaranteed"
-	default:
-		return "unknown"
+	if p < containerQosUnknown || p >= containerQosMax {
+		return containerQosStrings[containerQosUnknown]
 	}
+
+	return containerQosStrings[p]
 }
 
 // MarshalJSON marshal container qos to json.
@@ -75,17 +79,7 @@ func (p *ContainerQos) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	switch s {
-	case "burstable", string(corev1.PodQOSBurstable):
-		*p = containerQosBurstable
-	case "besteffort", string(corev1.PodQOSBestEffort):
-		*p = containerQosBestEffort
-	case "guaranteed", string(corev1.PodQOSGuaranteed):
-		*p = containerQosGuaranteed
-	default:
-		*p = containerQosUnknown
-	}
-
+	*p = containerQosByString[s]
 	return nil
 }
 

--- a/internal/pod/container_type.go
+++ b/internal/pod/container_type.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,6 +65,10 @@ func (t *ContainerType) UnmarshalJSON(data []byte) error {
 		*t = ContainerTypeDaemonSet
 	case containerType2String[ContainerTypeNormal]:
 		*t = ContainerTypeNormal
+	case containerType2String[ContainerTypeNode]:
+		*t = ContainerTypeNode
+	case containerType2String[ContainerTypeStatic]:
+		*t = ContainerTypeStatic
 	default:
 		*t = ContainerTypeUnknown
 	}


### PR DESCRIPTION
## Summary

- make `ContainerQos` accept the lowercase values emitted by its JSON marshaler
- decode the existing `node` and `static` container type values
- cover every declared container type and QoS value with JSON round-trip tests
- retain the existing fallback to `unknown` for unrecognized input

## Why

The two enum types did not satisfy the expected `MarshalJSON`/`UnmarshalJSON` round-trip contract. QoS values were serialized in lowercase but decoded only in Kubernetes title case, while two valid container types were missing from the decoder.

Fixes #619

## Validation

- `go test internal/pod/container_type.go internal/pod/container_level_default.go internal/pod/container_json_test.go -run 'TestContainer(Type|Qos)JSONRoundTrip|TestContainerJSONUnknownValues' -count=1`
- `go vet internal/pod/container_type.go internal/pod/container_level_default.go`
- `goimports` and `gofumpt` on all changed Go files
- `git diff --check`

The full repository check requires generated BPF ABI files and a Linux BPF toolchain, which are not available in this Windows environment; GitHub CI will run the repository-wide build and lint jobs.