### PR TITLE
fix(storage): restore shutdown cleanup

### DIFF
--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -80,6 +80,11 @@ type Daemon struct {
 	tracer  *tracing.Manager
 }
 
+type daemonSetupStep struct {
+	name  string
+	setup func(*Daemon) (func(context.Context) error, error)
+}
+
 func NewDaemon(opts *Options) *Daemon {
 	return &Daemon{opts: opts}
 }
@@ -118,22 +123,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return nil
 	}
 
-	steps := []struct {
-		name  string
-		setup func(*Daemon) (func(context.Context) error, error)
-	}{
-		{"pidfile", lockPidfile},
-		{"cgroup", setupCgroup},
-		{"storage", setupStorage},
-		{"bpf", setupBPF},
-		{"pod", setupPodManager},
-		{"metrics", setupMetrics},
-		{"toolstream", startToolstream},
-		{"tracing", startTracing},
-		{"handlers", startHandlers},
-		{"cgroup-cpu-quota", applyCgroupCPUQuota},
-	}
-	for _, s := range steps {
+	for _, s := range daemonSetupSteps() {
 		if err := run(s.name, s.setup); err != nil {
 			return err
 		}
@@ -148,6 +138,21 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func daemonSetupSteps() []daemonSetupStep {
+	return []daemonSetupStep{
+		{"pidfile", lockPidfile},
+		{"cgroup", setupCgroup},
+		{"bpf", setupBPF},
+		{"storage", setupStorage},
+		{"pod", setupPodManager},
+		{"metrics", setupMetrics},
+		{"toolstream", startToolstream},
+		{"tracing", startTracing},
+		{"handlers", startHandlers},
+		{"cgroup-cpu-quota", applyCgroupCPUQuota},
+	}
 }
 
 func (d *Daemon) waitForSignal(ctx context.Context) os.Signal {

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
@@ -27,21 +28,54 @@ import (
 	"huatuo-bamai/pkg/tracing"
 )
 
+type documentStoreFactory func(
+	context.Context,
+	*driver.Config,
+	string,
+	driver.Mapper[*tracing.Document],
+) (*storage.Store[*tracing.Document], error)
+
 func setupStorage(d *Daemon) (func(context.Context) error, error) {
 	if d.opts.DisableStorage {
 		log.Infof("storage backends disabled by --disable-storage")
 		return nil, nil
 	}
 
-	return nil, initStorage(d.opts.Region, config.Get())
+	if err := initStorage(d.opts.Region, config.Get()); err != nil {
+		return nil, err
+	}
+	return tracing.CloseStores, nil
 }
 
 func initStorage(storageRegion string, cfg *config.Config) error {
+	return initStorageWithFactory(
+		storageRegion,
+		cfg,
+		storage.NewFromConfig[*tracing.Document],
+	)
+}
+
+func initStorageWithFactory(
+	storageRegion string,
+	cfg *config.Config,
+	newStore documentStoreFactory,
+) (retErr error) {
 	var esStore *storage.Store[*tracing.Document]
+	var profileStore *storage.Store[*tracing.Document]
 
 	tracingMetadataStores := make([]*storage.Store[*tracing.Document], 0, 2)
+	initializedStores := make([]*storage.Store[*tracing.Document], 0, 3)
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(
+				retErr,
+				closeInitializedStores(context.Background(), initializedStores),
+			)
+		}
+	}()
+
 	if cfg.Storage.Elasticsearch.Enabled() {
-		store, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
+		store, err := newStore(context.Background(), &driver.Config{
 			Driver:      "elasticsearch",
 			ESAddresses: strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
 			ESUsername:  cfg.Storage.Elasticsearch.Username,
@@ -53,10 +87,11 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 		}
 		esStore = store
 		tracingMetadataStores = append(tracingMetadataStores, esStore)
+		initializedStores = append(initializedStores, esStore)
 	}
 
 	if cfg.Storage.LocalFile.Path != "" {
-		localFileStore, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
+		localFileStore, err := newStore(context.Background(), &driver.Config{
 			Driver:                "localfile",
 			LocalFilePath:         cfg.Storage.LocalFile.Path,
 			LocalFileMaxRotation:  cfg.Storage.LocalFile.MaxRotatedFiles,
@@ -66,22 +101,11 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 			return fmt.Errorf("new tracing document store (localfile): %w", err)
 		}
 		tracingMetadataStores = append(tracingMetadataStores, localFileStore)
-	}
-
-	if len(tracingMetadataStores) > 0 {
-		tracing.SetTracingStore(
-			tracingMetadataStores,
-			tracing.DocumentOptions{
-				Region: storageRegion,
-			},
-		)
-	}
-	if esStore != nil {
-		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, tracing.DocumentOptions{Region: storageRegion})
+		initializedStores = append(initializedStores, localFileStore)
 	}
 
 	if cfg.Storage.Elasticsearch.Enabled() {
-		profileStore, err := storage.NewFromConfig[*tracing.Document](context.Background(), &driver.Config{
+		store, err := newStore(context.Background(), &driver.Config{
 			Driver:      "elasticsearch",
 			ESAddresses: strutil.SplitCommaList(cfg.Storage.Elasticsearch.Address),
 			ESUsername:  cfg.Storage.Elasticsearch.Username,
@@ -91,11 +115,41 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 		if err != nil {
 			return fmt.Errorf("new profiling document store (elasticsearch): %w", err)
 		}
-		tracing.SetProfileStore(
-			[]*storage.Store[*tracing.Document]{profileStore},
-			tracing.DocumentOptions{Region: storageRegion},
-		)
+		profileStore = store
+		initializedStores = append(initializedStores, profileStore)
+	}
+
+	options := tracing.DocumentOptions{Region: storageRegion}
+	if len(tracingMetadataStores) > 0 {
+		tracing.SetTracingStore(tracingMetadataStores, options)
+	}
+	if esStore != nil {
+		tracing.SetTaskStore([]*storage.Store[*tracing.Document]{esStore}, options)
+	}
+	if profileStore != nil {
+		tracing.SetProfileStore([]*storage.Store[*tracing.Document]{profileStore}, options)
 	}
 
 	return nil
+}
+
+func closeInitializedStores(
+	ctx context.Context,
+	stores []*storage.Store[*tracing.Document],
+) error {
+	seen := make(map[*storage.Store[*tracing.Document]]struct{}, len(stores))
+	var errs []error
+	for _, store := range stores {
+		if store == nil {
+			continue
+		}
+		if _, ok := seen[store]; ok {
+			continue
+		}
+		seen[store] = struct{}{}
+		if err := store.Close(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("close initialized store %q: %w", store.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/huatuo-bamai/storage_test.go
+++ b/cmd/huatuo-bamai/storage_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/cmd/huatuo-bamai/config"
+	internalconfig "huatuo-bamai/internal/config"
+	"huatuo-bamai/internal/profiler"
+	"huatuo-bamai/internal/storage"
+	"huatuo-bamai/internal/storage/driver"
+	"huatuo-bamai/pkg/tracing"
+)
+
+type storageTestBackend struct {
+	closeCalls int
+	closeCtx   context.Context
+	closeErr   error
+	closeLog   *[]string
+	saveCalls  int
+}
+
+func (*storageTestBackend) Init(context.Context, string, []driver.Index) error {
+	return nil
+}
+
+func (b *storageTestBackend) Save(context.Context, driver.Record) error {
+	b.saveCalls++
+	return nil
+}
+
+func (*storageTestBackend) Get(context.Context, string) (driver.Record, error) {
+	return driver.Record{}, driver.ErrNotFound
+}
+
+func (*storageTestBackend) Delete(context.Context, string) error {
+	return nil
+}
+
+func (*storageTestBackend) Query(context.Context, driver.Query) ([]driver.Record, error) {
+	return nil, nil
+}
+
+func (*storageTestBackend) Count(context.Context, driver.Query) (int64, error) {
+	return 0, nil
+}
+
+func (*storageTestBackend) Values(context.Context, string, driver.Query, int) ([]string, error) {
+	return nil, nil
+}
+
+func (b *storageTestBackend) Close(ctx context.Context) error {
+	b.closeCalls++
+	b.closeCtx = ctx
+	if b.closeLog != nil {
+		*b.closeLog = append(*b.closeLog, "storage")
+	}
+	return b.closeErr
+}
+
+type storageTestManagerCloser struct {
+	closeLog *[]string
+}
+
+func (m *storageTestManagerCloser) Close(context.Context) error {
+	*m.closeLog = append(*m.closeLog, "tracing")
+	return nil
+}
+
+func resetTracingStores() {
+	tracing.SetTracingStore(nil, tracing.DocumentOptions{})
+	tracing.SetTaskStore(nil, tracing.DocumentOptions{})
+	tracing.SetProfileStore(nil, tracing.DocumentOptions{})
+}
+
+func TestSetupStorageRegistersCleanup(t *testing.T) {
+	resetTracingStores()
+	t.Cleanup(resetTracingStores)
+
+	cleanup, err := setupStorage(&Daemon{opts: &Options{DisableStorage: true}})
+	if err != nil {
+		t.Fatalf("setupStorage(disabled) error = %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("setupStorage(disabled) cleanup is non-nil")
+	}
+
+	cleanup, err = setupStorage(&Daemon{opts: &Options{}})
+	if err != nil {
+		t.Fatalf("setupStorage() error = %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("setupStorage() cleanup is nil")
+	}
+	if err := cleanup(context.Background()); err != nil {
+		t.Fatalf("storage cleanup error = %v", err)
+	}
+}
+
+func TestStorageCleanupHasSingleOwnerAndRunsBeforeBPF(t *testing.T) {
+	resetTracingStores()
+	t.Cleanup(resetTracingStores)
+
+	var closeLog []string
+	backend := &storageTestBackend{closeLog: &closeLog}
+	store, err := storage.NewStore[*tracing.Document](
+		context.Background(),
+		"test",
+		backend,
+		tracing.DocumentCollection,
+		tracing.DocumentStoreMapper{},
+	)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	tracing.SetTracingStore(
+		[]*storage.Store[*tracing.Document]{store},
+		tracing.DocumentOptions{},
+	)
+
+	tracingCleanup := closeTracingManager(&storageTestManagerCloser{closeLog: &closeLog})
+	if err := tracingCleanup(context.Background()); err != nil {
+		t.Fatalf("tracing cleanup error = %v", err)
+	}
+	if err := tracing.CloseStores(context.Background()); err != nil {
+		t.Fatalf("storage cleanup error = %v", err)
+	}
+	if backend.closeCalls != 1 {
+		t.Fatalf("backend close calls = %d, want 1", backend.closeCalls)
+	}
+	if got := strings.Join(closeLog, ","); got != "tracing,storage" {
+		t.Fatalf("cleanup order = %q, want tracing,storage", got)
+	}
+
+	positions := make(map[string]int)
+	for i, step := range daemonSetupSteps() {
+		positions[step.name] = i
+	}
+	if !(positions["bpf"] < positions["storage"] &&
+		positions["storage"] < positions["tracing"]) {
+		t.Fatalf(
+			"setup order bpf=%d storage=%d tracing=%d does not produce tracing, storage, bpf cleanup",
+			positions["bpf"],
+			positions["storage"],
+			positions["tracing"],
+		)
+	}
+}
+
+func TestInitStoragePublishesOnlyAfterCompleteConstruction(t *testing.T) {
+	resetTracingStores()
+	t.Cleanup(resetTracingStores)
+
+	cfg := storageTestConfig()
+	var backends []*storageTestBackend
+	var collections []string
+	shutdownErr := errors.New("profile store close failed")
+	factory := func(
+		ctx context.Context,
+		storeConfig *driver.Config,
+		collection string,
+		mapper driver.Mapper[*tracing.Document],
+	) (*storage.Store[*tracing.Document], error) {
+		backend := &storageTestBackend{}
+		if collection == profiler.MetadataCollection {
+			backend.closeErr = shutdownErr
+		}
+		backends = append(backends, backend)
+		collections = append(collections, collection)
+		return storage.NewStore(ctx, storeConfig.Driver, backend, collection, mapper)
+	}
+
+	if err := initStorageWithFactory("test-region", cfg, factory); err != nil {
+		t.Fatalf("initStorageWithFactory() error = %v", err)
+	}
+	wantCollections := []string{
+		tracing.DocumentCollection,
+		tracing.DocumentCollection,
+		profiler.MetadataCollection,
+	}
+	if len(collections) != len(wantCollections) {
+		t.Fatalf("constructed collections = %v, want %v", collections, wantCollections)
+	}
+	for i := range wantCollections {
+		if collections[i] != wantCollections[i] {
+			t.Fatalf("collection %d = %q, want %q", i, collections[i], wantCollections[i])
+		}
+	}
+
+	type contextKey string
+	shutdownCtx := context.WithValue(context.Background(), contextKey("shutdown"), true)
+	if err := tracing.CloseStores(shutdownCtx); !errors.Is(err, shutdownErr) {
+		t.Fatalf("CloseStores() error = %v, want profile close error", err)
+	}
+	if len(backends) != 3 {
+		t.Fatalf("constructed backends = %d, want 3", len(backends))
+	}
+	for i, backend := range backends {
+		if backend.closeCalls != 1 {
+			t.Fatalf("backend %d close calls = %d, want 1", i, backend.closeCalls)
+		}
+		if backend.closeCtx != shutdownCtx {
+			t.Fatalf("backend %d did not receive shutdown context", i)
+		}
+	}
+}
+
+func TestInitStorageClosesEarlierStoresOnFailure(t *testing.T) {
+	resetTracingStores()
+	t.Cleanup(resetTracingStores)
+
+	cfg := storageTestConfig()
+	constructorErr := errors.New("profile store construction failed")
+	closeErr := errors.New("tracing store close failed")
+	first := &storageTestBackend{closeErr: closeErr}
+	second := &storageTestBackend{}
+	backends := []*storageTestBackend{first, second}
+	call := 0
+	factory := func(
+		ctx context.Context,
+		storeConfig *driver.Config,
+		collection string,
+		mapper driver.Mapper[*tracing.Document],
+	) (*storage.Store[*tracing.Document], error) {
+		if call == len(backends) {
+			return nil, constructorErr
+		}
+		backend := backends[call]
+		call++
+		return storage.NewStore(ctx, storeConfig.Driver, backend, collection, mapper)
+	}
+
+	err := initStorageWithFactory("test-region", cfg, factory)
+	if !errors.Is(err, constructorErr) {
+		t.Fatalf("init error = %v, want constructor error", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("init error = %v, want cleanup error", err)
+	}
+	for i, backend := range backends {
+		if backend.closeCalls != 1 {
+			t.Fatalf("backend %d close calls = %d, want 1", i, backend.closeCalls)
+		}
+	}
+
+	request := &tracing.WriteRequest{}
+	if err := tracing.Save(request); err != nil {
+		t.Fatalf("Save() after failed setup error = %v", err)
+	}
+	if err := tracing.SaveTaskOutputText(request); err != nil {
+		t.Fatalf("SaveTaskOutputText() after failed setup error = %v", err)
+	}
+	if err := tracing.SaveProfile(request); err != nil {
+		t.Fatalf("SaveProfile() after failed setup error = %v", err)
+	}
+	for i, backend := range backends {
+		if backend.saveCalls != 0 {
+			t.Fatalf("backend %d save calls = %d after failed setup", i, backend.saveCalls)
+		}
+	}
+}
+
+func storageTestConfig() *config.Config {
+	return &config.Config{
+		Storage: config.StorageConfig{
+			Elasticsearch: internalconfig.ElasticsearchConfig{
+				Address:  "http://127.0.0.1:9200",
+				Username: "user",
+				Password: "password",
+				Index:    "huatuo-test",
+			},
+			LocalFile: config.LocalFileConfig{
+				Path:            "/tmp/huatuo-test",
+				RotationSizeMiB: 1,
+				MaxRotatedFiles: 1,
+			},
+		},
+	}
+}

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -60,16 +60,20 @@ func startTracing(d *Daemon) (func(context.Context) error, error) {
 	}
 
 	d.tracer = mgr
-	// Stop collectors first, then drain bulk-buffered writes before BPF teardown.
+	return closeTracingManager(mgr), nil
+}
+
+type tracingManagerCloser interface {
+	Close(ctx context.Context) error
+}
+
+func closeTracingManager(mgr tracingManagerCloser) func(context.Context) error {
 	return func(ctx context.Context) error {
 		if err := mgr.Close(ctx); err != nil {
 			return fmt.Errorf("stop: %w", err)
 		}
-		if err := tracing.CloseStores(ctx); err != nil {
-			return fmt.Errorf("close stores: %w", err)
-		}
 		return nil
-	}, nil
+	}
 }
 
 func startHandlers(d *Daemon) (func(context.Context) error, error) {


### PR DESCRIPTION
## Summary

- return storage cleanup to the daemon lifecycle after successful setup;
- give backend shutdown a single owner so every store closes exactly once;
- stop tracing collectors before draining stores, and drain stores before BPF
  teardown;
- construct all required stores transactionally before publishing writers;
- close already-created stores when a later constructor fails;
- preserve constructor and rollback-close errors together;
- add deterministic shutdown-order and partial-initialization regression tests.

## Problem

The daemon records each non-nil cleanup returned by a setup step and executes
those cleanups in reverse order during normal shutdown and startup rollback.
`setupStorage` initialized and registered stores but returned a nil cleanup:

```go
return nil, initStorage(d.opts.Region, config.Get())
```

As a result, storage did not own a cleanup in the daemon stack. At the same
time, `startTracing` closed both the tracing manager and all stores. That made
store lifetime depend on tracing startup: if a setup step failed after storage
but before tracing, the created stores were never closed.

Simply registering `tracing.CloseStores` in `setupStorage` without changing
`startTracing` would introduce a second owner. On normal shutdown the tracing
cleanup would close the Elasticsearch bulk indexer, and the later storage
cleanup would close it again. The vendored bulk indexer closes its queue
channel in `Close`, so the second close can panic with `close of closed channel`.

There was also a partial-initialization boundary inside `initStorage`. Tracing
and task writers were published before the profiling store was constructed. If
that later constructor failed, earlier stores remained open and global writers
could point at a setup attempt that had already returned an error.

## Implementation

### Single shutdown owner

When storage is disabled, `setupStorage` still returns `(nil, nil)`. After a
successful enabled setup, it now returns `tracing.CloseStores`. Storage is the
only daemon component that closes stores.

`startTracing` now owns only the tracing manager. Its cleanup stops and waits
for collectors, but does not close storage backends.

The daemon setup order places BPF before storage and tracing after storage:

```text
setup:   BPF -> storage -> tracing
cleanup: tracing -> storage -> BPF
```

This preserves the required lifecycle:

1. stop collectors so no new records are produced;
2. drain and close storage backends exactly once;
3. tear down BPF resources.

### Transactional construction

`initStorageWithFactory` keeps newly constructed stores in local slices while
creating:

1. the Elasticsearch tracing/task store, when enabled;
2. the local-file tracing store, when configured;
3. the Elasticsearch profiling store, when enabled.

Tracing, task, and profile writers are published only after all required
constructors succeed. A profiling-store failure can therefore no longer expose
partially configured global writers.

### Failure rollback

A deferred rollback closes every distinct store created by the failed setup
attempt. It deduplicates store pointers and joins close failures with the
original constructor error. This preserves both the reason initialization
failed and any resource-release failure.

The production constructor remains `storage.NewFromConfig`. The unexported
factory and manager-closer seams exist only to make lifecycle boundaries
deterministic in unit tests.

## Error and lifecycle behavior

- Disabled storage creates no stores and returns no cleanup.
- Successful enabled setup returns one storage cleanup function.
- Tracing cleanup stops collectors but never closes stores.
- The same Elasticsearch store registered for tracing and task output is
  closed once by `tracing.CloseStores`.
- Distinct tracing, local-file, and profiling stores are all closed even if one
  close operation fails.
- The daemon-provided shutdown context reaches every backend `Close` call.
- A later constructor failure closes all stores created earlier in that setup.
- Constructor and rollback-close errors remain discoverable through
  `errors.Is`.
- No tracing, task, or profile writer is published by a failed setup attempt.

## Regression coverage

The tests verify:

- the disabled path returns no cleanup;
- enabled setup returns an invokable cleanup;
- construction of both tracing stores and the profiling store;
- successful publication only after complete construction;
- shutdown closes all three distinct backends;
- the tracing Elasticsearch store shared by two writers is closed exactly
  once;
- tracing cleanup and storage cleanup execute in order without double-closing
  the backend;
- daemon setup order produces tracing, storage, then BPF cleanup order;
- close errors are returned without preventing other stores from closing;
- the exact shutdown context is propagated to every backend;
- profiling-constructor failure rolls back both earlier stores;
- constructor and rollback errors are joined;
- failed setup does not route tracing, task, or profiling writes to the rolled
  back backends.

## Validation

Passed after the shutdown-ownership revision:

```text
go test ./cmd/huatuo-bamai -count=1
go test -race ./cmd/huatuo-bamai -count=1
go vet ./cmd/huatuo-bamai
golangci-lint run -v ./cmd/huatuo-bamai --timeout=5m --config .golangci.yaml
golangci-lint run -v ./... --timeout=10m --config .golangci.yaml
make check
git diff --check
```

`make check` was executed against an LF-preserving archive of `upstream/main`
with this patch staged, inside the repository development image. Generation,
formatting, the configured full-repository lint, and the final diff check all
completed successfully.

Fixes #635