### PR TITLE
fix(executil): restore UTS namespace after hostname lookup

### DIFF
--- a/internal/utils/executil/exec.go
+++ b/internal/utils/executil/exec.go
@@ -173,21 +173,113 @@ func RunningDir() (string, error) {
 	return filepath.Dir(exePath), nil
 }
 
+const currentThreadUTSNamespace = "/proc/thread-self/ns/uts"
+
+type namespaceHandle interface {
+	Fd() uintptr
+	Close() error
+}
+
+type utsNamespaceOperations struct {
+	open     func(string) (namespaceHandle, error)
+	setns    func(int, int) error
+	hostname func() (string, error)
+}
+
+type utsHostnameResult struct {
+	hostname      string
+	err           error
+	discardThread bool
+}
+
 func HostnameByPid(pid uint32) (string, error) {
-	var empty string
-	fd, err := os.Open(procfs.Path(fmt.Sprintf("%d", pid), "ns/uts"))
+	targetPath := procfs.Path(fmt.Sprintf("%d", pid), "ns/uts")
+	return hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			return os.Open(path)
+		},
+		setns:    unix.Setns,
+		hostname: os.Hostname,
+	})
+}
+
+func hostnameByUTSNamespace(
+	targetPath string,
+	operations utsNamespaceOperations,
+) (string, error) {
+	resultCh := make(chan utsHostnameResult, 1)
+	go func() {
+		runtime.LockOSThread()
+		result := readHostnameInUTSNamespace(targetPath, operations)
+		resultCh <- result
+		if !result.discardThread {
+			runtime.UnlockOSThread()
+		}
+		// Exiting while still locked makes the runtime terminate a thread
+		// whose original namespace could not be restored.
+	}()
+
+	result := <-resultCh
+	return result.hostname, result.err
+}
+
+func readHostnameInUTSNamespace(
+	targetPath string,
+	operations utsNamespaceOperations,
+) utsHostnameResult {
+	current, err := operations.open(currentThreadUTSNamespace)
 	if err != nil {
-		return empty, err
+		return utsHostnameResult{
+			err: fmt.Errorf("open current thread UTS namespace: %w", err),
+		}
 	}
-	defer fd.Close()
 
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	if err := unix.Setns(int(fd.Fd()), unix.CLONE_NEWUTS); err != nil {
-		return empty, err
+	target, err := operations.open(targetPath)
+	if err != nil {
+		return utsHostnameResult{
+			err: errors.Join(
+				fmt.Errorf("open target UTS namespace %q: %w", targetPath, err),
+				closeNamespaceHandle(current, "current thread UTS namespace"),
+			),
+		}
 	}
-	return os.Hostname()
+
+	if err := operations.setns(int(target.Fd()), unix.CLONE_NEWUTS); err != nil {
+		return utsHostnameResult{
+			err: errors.Join(
+				fmt.Errorf("enter target UTS namespace %q: %w", targetPath, err),
+				closeNamespaceHandle(target, "target UTS namespace"),
+				closeNamespaceHandle(current, "current thread UTS namespace"),
+			),
+		}
+	}
+
+	hostname, hostnameErr := operations.hostname()
+	restoreErr := operations.setns(int(current.Fd()), unix.CLONE_NEWUTS)
+	if hostnameErr != nil {
+		hostnameErr = fmt.Errorf("read hostname in target UTS namespace %q: %w", targetPath, hostnameErr)
+	}
+	if restoreErr != nil {
+		restoreErr = fmt.Errorf("restore current thread UTS namespace: %w", restoreErr)
+	}
+
+	return utsHostnameResult{
+		hostname: hostname,
+		err: errors.Join(
+			hostnameErr,
+			restoreErr,
+			closeNamespaceHandle(target, "target UTS namespace"),
+			closeNamespaceHandle(current, "current thread UTS namespace"),
+		),
+		discardThread: restoreErr != nil,
+	}
+}
+
+func closeNamespaceHandle(handle namespaceHandle, description string) error {
+	if err := handle.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", description, err)
+	}
+	return nil
 }
 
 func ProcNameByPid(pid uint32) (string, error) {

--- a/internal/utils/executil/exec_test.go
+++ b/internal/utils/executil/exec_test.go
@@ -28,6 +28,8 @@ import (
 	"huatuo-bamai/internal/procfs"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func withProcRoot(t *testing.T, root string) {
@@ -266,4 +268,203 @@ func TestHostnameByPid(t *testing.T) {
 			tt.validate(t, got, currentHost, err)
 		})
 	}
+}
+
+type fakeNamespaceHandle struct {
+	fd       uintptr
+	closed   bool
+	closeErr error
+}
+
+func (h *fakeNamespaceHandle) Fd() uintptr {
+	return h.fd
+}
+
+func (h *fakeNamespaceHandle) Close() error {
+	h.closed = true
+	return h.closeErr
+}
+
+func TestHostnameByUTSNamespaceRestoresCallingThread(t *testing.T) {
+	const targetPath = "/proc/4242/ns/uts"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	var entered []int
+
+	hostname, err := hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			switch path {
+			case currentThreadUTSNamespace:
+				return current, nil
+			case targetPath:
+				return target, nil
+			default:
+				return nil, fmt.Errorf("unexpected namespace path %q", path)
+			}
+		},
+		setns: func(fd, namespaceType int) error {
+			assert.Equal(t, unix.CLONE_NEWUTS, namespaceType)
+			entered = append(entered, fd)
+			return nil
+		},
+		hostname: func() (string, error) {
+			return "container-host", nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "container-host", hostname)
+	assert.Equal(t, []int{int(target.fd), int(current.fd)}, entered)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestHostnameByUTSNamespaceRestoresAfterHostnameFailure(t *testing.T) {
+	const targetPath = "/proc/4242/ns/uts"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	hostnameErr := errors.New("uname failed")
+	var entered []int
+
+	hostname, err := hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			if path == currentThreadUTSNamespace {
+				return current, nil
+			}
+			return target, nil
+		},
+		setns: func(fd, _ int) error {
+			entered = append(entered, fd)
+			return nil
+		},
+		hostname: func() (string, error) {
+			return "", hostnameErr
+		},
+	})
+
+	assert.Empty(t, hostname)
+	require.ErrorIs(t, err, hostnameErr)
+	assert.Contains(t, err.Error(), "read hostname in target UTS namespace")
+	assert.Equal(t, []int{int(target.fd), int(current.fd)}, entered)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestHostnameByUTSNamespaceReportsRestoreFailure(t *testing.T) {
+	const targetPath = "/proc/4242/ns/uts"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	restoreErr := errors.New("setns restore failed")
+
+	hostname, err := hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			if path == currentThreadUTSNamespace {
+				return current, nil
+			}
+			return target, nil
+		},
+		setns: func(fd, _ int) error {
+			if fd == int(current.fd) {
+				return restoreErr
+			}
+			return nil
+		},
+		hostname: func() (string, error) {
+			return "container-host", nil
+		},
+	})
+
+	assert.Equal(t, "container-host", hostname)
+	require.ErrorIs(t, err, restoreErr)
+	assert.Contains(t, err.Error(), "restore current thread UTS namespace")
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestHostnameByUTSNamespaceCleansUpTargetEntryFailure(t *testing.T) {
+	const targetPath = "/proc/4242/ns/uts"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	enterErr := errors.New("setns target failed")
+	hostnameCalled := false
+
+	hostname, err := hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			if path == currentThreadUTSNamespace {
+				return current, nil
+			}
+			return target, nil
+		},
+		setns: func(int, int) error {
+			return enterErr
+		},
+		hostname: func() (string, error) {
+			hostnameCalled = true
+			return "unexpected", nil
+		},
+	})
+
+	assert.Empty(t, hostname)
+	require.ErrorIs(t, err, enterErr)
+	assert.Contains(t, err.Error(), "enter target UTS namespace")
+	assert.False(t, hostnameCalled)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestHostnameByUTSNamespaceClosesCurrentWhenTargetOpenFails(t *testing.T) {
+	const targetPath = "/proc/4242/ns/uts"
+	current := &fakeNamespaceHandle{fd: 10}
+	targetOpenErr := errors.New("target disappeared")
+
+	hostname, err := hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			if path == currentThreadUTSNamespace {
+				return current, nil
+			}
+			return nil, targetOpenErr
+		},
+		setns: func(int, int) error {
+			return errors.New("setns must not be called")
+		},
+		hostname: func() (string, error) {
+			return "unexpected", errors.New("hostname must not be called")
+		},
+	})
+
+	assert.Empty(t, hostname)
+	require.ErrorIs(t, err, targetOpenErr)
+	assert.Contains(t, err.Error(), targetPath)
+	assert.True(t, current.closed)
+}
+
+func TestHostnameByUTSNamespacePreservesCloseErrors(t *testing.T) {
+	const targetPath = "/proc/4242/ns/uts"
+	currentCloseErr := errors.New("close current failed")
+	targetCloseErr := errors.New("close target failed")
+	current := &fakeNamespaceHandle{fd: 10, closeErr: currentCloseErr}
+	target := &fakeNamespaceHandle{fd: 20, closeErr: targetCloseErr}
+
+	hostname, err := hostnameByUTSNamespace(targetPath, utsNamespaceOperations{
+		open: func(path string) (namespaceHandle, error) {
+			if path == currentThreadUTSNamespace {
+				return current, nil
+			}
+			return target, nil
+		},
+		setns: func(int, int) error {
+			return nil
+		},
+		hostname: func() (string, error) {
+			return "container-host", nil
+		},
+	})
+
+	assert.Equal(t, "container-host", hostname)
+	require.ErrorIs(t, err, currentCloseErr)
+	require.ErrorIs(t, err, targetCloseErr)
+	assert.Contains(t, err.Error(), "close target UTS namespace")
+	assert.Contains(t, err.Error(), "close current thread UTS namespace")
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
 }


### PR DESCRIPTION
## Summary

- snapshot the calling operating-system thread's UTS namespace before entering a target process namespace
- restore that exact namespace after reading the target hostname, including hostname-error paths
- prevent a thread with a failed namespace restoration from returning to the Go scheduler
- close both namespace descriptors on every path and preserve cleanup errors
- add deterministic unit coverage that does not require `CAP_SYS_ADMIN`

Fixes #629.

## Problem

`HostnameByPid` previously called `runtime.LockOSThread`, entered `/proc/<pid>/ns/uts`, read the hostname, and then called `runtime.UnlockOSThread` without restoring the original namespace.

UTS namespace membership belongs to the Linux task/thread. Unlocking a Go goroutine does not undo `setns(2)`; it only makes the operating-system thread reusable. A successful iotracing hostname lookup could therefore return a thread that still belonged to a container UTS namespace to the scheduler, allowing unrelated goroutines to observe the wrong namespace.

The existing test used the current process PID, so entering the same UTS namespace could not expose this lifecycle defect.

## Implementation

`HostnameByPid` now delegates the transition to a dedicated goroutine that owns a locked operating-system thread.

The worker:

1. opens `/proc/thread-self/ns/uts`, which snapshots the namespace of the exact locked thread;
2. opens the requested `/proc/<pid>/ns/uts` handle;
3. enters the target namespace;
4. reads the hostname;
5. restores the saved namespace even when hostname lookup fails;
6. closes both namespace handles and joins any close errors;
7. unlocks the thread only when restoration succeeds.

If restoration fails, the result is returned to the caller and the worker exits without `runtime.UnlockOSThread`. Go terminates an operating-system thread when its locked goroutine exits, so a namespace-contaminated thread cannot re-enter the scheduler pool.

The production path still uses `os.Open`, `unix.Setns`, and `os.Hostname`. A small unexported operations seam makes lifecycle behavior deterministic in unit tests without changing the public API.

## Error behavior

Errors now identify the failed lifecycle stage:

- opening the current thread namespace;
- opening the target namespace;
- entering the target namespace;
- reading the target hostname;
- restoring the original namespace;
- closing either namespace descriptor.

`errors.Join` preserves simultaneous hostname, restoration, and close failures for `errors.Is` callers.

## Regression coverage

The new tests verify:

- target entry followed by restoration in the correct order;
- restoration after `os.Hostname` failure;
- restoration errors are returned while the resolved hostname remains available;
- target-entry failures do not call the hostname operation;
- both descriptors close after success and failures;
- the current descriptor closes when opening the target namespace fails;
- close errors from both descriptors remain discoverable.

The existing Linux syscall test remains in place for the real `HostnameByPid` path and still skips when the environment lacks the required namespace capability.

## Validation

- `go test ./internal/utils/executil -count=1`
- `go test -race ./internal/utils/executil -count=1`
- `go vet ./internal/utils/executil`
- `golangci-lint run -v ./internal/utils/executil --timeout=5m --config .golangci.yaml`
- `golangci-lint run -v ./... --timeout=10m --config .golangci.yaml`
- `git diff --check`

All commands above passed. The full repository lint used all 26 configured linters and completed with no reportable issues.
