### PR TITLE
fix(ascend): roll back failed DCMI initialization

### DIFF
--- a/core/metrics/ascend/dcmi/init.go
+++ b/core/metrics/ascend/dcmi/init.go
@@ -15,12 +15,23 @@
 
 package dcmi
 
+import (
+	"errors"
+	"fmt"
+)
+
 // DcInit loads and initializes the Ascend DCMI library.
 func DcInit() error {
 	if err := libdcmi.load(); err != nil {
 		return err
 	}
-	return checkReturnCode("dcmi_init", dcmiInit())
+	if err := checkReturnCode("dcmi_init", dcmiInit()); err != nil {
+		if closeErr := libdcmi.close(); closeErr != nil {
+			return errors.Join(err, fmt.Errorf("roll back DCMI library load: %w", closeErr))
+		}
+		return err
+	}
+	return nil
 }
 
 // DcShutDown shuts down the Ascend DCMI library.

--- a/core/metrics/ascend/dcmi/init_test.go
+++ b/core/metrics/ascend/dcmi/init_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dcmi
+
+import "testing"
+
+type fakeDynamicLibrary struct {
+	openCalls  int
+	closeCalls int
+}
+
+func (f *fakeDynamicLibrary) Open() error {
+	f.openCalls++
+	return nil
+}
+
+func (f *fakeDynamicLibrary) Close() error {
+	f.closeCalls++
+	return nil
+}
+
+func (f *fakeDynamicLibrary) Handle() uintptr {
+	return 1
+}
+
+func TestDcInitRollsBackFailedInitializationAndAllowsRetry(t *testing.T) {
+	fake := installFakeLibrary(t)
+	initCalls := 0
+	dcmiInit = func() Return {
+		initCalls++
+		if initCalls == 1 {
+			return Return(-8005)
+		}
+		return Success
+	}
+
+	if err := DcInit(); err == nil {
+		t.Fatal("first DcInit() error = nil, want initialization failure")
+	}
+	if fake.openCalls != 1 || fake.closeCalls != 1 || libdcmi.refcount != 0 {
+		t.Fatalf(
+			"after failed init: open calls = %d, close calls = %d, refcount = %d; want 1, 1, 0",
+			fake.openCalls, fake.closeCalls, libdcmi.refcount,
+		)
+	}
+
+	if err := DcInit(); err != nil {
+		t.Fatalf("retry DcInit() error = %v", err)
+	}
+	if fake.openCalls != 2 || fake.closeCalls != 1 || libdcmi.refcount != 1 {
+		t.Fatalf(
+			"after successful retry: open calls = %d, close calls = %d, refcount = %d; want 2, 1, 1",
+			fake.openCalls, fake.closeCalls, libdcmi.refcount,
+		)
+	}
+
+	if err := DcShutDown(); err != nil {
+		t.Fatalf("DcShutDown() error = %v", err)
+	}
+	if fake.closeCalls != 2 || libdcmi.refcount != 0 {
+		t.Fatalf(
+			"after shutdown: close calls = %d, refcount = %d; want 2, 0",
+			fake.closeCalls, libdcmi.refcount,
+		)
+	}
+}
+
+func TestDcInitSuccessfulReferenceLifecycle(t *testing.T) {
+	fake := installFakeLibrary(t)
+	dcmiInit = func() Return { return Success }
+
+	if err := DcInit(); err != nil {
+		t.Fatalf("first DcInit() error = %v", err)
+	}
+	if err := DcInit(); err != nil {
+		t.Fatalf("second DcInit() error = %v", err)
+	}
+	if fake.openCalls != 1 || libdcmi.refcount != 2 {
+		t.Fatalf("after init: open calls = %d, refcount = %d; want 1, 2", fake.openCalls, libdcmi.refcount)
+	}
+
+	if err := DcShutDown(); err != nil {
+		t.Fatalf("first DcShutDown() error = %v", err)
+	}
+	if fake.closeCalls != 0 || libdcmi.refcount != 1 {
+		t.Fatalf("after first shutdown: close calls = %d, refcount = %d; want 0, 1", fake.closeCalls, libdcmi.refcount)
+	}
+
+	if err := DcShutDown(); err != nil {
+		t.Fatalf("second DcShutDown() error = %v", err)
+	}
+	if fake.closeCalls != 1 || libdcmi.refcount != 0 {
+		t.Fatalf("after final shutdown: close calls = %d, refcount = %d; want 1, 0", fake.closeCalls, libdcmi.refcount)
+	}
+}
+
+func installFakeLibrary(t *testing.T) *fakeDynamicLibrary {
+	t.Helper()
+	originalLibrary := libdcmi
+	originalInit := dcmiInit
+	t.Cleanup(func() {
+		libdcmi = originalLibrary
+		dcmiInit = originalInit
+	})
+
+	fake := &fakeDynamicLibrary{}
+	libdcmi = &library{
+		dl:              fake,
+		registerSymbols: func(uintptr) {},
+	}
+	return fake
+}

--- a/core/metrics/ascend/dcmi/lib.go
+++ b/core/metrics/ascend/dcmi/lib.go
@@ -37,8 +37,9 @@ type dynamicLibrary interface {
 // while delegating loading/unloading to dynamicLibrary.
 type library struct {
 	sync.Mutex
-	refcount refcount
-	dl       dynamicLibrary
+	refcount        refcount
+	dl              dynamicLibrary
+	registerSymbols func(uintptr)
 }
 
 // global singleton instance
@@ -46,9 +47,11 @@ var libdcmi = newLibrary()
 
 func newLibrary() *library {
 	path := defaultDcmiLibraryPath()
-	return &library{
+	library := &library{
 		dl: dl.New(path, purego.RTLD_NOW|purego.RTLD_GLOBAL),
 	}
+	library.registerSymbols = library.registerDcmiLibSymbols
+	return library
 }
 
 func defaultDcmiLibraryPath() string {
@@ -76,7 +79,7 @@ func (l *library) load() (rerr error) {
 	}
 
 	// Register all symbols after successful loading.
-	l.registerDcmiLibSymbols(l.dl.Handle())
+	l.registerSymbols(l.dl.Handle())
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- release the library reference acquired by `DcInit` when native `dcmi_init` fails
- preserve both the initialization and rollback errors if closing the library also fails
- make symbol registration injectable for lifecycle tests while retaining the production registrar
- test failed-init rollback, successful retry, balanced reference counts, and normal shutdown

## Problem

`libdcmi.load()` increments the reference count before the native initialization call. The previous error path returned without balancing that reference, leaving the library open and causing later retries and shutdowns to operate on stale lifecycle state.

## Testing

- `GOOS=linux go test -c ./core/metrics/ascend/dcmi` (Linux test binary compiles)
- `GOOS=linux go vet ./core/metrics/ascend/dcmi`
- `GOOS=linux golangci-lint run --no-config --disable-all -E govet -E staticcheck -E errcheck ./core/metrics/ascend/dcmi/...`
- `git diff --check`

The package tests cannot execute on the Windows development host because `purego.Dlopen` is Linux-only; CI will execute the compiled lifecycle tests on Linux.

Fixes #624