### PR TITLE
fix(netutil): restore namespace after cookie lookup

### DIFF
--- a/integration/lib_namespace.sh
+++ b/integration/lib_namespace.sh
@@ -23,6 +23,9 @@ TCP_NS_VETH_CLIENT=""
 TCP_NS_SERVER_ADDR=""
 TCP_NS_CLIENT_ADDR=""
 
+PROCESS_NET_NAMESPACE=""
+PROCESS_NET_NAMESPACE_PID=""
+
 tcp_namespace_setup() {
 	local prefix=$1 server_addr=$2 client_addr=$3 netmask=${4:-24}
 
@@ -51,4 +54,43 @@ tcp_namespace_setup() {
 tcp_namespace_cleanup() {
 	[[ -z "${TCP_NS_SERVER}" ]] || ip netns del "${TCP_NS_SERVER}" 2> /dev/null || true
 	[[ -z "${TCP_NS_CLIENT}" ]] || ip netns del "${TCP_NS_CLIENT}" 2> /dev/null || true
+}
+
+process_network_namespace_setup() {
+	local prefix=$1
+	local attempt
+
+	PROCESS_NET_NAMESPACE="pn_${prefix}_$$"
+	ip netns add "${PROCESS_NET_NAMESPACE}" \
+		|| fatal "failed to create process netns ${PROCESS_NET_NAMESPACE}"
+	ip netns exec "${PROCESS_NET_NAMESPACE}" sleep 300 &
+	local launcher_pid=$!
+
+	for ((attempt = 0; attempt < 50; attempt++)); do
+		PROCESS_NET_NAMESPACE_PID=$(ip netns pids "${PROCESS_NET_NAMESPACE}" | head -n 1)
+		[[ -n "${PROCESS_NET_NAMESPACE_PID}" ]] && break
+		sleep 0.1
+	done
+	if [[ -z "${PROCESS_NET_NAMESPACE_PID}" ]]; then
+		kill "${launcher_pid}" 2> /dev/null || true
+		fatal "no live process found in netns ${PROCESS_NET_NAMESPACE}"
+	fi
+
+	local process_inode namespace_inode
+	process_inode=$(stat -Lc '%i' "/proc/${PROCESS_NET_NAMESPACE_PID}/ns/net")
+	namespace_inode=$(stat -Lc '%i' "/run/netns/${PROCESS_NET_NAMESPACE}")
+	[[ "${process_inode}" == "${namespace_inode}" ]] \
+		|| fatal "pid ${PROCESS_NET_NAMESPACE_PID} is not in ${PROCESS_NET_NAMESPACE}"
+}
+
+process_network_namespace_cleanup() {
+	if [[ -n "${PROCESS_NET_NAMESPACE_PID}" ]]; then
+		kill "${PROCESS_NET_NAMESPACE_PID}" 2> /dev/null || true
+		wait "${PROCESS_NET_NAMESPACE_PID}" 2> /dev/null || true
+	fi
+	[[ -z "${PROCESS_NET_NAMESPACE}" ]] \
+		|| ip netns del "${PROCESS_NET_NAMESPACE}" 2> /dev/null \
+		|| true
+	PROCESS_NET_NAMESPACE=""
+	PROCESS_NET_NAMESPACE_PID=""
 }

--- a/integration/test_netnamespace_cookie.sh
+++ b/integration/test_netnamespace_cookie.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+source "${ROOT_DIR}/integration/lib_namespace.sh"
+
+[[ ${EUID} -eq 0 ]] || skip "requires root"
+command -v ip > /dev/null 2>&1 || skip "iproute2 is required"
+command -v go > /dev/null 2>&1 || skip "Go toolchain is required"
+
+WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/netns-cookie.XXXXXX")
+PROBE_BIN="${WORK_DIR}/netnamespace-cookie"
+
+cleanup_all() {
+	process_network_namespace_cleanup
+}
+trap cleanup_all EXIT
+
+log_info "compiling network namespace cookie probe"
+go build -mod=vendor -tags=integration \
+	-o "${PROBE_BIN}" \
+	"${ROOT_DIR}/integration/testdata/test_netnamespace_cookie.go"
+
+process_network_namespace_setup cookie
+
+expected=$(ip netns exec "${PROCESS_NET_NAMESPACE}" "${PROBE_BIN}" current)
+if [[ "${expected}" == "unsupported" ]]; then
+	skip "SO_NETNS_COOKIE is not supported by this kernel"
+fi
+
+actual=$("${PROBE_BIN}" target "${PROCESS_NET_NAMESPACE_PID}")
+assert_eq "${actual}" "${expected}" \
+	"public helper must return the target namespace cookie" \
+	|| fatal "network namespace cookie mismatch"
+
+log_info "network namespace cookie integration test passed: ${actual}"

--- a/integration/testdata/test_netnamespace_cookie.go
+++ b/integration/testdata/test_netnamespace_cookie.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"huatuo-bamai/internal/utils/netutil"
+
+	"golang.org/x/sys/unix"
+)
+
+const namespaceSamples = 64
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "network namespace cookie probe: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 2 {
+		return errors.New("usage: netnamespace_cookie current | target PID")
+	}
+
+	switch os.Args[1] {
+	case "current":
+		cookie, err := currentNamespaceCookie()
+		if errors.Is(err, unix.ENOPROTOOPT) {
+			fmt.Println("unsupported")
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Println(cookie)
+		return nil
+	case "target":
+		if len(os.Args) != 3 {
+			return errors.New("usage: netnamespace_cookie target PID")
+		}
+		pid, err := strconv.Atoi(os.Args[2])
+		if err != nil {
+			return fmt.Errorf("parse target pid: %w", err)
+		}
+		return probeTargetNamespace(pid)
+	default:
+		return fmt.Errorf("unknown mode %q", os.Args[1])
+	}
+}
+
+func probeTargetNamespace(pid int) error {
+	hostInum, err := namespaceInum("/proc/self/ns/net")
+	if err != nil {
+		return fmt.Errorf("read host network namespace: %w", err)
+	}
+
+	cookie, err := netutil.NetNamespaceCookieByPID(pid)
+	if err != nil {
+		return fmt.Errorf("read target network namespace cookie: %w", err)
+	}
+	if err := verifySchedulerNamespaces(hostInum); err != nil {
+		return err
+	}
+
+	fmt.Println(cookie)
+	return nil
+}
+
+func currentNamespaceCookie() (uint64, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return 0, fmt.Errorf("create cookie socket: %w", err)
+	}
+	defer unix.Close(fd) //nolint:errcheck // process exits after the probe
+
+	cookie, err := unix.GetsockoptUint64(fd, unix.SOL_SOCKET, unix.SO_NETNS_COOKIE)
+	if err != nil {
+		return 0, fmt.Errorf("read SO_NETNS_COOKIE: %w", err)
+	}
+	return cookie, nil
+}
+
+func verifySchedulerNamespaces(hostInum uint64) error {
+	results := make(chan error, namespaceSamples)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(namespaceSamples)
+
+	for range namespaceSamples {
+		go func() {
+			ready.Done()
+			<-start
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
+
+			inum, err := namespaceInum("/proc/thread-self/ns/net")
+			if err != nil {
+				results <- err
+				return
+			}
+			if inum != hostInum {
+				results <- fmt.Errorf(
+					"scheduler thread network namespace = %d, want host %d",
+					inum,
+					hostInum,
+				)
+				return
+			}
+			results <- nil
+		}()
+	}
+
+	ready.Wait()
+	close(start)
+	for range namespaceSamples {
+		if err := <-results; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func namespaceInum(path string) (uint64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("unexpected stat type %T", info.Sys())
+	}
+	return stat.Ino, nil
+}

--- a/internal/utils/netutil/netns.go
+++ b/internal/utils/netutil/netns.go
@@ -24,6 +24,32 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const currentThreadNetNamespace = "/proc/thread-self/ns/net"
+
+type namespaceHandle interface {
+	Fd() uintptr
+	Close() error
+}
+
+type netNamespaceCookieOperations struct {
+	open       func(string) (namespaceHandle, error)
+	setns      func(int, int) error
+	socket     func(int, int, int) (int, error)
+	getsockopt func(int, int, int) (uint64, error)
+	close      func(int) error
+}
+
+type netNamespaceThreadOperations struct {
+	lock   func()
+	unlock func()
+}
+
+type netNamespaceCookieResult struct {
+	cookie        uint64
+	err           error
+	discardThread bool
+}
+
 // NetNamespaceInumByPID returns the network namespace inum for pid.
 func NetNamespaceInumByPID(pid int) (uint64, error) {
 	netnsStat, err := os.Stat(fmt.Sprintf("/proc/%d/ns/net", pid))
@@ -36,38 +62,121 @@ func NetNamespaceInumByPID(pid int) (uint64, error) {
 // NetNamespaceCookieByPID returns the network namespace cookie for pid.
 // Requires Linux 5.14+ (SO_NETNS_COOKIE). Returns 0, nil on older kernels.
 func NetNamespaceCookieByPID(pid int) (uint64, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
+	targetPath := fmt.Sprintf("/proc/%d/ns/net", pid)
+	return netNamespaceCookie(targetPath, netNamespaceCookieOperations{
+		open: func(path string) (namespaceHandle, error) {
+			return os.Open(path)
+		},
+		setns:      unix.Setns,
+		socket:     unix.Socket,
+		getsockopt: unix.GetsockoptUint64,
+		close:      unix.Close,
+	})
+}
 
-	curNS, err := os.Open("/proc/self/ns/net")
-	if err != nil {
-		return 0, fmt.Errorf("open self netns: %w", err)
-	}
-	defer curNS.Close()
+func netNamespaceCookie(
+	targetPath string,
+	operations netNamespaceCookieOperations,
+) (uint64, error) {
+	return netNamespaceCookieWithThreadOperations(
+		targetPath,
+		operations,
+		netNamespaceThreadOperations{
+			lock:   runtime.LockOSThread,
+			unlock: runtime.UnlockOSThread,
+		},
+	)
+}
 
-	targetNS, err := os.Open(fmt.Sprintf("/proc/%d/ns/net", pid))
-	if err != nil {
-		return 0, fmt.Errorf("open pid %d netns: %w", pid, err)
-	}
-	defer targetNS.Close()
-
-	if err := unix.Setns(int(targetNS.Fd()), unix.CLONE_NEWNET); err != nil {
-		return 0, fmt.Errorf("setns pid %d: %w", pid, err)
-	}
-	defer unix.Setns(int(curNS.Fd()), unix.CLONE_NEWNET) //nolint:errcheck // best-effort restore
-
-	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
-	if err != nil {
-		return 0, fmt.Errorf("socket: %w", err)
-	}
-	defer unix.Close(fd)
-
-	cookie, err := unix.GetsockoptUint64(fd, unix.SOL_SOCKET, unix.SO_NETNS_COOKIE)
-	if err != nil {
-		if errors.Is(err, unix.ENOPROTOOPT) {
-			return 0, nil
+func netNamespaceCookieWithThreadOperations(
+	targetPath string,
+	operations netNamespaceCookieOperations,
+	threadOperations netNamespaceThreadOperations,
+) (uint64, error) {
+	resultCh := make(chan netNamespaceCookieResult, 1)
+	go func() {
+		threadOperations.lock()
+		result := readNetNamespaceCookie(targetPath, operations)
+		if !result.discardThread {
+			threadOperations.unlock()
 		}
-		return 0, fmt.Errorf("getsockopt SO_NETNS_COOKIE: %w", err)
+		resultCh <- result
+		// A goroutine that exits while locked takes a namespace-contaminated
+		// operating-system thread out of the scheduler pool.
+	}()
+
+	result := <-resultCh
+	return result.cookie, result.err
+}
+
+func readNetNamespaceCookie(
+	targetPath string,
+	operations netNamespaceCookieOperations,
+) netNamespaceCookieResult {
+	current, err := operations.open(currentThreadNetNamespace)
+	if err != nil {
+		return netNamespaceCookieResult{
+			err: fmt.Errorf("open current thread network namespace: %w", err),
+		}
 	}
-	return cookie, nil
+
+	target, err := operations.open(targetPath)
+	if err != nil {
+		return netNamespaceCookieResult{err: errors.Join(
+			fmt.Errorf("open target network namespace %q: %w", targetPath, err),
+			closeNamespaceHandle(current, "current thread network namespace"),
+		)}
+	}
+
+	if err := operations.setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
+		return netNamespaceCookieResult{err: errors.Join(
+			fmt.Errorf("enter target network namespace %q: %w", targetPath, err),
+			closeNamespaceHandle(target, "target network namespace"),
+			closeNamespaceHandle(current, "current thread network namespace"),
+		)}
+	}
+
+	cookie, operationErr := readCookieFromSocket(operations)
+	restoreErr := operations.setns(int(current.Fd()), unix.CLONE_NEWNET)
+	if restoreErr != nil {
+		restoreErr = fmt.Errorf("restore current thread network namespace: %w", restoreErr)
+	}
+
+	return netNamespaceCookieResult{
+		cookie: cookie,
+		err: errors.Join(
+			operationErr,
+			restoreErr,
+			closeNamespaceHandle(target, "target network namespace"),
+			closeNamespaceHandle(current, "current thread network namespace"),
+		),
+		discardThread: restoreErr != nil,
+	}
+}
+
+func readCookieFromSocket(operations netNamespaceCookieOperations) (uint64, error) {
+	fd, err := operations.socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return 0, fmt.Errorf("create network namespace cookie socket: %w", err)
+	}
+
+	cookie, cookieErr := operations.getsockopt(fd, unix.SOL_SOCKET, unix.SO_NETNS_COOKIE)
+	if errors.Is(cookieErr, unix.ENOPROTOOPT) {
+		cookieErr = nil
+		cookie = 0
+	} else if cookieErr != nil {
+		cookieErr = fmt.Errorf("read SO_NETNS_COOKIE: %w", cookieErr)
+	}
+	closeErr := operations.close(fd)
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close network namespace cookie socket: %w", closeErr)
+	}
+	return cookie, errors.Join(cookieErr, closeErr)
+}
+
+func closeNamespaceHandle(handle namespaceHandle, description string) error {
+	if err := handle.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", description, err)
+	}
+	return nil
 }

--- a/internal/utils/netutil/netns_test.go
+++ b/internal/utils/netutil/netns_test.go
@@ -15,8 +15,13 @@
 package netutil
 
 import (
+	"errors"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestNetNamespaceInumByPID(t *testing.T) {
@@ -52,5 +57,284 @@ func TestNetNamespaceInumByPID(t *testing.T) {
 				t.Errorf("NetNamespaceInumByPID() got = %v, want non-zero inum", got)
 			}
 		})
+	}
+}
+
+type fakeNamespaceHandle struct {
+	fd       uintptr
+	closed   bool
+	closeErr error
+}
+
+func (h *fakeNamespaceHandle) Fd() uintptr {
+	return h.fd
+}
+
+func (h *fakeNamespaceHandle) Close() error {
+	h.closed = true
+	return h.closeErr
+}
+
+func TestNetNamespaceCookieRestoresCallingThread(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	var entered []int
+	socketClosed := false
+	lockCalls := 0
+	unlockCalls := 0
+
+	cookie, err := netNamespaceCookieWithThreadOperations(
+		targetPath,
+		netNamespaceCookieOperations{
+			open: namespaceOpenFixture(t, targetPath, current, target),
+			setns: func(fd, namespaceType int) error {
+				assert.Equal(t, unix.CLONE_NEWNET, namespaceType)
+				entered = append(entered, fd)
+				return nil
+			},
+			socket: func(domain, typ, protocol int) (int, error) {
+				assert.Equal(t, unix.AF_INET, domain)
+				assert.Equal(t, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, typ)
+				assert.Zero(t, protocol)
+				return 30, nil
+			},
+			getsockopt: func(fd, level, option int) (uint64, error) {
+				assert.Equal(t, 30, fd)
+				assert.Equal(t, unix.SOL_SOCKET, level)
+				assert.Equal(t, unix.SO_NETNS_COOKIE, option)
+				return 2026, nil
+			},
+			close: func(fd int) error {
+				assert.Equal(t, 30, fd)
+				socketClosed = true
+				return nil
+			},
+		},
+		netNamespaceThreadOperations{
+			lock:   func() { lockCalls++ },
+			unlock: func() { unlockCalls++ },
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2026), cookie)
+	assert.Equal(t, []int{int(target.fd), int(current.fd)}, entered)
+	assert.True(t, socketClosed)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+	assert.Equal(t, 1, lockCalls)
+	assert.Equal(t, 1, unlockCalls)
+}
+
+func TestNetNamespaceCookiePreservesOldKernelCompatibility(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	socketClosed := false
+
+	cookie, err := netNamespaceCookie(targetPath, netNamespaceCookieOperations{
+		open:  namespaceOpenFixture(t, targetPath, current, target),
+		setns: func(int, int) error { return nil },
+		socket: func(int, int, int) (int, error) {
+			return 30, nil
+		},
+		getsockopt: func(int, int, int) (uint64, error) {
+			return 0, unix.ENOPROTOOPT
+		},
+		close: func(int) error {
+			socketClosed = true
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Zero(t, cookie)
+	assert.True(t, socketClosed)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestNetNamespaceCookieRestoresAfterSocketFailure(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	socketErr := errors.New("socket failed")
+	var entered []int
+
+	cookie, err := netNamespaceCookie(targetPath, netNamespaceCookieOperations{
+		open: namespaceOpenFixture(t, targetPath, current, target),
+		setns: func(fd, _ int) error {
+			entered = append(entered, fd)
+			return nil
+		},
+		socket: func(int, int, int) (int, error) {
+			return -1, socketErr
+		},
+		getsockopt: func(int, int, int) (uint64, error) {
+			return 0, errors.New("getsockopt must not be called")
+		},
+		close: func(int) error {
+			return errors.New("close must not be called")
+		},
+	})
+
+	assert.Zero(t, cookie)
+	require.ErrorIs(t, err, socketErr)
+	assert.Equal(t, []int{int(target.fd), int(current.fd)}, entered)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestNetNamespaceCookieReportsRestoreAndSocketCloseFailures(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	restoreErr := errors.New("restore failed")
+	closeErr := errors.New("socket close failed")
+	lockCalls := 0
+	unlockCalls := 0
+
+	cookie, err := netNamespaceCookieWithThreadOperations(
+		targetPath,
+		netNamespaceCookieOperations{
+			open: namespaceOpenFixture(t, targetPath, current, target),
+			setns: func(fd, _ int) error {
+				if fd == int(current.fd) {
+					return restoreErr
+				}
+				return nil
+			},
+			socket: func(int, int, int) (int, error) { return 30, nil },
+			getsockopt: func(int, int, int) (uint64, error) {
+				return 2026, nil
+			},
+			close: func(int) error { return closeErr },
+		},
+		netNamespaceThreadOperations{
+			lock:   func() { lockCalls++ },
+			unlock: func() { unlockCalls++ },
+		},
+	)
+
+	assert.Equal(t, uint64(2026), cookie)
+	require.ErrorIs(t, err, restoreErr)
+	require.ErrorIs(t, err, closeErr)
+	assert.Contains(t, err.Error(), "restore current thread network namespace")
+	assert.Contains(t, err.Error(), "close network namespace cookie socket")
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+	assert.Equal(t, 1, lockCalls)
+	assert.Zero(t, unlockCalls)
+}
+
+func TestNetNamespaceCookieCleansUpTargetEntryFailure(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	current := &fakeNamespaceHandle{fd: 10}
+	target := &fakeNamespaceHandle{fd: 20}
+	enterErr := errors.New("target setns failed")
+	socketCalled := false
+
+	cookie, err := netNamespaceCookie(targetPath, netNamespaceCookieOperations{
+		open: namespaceOpenFixture(t, targetPath, current, target),
+		setns: func(int, int) error {
+			return enterErr
+		},
+		socket: func(int, int, int) (int, error) {
+			socketCalled = true
+			return 30, nil
+		},
+		getsockopt: func(int, int, int) (uint64, error) { return 0, nil },
+		close:      func(int) error { return nil },
+	})
+
+	assert.Zero(t, cookie)
+	require.ErrorIs(t, err, enterErr)
+	assert.False(t, socketCalled)
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func TestNetNamespaceCookieCleansUpTargetOpenFailure(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	current := &fakeNamespaceHandle{fd: 10}
+	openErr := errors.New("target open failed")
+
+	cookie, err := netNamespaceCookie(targetPath, netNamespaceCookieOperations{
+		open: func(path string) (namespaceHandle, error) {
+			switch path {
+			case currentThreadNetNamespace:
+				return current, nil
+			case targetPath:
+				return nil, openErr
+			default:
+				return nil, errors.New("unexpected namespace path: " + path)
+			}
+		},
+		setns: func(int, int) error {
+			return errors.New("setns must not be called")
+		},
+		socket: func(int, int, int) (int, error) {
+			return -1, errors.New("socket must not be called")
+		},
+		getsockopt: func(int, int, int) (uint64, error) {
+			return 0, errors.New("getsockopt must not be called")
+		},
+		close: func(int) error {
+			return errors.New("socket close must not be called")
+		},
+	})
+
+	assert.Zero(t, cookie)
+	require.ErrorIs(t, err, openErr)
+	assert.True(t, current.closed)
+}
+
+func TestNetNamespaceCookiePreservesOperationAndNamespaceCloseFailures(t *testing.T) {
+	const targetPath = "/proc/4242/ns/net"
+	currentCloseErr := errors.New("current close failed")
+	targetCloseErr := errors.New("target close failed")
+	getCookieErr := errors.New("getsockopt failed")
+	current := &fakeNamespaceHandle{fd: 10, closeErr: currentCloseErr}
+	target := &fakeNamespaceHandle{fd: 20, closeErr: targetCloseErr}
+
+	cookie, err := netNamespaceCookie(targetPath, netNamespaceCookieOperations{
+		open:  namespaceOpenFixture(t, targetPath, current, target),
+		setns: func(int, int) error { return nil },
+		socket: func(int, int, int) (int, error) {
+			return 30, nil
+		},
+		getsockopt: func(int, int, int) (uint64, error) {
+			return 0, getCookieErr
+		},
+		close: func(int) error { return nil },
+	})
+
+	assert.Zero(t, cookie)
+	require.ErrorIs(t, err, getCookieErr)
+	require.ErrorIs(t, err, targetCloseErr)
+	require.ErrorIs(t, err, currentCloseErr)
+	assert.Contains(t, err.Error(), "read SO_NETNS_COOKIE")
+	assert.Contains(t, err.Error(), "close target network namespace")
+	assert.Contains(t, err.Error(), "close current thread network namespace")
+	assert.True(t, target.closed)
+	assert.True(t, current.closed)
+}
+
+func namespaceOpenFixture(
+	t *testing.T,
+	targetPath string,
+	current, target namespaceHandle,
+) func(string) (namespaceHandle, error) {
+	t.Helper()
+	return func(path string) (namespaceHandle, error) {
+		switch path {
+		case currentThreadNetNamespace:
+			return current, nil
+		case targetPath:
+			return target, nil
+		default:
+			return nil, errors.New("unexpected namespace path: " + path)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- rebase the lifecycle fix onto current `main` and the renamed
  `NetNamespaceCookieByPID` API;
- save the network namespace of the exact locked worker thread;
- restore that namespace before returning the thread to the Go scheduler;
- discard the locked OS thread when restoration fails;
- preserve the existing `ENOPROTOOPT` compatibility result;
- make lock/unlock behavior deterministic and observable in unit tests;
- add a privileged integration regression for real procfs, `setns`, namespace
  cookies, and subsequent scheduler-thread namespace state.

## Problem

`NetNamespaceCookieByPID` previously entered `/proc/<pid>/ns/net` on a locked
OS thread and deferred a best-effort restoration. The restoration error was
ignored, but `runtime.UnlockOSThread` still ran. Because network namespace
membership is thread scoped, a failed restoration could put that mutated
thread back into the scheduler pool. Unrelated goroutines could then execute
inside a container network namespace.

The helper also opened `/proc/self/ns/net`. This change uses
`/proc/thread-self/ns/net` so the saved handle unambiguously belongs to the
exact OS thread performing both `setns` calls.

The branch has been rebased onto current `main` at
`a1e74a8ef58499c98368e61fa892f168e989bb87`. It keeps the current exported API
introduced by the intervening refactor:

```go
NetNamespaceInumByPID
NetNamespaceCookieByPID
```

The production caller in `internal/pod` compiles against that API.

## Implementation

The public `NetNamespaceCookieByPID` API delegates the namespace-sensitive
work to a dedicated goroutine which:

1. locks its OS thread;
2. opens `/proc/thread-self/ns/net` and the target namespace;
3. enters the target namespace;
4. creates the datagram socket and reads `SO_NETNS_COOKIE`;
5. restores the saved namespace on every post-entry result path;
6. unlocks only after successful restoration.

If restoration fails, the result includes that error and the locked goroutine
exits without calling `runtime.UnlockOSThread`. This prevents the contaminated
OS thread from being returned to the scheduler pool.

The worker now sends its result only after the unlock decision. This makes the
lifecycle complete before the caller returns and lets tests deterministically
assert the exact lock/unlock counts.

Small unexported operation seams cover namespace, socket, and thread-lifecycle
operations. Production still uses `runtime.LockOSThread`,
`runtime.UnlockOSThread`, `os.Open`, and the real `unix` syscalls.

## Error behavior

- `ENOPROTOOPT` still returns `0, nil` when all cleanup succeeds.
- Socket creation and `getsockopt` failures still trigger restoration.
- Target-entry failures close both namespace handles without attempting socket
  operations.
- `errors.Join` preserves primary operation, restoration, socket-close, and
  namespace-handle close failures.
- A successful cookie can be returned with a non-nil cleanup error when the
  value was read but lifecycle completion failed.
- Restoration failure never invokes the injected or production unlock
  operation.

## Deterministic regression coverage

The unit tests verify:

- successful target entry, cookie retrieval, restoration order, and cleanup;
- successful restoration locks once and unlocks exactly once;
- restoration failure locks once and never unlocks;
- the Linux <5.14 `ENOPROTOOPT` compatibility path;
- restoration after socket creation failure;
- joined restoration and socket-close failures;
- target `setns` failure without socket creation;
- target namespace open failure and current-handle cleanup;
- preservation of `getsockopt` and both namespace-close errors.

A negative mutation that replaced the conditional unlock with an unconditional
unlock fails `TestNetNamespaceCookieReportsRestoreAndSocketCloseFailures` with
`unlockCalls = 1, want 0`.

## Privileged integration coverage

`integration/test_netnamespace_cookie.sh` uses the root integration harness and
`integration/lib_namespace.sh` to:

1. create a target network namespace with a live process;
2. build an integration-tagged Go probe;
3. read `SO_NETNS_COOKIE` directly from a socket executed inside the target
   namespace;
4. call the public `NetNamespaceCookieByPID` helper from the host namespace;
5. compare the public helper result with the independently read target cookie;
6. run 64 subsequent goroutines locked to OS threads and verify every one still
   observes the host network namespace.

The test skips cleanly when the kernel does not support `SO_NETNS_COOKIE`.

## Validation

Passed on the final rebased head:

```text
go test ./internal/utils/netutil ./internal/pod -count=1
go test -race ./internal/utils/netutil -count=1
go vet ./internal/utils/netutil ./internal/pod
golangci-lint run -v ./internal/utils/netutil ./internal/pod \
  --timeout=5m --config .golangci.yaml
golangci-lint run -v ./... --timeout=10m --config .golangci.yaml
docker run --rm --privileged ... \
  bash integration/run.sh test_netnamespace_cookie.sh
make check
git diff --check
```

The privileged integration test passed twice on the development container,
with target cookies `28673` and `12291`. The full configured lint completed
with zero issues. `make check` passed against an LF-preserving archive of the
current upstream base with this patch staged.

Fixes #631