### PR TITLE
fix(ascend): require complete PCIe link samples

### DIFF
--- a/core/metrics/ascend/pcie/pcie.go
+++ b/core/metrics/ascend/pcie/pcie.go
@@ -23,7 +23,9 @@ package pcie
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -40,28 +42,33 @@ type PCIeLinkInfo struct {
 
 // GetPCIeLinkInfo reads PCIe link info from sysfs for the given BDF.
 func GetPCIeLinkInfo(bdf string) (*PCIeLinkInfo, error) {
-	base := pciDevicesPath + "/" + bdf
+	return getPCIeLinkInfo(filepath.Join(pciDevicesPath, bdf))
+}
 
-	info := &PCIeLinkInfo{}
+func getPCIeLinkInfo(base string) (*PCIeLinkInfo, error) {
+	capSpeed, err := parseSpeed(filepath.Join(base, "max_link_speed"))
+	if err != nil {
+		return nil, fmt.Errorf("read maximum link speed: %w", err)
+	}
+	capWidth, err := parseWidth(filepath.Join(base, "max_link_width"))
+	if err != nil {
+		return nil, fmt.Errorf("read maximum link width: %w", err)
+	}
+	statusSpeed, err := parseSpeed(filepath.Join(base, "current_link_speed"))
+	if err != nil {
+		return nil, fmt.Errorf("read current link speed: %w", err)
+	}
+	statusWidth, err := parseWidth(filepath.Join(base, "current_link_width"))
+	if err != nil {
+		return nil, fmt.Errorf("read current link width: %w", err)
+	}
 
-	if s, err := parseSpeed(base + "/max_link_speed"); err == nil {
-		info.CapSpeed = s
-	}
-	if w, err := parseWidth(base + "/max_link_width"); err == nil {
-		info.CapWidth = w
-	}
-	if s, err := parseSpeed(base + "/current_link_speed"); err == nil {
-		info.StatusSpeed = s
-	}
-	if w, err := parseWidth(base + "/current_link_width"); err == nil {
-		info.StatusWidth = w
-	}
-
-	if info.CapSpeed == 0 && info.StatusSpeed == 0 {
-		return nil, fmt.Errorf("sysfs: unable to read link info for %s", bdf)
-	}
-
-	return info, nil
+	return &PCIeLinkInfo{
+		CapSpeed:    capSpeed,
+		CapWidth:    capWidth,
+		StatusSpeed: statusSpeed,
+		StatusWidth: statusWidth,
+	}, nil
 }
 
 func parseSpeed(path string) (float64, error) {
@@ -74,7 +81,11 @@ func parseSpeed(path string) (float64, error) {
 	if len(fields) == 0 {
 		return 0, fmt.Errorf("empty speed in %s", path)
 	}
-	return strconv.ParseFloat(fields[0], 64)
+	speed, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || math.IsNaN(speed) || math.IsInf(speed, 0) || speed <= 0 {
+		return 0, fmt.Errorf("invalid speed in %s: %q", path, fields[0])
+	}
+	return speed, nil
 }
 
 func parseWidth(path string) (uint32, error) {
@@ -86,6 +97,9 @@ func parseWidth(path string) (uint32, error) {
 	width, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("invalid width in %s: %w", path, err)
+	}
+	if width == 0 {
+		return 0, fmt.Errorf("invalid width in %s: must be greater than zero", path)
 	}
 	return uint32(width), nil
 }

--- a/core/metrics/ascend/pcie/pcie_test.go
+++ b/core/metrics/ascend/pcie/pcie_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcie
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var validLinkFiles = map[string]string{
+	"max_link_speed":     "32.0 GT/s\n",
+	"max_link_width":     "16\n",
+	"current_link_speed": "16.0 GT/s\n",
+	"current_link_width": "8\n",
+}
+
+func TestGetPCIeLinkInfo(t *testing.T) {
+	base := writeLinkFiles(t, validLinkFiles)
+
+	info, err := getPCIeLinkInfo(base)
+	if err != nil {
+		t.Fatalf("getPCIeLinkInfo() error = %v", err)
+	}
+	want := PCIeLinkInfo{CapSpeed: 32, CapWidth: 16, StatusSpeed: 16, StatusWidth: 8}
+	if *info != want {
+		t.Errorf("getPCIeLinkInfo() = %+v, want %+v", *info, want)
+	}
+}
+
+func TestGetPCIeLinkInfoRejectsIncompleteSample(t *testing.T) {
+	tests := []struct {
+		name        string
+		missing     string
+		wantErrPart string
+	}{
+		{name: "maximum speed", missing: "max_link_speed", wantErrPart: "maximum link speed"},
+		{name: "maximum width", missing: "max_link_width", wantErrPart: "maximum link width"},
+		{name: "current speed", missing: "current_link_speed", wantErrPart: "current link speed"},
+		{name: "current width", missing: "current_link_width", wantErrPart: "current link width"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := cloneLinkFiles()
+			delete(files, tt.missing)
+			_, err := getPCIeLinkInfo(writeLinkFiles(t, files))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrPart) {
+				t.Fatalf("getPCIeLinkInfo() error = %v, want error containing %q", err, tt.wantErrPart)
+			}
+		})
+	}
+}
+
+func TestGetPCIeLinkInfoRejectsInvalidValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		file        string
+		value       string
+		wantErrPart string
+	}{
+		{name: "non-numeric maximum speed", file: "max_link_speed", value: "unknown\n", wantErrPart: "maximum link speed"},
+		{name: "NaN current speed", file: "current_link_speed", value: "NaN GT/s\n", wantErrPart: "current link speed"},
+		{name: "zero maximum width", file: "max_link_width", value: "0\n", wantErrPart: "maximum link width"},
+		{name: "non-numeric current width", file: "current_link_width", value: "x8\n", wantErrPart: "current link width"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := cloneLinkFiles()
+			files[tt.file] = tt.value
+			_, err := getPCIeLinkInfo(writeLinkFiles(t, files))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErrPart) {
+				t.Fatalf("getPCIeLinkInfo() error = %v, want error containing %q", err, tt.wantErrPart)
+			}
+		})
+	}
+}
+
+func cloneLinkFiles() map[string]string {
+	files := make(map[string]string, len(validLinkFiles))
+	for name, value := range validLinkFiles {
+		files[name] = value
+	}
+	return files
+}
+
+func writeLinkFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	base := t.TempDir()
+	for name, value := range files {
+		if err := os.WriteFile(filepath.Join(base, name), []byte(value), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return base
+}


### PR DESCRIPTION
## Summary

- read all four PCIe capability and status attributes as one complete sample
- return field-specific errors instead of publishing missing values as zero
- reject non-finite or non-positive speeds and zero-width links
- add sysfs-shaped fixtures covering every missing field and invalid speed/width values

## Problem

The previous implementation ignored each individual sysfs error and returned success whenever either speed was non-zero. Because the caller publishes all four metrics together, a missing width or speed was exposed as a real `0` value such as PCIe `x0`.

## Testing

- `go test ./core/metrics/ascend/pcie -count=1`
- `go vet ./core/metrics/ascend/pcie`
- `golangci-lint run ./core/metrics/ascend/pcie/...`
- `git diff --check`

Fixes #623