### PR TITLE
fix(config): sync directory after atomic replace

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -33,6 +34,27 @@ var (
 	// CoreBpfDir is the directory where BPF object files are stored.
 	CoreBpfDir = ""
 )
+
+type syncFile interface {
+	io.Writer
+	Name() string
+	Chmod(mode os.FileMode) error
+	Sync() error
+	Close() error
+}
+
+type syncDirectory interface {
+	Sync() error
+	Close() error
+}
+
+type syncOperations struct {
+	createTemp    func(string, string) (syncFile, error)
+	stat          func(string) (os.FileInfo, error)
+	rename        func(string, string) error
+	remove        func(string) error
+	openDirectory func(string) (syncDirectory, error)
+}
 
 func init() {
 	if exePath, err := os.Executable(); err == nil {
@@ -55,8 +77,22 @@ func Load(path string, dst any) error {
 // Sync atomically replaces path with the TOML encoding of src. Callers must
 // prevent concurrent mutation of src until Sync returns.
 func Sync(path string, src any) (retErr error) {
+	return syncConfig(path, src, syncOperations{
+		createTemp: func(dir, pattern string) (syncFile, error) {
+			return os.CreateTemp(dir, pattern)
+		},
+		stat:   os.Stat,
+		rename: os.Rename,
+		remove: os.Remove,
+		openDirectory: func(path string) (syncDirectory, error) {
+			return os.Open(path)
+		},
+	})
+}
+
+func syncConfig(path string, src any, operations syncOperations) (retErr error) {
 	dir := filepath.Dir(path)
-	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	f, err := operations.createTemp(dir, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
 		return fmt.Errorf("creating temporary config file: %w", err)
 	}
@@ -68,13 +104,13 @@ func Sync(path string, src any) (retErr error) {
 		if err := f.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			retErr = errors.Join(retErr, fmt.Errorf("closing temporary config file: %w", err))
 		}
-		if err := os.Remove(tempPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := operations.remove(tempPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			retErr = errors.Join(retErr, fmt.Errorf("removing temporary config file: %w", err))
 		}
 	}()
 
 	mode := os.FileMode(0o600)
-	info, err := os.Stat(path)
+	info, err := operations.stat(path)
 	switch {
 	case err == nil:
 		mode = info.Mode().Perm()
@@ -94,11 +130,34 @@ func Sync(path string, src any) (retErr error) {
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("closing temporary config file: %w", err)
 	}
-	if err := os.Rename(tempPath, path); err != nil {
+	if err := operations.rename(tempPath, path); err != nil {
 		return fmt.Errorf("replacing config file: %w", err)
+	}
+	if err := syncConfigDirectory(dir, operations.openDirectory); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func syncConfigDirectory(
+	path string,
+	openDirectory func(string) (syncDirectory, error),
+) error {
+	dir, err := openDirectory(path)
+	if err != nil {
+		return fmt.Errorf("opening config directory for sync: %w", err)
+	}
+
+	syncErr := dir.Sync()
+	if syncErr != nil {
+		syncErr = fmt.Errorf("syncing config directory: %w", syncErr)
+	}
+	closeErr := dir.Close()
+	if closeErr != nil {
+		closeErr = fmt.Errorf("closing config directory after sync: %w", closeErr)
+	}
+	return errors.Join(syncErr, closeErr)
 }
 
 // Set modifies an unpublished config value by dot-separated key. Callers must

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -162,6 +163,9 @@ func TestSyncAndSet(t *testing.T) {
 	if err := Set(cfg, "Nested.Value", "kernel_sched_tick"); err != nil {
 		t.Fatalf("Set Nested.Value returned error: %v", err)
 	}
+	if err := os.Chmod(path, 0o640); err != nil {
+		t.Fatalf("chmod synced config: %v", err)
+	}
 
 	if err := Sync(path, cfg); err != nil {
 		t.Fatalf("Sync after Set returned error: %v", err)
@@ -185,6 +189,20 @@ func TestSyncAndSet(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), "name = \"huatuo-region\"") {
 		t.Errorf("synced file should contain updated name, got: %s", string(raw))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat synced file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("synced file mode = %o, want 640", got)
+	}
+	temps, err := filepath.Glob(filepath.Join(tmpDir, ".sync-config.toml.tmp-*"))
+	if err != nil {
+		t.Fatalf("find temporary config files: %v", err)
+	}
+	if len(temps) != 0 {
+		t.Fatalf("temporary config files remain after success: %v", temps)
 	}
 }
 
@@ -253,5 +271,230 @@ func TestSyncPreservesOriginalOnEncodeFailure(t *testing.T) {
 	}
 	if len(temps) != 0 {
 		t.Fatalf("temporary config files remain: %v", temps)
+	}
+}
+
+type fakeSyncFile struct {
+	name   string
+	events *[]string
+	wrote  bool
+	closed bool
+}
+
+func (f *fakeSyncFile) Write(p []byte) (int, error) {
+	if !f.wrote {
+		*f.events = append(*f.events, "write")
+		f.wrote = true
+	}
+	return len(p), nil
+}
+
+func (f *fakeSyncFile) Name() string {
+	return f.name
+}
+
+func (f *fakeSyncFile) Chmod(os.FileMode) error {
+	*f.events = append(*f.events, "chmod")
+	return nil
+}
+
+func (f *fakeSyncFile) Sync() error {
+	*f.events = append(*f.events, "file-sync")
+	return nil
+}
+
+func (f *fakeSyncFile) Close() error {
+	if f.closed {
+		return os.ErrClosed
+	}
+	f.closed = true
+	*f.events = append(*f.events, "file-close")
+	return nil
+}
+
+type fakeSyncDirectory struct {
+	events   *[]string
+	syncErr  error
+	closeErr error
+}
+
+func (d *fakeSyncDirectory) Sync() error {
+	*d.events = append(*d.events, "directory-sync")
+	return d.syncErr
+}
+
+func (d *fakeSyncDirectory) Close() error {
+	*d.events = append(*d.events, "directory-close")
+	return d.closeErr
+}
+
+func TestSyncFlushesDirectoryAfterRename(t *testing.T) {
+	var events []string
+	const tempPath = "/config/.huatuo.toml.tmp-test"
+	file := &fakeSyncFile{name: tempPath, events: &events}
+	directory := &fakeSyncDirectory{events: &events}
+	operations := syncOperations{
+		createTemp: func(dir, pattern string) (syncFile, error) {
+			if dir != "/config" {
+				t.Fatalf("temporary directory = %q, want /config", dir)
+			}
+			if pattern != ".huatuo.toml.tmp-*" {
+				t.Fatalf("temporary pattern = %q", pattern)
+			}
+			events = append(events, "create")
+			return file, nil
+		},
+		stat: func(string) (os.FileInfo, error) {
+			events = append(events, "stat")
+			return nil, os.ErrNotExist
+		},
+		rename: func(oldPath, newPath string) error {
+			if oldPath != tempPath || newPath != "/config/huatuo.toml" {
+				t.Fatalf("rename(%q, %q)", oldPath, newPath)
+			}
+			events = append(events, "rename")
+			return nil
+		},
+		remove: func(path string) error {
+			t.Fatalf("unexpected remove(%q)", path)
+			return nil
+		},
+		openDirectory: func(path string) (syncDirectory, error) {
+			if path != "/config" {
+				t.Fatalf("directory path = %q, want /config", path)
+			}
+			events = append(events, "directory-open")
+			return directory, nil
+		},
+	}
+
+	if err := syncConfig("/config/huatuo.toml", sampleConfig{}, operations); err != nil {
+		t.Fatalf("syncConfig() error = %v", err)
+	}
+	want := []string{
+		"create",
+		"stat",
+		"chmod",
+		"write",
+		"file-sync",
+		"file-close",
+		"rename",
+		"directory-open",
+		"directory-sync",
+		"directory-close",
+	}
+	if strings.Join(events, ",") != strings.Join(want, ",") {
+		t.Fatalf("operation order = %v, want %v", events, want)
+	}
+}
+
+func TestSyncReturnsDirectoryDurabilityErrors(t *testing.T) {
+	openErr := errors.New("directory open failed")
+	syncErr := errors.New("directory sync failed")
+	closeErr := errors.New("directory close failed")
+	tests := []struct {
+		name      string
+		openErr   error
+		syncErr   error
+		closeErr  error
+		wantError []error
+	}{
+		{name: "open", openErr: openErr, wantError: []error{openErr}},
+		{name: "sync", syncErr: syncErr, wantError: []error{syncErr}},
+		{name: "close", closeErr: closeErr, wantError: []error{closeErr}},
+		{
+			name:      "sync and close",
+			syncErr:   syncErr,
+			closeErr:  closeErr,
+			wantError: []error{syncErr, closeErr},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []string
+			const tempPath = "/config/.huatuo.toml.tmp-test"
+			file := &fakeSyncFile{name: tempPath, events: &events}
+			operations := syncOperations{
+				createTemp: func(string, string) (syncFile, error) {
+					return file, nil
+				},
+				stat: func(string) (os.FileInfo, error) {
+					return nil, os.ErrNotExist
+				},
+				rename: func(string, string) error {
+					events = append(events, "rename")
+					return nil
+				},
+				remove: func(path string) error {
+					if path != tempPath {
+						t.Fatalf("remove path = %q, want %q", path, tempPath)
+					}
+					events = append(events, "remove-temp")
+					return os.ErrNotExist
+				},
+				openDirectory: func(string) (syncDirectory, error) {
+					events = append(events, "directory-open")
+					if tt.openErr != nil {
+						return nil, tt.openErr
+					}
+					return &fakeSyncDirectory{
+						events:   &events,
+						syncErr:  tt.syncErr,
+						closeErr: tt.closeErr,
+					}, nil
+				},
+			}
+
+			err := syncConfig("/config/huatuo.toml", sampleConfig{}, operations)
+			if err == nil {
+				t.Fatal("syncConfig() error = nil, want durability error")
+			}
+			for _, wantErr := range tt.wantError {
+				if !errors.Is(err, wantErr) {
+					t.Fatalf("syncConfig() error = %v, want errors.Is(%v)", err, wantErr)
+				}
+			}
+			if !strings.Contains(strings.Join(events, ","), "rename,directory-open") {
+				t.Fatalf("directory was not opened immediately after rename: %v", events)
+			}
+			if events[len(events)-1] != "remove-temp" {
+				t.Fatalf("temporary cleanup was not last: %v", events)
+			}
+		})
+	}
+}
+
+func TestSyncSkipsDirectorySyncAfterRenameFailure(t *testing.T) {
+	var events []string
+	const tempPath = "/config/.huatuo.toml.tmp-test"
+	renameErr := errors.New("rename failed")
+	file := &fakeSyncFile{name: tempPath, events: &events}
+	operations := syncOperations{
+		createTemp: func(string, string) (syncFile, error) { return file, nil },
+		stat:       func(string) (os.FileInfo, error) { return nil, os.ErrNotExist },
+		rename: func(string, string) error {
+			events = append(events, "rename")
+			return renameErr
+		},
+		remove: func(path string) error {
+			if path != tempPath {
+				t.Fatalf("remove path = %q, want %q", path, tempPath)
+			}
+			events = append(events, "remove-temp")
+			return nil
+		},
+		openDirectory: func(string) (syncDirectory, error) {
+			t.Fatal("directory must not be opened after rename failure")
+			return nil, nil
+		},
+	}
+
+	err := syncConfig("/config/huatuo.toml", sampleConfig{}, operations)
+	if !errors.Is(err, renameErr) {
+		t.Fatalf("syncConfig() error = %v, want rename error", err)
+	}
+	if events[len(events)-1] != "remove-temp" {
+		t.Fatalf("temporary file not removed after rename failure: %v", events)
 	}
 }


### PR DESCRIPTION
## Summary

- synchronize the containing directory after atomically replacing a persisted
  configuration file;
- return contextual directory open, sync, and close failures;
- add deterministic durability-order and cleanup tests;
- retain real-filesystem coverage for content, permissions, and temporary-file
  cleanup.

## Problem

`internal/config.Sync` flushed and closed its staged file before atomically
renaming it over the destination, but returned immediately after `os.Rename`.
The file data was durable, while the rename remained directory metadata that
had not been synchronized.

On Linux filesystems, rename atomicity and crash durability are separate
properties. A process sees the replacement atomically after a successful
rename, but a power loss or kernel crash can occur before that directory-entry
update reaches stable storage. `UpdateAndSync` could therefore report success
and publish the new runtime configuration even though the persisted replacement
was not yet durably committed.

## Implementation

`Sync(path, src)` keeps its public API and existing staging behavior. After the
temporary file is encoded, flushed, closed, and renamed, it now:

1. opens `filepath.Dir(path)`;
2. calls `Sync` on the directory handle;
3. closes the directory handle;
4. returns joined, contextual sync and close errors.

The sequence is now:

```text
create temp -> chmod -> encode -> file fsync -> file close -> rename
-> directory open -> directory fsync -> directory close
```

A small unexported operations seam makes the ordering and post-rename failures
deterministic in unit tests. Production operations still delegate directly to
`os.CreateTemp`, `os.Stat`, `os.Rename`, `os.Remove`, and `os.Open`.

## Error behavior

- A rename failure does not open or synchronize the directory.
- Pre-rename failures continue to close and remove the staged temporary file.
- Directory open, sync, and close failures are returned with distinct context.
- Simultaneous directory sync and close failures are preserved with
  `errors.Join`.
- After a successful rename, cleanup only addresses the old temporary path; it
  never removes the replacement destination.
- Existing target permissions remain preserved.

## Regression coverage

The tests verify:

- exact successful operation order, including directory sync after rename;
- directory-open failure propagation;
- directory-sync failure propagation;
- directory-close failure propagation;
- preservation of simultaneous sync and close errors;
- no directory operation after rename failure;
- temporary-file cleanup after rename and durability failures;
- successful TOML reload from the real filesystem;
- preservation of an existing `0640` target mode;
- absence of temporary files after successful replacement.

## Validation

Passed:

```text
go test ./internal/config -count=1
go test -race ./internal/config -count=1
go vet ./internal/config
golangci-lint run -v ./internal/config --timeout=5m --config .golangci.yaml
golangci-lint run -v ./... --timeout=10m --config .golangci.yaml
git diff --check
```

Both configured lint runs completed with zero issues. `make check` was also
executed in a container-local copy: generation and lint completed, while its
final `git diff --exit-code` exposed checkout-wide CRLF conversions introduced
by copying the Windows working tree into that container. Those unrelated
line-ending changes are not present in this branch.

Fixes #633