### PR TITLE
fix(server): constrain recursive auth wildcards

### DIFF
--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -109,18 +109,9 @@ func splitPermission(permission string) (string, string) {
 
 // matchesPath performs simple path matching, supporting basic wildcards and path parameters.
 func (s *authService) matchesPath(permission, path string) bool {
-	// 1. Exact match
 	if permission == path {
 		return true
 	}
-
-	// 2. Handle wildcard ** (matches all sub-paths)
-	if strings.Contains(permission, "**") {
-		prefix := strings.Split(permission, "**")[0]
-		return strings.HasPrefix(path, prefix)
-	}
-
-	// 3. Handle single-level wildcard * and path parameter :param
 	return s.matchesSegments(permission, path)
 }
 
@@ -129,28 +120,41 @@ func (s *authService) matchesSegments(permission, path string) bool {
 	permSegments := strings.Split(strings.Trim(permission, "/"), "/")
 	pathSegments := strings.Split(strings.Trim(path, "/"), "/")
 
-	// Segments must be the same length (unless there's a wildcard)
-	if len(permSegments) != len(pathSegments) {
-		return false
+	memo := make(map[[2]int]bool)
+	visited := make(map[[2]int]bool)
+
+	var match func(int, int) bool
+	match = func(permissionIndex, pathIndex int) bool {
+		pos := [2]int{permissionIndex, pathIndex}
+		if visited[pos] {
+			return memo[pos]
+		}
+		visited[pos] = true
+
+		matched := false
+		switch {
+		case permissionIndex == len(permSegments):
+			matched = pathIndex == len(pathSegments)
+		case permSegments[permissionIndex] == "**":
+			// Recursive wildcards represent descendants, so they consume at
+			// least one complete segment. This preserves the documented need
+			// for a separate permission for the collection path itself.
+			matched = pathIndex < len(pathSegments) &&
+				(match(permissionIndex+1, pathIndex+1) ||
+					match(permissionIndex, pathIndex+1))
+		case pathIndex < len(pathSegments):
+			permissionSegment := permSegments[permissionIndex]
+			matched = (permissionSegment == pathSegments[pathIndex] ||
+				permissionSegment == "*" ||
+				strings.HasPrefix(permissionSegment, ":")) &&
+				match(permissionIndex+1, pathIndex+1)
+		}
+
+		memo[pos] = matched
+		return matched
 	}
 
-	// Compare each segment
-	for i, permSeg := range permSegments {
-		pathSeg := pathSegments[i]
-
-		if permSeg == pathSeg {
-			continue
-		}
-		if strings.HasPrefix(permSeg, ":") {
-			continue
-		}
-		if permSeg == "*" {
-			continue
-		}
-		return false
-	}
-
-	return true
+	return match(0, 0)
 }
 
 // NewAuthMiddleware returns a HandlerContextFunc that validates requests using the given authService.

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -120,6 +120,27 @@ func TestAuthServiceMatchesPath(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "double star requires descendant",
+			permission: "/v1/traces/**",
+			path:       "/v1/traces",
+		},
+		{
+			name:       "double star rejects sibling prefix",
+			permission: "/v1/traces/**",
+			path:       "/v1/traces-archive/task-2026",
+		},
+		{
+			name:       "double star preserves suffix",
+			permission: "/v1/**/result",
+			path:       "/v1/tasks/task-2026/result",
+			want:       true,
+		},
+		{
+			name:       "double star enforces suffix",
+			permission: "/v1/**/result",
+			path:       "/v1/tasks/task-2026/delete",
+		},
+		{
 			name:       "path parameter",
 			permission: "/v1/tasks/:taskID",
 			path:       "/v1/tasks/task-2026",
@@ -198,6 +219,13 @@ func TestNewAuthMiddleware(t *testing.T) {
 			wantUserID:     "admin-2026",
 			wantIsAdmin:    true,
 		},
+		{
+			name:         "recursive permission rejects sibling prefix",
+			authHeader:   "Bearer viewer-secret",
+			path:         "/v1/profiles-archive/export",
+			wantStatus:   http.StatusForbidden,
+			wantBodyPart: "does not have permission",
+		},
 	}
 
 	for _, tt := range tests {
@@ -219,6 +247,11 @@ func TestNewAuthMiddleware(t *testing.T) {
 			)
 			engine.GET(
 				"/v1/tasks/:taskID/result",
+				wrapHandler(NewAuthMiddleware(svc)),
+				handler,
+			)
+			engine.GET(
+				"/v1/profiles-archive/export",
 				wrapHandler(NewAuthMiddleware(svc)),
 				handler,
 			)
@@ -249,6 +282,68 @@ func TestNewAuthMiddleware(t *testing.T) {
 			}
 			if gotIsAdmin != tt.wantIsAdmin {
 				t.Errorf("ctx.IsAdmin = %v, want %v", gotIsAdmin, tt.wantIsAdmin)
+			}
+		})
+	}
+}
+
+func TestNewAuthMiddlewarePublicRecursiveWildcardBoundary(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+	svc := newTestAuthService()
+
+	tests := []struct {
+		name         string
+		path         string
+		wantStatus   int
+		wantHandler  bool
+		wantBodyPart string
+	}{
+		{
+			name:        "descendant is public",
+			path:        "/v1/profiles/task-2026",
+			wantStatus:  http.StatusNoContent,
+			wantHandler: true,
+		},
+		{
+			name:         "sibling prefix still requires authentication",
+			path:         "/v1/profiles-archive/export",
+			wantStatus:   http.StatusUnauthorized,
+			wantBodyPart: "missing bearer token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := httpGin.New()
+			var handlerRan bool
+			handler := wrapHandler(func(ctx *Context) {
+				handlerRan = true
+				ctx.Status(http.StatusNoContent)
+			})
+			middleware := wrapHandler(NewAuthMiddleware(
+				svc,
+				[]string{"/v1/profiles/**"},
+			))
+			engine.GET("/v1/profiles/:id", middleware, handler)
+			engine.GET("/v1/profiles-archive/export", middleware, handler)
+
+			request := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, request)
+
+			if recorder.Code != tt.wantStatus {
+				t.Errorf("response status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if handlerRan != tt.wantHandler {
+				t.Errorf("handler executed = %v, want %v", handlerRan, tt.wantHandler)
+			}
+			if tt.wantBodyPart != "" &&
+				!strings.Contains(recorder.Body.String(), tt.wantBodyPart) {
+				t.Errorf(
+					"response body = %q, want substring %q",
+					recorder.Body.String(),
+					tt.wantBodyPart,
+				)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- replace byte-prefix matching for recursive authorization wildcards with segment-aware matching
- preserve the documented distinction between a collection path and its descendants
- enforce permission suffixes that follow a recursive wildcard
- add helper-level and middleware-level regression coverage for user and public-path authorization

Fixes #627.

## Problem

`authService.matchesPath` previously handled any permission containing `**` by splitting at the first wildcard and calling `strings.HasPrefix` on the request path.

That had two authorization-boundary consequences:

1. `/v1/profiles/**` also matched `/v1/profiles-archive/export` because both strings share the `/v1/profiles` byte prefix.
2. `/v1/**/result` matched unrelated paths such as `/v1/tasks/task-1/delete` because the suffix after `**` was never evaluated.

The same matcher is used for normal user permissions and configured public or administrator paths, so this was not limited to one endpoint family.

## Implementation

The matcher now evaluates complete path segments with a memoized recursive search:

- literal segments must be equal;
- `*` and `:param` consume exactly one segment;
- `**` consumes one or more complete segments;
- matching resumes after `**`, so a suffix remains mandatory;
- the request must be fully consumed before the permission matches.

Requiring `**` to consume at least one segment intentionally preserves the existing documented behavior: a permission for `/v1/profiles/**` covers descendants, while `/v1/profiles` remains a separate permission.

The memo table is bounded by `len(permissionSegments) * len(pathSegments)`, avoiding repeated exploration when a pattern contains multiple recursive wildcards.

## Regression coverage

`TestAuthServiceMatchesPath` now covers:

- nested recursive descendants;
- the base path remaining distinct;
- rejection of sibling prefixes;
- suffix matching after `**`;
- suffix rejection for unrelated endpoints;
- the existing exact, single-wildcard, path-parameter, and segment-count behavior.

Middleware tests additionally verify the externally visible boundaries:

- a viewer with `/v1/profiles/**` cannot access `/v1/profiles-archive/export`;
- a configured public `/v1/profiles/**` descendant remains public;
- `/v1/profiles-archive/export` still requires authentication.

## Validation

- `go test ./internal/server -count=1`
- `go test -race ./internal/server -count=1`
- `go vet ./internal/server`
- `golangci-lint run -v ./internal/server --timeout=5m --config .golangci.yaml`
- `golangci-lint run -v ./... --timeout=10m --config .golangci.yaml`
- `git diff --check`

All commands above passed. The full linter used the repository's 26 configured linters and completed with no reportable issues.

`make check` was also invoked in the official development image. Its fixed five-minute linter deadline expired while `go/packages` was loading the bind-mounted Windows workspace; it reported no source finding before the infrastructure timeout. Running the same configured full-repository lint on a container-local copy completed successfully in 1 minute 29 seconds.
