### PR TITLE
feat(mthread): add MooreThreads GPU monitoring metrics

### DIFF
--- a/core/metrics/config.go
+++ b/core/metrics/config.go
@@ -27,6 +27,12 @@ type Config struct {
 		EnableHCCN bool `default:"false"`
 	}
 
+	Mthreads struct {
+		EnableHealth bool `default:"true"`
+		EnablePCIe   bool `default:"false"`
+		EnableMTLink bool `default:"false"`
+	}
+
 	NetdevStats struct {
 		EnableNetlink  bool `default:"false"`
 		DeviceExcluded string

--- a/core/metrics/mthreads/dl/dl.go
+++ b/core/metrics/mthreads/dl/dl.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dl
+
+import (
+	"fmt"
+
+	"github.com/ebitengine/purego"
+)
+
+// DynamicLibrary wraps purego's Dlopen/Dlclose so the mtml package stays
+// decoupled from any particular vendor's dl package.
+type DynamicLibrary struct {
+	path   string
+	flags  int
+	handle uintptr
+}
+
+// New creates a new dynamic library loader for the given path and flags.
+func New(path string, flags int) *DynamicLibrary {
+	return &DynamicLibrary{
+		path:  path,
+		flags: flags,
+	}
+}
+
+// Open loads the shared library if it is not already loaded.
+func (dl *DynamicLibrary) Open() error {
+	if dl.handle != 0 {
+		return fmt.Errorf("library %s already opened", dl.path)
+	}
+
+	handle, err := purego.Dlopen(dl.path, dl.flags)
+	if err != nil {
+		return fmt.Errorf("dlopen %s failed: %w", dl.path, err)
+	}
+
+	dl.handle = handle
+	return nil
+}
+
+// Close unloads the shared library if it is currently loaded.
+func (dl *DynamicLibrary) Close() error {
+	if dl.handle == 0 {
+		return nil
+	}
+
+	if err := purego.Dlclose(dl.handle); err != nil {
+		return fmt.Errorf("dlclose %s failed: %w", dl.path, err)
+	}
+
+	dl.handle = 0
+	return nil
+}
+
+// Handle returns the underlying dlopen handle.
+// It is valid only after a successful Open call.
+func (dl *DynamicLibrary) Handle() uintptr {
+	return dl.handle
+}

--- a/core/metrics/mthreads/mtml/device.go
+++ b/core/metrics/mthreads/mtml/device.go
@@ -1,0 +1,709 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+// LibraryVersion returns the MTML library version string.
+func LibraryVersion() (string, error) {
+	if !IsReady() {
+		return "", errNotReady
+	}
+	if mtmlLibraryGetVersion == nil {
+		return "", errNotSupportedSymbol("mtmlLibraryGetVersion")
+	}
+	return getString("mtmlLibraryGetVersion", libmtml.Lib(), libraryVersionBufferSize,
+		func(buf []byte) Return {
+			return mtmlLibraryGetVersion(libmtml.Lib(), &buf[0], uint32(len(buf)))
+		})
+}
+
+// CountDevice returns the number of MTML-visible GPU devices.
+func CountDevice() (uint32, error) {
+	if !IsReady() {
+		return 0, errNotReady
+	}
+	var count uint32
+	if err := checkReturnCode("mtmlLibraryCountDevice", mtmlLibraryCountDevice(libmtml.Lib(), &count)); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// Device is a live MtmlDevice* handle. Close it with Close when done.
+type Device struct{ handle uintptr }
+
+// InitDeviceByIndex returns the device at the given index. Close it when done.
+func InitDeviceByIndex(index uint32) (*Device, error) {
+	if !IsReady() {
+		return nil, errNotReady
+	}
+	var dev uintptr
+	if err := checkReturnCode("mtmlLibraryInitDeviceByIndex",
+		mtmlLibraryInitDeviceByIndex(libmtml.Lib(), index, &dev)); err != nil {
+		return nil, err
+	}
+	return &Device{handle: dev}, nil
+}
+
+// Close frees the device handle (mtmlLibraryFreeDevice).
+func (d *Device) Close() error {
+	if d.handle == 0 {
+		return nil
+	}
+	err := checkReturnCode("mtmlLibraryFreeDevice", mtmlLibraryFreeDevice(d.handle))
+	if err == nil {
+		d.handle = 0
+	}
+	return err
+}
+
+// Index returns the device index.
+func (d *Device) Index() (uint32, error) {
+	if mtmlDeviceGetIndex == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetIndex")
+	}
+	var idx uint32
+	if err := checkReturnCode("mtmlDeviceGetIndex", mtmlDeviceGetIndex(d.handle, &idx)); err != nil {
+		return 0, err
+	}
+	return idx, nil
+}
+
+// Name returns the device product name.
+func (d *Device) Name() (string, error) {
+	if mtmlDeviceGetName == nil {
+		return "", errNotSupportedSymbol("mtmlDeviceGetName")
+	}
+	return getString("mtmlDeviceGetName", d.handle, deviceNameBufferSize,
+		func(buf []byte) Return {
+			return mtmlDeviceGetName(d.handle, &buf[0], uint32(len(buf)))
+		})
+}
+
+// UUID returns the device UUID.
+func (d *Device) UUID() (string, error) {
+	if mtmlDeviceGetUUID == nil {
+		return "", errNotSupportedSymbol("mtmlDeviceGetUUID")
+	}
+	return getString("mtmlDeviceGetUUID", d.handle, deviceUUIDBufferSize,
+		func(buf []byte) Return {
+			return mtmlDeviceGetUUID(d.handle, &buf[0], uint32(len(buf)))
+		})
+}
+
+func (d *Device) Brand() (Brand, error) {
+	if mtmlDeviceGetBrand == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetBrand")
+	}
+	var brand uint32
+	if err := checkReturnCode("mtmlDeviceGetBrand", mtmlDeviceGetBrand(d.handle, &brand)); err != nil {
+		return 0, err
+	}
+	return Brand(brand), nil
+}
+
+// SerialNumber returns the device serial number.
+// NOTE: MTML's signature is (dev, length, buf) — length before buffer.
+func (d *Device) SerialNumber() (string, error) {
+	if mtmlDeviceGetSerialNumber == nil {
+		return "", errNotSupportedSymbol("mtmlDeviceGetSerialNumber")
+	}
+	return getStringSerialLenFirst("mtmlDeviceGetSerialNumber", d.handle, deviceSerialNumberBufferSize,
+		func(buf []byte) Return {
+			return mtmlDeviceGetSerialNumber(d.handle, uint32(len(buf)), &buf[0])
+		})
+}
+
+// BiosVersion returns the device BIOS version.
+func (d *Device) BiosVersion() (string, error) {
+	if mtmlDeviceGetMtBiosVersion == nil {
+		return "", errNotSupportedSymbol("mtmlDeviceGetMtBiosVersion")
+	}
+	return getString("mtmlDeviceGetMtBiosVersion", d.handle, biosVersionBufferSize,
+		func(buf []byte) Return {
+			return mtmlDeviceGetMtBiosVersion(d.handle, &buf[0], uint32(len(buf)))
+		})
+}
+
+// GpuCores returns the number of GPU cores.
+func (d *Device) GpuCores() (uint32, error) {
+	if mtmlDeviceCountGpuCores == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceCountGpuCores")
+	}
+	var cores uint32
+	if err := checkReturnCode("mtmlDeviceCountGpuCores", mtmlDeviceCountGpuCores(d.handle, &cores)); err != nil {
+		return 0, err
+	}
+	return cores, nil
+}
+
+// PciSbdf returns the PCI SBDF string (e.g. "0000:01:00.0").
+func (d *Device) PciSbdf() (string, error) {
+	if mtmlDeviceGetPciInfo == nil {
+		return "", errNotSupportedSymbol("mtmlDeviceGetPciInfo")
+	}
+	var info mtmlPciInfo
+	if err := checkReturnCode("mtmlDeviceGetPciInfo", mtmlDeviceGetPciInfo(d.handle, &info)); err != nil {
+		return "", err
+	}
+	return cString(info.sbdf[:]), nil
+}
+
+// PciInfo returns the parsed PCIe link info (current/max speed in GT/s and width in lanes).
+func (d *Device) PciInfo() (*PciLinkInfo, error) {
+	if mtmlDeviceGetPciInfo == nil {
+		return nil, errNotSupportedSymbol("mtmlDeviceGetPciInfo")
+	}
+	var info mtmlPciInfo
+	if err := checkReturnCode("mtmlDeviceGetPciInfo", mtmlDeviceGetPciInfo(d.handle, &info)); err != nil {
+		return nil, err
+	}
+	return &PciLinkInfo{
+		CurSpeed: float64(info.pciCurSpeed),
+		MaxSpeed: float64(info.pciMaxSpeed),
+		CurWidth: info.pciCurWidth,
+		MaxWidth: info.pciMaxWidth,
+	}, nil
+}
+
+// PcieReplayCounter returns the PCIe replay (retransmission) counter.
+func (d *Device) PcieReplayCounter() (uint32, error) {
+	if mtmlDeviceGetPcieReplayCounter == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetPcieReplayCounter")
+	}
+	var count uint32
+	if err := checkReturnCode("mtmlDeviceGetPcieReplayCounter",
+		mtmlDeviceGetPcieReplayCounter(d.handle, &count)); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// PciLinkInfo holds PCIe link speed (GT/s) and width (lanes).
+type PciLinkInfo struct {
+	CurSpeed float64 // current link speed, GT/s
+	MaxSpeed float64 // max link speed, GT/s
+	CurWidth uint32  // current link width, lanes
+	MaxWidth uint32  // max link width, lanes
+}
+
+// PowerUsage returns the device power consumption in milliwatts.
+func (d *Device) PowerUsage() (uint32, error) {
+	if mtmlDeviceGetPowerUsage == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetPowerUsage")
+	}
+	var power uint32
+	if err := checkReturnCode("mtmlDeviceGetPowerUsage", mtmlDeviceGetPowerUsage(d.handle, &power)); err != nil {
+		return 0, err
+	}
+	return power, nil
+}
+
+// PerformanceState returns the device performance state (P-state) as a numeric
+// value (0 = P0, etc.).
+func (d *Device) PerformanceState() (int32, error) {
+	if mtmlDeviceGetPerformanceState == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetPerformanceState")
+	}
+	var pstate int32
+	if err := checkReturnCode("mtmlDeviceGetPerformanceState",
+		mtmlDeviceGetPerformanceState(d.handle, &pstate)); err != nil {
+		return 0, err
+	}
+	return pstate, nil
+}
+
+// MusaComputeCapability returns the MUSA compute capability major/minor version
+// (e.g. major=3, minor=0).
+func (d *Device) MusaComputeCapability() (major, minor int32, err error) {
+	if mtmlDeviceGetMusaComputeCapability == nil {
+		return 0, 0, errNotSupportedSymbol("mtmlDeviceGetMusaComputeCapability")
+	}
+	if err := checkReturnCode("mtmlDeviceGetMusaComputeCapability",
+		mtmlDeviceGetMusaComputeCapability(d.handle, &major, &minor)); err != nil {
+		return 0, 0, err
+	}
+	return major, minor, nil
+}
+
+// FanCount returns the number of fans on the device.
+func (d *Device) FanCount() (uint32, error) {
+	if mtmlDeviceCountFan == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceCountFan")
+	}
+	var count uint32
+	if err := checkReturnCode("mtmlDeviceCountFan", mtmlDeviceCountFan(d.handle, &count)); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// FanSpeed returns the fan speed as a percentage of the max noise-tolerance
+// speed (may exceed 100%).
+func (d *Device) FanSpeed(fanIndex uint32) (uint32, error) {
+	if mtmlDeviceGetFanSpeed == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetFanSpeed")
+	}
+	var speed uint32
+	if err := checkReturnCode("mtmlDeviceGetFanSpeed", mtmlDeviceGetFanSpeed(d.handle, fanIndex, &speed)); err != nil {
+		return 0, err
+	}
+	return speed, nil
+}
+
+// FanRpm returns the fan speed in RPM.
+func (d *Device) FanRpm(fanIndex uint32) (uint32, error) {
+	if mtmlDeviceGetFanRpm == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetFanRpm")
+	}
+	var rpm uint32
+	if err := checkReturnCode("mtmlDeviceGetFanRpm", mtmlDeviceGetFanRpm(d.handle, fanIndex, &rpm)); err != nil {
+		return 0, err
+	}
+	return rpm, nil
+}
+
+// Gpu is a live MtmlGpu* handle.
+type Gpu struct{ handle uintptr }
+
+// InitGpu returns the Gpu sub-object of the device. Close it when done.
+func (d *Device) InitGpu() (*Gpu, error) {
+	if mtmlDeviceInitGpu == nil {
+		return nil, errNotSupportedSymbol("mtmlDeviceInitGpu")
+	}
+	var gpu uintptr
+	if err := checkReturnCode("mtmlDeviceInitGpu", mtmlDeviceInitGpu(d.handle, &gpu)); err != nil {
+		return nil, err
+	}
+	return &Gpu{handle: gpu}, nil
+}
+
+// Close frees the gpu handle.
+func (g *Gpu) Close() error {
+	if g.handle == 0 {
+		return nil
+	}
+	if mtmlDeviceFreeGpu == nil {
+		g.handle = 0
+		return errNotSupportedSymbol("mtmlDeviceFreeGpu")
+	}
+	err := checkReturnCode("mtmlDeviceFreeGpu", mtmlDeviceFreeGpu(g.handle))
+	g.handle = 0
+	return err
+}
+
+// Temperature returns the GPU temperature in degrees Celsius.
+func (g *Gpu) Temperature() (int32, error) {
+	if mtmlGpuGetTemperature == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetTemperature")
+	}
+	var temp int32
+	if err := checkReturnCode("mtmlGpuGetTemperature", mtmlGpuGetTemperature(g.handle, &temp)); err != nil {
+		return 0, err
+	}
+	return temp, nil
+}
+
+// Utilization returns the GPU utilization as a percentage (0-100).
+func (g *Gpu) Utilization() (uint32, error) {
+	if mtmlGpuGetUtilization == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetUtilization")
+	}
+	var util uint32
+	if err := checkReturnCode("mtmlGpuGetUtilization", mtmlGpuGetUtilization(g.handle, &util)); err != nil {
+		return 0, err
+	}
+	return util, nil
+}
+
+// Clock returns the GPU clock frequency in MHz.
+func (g *Gpu) Clock() (uint32, error) {
+	if mtmlGpuGetClock == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetClock")
+	}
+	var clock uint32
+	if err := checkReturnCode("mtmlGpuGetClock", mtmlGpuGetClock(g.handle, &clock)); err != nil {
+		return 0, err
+	}
+	return clock, nil
+}
+
+// MaxClock returns the GPU maximum clock frequency in MHz.
+func (g *Gpu) MaxClock() (uint32, error) {
+	if mtmlGpuGetMaxClock == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetMaxClock")
+	}
+	var clock uint32
+	if err := checkReturnCode("mtmlGpuGetMaxClock", mtmlGpuGetMaxClock(g.handle, &clock)); err != nil {
+		return 0, err
+	}
+	return clock, nil
+}
+
+// Voltage returns the GPU voltage in millivolts.
+func (g *Gpu) Voltage() (int32, error) {
+	if mtmlGpuGetVoltage == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetVoltage")
+	}
+	var v int32
+	if err := checkReturnCode("mtmlGpuGetVoltage", mtmlGpuGetVoltage(g.handle, &v)); err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// EnforcedPowerLimit returns the enforced GPU power limit in milliwatts.
+func (g *Gpu) EnforcedPowerLimit() (int32, error) {
+	if mtmlGpuGetEnforcedPowerLimit == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetEnforcedPowerLimit")
+	}
+	var limit int32
+	if err := checkReturnCode("mtmlGpuGetEnforcedPowerLimit",
+		mtmlGpuGetEnforcedPowerLimit(g.handle, &limit)); err != nil {
+		return 0, err
+	}
+	return limit, nil
+}
+
+// PowerManagementDefaultLimit returns the default GPU power management limit in milliwatts.
+func (g *Gpu) PowerManagementDefaultLimit() (int32, error) {
+	if mtmlGpuGetPowerManagementDefaultLimit == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetPowerManagementDefaultLimit")
+	}
+	var limit int32
+	if err := checkReturnCode("mtmlGpuGetPowerManagementDefaultLimit",
+		mtmlGpuGetPowerManagementDefaultLimit(g.handle, &limit)); err != nil {
+		return 0, err
+	}
+	return limit, nil
+}
+
+// TemperatureThreshold returns a GPU temperature threshold in degrees Celsius.
+// thresholdType is a TempThreshold* constant (0=shutdown, 1=slowdown).
+func (g *Gpu) TemperatureThreshold(thresholdType int32) (int32, error) {
+	if mtmlGpuGetTemperatureThreshold == nil {
+		return 0, errNotSupportedSymbol("mtmlGpuGetTemperatureThreshold")
+	}
+	var temp int32
+	if err := checkReturnCode("mtmlGpuGetTemperatureThreshold",
+		mtmlGpuGetTemperatureThreshold(g.handle, thresholdType, &temp)); err != nil {
+		return 0, err
+	}
+	return temp, nil
+}
+
+// Memory is a live MtmlMemory* handle.
+type Memory struct{ handle uintptr }
+
+// InitMemory returns the Memory sub-object of the device. Close it when done.
+func (d *Device) InitMemory() (*Memory, error) {
+	if mtmlDeviceInitMemory == nil {
+		return nil, errNotSupportedSymbol("mtmlDeviceInitMemory")
+	}
+	var mem uintptr
+	if err := checkReturnCode("mtmlDeviceInitMemory", mtmlDeviceInitMemory(d.handle, &mem)); err != nil {
+		return nil, err
+	}
+	return &Memory{handle: mem}, nil
+}
+
+// Close frees the memory handle.
+func (m *Memory) Close() error {
+	if m.handle == 0 {
+		return nil
+	}
+	if mtmlDeviceFreeMemory == nil {
+		m.handle = 0
+		return errNotSupportedSymbol("mtmlDeviceFreeMemory")
+	}
+	err := checkReturnCode("mtmlDeviceFreeMemory", mtmlDeviceFreeMemory(m.handle))
+	m.handle = 0
+	return err
+}
+
+// Total returns the total VRAM in bytes.
+func (m *Memory) Total() (uint64, error) {
+	if mtmlMemoryGetTotal == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetTotal")
+	}
+	var total uint64
+	if err := checkReturnCode("mtmlMemoryGetTotal", mtmlMemoryGetTotal(m.handle, &total)); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// Used returns the used VRAM in bytes.
+func (m *Memory) Used() (uint64, error) {
+	if mtmlMemoryGetUsed == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetUsed")
+	}
+	var used uint64
+	if err := checkReturnCode("mtmlMemoryGetUsed", mtmlMemoryGetUsed(m.handle, &used)); err != nil {
+		return 0, err
+	}
+	return used, nil
+}
+
+// Utilization returns the memory utilization as a percentage (0-100).
+func (m *Memory) Utilization() (uint32, error) {
+	if mtmlMemoryGetUtilization == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetUtilization")
+	}
+	var util uint32
+	if err := checkReturnCode("mtmlMemoryGetUtilization", mtmlMemoryGetUtilization(m.handle, &util)); err != nil {
+		return 0, err
+	}
+	return util, nil
+}
+
+// Temperature returns the memory temperature in degrees Celsius.
+func (m *Memory) Temperature() (int32, error) {
+	if mtmlMemoryGetTemperature == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetTemperature")
+	}
+	var temp int32
+	if err := checkReturnCode("mtmlMemoryGetTemperature", mtmlMemoryGetTemperature(m.handle, &temp)); err != nil {
+		return 0, err
+	}
+	return temp, nil
+}
+
+// Clock returns the memory clock frequency in MHz.
+func (m *Memory) Clock() (uint32, error) {
+	if mtmlMemoryGetClock == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetClock")
+	}
+	var clock uint32
+	if err := checkReturnCode("mtmlMemoryGetClock", mtmlMemoryGetClock(m.handle, &clock)); err != nil {
+		return 0, err
+	}
+	return clock, nil
+}
+
+// MaxClock returns the memory maximum clock frequency in MHz.
+func (m *Memory) MaxClock() (uint32, error) {
+	if mtmlMemoryGetMaxClock == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetMaxClock")
+	}
+	var clock uint32
+	if err := checkReturnCode("mtmlMemoryGetMaxClock", mtmlMemoryGetMaxClock(m.handle, &clock)); err != nil {
+		return 0, err
+	}
+	return clock, nil
+}
+
+// BusWidth returns the memory bus width in bits.
+func (m *Memory) BusWidth() (uint32, error) {
+	if mtmlMemoryGetBusWidth == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetBusWidth")
+	}
+	var width uint32
+	if err := checkReturnCode("mtmlMemoryGetBusWidth", mtmlMemoryGetBusWidth(m.handle, &width)); err != nil {
+		return 0, err
+	}
+	return width, nil
+}
+
+// Bandwidth returns the memory bandwidth in GB/s.
+func (m *Memory) Bandwidth() (uint32, error) {
+	if mtmlMemoryGetBandwidth == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetBandwidth")
+	}
+	var bw uint32
+	if err := checkReturnCode("mtmlMemoryGetBandwidth", mtmlMemoryGetBandwidth(m.handle, &bw)); err != nil {
+		return 0, err
+	}
+	return bw, nil
+}
+
+// Speed returns the memory speed in Mbps.
+func (m *Memory) Speed() (uint32, error) {
+	if mtmlMemoryGetSpeed == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetSpeed")
+	}
+	var speed uint32
+	if err := checkReturnCode("mtmlMemoryGetSpeed", mtmlMemoryGetSpeed(m.handle, &speed)); err != nil {
+		return 0, err
+	}
+	return speed, nil
+}
+
+// MemoryType returns the memory type code (0 = LPDDR4, 1 = GDDR6).
+func (m *Memory) MemoryType() (uint32, error) {
+	if mtmlMemoryGetType == nil {
+		return 0, errNotSupportedSymbol("mtmlMemoryGetType")
+	}
+	var typ uint32
+	if err := checkReturnCode("mtmlMemoryGetType", mtmlMemoryGetType(m.handle, &typ)); err != nil {
+		return 0, err
+	}
+	return typ, nil
+}
+
+// Vendor returns the memory vendor string.
+// NOTE: MTML's signature is (mem, length, buf) — length before buffer.
+func (m *Memory) Vendor() (string, error) {
+	if mtmlMemoryGetVendor == nil {
+		return "", errNotSupportedSymbol("mtmlMemoryGetVendor")
+	}
+	return getStringSerialLenFirst("mtmlMemoryGetVendor", m.handle, memoryVendorBufferSize,
+		func(buf []byte) Return {
+			return mtmlMemoryGetVendor(m.handle, uint32(len(buf)), &buf[0])
+		})
+}
+
+// Vpu is a live MtmlVpu* handle.
+type Vpu struct{ handle uintptr }
+
+// InitVpu returns the VPU sub-object of the device. Close it when done.
+func (d *Device) InitVpu() (*Vpu, error) {
+	if mtmlDeviceInitVpu == nil {
+		return nil, errNotSupportedSymbol("mtmlDeviceInitVpu")
+	}
+	var vpu uintptr
+	if err := checkReturnCode("mtmlDeviceInitVpu", mtmlDeviceInitVpu(d.handle, &vpu)); err != nil {
+		return nil, err
+	}
+	return &Vpu{handle: vpu}, nil
+}
+
+// Close frees the vpu handle.
+func (v *Vpu) Close() error {
+	if v.handle == 0 {
+		return nil
+	}
+	if mtmlDeviceFreeVpu == nil {
+		v.handle = 0
+		return errNotSupportedSymbol("mtmlDeviceFreeVpu")
+	}
+	err := checkReturnCode("mtmlDeviceFreeVpu", mtmlDeviceFreeVpu(v.handle))
+	v.handle = 0
+	return err
+}
+
+// CodecUtil returns the VPU (codec) utilization. encUtil/decUtil are the
+// encoder/decoder utilization rates as percentages.
+type CodecUtil struct {
+	Util    uint32 // overall utilization, %
+	Period  uint32 // sampling period, microseconds
+	EncUtil uint32 // encoder utilization, %
+	DecUtil uint32 // decoder utilization, %
+}
+
+// Utilization returns the VPU codec utilization.
+func (v *Vpu) Utilization() (*CodecUtil, error) {
+	if mtmlVpuGetUtilization == nil {
+		return nil, errNotSupportedSymbol("mtmlVpuGetUtilization")
+	}
+	var raw mtmlCodecUtil
+	if err := checkReturnCode("mtmlVpuGetUtilization", mtmlVpuGetUtilization(v.handle, &raw)); err != nil {
+		return nil, err
+	}
+	return &CodecUtil{
+		Util:    raw.util,
+		Period:  raw.period,
+		EncUtil: raw.encUtil,
+		DecUtil: raw.decUtil,
+	}, nil
+}
+
+// Clock returns the VPU clock frequency in MHz.
+func (v *Vpu) Clock() (uint32, error) {
+	if mtmlVpuGetClock == nil {
+		return 0, errNotSupportedSymbol("mtmlVpuGetClock")
+	}
+	var clock uint32
+	if err := checkReturnCode("mtmlVpuGetClock", mtmlVpuGetClock(v.handle, &clock)); err != nil {
+		return 0, err
+	}
+	return clock, nil
+}
+
+// MaxClock returns the VPU maximum clock frequency in MHz.
+func (v *Vpu) MaxClock() (uint32, error) {
+	if mtmlVpuGetMaxClock == nil {
+		return 0, errNotSupportedSymbol("mtmlVpuGetMaxClock")
+	}
+	var clock uint32
+	if err := checkReturnCode("mtmlVpuGetMaxClock", mtmlVpuGetMaxClock(v.handle, &clock)); err != nil {
+		return 0, err
+	}
+	return clock, nil
+}
+
+// MtLinkSpec holds MtLink specifications.
+type MtLinkSpec struct {
+	Version   uint32 // 10000*major + 100*minor + patch
+	BandWidth uint32 // Gb/s per link
+	LinkNum   uint32 // max number of supported links
+}
+
+// MtLinkSpec returns the device's MtLink specifications.
+func (d *Device) MtLinkSpec() (*MtLinkSpec, error) {
+	if mtmlDeviceGetMtLinkSpec == nil {
+		return nil, errNotSupportedSymbol("mtmlDeviceGetMtLinkSpec")
+	}
+	var spec mtmlMtLinkSpec
+	if err := checkReturnCode("mtmlDeviceGetMtLinkSpec",
+		mtmlDeviceGetMtLinkSpec(d.handle, &spec)); err != nil {
+		return nil, err
+	}
+	return &MtLinkSpec{
+		Version:   spec.version,
+		BandWidth: spec.bandWidth,
+		LinkNum:   spec.linkNum,
+	}, nil
+}
+
+// MtLinkState returns the state of MtLink link linkId: 0=DOWN, 1=UP, 2=DOWNGRADE.
+func (d *Device) MtLinkState(linkId uint32) (uint32, error) {
+	if mtmlDeviceGetMtLinkState == nil {
+		return 0, errNotSupportedSymbol("mtmlDeviceGetMtLinkState")
+	}
+	var state uint32
+	if err := checkReturnCode("mtmlDeviceGetMtLinkState",
+		mtmlDeviceGetMtLinkState(d.handle, linkId, &state)); err != nil {
+		return 0, err
+	}
+	return state, nil
+}
+
+// getString allocates a buffer, invokes fn to fill it, and returns the C string
+// truncated at the first NUL byte. For APIs with signature (handle, *byte, length).
+func getString(symbol string, _ uintptr, size int, fn func(buf []byte) Return) (string, error) {
+	buf := make([]byte, size)
+	clear(buf)
+	if err := checkReturnCode(symbol, fn(buf)); err != nil {
+		return "", err
+	}
+	return cString(buf), nil
+}
+
+// getStringSerialLenFirst is like getString but for APIs with the unusual
+// signature (handle, length, *byte) — e.g. mtmlDeviceGetSerialNumber,
+// mtmlMemoryGetVendor.
+func getStringSerialLenFirst(symbol string, _ uintptr, size int, fn func(buf []byte) Return) (string, error) {
+	return getString(symbol, 0, size, fn)
+}
+
+func cString(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}

--- a/core/metrics/mthreads/mtml/errors.go
+++ b/core/metrics/mthreads/mtml/errors.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error wraps an MTML return code with the symbol that produced it.
+type Error struct {
+	symbol string
+	code   Return
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s failed: %s", e.symbol, e.code.String())
+}
+
+// IsNotSupported reports whether err means the operation is not supported by
+// the current device/driver.
+func IsNotSupported(err error) bool {
+	var e *Error
+	return errors.As(err, &e) && e.code == ErrorNotSupported
+}
+
+// IsRecoverable reports whether err — or any error in an errors.Join
+// tree rooted at err — indicates a transient driver/library state
+// that a Shutdown+Init cycle may fix. These codes are typically
+// returned after a driver upgrade, device hot-plug, or when the
+// driver state has been torn down externally (e.g. modprobe -r
+// mthreads).
+func IsRecoverable(err error) bool {
+	return hasRecoverableCode(err)
+}
+
+// hasRecoverableCode walks the error tree rooted at err and reports
+// whether any leaf is an *Error with a recoverable return code.
+func hasRecoverableCode(err error) bool {
+	if err == nil {
+		return false
+	}
+	if joiner, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range joiner.Unwrap() {
+			if hasRecoverableCode(e) {
+				return true
+			}
+		}
+		return false
+	}
+	var e *Error
+	if errors.As(err, &e) {
+		switch e.code {
+		case ErrorDriverNotLoaded, ErrorDriverFailure,
+			ErrorResourceIsBusy, ErrorTimeout:
+			return true
+		}
+	}
+	return false
+}
+
+// checkReturnCode converts a non-success return code into an *Error.
+func checkReturnCode(symbol string, code Return) error {
+	if code == Success {
+		return nil
+	}
+	return &Error{symbol: symbol, code: code}
+}
+
+// errNotSupportedSymbol returns a NotSupported error for an optional symbol
+// whose C function pointer was not resolved (symbol absent from libmtml.so).
+func errNotSupportedSymbol(symbol string) error {
+	return &Error{symbol: symbol, code: ErrorNotSupported}
+}
+
+// MakeError constructs an *Error for the given symbol and code. It is
+// exported for test-only use (so callers and tests can build recognizable
+// errors without re-implementing the unexported type). Production code
+// paths should use checkReturnCode and errNotSupportedSymbol directly.
+func MakeError(symbol string, code Return) error {
+	return &Error{symbol: symbol, code: code}
+}
+
+// errNotReady is returned by native API entry points when the library
+// is in a not-ready state (fresh process, post-Shutdown, or post-failed-
+// Init).
+var errNotReady = &notReadyError{}
+
+type notReadyError struct{}
+
+func (e *notReadyError) Error() string {
+	return "mtml library is not ready (Init has not succeeded or Shutdown was called)"
+}
+
+// IsNotReady reports whether err is the not-ready sentinel returned
+// by native entry points when the library has not been successfully
+// initialized.
+func IsNotReady(err error) bool {
+	var e *notReadyError
+	return errors.As(err, &e)
+}
+
+// String returns a human-readable description of a Return code.
+func (r Return) String() string {
+	switch r {
+	case Success:
+		return "success"
+	case ErrorDriverNotLoaded:
+		return "driver not loaded"
+	case ErrorDriverFailure:
+		return "driver failure"
+	case ErrorInvalidArgument:
+		return "invalid argument"
+	case ErrorNotSupported:
+		return "not supported"
+	case ErrorNoPermission:
+		return "no permission"
+	case ErrorInsufficientSize:
+		return "insufficient size"
+	case ErrorNotFound:
+		return "not found"
+	case ErrorInsufficientMemory:
+		return "insufficient memory"
+	case ErrorDriverTooOld:
+		return "driver too old"
+	case ErrorDriverTooNew:
+		return "driver too new"
+	case ErrorTimeout:
+		return "timeout"
+	case ErrorResourceIsBusy:
+		return "resource is busy"
+	case ErrorUnknown:
+		return "unknown"
+	}
+	return fmt.Sprintf("mtml error code %d", int32(r))
+}

--- a/core/metrics/mthreads/mtml/init.go
+++ b/core/metrics/mthreads/mtml/init.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+// Init obtains a MtmlLibrary* interface handle from libmtml.so.
+//
+// On first call: dlopens libmtml.so (if not already loaded) and calls
+// mtmlLibraryInit. On subsequent calls (e.g. the collector's
+// recoverable-error recovery path after a Shutdown): the .so is
+// already mapped, so we only re-issue mtmlLibraryInit to obtain a
+// fresh MtmlLibrary* handle. The dlopen mapping is never released
+// for the process lifetime.
+func Init() error {
+	libmtml.Lock()
+	defer libmtml.Unlock()
+
+	if libmtml.ready {
+		return nil
+	}
+
+	if _, err := libmtml.loadLocked(); err != nil {
+		libmtml.ready = false
+		return err
+	}
+
+	// mtmlLibraryInit(MtmlLibrary** lib) — called on first Init and
+	// on every re-init after a Shutdown.
+	var lib uintptr
+	if mtmlErr := checkReturnCode("mtmlLibraryInit", mtmlLibraryInit(&lib)); mtmlErr != nil {
+		libmtml.ready = false
+		libmtml.lib = 0
+		return mtmlErr
+	}
+
+	libmtml.lib = lib
+	libmtml.ready = true
+	return nil
+}
+
+// Shutdown releases the MtmlLibrary* interface handle (mtmlLibraryShutDown).
+//
+// The .so mapping is intentionally NOT released. This matches the
+// vendor binding's lifecycle (pymtml.py: "Leave the library loaded,
+// but shutdown the interface"): all purego-registered mtml* function
+// pointers (types.go) keep pointing into the .so code section, so
+// subsequent mtml.* calls stay valid. A subsequent Init() re-issues
+// mtmlLibraryInit to obtain a fresh MtmlLibrary* handle without
+// reloading the .so or re-registering any symbol.
+func Shutdown() error {
+	libmtml.Lock()
+	defer libmtml.Unlock()
+
+	if libmtml.loadedAs == "" {
+		return nil
+	}
+
+	if libmtml.lib == 0 {
+		return nil
+	}
+
+	if err := checkReturnCode("mtmlLibraryShutDown", mtmlLibraryShutDown(libmtml.lib)); err != nil {
+		return err
+	}
+	libmtml.lib = 0
+	libmtml.ready = false
+	return nil
+}
+
+// IsReady reports whether the mtml library is in a state where
+// native calls are safe.
+func IsReady() bool {
+	libmtml.Lock()
+	defer libmtml.Unlock()
+	return libmtml.ready
+}

--- a/core/metrics/mthreads/mtml/init_test.go
+++ b/core/metrics/mthreads/mtml/init_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// resetLibrary wipes libmtml to a known-empty state. Tests must call this
+// in setup so a previous test's dlopen does not leak into the next.
+func resetLibrary(t *testing.T) {
+	t.Helper()
+	libmtml.Lock()
+	defer libmtml.Unlock()
+	libmtml.handle = 0
+	libmtml.loadedAs = ""
+	libmtml.lib = 0
+	libmtml.ready = false
+}
+
+func TestIsRecoverable_TableDriven(t *testing.T) {
+	cases := []struct {
+		name string
+		code Return
+		want bool
+	}{
+		{"driver not loaded is recoverable", ErrorDriverNotLoaded, true},
+		{"driver failure is recoverable", ErrorDriverFailure, true},
+		{"resource busy is recoverable", ErrorResourceIsBusy, true},
+		{"timeout is recoverable", ErrorTimeout, true},
+		{"success is not", Success, false},
+		{"invalid argument is not", ErrorInvalidArgument, false},
+		{"not supported is not", ErrorNotSupported, false},
+		{"unknown is not", ErrorUnknown, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &Error{symbol: "test", code: tc.code}
+			if got := IsRecoverable(err); got != tc.want {
+				t.Fatalf("IsRecoverable(%v) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRecoverable_NilAndUnrelated(t *testing.T) {
+	if IsRecoverable(nil) {
+		t.Fatal("IsRecoverable(nil) = true, want false")
+	}
+	if IsRecoverable(errors.New("plain error")) {
+		t.Fatal("IsRecoverable(plain) = true, want false")
+	}
+}
+
+func TestIsRecoverable_JoinsAcrossLeaves(t *testing.T) {
+	// One recoverable leaf among many non-recoverable leaves must still
+	// trigger recovery. This mirrors the errors.Join tree built by
+	// mthreadsGpuCollector.collect() (per-device workers each append
+	// their own errs slice).
+	joined := errors.Join(
+		fmt.Errorf("gpu 0: name: %w", &Error{symbol: "mtmlDeviceGetName", code: ErrorInvalidArgument}),
+		fmt.Errorf("gpu 0: pci sbdf: %w", &Error{symbol: "mtmlDeviceGetPciInfo", code: ErrorDriverFailure}),
+		fmt.Errorf("gpu 0: bios: %w", &Error{symbol: "mtmlDeviceGetMtBiosVersion", code: ErrorNotFound}),
+	)
+	if !IsRecoverable(joined) {
+		t.Fatal("IsRecoverable(joined with one recoverable leaf) = false, want true")
+	}
+}
+
+func TestIsRecoverable_NestedErrorsJoin(t *testing.T) {
+	// Two layers of errors.Join: a wrapped recoverable error inside a
+	// group joined into a higher-level error.
+	inner := errors.Join(
+		fmt.Errorf("device sub: %w", &Error{symbol: "mtmlDeviceInitGpu", code: ErrorResourceIsBusy}),
+	)
+	outer := errors.Join(inner, fmt.Errorf("top-level: transient"))
+	if !IsRecoverable(outer) {
+		t.Fatal("nested errors.Join with recoverable leaf = false, want true")
+	}
+}
+
+func TestEnforceInitFreePair_ConstructorWithoutDestructor(t *testing.T) {
+	// If a constructor resolved but its matching destructor did not, the
+	// constructor must be cleared so callers see a uniform NotSupported
+	// rather than a SIGSEGV from a freed sub-handle.
+	called := false
+	ctor := func(uintptr, *uintptr) Return { called = true; return Success }
+	enforceInitFreePair(&ctor, nil)
+	if ctor != nil {
+		t.Fatal("enforceInitFreePair did not clear the constructor when destructor is nil")
+	}
+	// And calling the now-nil function via a wrapper must not invoke the
+	// underlying symbol (we only check it didn't get re-bound to something
+	// dangerous — the variable is nil, so any direct call would NPE, which
+	// the production code already guards against via nil checks).
+	_ = called
+}
+
+func TestEnforceInitFreePair_BothPresentNoOp(t *testing.T) {
+	ctor := func(uintptr, *uintptr) Return { return Success }
+	free := func(uintptr) Return { return Success }
+	enforceInitFreePair(&ctor, free)
+	if ctor == nil {
+		t.Fatal("enforceInitFreePair cleared the constructor when destructor was present")
+	}
+}
+
+func TestEnforceInitFreePair_BothNilNoOp(t *testing.T) {
+	// Both sides nil: nothing to enforce, must not panic. The init pointer
+	// is a *func — it must be non-nil for the dereference to be safe;
+	// the constructor variable itself may be nil (the value it points
+	// to), which is the "both sides nil" case at the value level.
+	var ctor func(uintptr, *uintptr) Return // nil
+	enforceInitFreePair(&ctor, nil)
+	if ctor != nil {
+		t.Fatal("enforceInitFreePair modified a nil constructor")
+	}
+}
+
+func TestShutdown_NotLoadedIsNoOp(t *testing.T) {
+	resetLibrary(t)
+	if err := Shutdown(); err != nil {
+		t.Fatalf("Shutdown() on empty library returned %v, want nil", err)
+	}
+	if IsReady() {
+		t.Fatal("IsReady() = true after Shutdown on empty library, want false")
+	}
+}
+
+func TestShutdown_NoLibIsNoOp(t *testing.T) {
+	// Simulate the post-Init-failure state: .so loaded (so Shutdown knows
+	// the library exists) but lib == 0 (no interface handle to release).
+	resetLibrary(t)
+	libmtml.handle = 0xDEADBEEF // any non-zero sentinel
+	libmtml.loadedAs = "libmtml.so.2"
+	libmtml.lib = 0
+	libmtml.ready = false
+
+	if err := Shutdown(); err != nil {
+		t.Fatalf("Shutdown() with lib=0 returned %v, want nil", err)
+	}
+}
+
+func TestInit_WithoutLoadedSo_FailsAndLeavesReadyFalse(t *testing.T) {
+	// No .so on this test box (CI), or loadLocked has no candidates:
+	// Init must surface the error and leave ready=false. We do not assert
+	// on the error text — the candidate list depends on the host.
+	resetLibrary(t)
+	err := Init()
+	if err == nil {
+		t.Skip("a real libmtml.so is mapped on this host; skipping synthetic fail test")
+	}
+	if IsReady() {
+		t.Fatal("IsReady() = true after failed Init, want false")
+	}
+	if libmtml.lib != 0 {
+		t.Fatal("libmtml.lib is non-zero after failed Init")
+	}
+}
+
+func TestInit_ReadyShortCircuits(t *testing.T) {
+	// If ready is already true (set by a prior successful Init), a second
+	// Init must return nil without re-running loadLocked or mtmlLibraryInit.
+	// We can't observe the latter directly, but we CAN observe that no
+	// error is returned even though no .so is loaded — proving the early
+	// return fired.
+	//
+	// The cleanup is critical: the test directly mutates the global
+	// libmtml.ready without going through the real Init path, so without
+	// reset the rest of the suite would see ready=true with nil function
+	// pointers and panic on the first device call.
+	resetLibrary(t)
+	libmtml.ready = true
+	t.Cleanup(func() { resetLibrary(t) })
+	if err := Init(); err != nil {
+		t.Fatalf("Init() on ready=true returned %v, want nil", err)
+	}
+}

--- a/core/metrics/mthreads/mtml/lib.go
+++ b/core/metrics/mthreads/mtml/lib.go
@@ -1,0 +1,295 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+
+	"huatuo-bamai/core/metrics/mthreads/dl"
+
+	"github.com/ebitengine/purego"
+)
+
+// library tracks the .so handle and the MtmlLibrary* returned by
+// mtmlLibraryInit. Bool-style: only one Init is expected per process
+// (at daemon start) and one Shutdown (at daemon exit); the struct is
+// mutex-guarded because a future second caller must not race.
+type library struct {
+	sync.Mutex
+	handle   uintptr // dlopen handle; 0 when not loaded
+	loadedAs string  // name that successfully loaded; "" when not loaded
+	lib      uintptr // MtmlLibrary* from mtmlLibraryInit; 0 when not initialized
+	ready    bool    // true iff lib != 0 and native calls are safe
+}
+
+// global singleton instance.
+var libmtml = newLibrary()
+
+func newLibrary() *library {
+	return &library{}
+}
+
+// defaultMtmlLibraryNames returns the ordered candidate names for loading the
+// MTML shared library, matching the discovery order used by the official
+// Moore Threads Python binding (pymtml). Bare names (no directory prefix)
+// let the system dynamic linker search LD_LIBRARY_PATH, /etc/ld.so.cache,
+// and the standard library directories, so installations that expose only
+// the versioned SONAME or place the library in a non-/usr/lib path are
+// handled automatically.
+func defaultMtmlLibraryNames() []string {
+	switch runtime.GOOS {
+	case "linux":
+		return []string{"libmtml.so.2", "libmtml.so"}
+	default:
+		return nil
+	}
+}
+
+// loadLocked dlopens libmtml.so and registers all symbols.
+//
+// Caller must hold l.Mutex. On success, returns the dlopen handle and
+// stores loadedAs/l.handle/l.handle. On error, any partially-opened
+// candidate has been closed and the library state is unchanged from
+// the caller's perspective (still unloaded).
+func (l *library) loadLocked() (uintptr, error) {
+	if l.loadedAs != "" {
+		return l.handle, nil
+	}
+
+	candidates := defaultMtmlLibraryNames()
+	if len(candidates) == 0 {
+		return 0, fmt.Errorf("no MTML library names configured for %s", runtime.GOOS)
+	}
+
+	var errs []string
+	for _, name := range candidates {
+		d := dl.New(name, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+		if err := d.Open(); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+
+		if err := registerSymbols(d.Handle()); err != nil {
+			_ = d.Close()
+			errs = append(errs, fmt.Sprintf("%s: registerSymbols: %v", name, err))
+			continue
+		}
+
+		l.loadedAs = name
+		l.handle = d.Handle()
+		return l.handle, nil
+	}
+
+	return 0, fmt.Errorf("failed to load MTML library (tried %s):\n  %s",
+		strings.Join(candidates, ", "),
+		strings.Join(errs, "\n  "))
+}
+
+// registerSymbols registers MTML library symbols using purego.Dlsym + RegisterFunc.
+// Returns error if any required symbol is missing.
+// Optional symbols that are missing are left as nil (callers return NotSupported).
+func registerSymbols(handle uintptr) error {
+	// Required symbols - library cannot function without these.
+	sym, err := purego.Dlsym(handle, "mtmlLibraryInit")
+	if err != nil {
+		return fmt.Errorf("required symbol mtmlLibraryInit not found: %w", err)
+	}
+	purego.RegisterFunc(&mtmlLibraryInit, sym)
+
+	sym, err = purego.Dlsym(handle, "mtmlLibraryShutDown")
+	if err != nil {
+		return fmt.Errorf("required symbol mtmlLibraryShutDown not found: %w", err)
+	}
+	purego.RegisterFunc(&mtmlLibraryShutDown, sym)
+
+	sym, err = purego.Dlsym(handle, "mtmlLibraryCountDevice")
+	if err != nil {
+		return fmt.Errorf("required symbol mtmlLibraryCountDevice not found: %w", err)
+	}
+	purego.RegisterFunc(&mtmlLibraryCountDevice, sym)
+
+	sym, err = purego.Dlsym(handle, "mtmlLibraryInitDeviceByIndex")
+	if err != nil {
+		return fmt.Errorf("required symbol mtmlLibraryInitDeviceByIndex not found: %w", err)
+	}
+	purego.RegisterFunc(&mtmlLibraryInitDeviceByIndex, sym)
+
+	sym, err = purego.Dlsym(handle, "mtmlLibraryFreeDevice")
+	if err != nil {
+		return fmt.Errorf("required symbol mtmlLibraryFreeDevice not found: %w", err)
+	}
+	purego.RegisterFunc(&mtmlLibraryFreeDevice, sym)
+
+	// Optional symbols - missing symbols are left as nil, callers return NotSupported.
+	if sym, err := purego.Dlsym(handle, "mtmlLibraryGetVersion"); err == nil {
+		purego.RegisterFunc(&mtmlLibraryGetVersion, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetIndex"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetIndex, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetName"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetName, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetUUID"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetUUID, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetBrand"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetBrand, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetSerialNumber"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetSerialNumber, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetMtBiosVersion"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetMtBiosVersion, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceCountGpuCores"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceCountGpuCores, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetPciInfo"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetPciInfo, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetPowerUsage"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetPowerUsage, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetPcieReplayCounter"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetPcieReplayCounter, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetPerformanceState"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetPerformanceState, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetMusaComputeCapability"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetMusaComputeCapability, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceInitGpu"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceInitGpu, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceFreeGpu"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceFreeGpu, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetTemperature"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetTemperature, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetUtilization"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetUtilization, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetClock"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetClock, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetMaxClock"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetMaxClock, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetVoltage"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetVoltage, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetEnforcedPowerLimit"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetEnforcedPowerLimit, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetPowerManagementDefaultLimit"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetPowerManagementDefaultLimit, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlGpuGetTemperatureThreshold"); err == nil {
+		purego.RegisterFunc(&mtmlGpuGetTemperatureThreshold, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceInitMemory"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceInitMemory, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceFreeMemory"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceFreeMemory, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetTotal"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetTotal, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetUsed"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetUsed, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetUtilization"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetUtilization, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetTemperature"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetTemperature, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetClock"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetClock, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetMaxClock"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetMaxClock, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetBusWidth"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetBusWidth, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetBandwidth"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetBandwidth, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetSpeed"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetSpeed, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetType"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetType, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlMemoryGetVendor"); err == nil {
+		purego.RegisterFunc(&mtmlMemoryGetVendor, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceInitVpu"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceInitVpu, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceFreeVpu"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceFreeVpu, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlVpuGetUtilization"); err == nil {
+		purego.RegisterFunc(&mtmlVpuGetUtilization, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlVpuGetClock"); err == nil {
+		purego.RegisterFunc(&mtmlVpuGetClock, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlVpuGetMaxClock"); err == nil {
+		purego.RegisterFunc(&mtmlVpuGetMaxClock, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceCountFan"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceCountFan, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetFanSpeed"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetFanSpeed, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetFanRpm"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetFanRpm, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetMtLinkSpec"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetMtLinkSpec, sym)
+	}
+	if sym, err := purego.Dlsym(handle, "mtmlDeviceGetMtLinkState"); err == nil {
+		purego.RegisterFunc(&mtmlDeviceGetMtLinkState, sym)
+	}
+
+	// for each constructor/destructor pair, if the constructor resolved
+	// but the destructor did not, force the constructor back to nil.
+	enforceInitFreePair(&mtmlDeviceInitGpu, mtmlDeviceFreeGpu)
+	enforceInitFreePair(&mtmlDeviceInitMemory, mtmlDeviceFreeMemory)
+	enforceInitFreePair(&mtmlDeviceInitVpu, mtmlDeviceFreeVpu)
+
+	return nil
+}
+
+func enforceInitFreePair(initPtr *func(uintptr, *uintptr) Return, freePtr func(uintptr) Return) {
+	if *initPtr != nil && freePtr == nil {
+		*initPtr = nil
+	}
+}
+
+// Lib returns the MtmlLibrary* handle for the initialized library.
+func (l *library) Lib() uintptr { return l.lib }

--- a/core/metrics/mthreads/mtml/smoke_test.go
+++ b/core/metrics/mthreads/mtml/smoke_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+import "testing"
+
+// resetForTest wipes libmtml to a known empty state. Tests must call this
+// in setup so a previous test's dlopen does not leak into the next.
+// Symmetric with the resetLibrary helper in init_test.go but kept here so
+// the smoke test file is self-contained.
+//
+// IMPORTANT: the caller must NOT hold any other reference to libmtml
+// (e.g. be inside IsReady) when this runs. libmtml.Mutex is not reentrant.
+func resetForTest() {
+	libmtml.Lock()
+	libmtml.handle = 0
+	libmtml.loadedAs = ""
+	libmtml.lib = 0
+	libmtml.ready = false
+	libmtml.Unlock()
+}
+
+// TestSmoke_InitCountVersion exercises the registry-free path: load the
+// .so, count devices, fetch the library version. The test is skipped on
+// hosts without libmtml.so (CI runners, dev boxes).
+func TestSmoke_InitCountVersion(t *testing.T) {
+	resetForTest()
+	if err := Init(); err != nil {
+		t.Skipf("libmtml.so not available on this host: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = Shutdown()
+		resetForTest()
+	})
+
+	if !IsReady() {
+		t.Fatal("IsReady() = false after successful Init")
+	}
+
+	count, err := CountDevice()
+	if err != nil {
+		t.Fatalf("CountDevice: %v", err)
+	}
+	t.Logf("detected %d device(s)", count)
+
+	// LibraryVersion is optional (mtmlLibraryGetVersion may be absent
+	// from older .so builds); a NotSupported return is acceptable.
+	if v, err := LibraryVersion(); err != nil {
+		if !IsNotSupported(err) {
+			t.Fatalf("LibraryVersion: %v", err)
+		}
+	} else {
+		t.Logf("library version: %q", v)
+	}
+}
+
+// TestSmoke_ShutdownReinitCycle exercises the lifecycle that
+// mthreadsGpuCollector.Update() takes on a recoverable error: the
+// .so stays mapped (pymtml-style), only the MtmlLibrary* interface
+// handle is re-issued. The second Init must succeed and CountDevice
+// must return the same number of devices.
+func TestSmoke_ShutdownReinitCycle(t *testing.T) {
+	resetForTest()
+	if err := Init(); err != nil {
+		t.Skipf("libmtml.so not available on this host: %v", err)
+	}
+
+	first, err := CountDevice()
+	if err != nil {
+		t.Fatalf("first CountDevice: %v", err)
+	}
+	if first == 0 {
+		_ = Shutdown()
+		resetForTest()
+		t.Skip("no devices attached; reinit cycle is meaningful only with devices")
+	}
+
+	if err := Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if IsReady() {
+		t.Fatal("IsReady() = true after Shutdown, want false")
+	}
+
+	if err := Init(); err != nil {
+		t.Fatalf("re-Init after Shutdown: %v", err)
+	}
+	if !IsReady() {
+		t.Fatal("IsReady() = false after re-Init, want true")
+	}
+	t.Cleanup(func() {
+		_ = Shutdown()
+		resetForTest()
+	})
+
+	second, err := CountDevice()
+	if err != nil {
+		t.Fatalf("second CountDevice: %v", err)
+	}
+	if second != first {
+		t.Fatalf("device count changed across reinit: first=%d second=%d", first, second)
+	}
+}
+
+// TestSmoke_RepeatedShutdownIsNoop verifies that calling Shutdown
+// multiple times after Init does not return an error or panic. The
+// collector reinit path sets ready=false but then may call Shutdown
+// again on the next recovery; this test pins the no-op contract.
+func TestSmoke_RepeatedShutdownIsNoop(t *testing.T) {
+	resetForTest()
+	if err := Init(); err != nil {
+		t.Skipf("libmtml.so not available on this host: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := Shutdown(); err != nil {
+			t.Fatalf("Shutdown #%d: %v", i+1, err)
+		}
+	}
+	// And one more Init/Shutdown after the repeated Shutdowns to
+	// confirm the .so mapping is still usable.
+	if err := Init(); err != nil {
+		t.Fatalf("Init after repeated Shutdown: %v", err)
+	}
+	if err := Shutdown(); err != nil {
+		t.Fatalf("final Shutdown: %v", err)
+	}
+	resetForTest()
+}
+
+// TestSmoke_NotReadyBeforeInit confirms the public gate: a fresh
+// process has IsReady()==false and any device API returns
+// errNotReady (recognized by IsNotReady). This is the contract that
+// protects every public entry point from a nil/nil-handle crash.
+func TestSmoke_NotReadyBeforeInit(t *testing.T) {
+	resetForTest()
+	t.Cleanup(resetForTest)
+
+	if IsReady() {
+		t.Fatal("IsReady() = true on a freshly reset library")
+	}
+	if _, err := CountDevice(); !IsNotReady(err) {
+		t.Fatalf("CountDevice on not-ready library returned %v, want not-ready", err)
+	}
+	if _, err := InitDeviceByIndex(0); !IsNotReady(err) {
+		t.Fatalf("InitDeviceByIndex on not-ready library returned %v, want not-ready", err)
+	}
+}

--- a/core/metrics/mthreads/mtml/types.go
+++ b/core/metrics/mthreads/mtml/types.go
@@ -1,0 +1,288 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtml
+
+import "fmt"
+
+// Return is the MTML return code type (MtmlReturn).
+type Return int32
+
+// Buffer sizes used by the string-returning MTML APIs (from mtml.h macros).
+const (
+	libraryVersionBufferSize     = 32
+	driverVersionBufferSize      = 80
+	deviceNameBufferSize         = 32
+	deviceUUIDBufferSize         = 48
+	biosVersionBufferSize        = 64
+	deviceSerialNumberBufferSize = 64
+	pciSbdfBufferSize            = 32
+	memoryVendorBufferSize       = 64
+)
+
+// MTML API raw symbols — C function pointers registered at init time via purego.
+//
+// The Mtml* handles are opaque C pointers; we carry them as uintptr so the GC
+// never inspects C-owned objects.
+//
+// === Public ABI (mtml.h, public 2.2 header) ===
+// All symbols present in mtml.h shipped with the 2.2 driver package are
+// treated as supported and resolved at init time. If a public symbol is
+// missing at runtime, Init() fails.
+//
+// === Private ABI (NOT in the 2.2 public header) ===
+// Compatibility contract:
+//
+//   - Verified against: libmtml.so.2 from MTT 270.80 driver, MTT S80
+//     GPU, on x86_64 Linux 5.15+.
+//
+//   - On older or non-MTT-S80 hardware the symbol may be absent; in that
+//     case the corresponding mtml.* method returns errNotSupportedSymbol
+//     and the metric is silently skipped — never panics, never crashes.
+//
+//   - Driver upgrades: tested up to MTT 275.x. Newer drivers may rename
+//     or remove private symbols; collectors that depend on them will
+//     then return NotSupported on that driver version. We do not
+//     commit to supporting renamed private symbols.
+//
+//     mtmlDeviceGetMusaComputeCapability  — verified MTT 270.80
+//     mtmlDeviceGetPcieReplayCounter      — verified MTT 270.80
+//     mtmlDeviceGetPerformanceState       — verified MTT 270.80
+//     mtmlGpuGetEnforcedPowerLimit        — verified MTT 270.80
+//     mtmlGpuGetPowerManagementDefaultLimit — verified MTT 270.80
+//     mtmlGpuGetTemperatureThreshold      — verified MTT 270.80
+//     mtmlGpuGetVoltage                   — verified MTT 270.80
+//     mtmlMemoryGetTemperature            — verified MTT 270.80
+//
+// MtLink private symbols (mtmlDeviceGetMtLinkSpec, mtmlDeviceGetMtLinkState)
+// are likewise resolved at runtime. They are gated behind EnableMTLink
+// (default off) and behind the existing errNotSupportedSymbol path.
+var (
+	// Library lifecycle: mtmlLibraryInit(*MtmlLibrary)
+	mtmlLibraryInit func(*uintptr) Return
+	// mtmlLibraryShutDown(MtmlLibrary*)
+	mtmlLibraryShutDown func(uintptr) Return
+	// mtmlLibraryGetVersion(MtmlLibrary*, char* version, unsigned int length)
+	mtmlLibraryGetVersion func(uintptr, *byte, uint32) Return
+
+	// Enumeration: mtmlLibraryCountDevice(MtmlLibrary*, unsigned int* count)
+	mtmlLibraryCountDevice func(uintptr, *uint32) Return
+	// mtmlLibraryInitDeviceByIndex(MtmlLibrary*, unsigned int index, MtmlDevice** dev)
+	mtmlLibraryInitDeviceByIndex func(uintptr, uint32, *uintptr) Return
+	// mtmlLibraryFreeDevice(MtmlDevice*)
+	mtmlLibraryFreeDevice func(uintptr) Return
+
+	// Device identity.
+	// mtmlDeviceGetIndex(MtmlDevice*, unsigned int* index)
+	mtmlDeviceGetIndex func(uintptr, *uint32) Return
+	// mtmlDeviceGetName(MtmlDevice*, char* name, unsigned int length)
+	mtmlDeviceGetName func(uintptr, *byte, uint32) Return
+	// mtmlDeviceGetUUID(MtmlDevice*, char* uuid, unsigned int length)
+	mtmlDeviceGetUUID func(uintptr, *byte, uint32) Return
+	// mtmlDeviceGetBrand(MtmlDevice*, MtmlBrandType* type)
+	mtmlDeviceGetBrand func(uintptr, *uint32) Return
+	// mtmlDeviceGetSerialNumber(MtmlDevice*, unsigned int length, char* serial)
+	mtmlDeviceGetSerialNumber func(uintptr, uint32, *byte) Return
+	// mtmlDeviceGetMtBiosVersion(MtmlDevice*, char* version, unsigned int length)
+	mtmlDeviceGetMtBiosVersion func(uintptr, *byte, uint32) Return
+	// mtmlDeviceCountGpuCores(MtmlDevice*, unsigned int* numCores)
+	mtmlDeviceCountGpuCores func(uintptr, *uint32) Return
+	// mtmlDeviceGetPciInfo(MtmlDevice*, MtmlPciInfo* pci)
+	mtmlDeviceGetPciInfo func(uintptr, *mtmlPciInfo) Return
+	// mtmlDeviceGetPowerUsage(MtmlDevice*, unsigned int* power) — milliwatts
+	mtmlDeviceGetPowerUsage func(uintptr, *uint32) Return
+	// mtmlDeviceGetPcieReplayCounter(MtmlDevice*, unsigned int* replayCounter)
+	mtmlDeviceGetPcieReplayCounter func(uintptr, *uint32) Return
+	// mtmlDeviceGetPerformanceState(MtmlDevice*, int* pstate)
+	mtmlDeviceGetPerformanceState func(uintptr, *int32) Return
+	// mtmlDeviceGetMusaComputeCapability(MtmlDevice*, int* major, int* minor)
+	mtmlDeviceGetMusaComputeCapability func(uintptr, *int32, *int32) Return
+
+	// mtmlDeviceInitGpu(MtmlDevice*, MtmlGpu** gpu)
+	mtmlDeviceInitGpu func(uintptr, *uintptr) Return
+	mtmlDeviceFreeGpu func(uintptr) Return
+	// mtmlGpuGetTemperature(MtmlGpu*, int* temp) — degrees Celsius
+	mtmlGpuGetTemperature func(uintptr, *int32) Return
+	// mtmlGpuGetUtilization(MtmlGpu*, unsigned int* utilization) — 0-100
+	mtmlGpuGetUtilization func(uintptr, *uint32) Return
+	// mtmlGpuGetClock(MtmlGpu*, unsigned int* clockMhz)
+	mtmlGpuGetClock    func(uintptr, *uint32) Return
+	mtmlGpuGetMaxClock func(uintptr, *uint32) Return
+	// mtmlGpuGetVoltage(MtmlGpu*, int* voltage) — millivolts
+	mtmlGpuGetVoltage func(uintptr, *int32) Return
+	// mtmlGpuGetEnforcedPowerLimit(MtmlGpu*, int* limit) — milliwatts
+	mtmlGpuGetEnforcedPowerLimit func(uintptr, *int32) Return
+	// mtmlGpuGetPowerManagementDefaultLimit(MtmlGpu*, int* limit) — milliwatts
+	mtmlGpuGetPowerManagementDefaultLimit func(uintptr, *int32) Return
+	// mtmlGpuGetTemperatureThreshold(MtmlGpu*, int thresholdType, int* temp)
+	// thresholdType: 0=shutdown, 1=slowdown (confirmed via cmp $0x1,%esi).
+	mtmlGpuGetTemperatureThreshold func(uintptr, int32, *int32) Return
+
+	// Memory sub-object: mtmlDeviceInitMemory(MtmlDevice*, MtmlMemory** mem)
+	mtmlDeviceInitMemory func(uintptr, *uintptr) Return
+	mtmlDeviceFreeMemory func(uintptr) Return
+	// mtmlMemoryGetTotal(MtmlMemory*, unsigned long long* total) — bytes
+	mtmlMemoryGetTotal func(uintptr, *uint64) Return
+	// mtmlMemoryGetUsed(MtmlMemory*, unsigned long long* used) — bytes
+	mtmlMemoryGetUsed func(uintptr, *uint64) Return
+	// mtmlMemoryGetUtilization(MtmlMemory*, unsigned int* utilization) — 0-100
+	mtmlMemoryGetUtilization func(uintptr, *uint32) Return
+	// mtmlMemoryGetTemperature(MtmlMemory*, int* temp) — degrees Celsius
+	mtmlMemoryGetTemperature func(uintptr, *int32) Return
+	// mtmlMemoryGetClock / GetMaxClock(MtmlMemory*, unsigned int* clockMhz)
+	mtmlMemoryGetClock    func(uintptr, *uint32) Return
+	mtmlMemoryGetMaxClock func(uintptr, *uint32) Return
+	// mtmlMemoryGetBusWidth(MtmlMemory*, unsigned int* busWidth) — bits
+	mtmlMemoryGetBusWidth func(uintptr, *uint32) Return
+	// mtmlMemoryGetBandwidth(MtmlMemory*, unsigned int* bandwidth) — GB/s
+	mtmlMemoryGetBandwidth func(uintptr, *uint32) Return
+	// mtmlMemoryGetSpeed(MtmlMemory*, unsigned int* speed) — Mbps
+	mtmlMemoryGetSpeed func(uintptr, *uint32) Return
+	// mtmlMemoryGetType(MtmlMemory*, MtmlMemoryType* type)
+	mtmlMemoryGetType func(uintptr, *uint32) Return
+	// mtmlMemoryGetVendor(MtmlMemory*, unsigned int length, char* vendor)
+	mtmlMemoryGetVendor func(uintptr, uint32, *byte) Return
+
+	// VPU sub-object: mtmlDeviceInitVpu(MtmlDevice*, MtmlVpu** vpu)
+	mtmlDeviceInitVpu func(uintptr, *uintptr) Return
+	mtmlDeviceFreeVpu func(uintptr) Return
+	// mtmlVpuGetUtilization(MtmlVpu*, MtmlCodecUtil* utilization)
+	mtmlVpuGetUtilization func(uintptr, *mtmlCodecUtil) Return
+	// mtmlVpuGetClock / GetMaxClock(MtmlVpu*, unsigned int* clockMhz)
+	mtmlVpuGetClock    func(uintptr, *uint32) Return
+	mtmlVpuGetMaxClock func(uintptr, *uint32) Return
+
+	// Fans: mtmlDeviceCountFan(MtmlDevice*, unsigned int* count)
+	mtmlDeviceCountFan func(uintptr, *uint32) Return
+	// mtmlDeviceGetFanSpeed(MtmlDevice*, unsigned int index, unsigned int* speed) — percent
+	mtmlDeviceGetFanSpeed func(uintptr, uint32, *uint32) Return
+	// mtmlDeviceGetFanRpm(MtmlDevice*, unsigned int fanIndex, unsigned int* fanRpm) — RPM
+	mtmlDeviceGetFanRpm func(uintptr, uint32, *uint32) Return
+
+	// MtLink: mtmlDeviceGetMtLinkSpec(MtmlDevice*, MtmlMtLinkSpec* spec)
+	mtmlDeviceGetMtLinkSpec func(uintptr, *mtmlMtLinkSpec) Return
+	// mtmlDeviceGetMtLinkState(MtmlDevice*, unsigned int linkId, MtmlMtLinkState* state)
+	// MtmlMtLinkState is an enum (int): 0=DOWN, 1=UP, 2=DOWNGRADE.
+	mtmlDeviceGetMtLinkState func(uintptr, uint32, *uint32) Return
+)
+
+// mtmlPciInfo mirrors the C struct MtmlPciInfo layout for purego.
+// sbdf is a fixed char[32]; followed by unsigned ints, two floats (speed), and
+// rsvd[6] int padding. Field order/type must match the C definition exactly.
+//
+// not by Go field access
+//
+//nolint:unused // fields are placeholders for C struct layout; purego reads by memory offset,
+type mtmlPciInfo struct {
+	sbdf           [pciSbdfBufferSize]byte
+	segment        uint32
+	bus            uint32
+	device         uint32
+	pciDeviceId    uint32
+	pciSubsystemId uint32
+	busWidth       uint32
+	pciMaxSpeed    float32
+	pciCurSpeed    float32
+	pciMaxWidth    uint32
+	pciCurWidth    uint32
+	pciMaxGen      uint32
+	pciCurGen      uint32
+	rsvd           [6]int32
+}
+
+// mtmlCodecUtil mirrors the C struct MtmlCodecUtil (VPU utilization).
+//
+// not by Go field access
+//
+//nolint:unused // fields are placeholders for C struct layout; purego reads by memory offset,
+type mtmlCodecUtil struct {
+	util    uint32 // overall utilization rate over the sampling period (%)
+	period  uint32 // sampling period, microseconds
+	encUtil uint32 // encoder utilization rate (%)
+	decUtil uint32 // decoder utilization rate (%)
+	rsvd    [2]int32
+}
+
+// mtmlMtLinkSpec mirrors the C struct MtmlMtLinkSpec.
+//
+//nolint:unused // rsvd is a C ABI padding slot; purego reads by offset, not by Go field access
+type mtmlMtLinkSpec struct {
+	version   uint32 // 10000*major + 100*minor + patch
+	bandWidth uint32 // bandwidth per link in Gb/s
+	linkNum   uint32 // max number of supported links
+	rsvd      [4]uint32
+}
+
+// MtmlMemoryType enum values (for mtmlMemoryGetType).
+const (
+	MemoryTypeLPDDR4 = 0
+	MemoryTypeGDDR6  = 1
+)
+
+// Brand is the MtmlBrandType enum returned by mtmlDeviceGetBrand.
+type Brand uint32
+
+// Brand enum values (MtmlBrandType, from mtml.h).
+const (
+	BrandMTT     Brand = 0 // MTML_BRAND_MTT — the Moore Threads vendor value.
+	BrandUnknown Brand = 1 // MTML_BRAND_UNKNOWN — the only other published value.
+)
+
+// String returns a stable label for the brand. Unrecognized values
+// (vendor may add new ones in future headers) are rendered as
+// "UNKNOWN(<n>)" so the metric label surfaces the raw vendor number
+// rather than silently dropping it or being conflated with the
+// known BrandUnknown=1 case.
+func (b Brand) String() string {
+	switch b {
+	case BrandMTT:
+		return "MTT"
+	case BrandUnknown:
+		return "UNKNOWN"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", uint32(b))
+	}
+}
+
+// Temperature threshold types for mtmlGpuGetTemperatureThreshold.
+const (
+	TempThresholdShutdown = 0
+	TempThresholdSlowdown = 1
+)
+
+// MtLink state enum values (MtmlMtLinkState) for mtmlDeviceGetMtLinkState.
+const (
+	MtLinkStateDown      = 0
+	MtLinkStateUp        = 1
+	MtLinkStateDowngrade = 2
+)
+
+// MTML return codes (MtmlReturn, from mtml.h).
+const (
+	Success                 Return = 0
+	ErrorDriverNotLoaded    Return = 1
+	ErrorDriverFailure      Return = 2
+	ErrorInvalidArgument    Return = 3
+	ErrorNotSupported       Return = 4
+	ErrorNoPermission       Return = 5
+	ErrorInsufficientSize   Return = 6
+	ErrorNotFound           Return = 7
+	ErrorInsufficientMemory Return = 8
+	ErrorDriverTooOld       Return = 9
+	ErrorDriverTooNew       Return = 10
+	ErrorTimeout            Return = 11
+	ErrorResourceIsBusy     Return = 12
+	ErrorUnknown            Return = 999
+)

--- a/core/metrics/mthreads_gpu.go
+++ b/core/metrics/mthreads_gpu.go
@@ -1,0 +1,814 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"huatuo-bamai/core/metrics/mthreads/mtml"
+	"huatuo-bamai/internal/log"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+func init() {
+	tracing.RegisterEventTracing("mthreads_gpu", newMthreadsGpuCollector)
+}
+
+// scrapeTimeout bounds the wall-clock time of a single Update() call per
+// metric group and device. Since MTML is a synchronous, non-cancelable C
+// library, ctx.Done() is checked only between devices and before each metric
+// group (health / PCIe / MtLink); once exceeded, remaining devices and groups
+// are skipped. If a C call hangs, Update() blocks until it returns — canceling
+// in-flight calls would require an async MTML API.
+const scrapeTimeout = 10 * time.Second
+
+// mthreadsGpuCollector monitors Moore Threads GPUs via the MTML library.
+// Static device info is cached and only rebuilt on re-init; dynamic metrics
+// are collected on every scrape.
+//
+// Concurrency model:
+//   - The framework serializes Update() calls via CollectorWrapper.mu
+//     (pkg/metric/collector.go), so there is at most one in-flight
+//     collect() per collector. The lock-free cache fast path below is
+//     safe under that contract: invalidateCache is only called from
+//     inside Update() (the recoverable-error re-init path), so a stale
+//     "built=true" read cannot outlive a concurrent invalidator — both
+//     run on the same goroutine.
+//   - If a future caller invokes collect() or invalidateCache() outside
+//     of Update(), the fast path must be revisited (see H-07).
+type mthreadsGpuCollector struct {
+	cache     atomic.Pointer[mthreadsCache] // immutable once stored; readers must not mutate
+	build     sync.Mutex                    // serializes concurrent buildCache callers
+	poisoned  atomic.Bool                   // once true, Update() short-circuits and never touches collect/Shutdown/Init again
+	poisonErr atomic.Pointer[error]         // root cause; errors.Is chain is preserved
+}
+
+// mthreadsCache holds the device list plus cached static info metrics. It is
+// rebuilt when the cache is invalidated (first use, or after a re-init).
+type mthreadsCache struct {
+	devices    []uint32       // device indices
+	staticInfo []*metric.Data // cached info metrics (library/driver/device/spec/bios/musa/memory_info)
+}
+
+func newMthreadsGpuCollector() (*tracing.EventTracingAttr, error) {
+	if err := mtml.Init(); err != nil {
+		log.Warnf("mthreads: GPU collector disabled (mtml init failed: %v)", err)
+		return nil, types.ErrNotSupported
+	}
+
+	c := &mthreadsGpuCollector{} // cache built lazily on first Update
+	return &tracing.EventTracingAttr{
+		TracingData: c,
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+// Update is called by the framework on every Prometheus scrape.
+func (c *mthreadsGpuCollector) Update() ([]*metric.Data, error) {
+	// Poison short-circuit: once Shutdown has failed, this collector is
+	// permanently abandoned. The contaminated path is physically unreachable
+	// — no collect, Shutdown, or Init is ever attempted again.
+	if c.poisoned.Load() {
+		return nil, c.poisonedErr()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), scrapeTimeout)
+	defer cancel()
+
+	metrics, err := c.collect(ctx)
+	if err == nil || !mtml.IsRecoverable(err) {
+		return metrics, err
+	}
+
+	// Recoverable MTML error: try exactly one Shutdown + Init + cache
+	// invalidate + retry cycle.
+	log.Warnf("mthreads: recoverable error, re-initing MTML: %v", err)
+	if serr := mtml.Shutdown(); serr != nil {
+		// Shutdown failed -> handle is frozen, permanently poisoned.
+		c.setPoisoned(serr)
+		return nil, fmt.Errorf("recoverable error %w; shutdown failed: %w", err, serr)
+	}
+	if ierr := mtml.Init(); ierr != nil {
+		return nil, fmt.Errorf("recoverable error %w; re-init failed: %w", err, ierr)
+	}
+	c.invalidateCache()
+	return c.collect(ctx)
+}
+
+// poisonedErr builds the error returned on short-circuit. The poison root
+// cause is chained via errors.Join so the errors.Is chain is preserved
+// (upstream alerts can still errors.Is(err, &mtml.Error{}) to recover
+// the original code).
+func (c *mthreadsGpuCollector) poisonedErr() error {
+	if ep := c.poisonErr.Load(); ep != nil {
+		return errors.Join(
+			errors.New("mthreads: GPU metrics disabled, library poisoned by prior failure"),
+			*ep,
+		)
+	}
+	return errors.New("mthreads: GPU metrics disabled, library poisoned")
+}
+
+func (c *mthreadsGpuCollector) setPoisoned(root error) {
+	if c.poisoned.Load() {
+		log.Warnf("mthreads: setPoisoned called on already-poisoned collector, ignoring: %v", root)
+		return
+	}
+	c.poisonErr.Store(&root)
+	c.poisoned.Store(true)
+	log.Warnf("mthreads: library poisoned by failed Shutdown, GPU metrics disabled: %v", root)
+}
+
+func (c *mthreadsGpuCollector) collect(ctx context.Context) ([]*metric.Data, error) {
+	cfg := configSnapshot()
+
+	// Library readiness gate.
+	if !mtml.IsReady() {
+		log.Warnf("mthreads: mtml not ready on scrape, attempting re-init")
+		if err := mtml.Init(); err != nil {
+			return nil, fmt.Errorf("mtml not ready and re-init failed: %w", err)
+		}
+		c.invalidateCache()
+	}
+
+	cache, err := c.getOrBuildCache(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build mthreads cache: %w", err)
+	}
+	if len(cache.devices) == 0 {
+		return nil, fmt.Errorf("no mthreads gpu devices found")
+	}
+
+	// Static info comes from cache (no per-scrape MTML calls).
+	metrics := append([]*metric.Data{}, cache.staticInfo...)
+
+	// Collect each device concurrently.
+	var (
+		mu      sync.Mutex
+		allErrs []error
+	)
+	eg, subCtx := errgroup.WithContext(ctx)
+	// Go 1.22+ scopes the loop variable per-iteration, so the closure
+	// below captures the correct `gpu` without the `gpu := gpu` rebind
+	// that was required pre-1.22. (go.mod: `go 1.24.0`.)
+	for _, gpu := range cache.devices {
+		eg.Go(func() error {
+			if subCtx.Err() != nil {
+				return fmt.Errorf("gpu %d: scrape deadline exceeded before collection: %w", gpu, subCtx.Err())
+			}
+			m, err := collectMthreadsDeviceMetrics(subCtx, cfg, gpu)
+			mu.Lock()
+			metrics = append(metrics, m...)
+			if err != nil {
+				allErrs = append(allErrs, err)
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	// eg.Wait returns the first non-nil error from any worker (or nil
+	// if all succeeded).
+	if werr := eg.Wait(); werr != nil {
+		allErrs = append(allErrs, werr)
+	}
+
+	return metrics, errors.Join(allErrs...)
+}
+
+// getOrBuildCache returns the current cache, building it if missing.
+func (c *mthreadsGpuCollector) getOrBuildCache(ctx context.Context) (*mthreadsCache, error) {
+	if cache := c.cache.Load(); cache != nil {
+		return cache, nil
+	}
+	c.build.Lock()
+	defer c.build.Unlock()
+	// Double-check: another goroutine may have completed the build while we
+	// were waiting for the lock.
+	if cache := c.cache.Load(); cache != nil {
+		return cache, nil
+	}
+	cache, err := c.buildCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.cache.Store(cache)
+	return cache, nil
+}
+
+// invalidateCache drops the cached static info so the next Update rebuilds.
+// Called by the recoverable-error re-init path in Update() after mtml.Shutdown
+// + mtml.Init succeeds; see H-06.
+func (c *mthreadsGpuCollector) invalidateCache() {
+	c.build.Lock()
+	defer c.build.Unlock()
+	c.cache.Store(nil)
+}
+
+// buildCache enumerates devices and collects static info.
+func (c *mthreadsGpuCollector) buildCache(ctx context.Context) (*mthreadsCache, error) {
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("scrape timeout exceeded before building cache: %w", ctx.Err())
+	}
+
+	count, err := mtml.CountDevice()
+	if err != nil {
+		return nil, fmt.Errorf("count mthreads devices: %w", err)
+	}
+	// Reject an empty enumeration: devices=[]
+	if count == 0 {
+		return nil, fmt.Errorf("no mthreads gpu devices found during cache build")
+	}
+
+	cache := &mthreadsCache{devices: make([]uint32, 0, count)}
+	for i := uint32(0); i < count; i++ {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("scrape timeout exceeded while enumerating devices: %w", ctx.Err())
+		}
+		cache.devices = append(cache.devices, i)
+	}
+
+	// Library/driver version: device-independent, emit once.
+	cache.staticInfo = collectMthreadsVersions(ctx)
+
+	for _, gpu := range cache.devices {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("scrape timeout before device %d static info: %w", gpu, ctx.Err())
+		}
+		m, derr := collectMthreadsDeviceInfo(ctx, gpu)
+		if derr != nil {
+			return nil, fmt.Errorf("gpu %d static info collection failed; cache not stored, will retry on next build: %w", gpu, derr)
+		}
+		cache.staticInfo = append(cache.staticInfo, m...)
+	}
+
+	return cache, nil
+}
+
+// collectMthreadsVersions emits the library version info metric.
+func collectMthreadsVersions(ctx context.Context) []*metric.Data {
+	var out []*metric.Data
+
+	if ctx.Err() != nil {
+		log.Debug("mthreads: scrape timeout exceeded before collecting library version, skipping")
+		return nil
+	}
+
+	if v, err := mtml.LibraryVersion(); err == nil {
+		out = append(out, metric.NewGaugeData("library_info", 1,
+			"MTML library info.", map[string]string{"version": v}))
+	} else {
+		log.Warnf("mthreads: mtml get library version failed: %v", err)
+		return nil
+	}
+
+	return out
+}
+
+// collectMthreadsDeviceInfo emits the per-device static info metrics (cached).
+func collectMthreadsDeviceInfo(ctx context.Context, gpu uint32) ([]*metric.Data, error) {
+	var (
+		out  []*metric.Data
+		errs []error
+	)
+	record := func(name string, err error) {
+		recordStaticRead(gpu, name, err, &errs)
+	}
+
+	if ctx.Err() != nil {
+		log.Debugf("mthreads: scrape timeout exceeded before device %d static info, skipping", gpu)
+		return nil, ctx.Err()
+	}
+
+	dev, err := mtml.InitDeviceByIndex(gpu)
+	if err != nil {
+		record("init device", err)
+		return nil, errors.Join(errs...)
+	}
+	defer dev.Close()
+
+	gpuLabel := strconv.Itoa(int(gpu))
+
+	// device_info: name/brand/serial.
+	var (
+		name      string
+		brandStr  string
+		serial    string
+		gotName   bool
+		gotBrand  bool
+		gotSerial bool
+	)
+	if n, err := dev.Name(); err == nil {
+		name = n
+		gotName = true
+	} else {
+		record("name", err)
+	}
+	if b, err := dev.Brand(); err == nil {
+		brandStr = b.String()
+		gotBrand = true
+	} else {
+		record("brand", err)
+	}
+	if s, err := dev.SerialNumber(); err == nil {
+		serial = s
+		gotSerial = true
+	} else {
+		record("serial", err)
+	}
+	// Emit device_info only when all three identity fields are present.
+	if gotName && gotBrand && gotSerial {
+		out = append(out, metric.NewGaugeData("device_info", 1, "GPU info.", map[string]string{
+			"gpu":    gpuLabel,
+			"name":   name,
+			"brand":  brandStr,
+			"serial": serial,
+		}))
+	}
+
+	// pci_info
+	if sbdf, err := dev.PciSbdf(); err == nil {
+		out = append(out, metric.NewGaugeData("device_pci_info", 1, "GPU PCI info.", map[string]string{
+			"gpu":  gpuLabel,
+			"sbdf": sbdf,
+		}))
+	} else {
+		record("pci sbdf", err)
+	}
+
+	// device_spec: cores
+	if cores, err := dev.GpuCores(); err == nil {
+		out = append(out, metric.NewGaugeData("device_spec", 1, "GPU spec.", map[string]string{
+			"gpu":   gpuLabel,
+			"cores": strconv.Itoa(int(cores)),
+		}))
+	} else {
+		record("gpu cores", err)
+	}
+
+	// bios version
+	if bios, err := dev.BiosVersion(); err == nil {
+		out = append(out, metric.NewGaugeData("device_bios_version", 1, "GPU BIOS version.", map[string]string{
+			"gpu":  gpuLabel,
+			"bios": bios,
+		}))
+	} else {
+		record("bios version", err)
+	}
+
+	// musa compute capability
+	if major, minor, err := dev.MusaComputeCapability(); err == nil {
+		out = append(out, metric.NewGaugeData("device_musa_capability", 1, "GPU MUSA compute capability.", map[string]string{
+			"gpu":             gpuLabel,
+			"musa_capability": fmt.Sprintf("%d.%d", major, minor),
+		}))
+	} else {
+		record("musa compute capability", err)
+	}
+
+	// memory info (static: type/vendor/bus_width)
+	if mem, err := dev.InitMemory(); err == nil {
+		defer mem.Close()
+		labels := map[string]string{
+			"gpu":       gpuLabel,
+			"type":      "Unknown",
+			"vendor":    "Unknown",
+			"bus_width": "Unknown",
+		}
+		if t, err := mem.MemoryType(); err == nil {
+			labels["type"] = memoryTypeName(t)
+		} else {
+			record("memory type", err)
+		}
+		if v, err := mem.Vendor(); err == nil {
+			labels["vendor"] = v
+		} else {
+			record("memory vendor", err)
+		}
+		if w, err := mem.BusWidth(); err == nil {
+			labels["bus_width"] = strconv.Itoa(int(w))
+		} else {
+			record("memory bus width", err)
+		}
+		out = append(out, metric.NewGaugeData("memory_info", 1, "GPU memory info.", labels))
+	} else {
+		record("init memory", err)
+	}
+
+	return out, errors.Join(errs...)
+}
+
+// collectMthreadsDeviceMetrics collects dynamic metrics for a single device.
+// It opens the device once and dispatches to per-category collectors (health /
+// PCIe / MtLink). The Health collector opens the gpu/memory/vpu sub-handles
+// and returns them; this function owns the close order so the lifecycle does
+// not depend on defer LIFO. Sub-handles are closed before the device, in the
+// order vpu → mem → gpu, which is the order MTML expects.
+func collectMthreadsDeviceMetrics(ctx context.Context, cfg *Config, gpu uint32) ([]*metric.Data, error) {
+	dev, err := mtml.InitDeviceByIndex(gpu)
+	if err != nil {
+		if mtml.IsNotSupported(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("gpu %d init device: %w", gpu, err)
+	}
+	defer dev.Close()
+
+	var out []*metric.Data
+	var errs []error
+
+	record := func(name string, err error) {
+		if err == nil || mtml.IsNotSupported(err) {
+			return
+		}
+		errs = append(errs, fmt.Errorf("gpu %d %s: %w", gpu, name, err))
+	}
+
+	if cfg.Mthreads.EnableHealth {
+		if ctx.Err() != nil {
+			record("health ctx", ctx.Err())
+		} else {
+			m, g, mem, vpu, err := collectMthreadsHealth(ctx, dev, gpu)
+			// Sub-handles must be closed before the device. Register in
+			// reverse so LIFO fires them in vpu → mem → gpu order.
+			defer func() {
+				if vpu != nil {
+					_ = vpu.Close()
+				}
+				if mem != nil {
+					_ = mem.Close()
+				}
+				if g != nil {
+					_ = g.Close()
+				}
+			}()
+			out = append(out, m...)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("health: %w", err))
+			}
+		}
+	}
+
+	if cfg.Mthreads.EnablePCIe {
+		if ctx.Err() != nil {
+			record("pcie ctx", ctx.Err())
+		} else {
+			m, err := collectMthreadsPCIe(ctx, dev, gpu)
+			out = append(out, m...)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("pcie: %w", err))
+			}
+		}
+	}
+
+	if cfg.Mthreads.EnableMTLink {
+		if ctx.Err() != nil {
+			record("mtlink ctx", ctx.Err())
+		} else {
+			m, err := collectMthreadsMtLink(ctx, dev, gpu)
+			out = append(out, m...)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("mtlink: %w", err))
+			}
+		}
+	}
+
+	return out, errors.Join(errs...)
+}
+
+// collectMthreadsHealth collects health metrics (temperature/power/utilization/
+// clocks/fans/pstate/vpu) for one device. It inits the gpu/memory/vpu handles
+// once and reuses them across all reads.
+func collectMthreadsHealth(ctx context.Context, dev *mtml.Device, gpu uint32) ([]*metric.Data, *mtml.Gpu, *mtml.Memory, *mtml.Vpu, error) {
+	gpuLabel := strconv.Itoa(int(gpu))
+	var out []*metric.Data
+	var errs []error
+
+	record := func(name string, err error) {
+		if err == nil || mtml.IsNotSupported(err) {
+			return
+		}
+		errs = append(errs, fmt.Errorf("gpu %d %s: %w", gpu, name, err))
+	}
+
+	if ctx.Err() != nil {
+		log.Debugf("mthreads: scrape timeout exceeded before health group on device %d, skipping", gpu)
+		return nil, nil, nil, nil, ctx.Err()
+	}
+
+	var g *mtml.Gpu
+	var mem *mtml.Memory
+	var vpu *mtml.Vpu
+	if h, err := dev.InitGpu(); err != nil {
+		record("init gpu", err)
+	} else {
+		g = h
+	}
+	if h, err := dev.InitMemory(); err != nil {
+		record("init memory", err)
+	} else {
+		mem = h
+	}
+	if h, err := dev.InitVpu(); err != nil {
+		record("init vpu", err)
+	} else {
+		vpu = h
+	}
+
+	// Temperature
+	if g != nil {
+		t, err := g.Temperature()
+		if err == nil {
+			out = append(out, metric.NewGaugeData("gpu_temperature_celsius", float64(t),
+				"GPU temperature in degrees Celsius.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu temperature", err)
+		}
+	}
+	if mem != nil {
+		t, err := mem.Temperature()
+		if err == nil {
+			out = append(out, metric.NewGaugeData("memory_temperature_celsius", float64(t),
+				"GPU memory temperature in degrees Celsius.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("memory temperature", err)
+		}
+	}
+
+	// Power & voltage
+	{
+		pw, err := dev.PowerUsage()
+		if err == nil {
+			out = append(out, metric.NewGaugeData("device_power_watts", float64(pw)/1000,
+				"GPU device power in watts.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("power usage", err)
+		}
+	}
+	if g != nil {
+		if v, err := g.Voltage(); err == nil {
+			out = append(out, metric.NewGaugeData("gpu_voltage_volts", float64(v)/1000,
+				"GPU voltage in volts.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu voltage", err)
+		}
+		if l, err := g.EnforcedPowerLimit(); err == nil {
+			out = append(out, metric.NewGaugeData("gpu_power_limit_watts", float64(l)/1000,
+				"GPU enforced power limit in watts.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu power limit", err)
+		}
+		if l, err := g.PowerManagementDefaultLimit(); err == nil {
+			out = append(out, metric.NewGaugeData("gpu_power_default_limit_watts", float64(l)/1000,
+				"GPU default power management limit in watts.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu default power limit", err)
+		}
+	}
+
+	// Utilization
+	if g != nil {
+		if u, err := g.Utilization(); err == nil {
+			out = append(out, metric.NewGaugeData("gpu_utilization_percent", float64(u),
+				"GPU utilization (0-100).", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu utilization", err)
+		}
+	}
+	if mem != nil {
+		if u, err := mem.Utilization(); err == nil {
+			out = append(out, metric.NewGaugeData("memory_utilization_percent", float64(u),
+				"GPU memory utilization (0-100).", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("memory utilization", err)
+		}
+		if total, err := mem.Total(); err == nil {
+			out = append(out, metric.NewGaugeData("memory_total_bytes", float64(total),
+				"Total GPU memory in bytes.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("memory total", err)
+		}
+		if used, err := mem.Used(); err == nil {
+			out = append(out, metric.NewGaugeData("memory_used_bytes", float64(used),
+				"Used GPU memory in bytes.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("memory used", err)
+		}
+	}
+
+	// Clocks
+	if g != nil {
+		if c, err := g.Clock(); err == nil {
+			out = append(out, metric.NewGaugeData("gpu_clock_mhz", float64(c),
+				"GPU clock in MHz.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu clock", err)
+		}
+		if c, err := g.MaxClock(); err == nil {
+			out = append(out, metric.NewGaugeData("gpu_max_clock_mhz", float64(c),
+				"GPU max clock in MHz.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("gpu max clock", err)
+		}
+	}
+	if mem != nil {
+		if c, err := mem.Clock(); err == nil {
+			out = append(out, metric.NewGaugeData("memory_clock_mhz", float64(c),
+				"GPU memory clock in MHz.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("memory clock", err)
+		}
+		if c, err := mem.MaxClock(); err == nil {
+			out = append(out, metric.NewGaugeData("memory_max_clock_mhz", float64(c),
+				"GPU memory max clock in MHz.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("memory max clock", err)
+		}
+	}
+
+	// Fans
+	if fanCount, err := dev.FanCount(); err == nil && fanCount > 0 {
+		for i := uint32(0); i < fanCount; i++ {
+			if rpm, err := dev.FanRpm(i); err == nil {
+				out = append(out, metric.NewGaugeData("fan_rpm", float64(rpm),
+					"GPU fan speed in RPM.", map[string]string{"gpu": gpuLabel, "fan": strconv.Itoa(int(i))}))
+			} else {
+				record(fmt.Sprintf("fan %d rpm", i), err)
+			}
+			if sp, err := dev.FanSpeed(i); err == nil {
+				out = append(out, metric.NewGaugeData("fan_speed_percent", float64(sp),
+					"GPU fan speed percent.", map[string]string{"gpu": gpuLabel, "fan": strconv.Itoa(int(i))}))
+			} else {
+				record(fmt.Sprintf("fan %d speed", i), err)
+			}
+		}
+	} else if err != nil {
+		record("fan count", err)
+	}
+
+	// pstate
+	if ps, err := dev.PerformanceState(); err == nil {
+		out = append(out, metric.NewGaugeData("gpu_pstate", float64(ps),
+			"GPU performance state (0=P0).", map[string]string{"gpu": gpuLabel}))
+	} else {
+		record("gpu pstate", err)
+	}
+
+	// VPU
+	if vpu != nil {
+		if util, err := vpu.Utilization(); err == nil {
+			out = append(out,
+				metric.NewGaugeData("vpu_utilization_percent", float64(util.Util),
+					"GPU VPU utilization (0-100).", map[string]string{"gpu": gpuLabel}),
+				metric.NewGaugeData("vpu_encoder_utilization_percent", float64(util.EncUtil),
+					"GPU VPU encoder utilization (0-100).", map[string]string{"gpu": gpuLabel}),
+				metric.NewGaugeData("vpu_decoder_utilization_percent", float64(util.DecUtil),
+					"GPU VPU decoder utilization (0-100).", map[string]string{"gpu": gpuLabel}),
+			)
+		} else {
+			record("vpu utilization", err)
+		}
+		if c, err := vpu.Clock(); err == nil {
+			out = append(out, metric.NewGaugeData("vpu_clock_mhz", float64(c),
+				"GPU VPU clock in MHz.", map[string]string{"gpu": gpuLabel}))
+		} else {
+			record("vpu clock", err)
+		}
+	}
+
+	return out, g, mem, vpu, errors.Join(errs...)
+}
+
+// collectMthreadsPCIe collects dynamic PCIe link metrics (cur / max
+// speed/width + replay counter) for one device.
+func collectMthreadsPCIe(ctx context.Context, dev *mtml.Device, gpu uint32) ([]*metric.Data, error) {
+	gpuLabel := strconv.Itoa(int(gpu))
+	var out []*metric.Data
+	var errs []error
+
+	record := func(name string, err error) {
+		if err == nil || mtml.IsNotSupported(err) {
+			return
+		}
+		errs = append(errs, fmt.Errorf("gpu %d %s: %w", gpu, name, err))
+	}
+
+	if ctx.Err() != nil {
+		log.Debugf("mthreads: scrape timeout exceeded before PCIe group on device %d, skipping", gpu)
+		return nil, ctx.Err()
+	}
+
+	if info, err := dev.PciInfo(); err == nil {
+		out = append(out,
+			metric.NewGaugeData("pcie_link_speed_gt_per_sec", info.CurSpeed,
+				"GPU PCIe current link speed in GT/s.", map[string]string{"gpu": gpuLabel}),
+			metric.NewGaugeData("pcie_link_width_lanes", float64(info.CurWidth),
+				"GPU PCIe current link width in lanes.", map[string]string{"gpu": gpuLabel}),
+			metric.NewGaugeData("pcie_link_max_speed_gt_per_sec", info.MaxSpeed,
+				"GPU PCIe max link speed in GT/s (hardware capability).", map[string]string{"gpu": gpuLabel}),
+			metric.NewGaugeData("pcie_link_max_width_lanes", float64(info.MaxWidth),
+				"GPU PCIe max link width in lanes (hardware capability).", map[string]string{"gpu": gpuLabel}),
+		)
+	} else {
+		record("pci info", err)
+	}
+	if rc, err := dev.PcieReplayCounter(); err == nil {
+		out = append(out, metric.NewCounterData("pcie_replay_total", float64(rc),
+			"GPU PCIe replay counter.", map[string]string{"gpu": gpuLabel}))
+	} else {
+		record("pcie replay counter", err)
+	}
+
+	return out, errors.Join(errs...)
+}
+
+// collectMthreadsMtLink collects MtLink interconnect metrics (per-link state
+// and bandwidth) for one device.
+func collectMthreadsMtLink(ctx context.Context, dev *mtml.Device, gpu uint32) ([]*metric.Data, error) {
+	gpuLabel := strconv.Itoa(int(gpu))
+	var out []*metric.Data
+	var errs []error
+
+	record := func(name string, err error) {
+		if err == nil || mtml.IsNotSupported(err) {
+			return
+		}
+		errs = append(errs, fmt.Errorf("gpu %d %s: %w", gpu, name, err))
+	}
+
+	if ctx.Err() != nil {
+		log.Debugf("mthreads: scrape timeout exceeded before MtLink group on device %d, skipping", gpu)
+		return nil, ctx.Err()
+	}
+
+	spec, err := dev.MtLinkSpec()
+	if err != nil {
+		record("mtlink spec", err)
+		return out, errors.Join(errs...)
+	}
+	// Bandwidth/count are per-device static specs (not per-link live throughput),
+	// so they don't get a `link` label.
+	out = append(out,
+		metric.NewGaugeData("mtlink_link_bandwidth_gb_s", float64(spec.BandWidth),
+			"GPU MtLink per-link max bandwidth in GB/s (device static spec, not live throughput).",
+			map[string]string{"gpu": gpuLabel}),
+		metric.NewGaugeData("mtlink_link_count", float64(spec.LinkNum),
+			"GPU MtLink max number of supported links (device static spec).",
+			map[string]string{"gpu": gpuLabel}),
+	)
+	for link := uint32(0); link < spec.LinkNum; link++ {
+		linkLabel := strconv.Itoa(int(link))
+		if st, err := dev.MtLinkState(link); err == nil {
+			out = append(out, metric.NewGaugeData("mtlink_state", float64(st),
+				"GPU MtLink state (0=DOWN,1=UP,2=DOWNGRADE).",
+				map[string]string{"gpu": gpuLabel, "link": linkLabel}))
+		} else {
+			record(fmt.Sprintf("mtlink %d state", link), err)
+		}
+	}
+
+	return out, errors.Join(errs...)
+}
+
+func memoryTypeName(t uint32) string {
+	switch t {
+	case mtml.MemoryTypeLPDDR4:
+		return "LPDDR4"
+	case mtml.MemoryTypeGDDR6:
+		return "GDDR6"
+	}
+	return "unknown"
+}
+
+// recordStaticRead appends a per-field static-read failure to errs, but
+// only if the error is operational. nil and NotSupported are both
+// suppressed so that a device which simply lacks a given static field
+// (or driver version) does not block cache publication.
+func recordStaticRead(gpu uint32, name string, err error, errs *[]error) {
+	if err == nil || mtml.IsNotSupported(err) {
+		return
+	}
+	*errs = append(*errs, fmt.Errorf("gpu %d %s: %w", gpu, name, err))
+}

--- a/core/metrics/mthreads_gpu_test.go
+++ b/core/metrics/mthreads_gpu_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 The HuaTuo Authors
+// Copyright 2026 The Mthreads Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"huatuo-bamai/core/metrics/mthreads/mtml"
+)
+
+// --- pure-function tests ----------------------------------------------------
+
+func TestRecordStaticRead_FiltersNilAndNotSupported(t *testing.T) {
+	// nil errors and NotSupported errors must NOT be appended to errs:
+	// the cache-publication path relies on this so a device that simply
+	// lacks a static field (or driver version) does not block cache.
+	var errs []error
+	recordStaticRead(0, "name", nil, &errs)
+	recordStaticRead(0, "pci", mtml.MakeError("mtmlDeviceGetPciInfo", mtml.ErrorNotSupported), &errs)
+	if len(errs) != 0 {
+		t.Fatalf("recordStaticRead appended %d errors for nil/NotSupported, want 0", len(errs))
+	}
+	if !mtml.IsNotSupported(mtml.MakeError("mtmlDeviceGetPciInfo", mtml.ErrorNotSupported)) {
+		t.Fatal("MakeError(ErrorNotSupported) does not pass IsNotSupported filter")
+	}
+
+	recordStaticRead(2, "bios", errors.New("transient"), &errs)
+	if len(errs) != 1 {
+		t.Fatalf("recordStaticRead did not append transient error, len=%d", len(errs))
+	}
+	if !strings.Contains(errs[0].Error(), "gpu 2 bios") {
+		t.Fatalf("error message lacks gpu/name prefix: %v", errs[0])
+	}
+}
+
+func TestRecordStaticRead_DoesNotPanicOnEmptyName(t *testing.T) {
+	// Defensive: an empty name should still produce a reasonable error
+	// string, not panic. This guards against a future call site that
+	// passes "" by mistake.
+	var errs []error
+	recordStaticRead(0, "", errors.New("oops"), &errs)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+}
+
+func TestMemoryTypeName(t *testing.T) {
+	cases := map[uint32]string{
+		mtml.MemoryTypeLPDDR4: "LPDDR4",
+		mtml.MemoryTypeGDDR6:  "GDDR6",
+		999:                   "unknown",
+	}
+	for in, want := range cases {
+		if got := memoryTypeName(in); got != want {
+			t.Errorf("memoryTypeName(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// --- collector state-machine tests (no mtml calls) -------------------------
+
+// TestInvalidateCache_ClearsStoredCache verifies that after invalidateCache,
+// the next getOrBuildCache will rebuild from scratch.
+func TestInvalidateCache_ClearsStoredCache(t *testing.T) {
+	c := &mthreadsGpuCollector{}
+	c.cache.Store(&mthreadsCache{devices: []uint32{0, 1, 2}})
+
+	c.invalidateCache()
+	if c.cache.Load() != nil {
+		t.Fatal("invalidateCache did not clear the stored cache")
+	}
+}
+
+// TestGetOrBuildCache_DoubleCheckLock guards the fast-path under the
+// framework's "one Update at a time" contract. We pre-load the cache so
+// the fast path returns without ever calling buildCache; the test
+// fails if the lock is taken in a way that races.
+func TestGetOrBuildCache_DoubleCheckLock(t *testing.T) {
+	c := &mthreadsGpuCollector{}
+	want := &mthreadsCache{devices: []uint32{0, 1, 2}}
+	c.cache.Store(want)
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			got, err := c.getOrBuildCache(context.Background())
+			if err != nil {
+				t.Errorf("getOrBuildCache returned err: %v", err)
+				return
+			}
+			if got != want {
+				t.Errorf("got %p, want %p", got, want)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// --- config transition tests (cfg-only, no mtml calls) ---------------------
+
+// TestMthreadsConfigTransitions_AllDisabled_AfterSet verifies the
+// zero-value Config disables every Mthreads sub-flag.
+func TestMthreadsConfigTransitions_AllDisabled_AfterSet(t *testing.T) {
+	cfg := &Config{}
+	Set(cfg)
+	got := configSnapshot()
+	if got.Mthreads.EnableHealth {
+		t.Fatal("EnableHealth is true after Set with zero-value config")
+	}
+	if got.Mthreads.EnablePCIe {
+		t.Fatal("EnablePCIe is true after Set with zero-value config")
+	}
+	if got.Mthreads.EnableMTLink {
+		t.Fatal("EnableMTLink is true after Set with zero-value config")
+	}
+}
+
+// TestMthreadsConfigTransitions_FlagFlips verifies that flipping each
+// sub-flag survives the Set/snapshot round-trip atomically. The
+// collector gates PCIe/MTLink/Health on these flags at scrape time, so a
+// stale snapshot would silently drop metric groups.
+func TestMthreadsConfigTransitions_FlagFlips(t *testing.T) {
+	for _, flip := range []bool{true, false, true, false} {
+		c := &Config{}
+		c.Mthreads.EnableHealth = flip
+		c.Mthreads.EnablePCIe = flip
+		c.Mthreads.EnableMTLink = flip
+		Set(c)
+		got := configSnapshot()
+		if got.Mthreads.EnableHealth != flip ||
+			got.Mthreads.EnablePCIe != flip ||
+			got.Mthreads.EnableMTLink != flip {
+			t.Fatalf("Set(%v) round-tripped as %+v", flip, got.Mthreads)
+		}
+	}
+}
+
+// --- joined-error classification --------------------------------------------
+
+// TestIsRecoverable_JoinsAcrossLeaves mirrors the errors.Join tree that
+// mthreadsGpuCollector.collect() builds (per-device workers each append
+// to a shared errs slice). A single recoverable leaf must trigger
+// recovery in Update().
+func TestIsRecoverable_JoinsAcrossLeaves(t *testing.T) {
+	joined := errors.Join(
+		fmt.Errorf("gpu 0: name: %w", mtml.MakeError("mtmlDeviceGetName", mtml.ErrorInvalidArgument)),
+		fmt.Errorf("gpu 0: pci sbdf: %w", mtml.MakeError("mtmlDeviceGetPciInfo", mtml.ErrorDriverFailure)),
+		fmt.Errorf("gpu 0: bios: %w", mtml.MakeError("mtmlDeviceGetMtBiosVersion", mtml.ErrorNotFound)),
+	)
+	if !mtml.IsRecoverable(joined) {
+		t.Fatal("IsRecoverable(joined with one recoverable leaf) = false, want true")
+	}
+}
+
+// --- poison state-machine tests (no mtml calls) ----------------------------
+//
+// setPoisoned is the gate that turns a one-time Shutdown failure into a
+// permanent "GPU metrics disabled" short-circuit. The tests below pin the
+// invariants that Update() relies on:
+//   1. The first poison wins; subsequent calls are no-ops so the original
+//      root cause is preserved.
+//   2. poisonedErr() returns a Join tree that keeps the root cause reachable
+//      via errors.Is — upstream alerts can still classify the underlying
+//      MTML error code (e.g. ErrorDriverFailure) even though the
+//      Update() caller only sees the wrapped error.
+//   3. The two atomic stores happen in the documented order: poisonErr
+//      first, then poisoned=true. A reordering would let Update() see
+//      poisoned=true with a nil poisonErr, dropping the root cause.
+
+// TestSetPoisoned_IsIdempotent verifies that the first setPoisoned wins
+// and subsequent calls are dropped. Repeated calls (which the framework
+// currently cannot produce because Update() is serialized, but a future
+// health-check hook might) must NOT overwrite the original root cause.
+func TestSetPoisoned_IsIdempotent(t *testing.T) {
+	c := &mthreadsGpuCollector{}
+
+	first := mtml.MakeError("mtmlLibraryShutDown", mtml.ErrorUnknown)
+	c.setPoisoned(first)
+
+	if !c.poisoned.Load() {
+		t.Fatal("poisoned.Load() = false after first setPoisoned")
+	}
+	if ep := c.poisonErr.Load(); ep == nil || !errors.Is(*ep, first) {
+		t.Fatalf("poisonErr = %v, want %v", ep, first)
+	}
+
+	// Second call with a different error must be ignored: the original
+	// root cause is preserved, and the function does not panic.
+	second := mtml.MakeError("mtmlLibraryInit", mtml.ErrorDriverFailure)
+	c.setPoisoned(second)
+
+	if !c.poisoned.Load() {
+		t.Fatal("poisoned.Load() = false after second setPoisoned")
+	}
+	if ep := c.poisonErr.Load(); ep == nil || !errors.Is(*ep, first) {
+		t.Fatalf("poisonErr overwritten by second setPoisoned: got %v, want %v", ep, first)
+	}
+}
+
+// TestPoisonedErr_ChainsRootCause verifies that the error returned by the
+// short-circuit path keeps the original MTML error reachable via
+// errors.Is + errors.As. Upstream alerts classify on the inner *Error;
+// losing the chain would silently mask the failure mode.
+func TestPoisonedErr_ChainsRootCause(t *testing.T) {
+	c := &mthreadsGpuCollector{}
+	root := mtml.MakeError("mtmlLibraryShutDown", mtml.ErrorDriverFailure)
+	c.setPoisoned(root)
+
+	got := c.poisonedErr()
+	if got == nil {
+		t.Fatal("poisonedErr() = nil after setPoisoned")
+	}
+
+	// errors.Is must still find the root cause inside the Join tree.
+	if !errors.Is(got, root) {
+		t.Fatalf("errors.Is(poisonedErr, root) = false; err = %v", got)
+	}
+
+	// And errors.As must extract the inner *Error so callers can read
+	// the MTML return code.
+	var inner *mtml.Error
+	if !errors.As(got, &inner) {
+		t.Fatalf("errors.As(poisonedErr, *mtml.Error) = false; err = %v", got)
+	}
+	if !errors.Is(inner, root) {
+		t.Fatalf("inner *mtml.Error = %v, want %v", inner, root)
+	}
+
+	// The wrapper must carry the human-readable short-circuit marker so
+	// log readers can tell the failure apart from a transient collect
+	// error.
+	if !strings.Contains(got.Error(), "library poisoned") {
+		t.Fatalf("poisonedErr text lacks marker: %q", got.Error())
+	}
+}
+
+// TestPoisonedErr_NilRootReturnsMarkerOnly covers the "no root cause
+// stored" branch: poisonedErr() must still return a non-nil error with
+// the marker, not panic. This is reachable if a future caller invokes
+// setPoisoned(nil) directly.
+func TestPoisonedErr_NilRootReturnsMarkerOnly(t *testing.T) {
+	c := &mthreadsGpuCollector{}
+	c.poisoned.Store(true) // skip setPoisoned to test the unguarded branch
+	// poisonErr is left nil deliberately.
+
+	got := c.poisonedErr()
+	if got == nil {
+		t.Fatal("poisonedErr() = nil with poisoned=true and poisonErr=nil")
+	}
+	if !strings.Contains(got.Error(), "library poisoned") {
+		t.Fatalf("poisonedErr text lacks marker: %q", got.Error())
+	}
+}

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -23,12 +23,12 @@ The configuration file uses **TOML** format and includes multiple sections such 
 # - BlackList
 # Global blacklist for tracing and metrics.
 #
-BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
+BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit", "mthreads_gpu"]
 ```
 
 - **BlackList**: Global blacklist for tracing and metrics.
 
-  Modules or hardware to exclude from tracing and metric collection. The default is `["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]`, which disables tracing and metrics for the network device hardware layer, Metax GPU, Ascend NPU, procfs-based disk I/O statistics, and TCP retransmission tracing. Remove `diskio` to enable disk I/O metrics or `tcp_retransmit` to enable TCP retransmission tracing and its drop-correlation cache. Supports arrays; extend as needed.
+  Modules or hardware to exclude from tracing and metric collection. The default is `["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit", "mthreads_gpu"]`, which disables tracing and metrics for the network device hardware layer, qdisc statistics, Metax GPU, Ascend NPU, procfs-based disk I/O statistics, TCP retransmission tracing, and Moore Threads GPU. Remove `diskio` to enable disk I/O metrics, `tcp_retransmit` to enable TCP retransmission tracing and its drop-correlation cache, or `mthreads_gpu` to enable Moore Threads GPU metric collection on hosts with MT GPUs. Supports arrays; extend as needed.
 
 ### 3. Logging
 
@@ -1011,6 +1011,54 @@ This section defines collection rules for various system and network metrics. Al
 - **Included / Excluded**: Same as above.
 
 - **MountPointsIncluded**: Regex for mount points to collect. Default includes /, /home, /boot.
+
+#### 9.7 Moore Threads GPU Metrics
+
+```bash
+# MetricCollector.Mthreads
+#
+# Moore Threads GPU metric collection via the MTML (Moore Threads Management
+# Library) shared library. The library is discovered automatically at startup
+# using SONAME search (libmtml.so.2, then libmtml.so) through the system
+# dynamic linker; no hardcoded path is required.
+#
+# Remove "mthreads_gpu" from BlackList to enable this collector.
+#
+# - EnableHealth
+# Enable health metrics: temperature, power, utilization, clocks, fans, pstate, VPU.
+# Default: true
+#
+# - EnablePCIe
+# Enable PCIe link metrics: current speed/width and replay counter.
+# Default: false
+#
+# - EnableMTLink
+# Enable MtLink interconnect metrics: per-link state and bandwidth.
+# Default: false
+#
+[MetricCollector.Mthreads]
+    # EnableHealth = true
+    # EnablePCIe = false
+    # EnableMTLink = false
+```
+
+- **EnableHealth**: Controls collection of health-related metrics.
+
+  Default: true. When enabled, collects: GPU/memory temperature (`gpu_temperature_celsius`, `memory_temperature_celsius`), power usage and limits (`device_power_watts`, `gpu_power_limit_watts`, `gpu_power_default_limit_watts`), GPU/memory utilization (`gpu_utilization_percent`, `memory_utilization_percent`), clock frequencies (`gpu_clock_mhz`, `gpu_max_clock_mhz`, `memory_clock_mhz`, `memory_max_clock_mhz`), voltage (`gpu_voltage_volts`), memory capacity (`memory_total_bytes`, `memory_used_bytes`), fan speed (`fan_rpm`, `fan_speed_percent`), performance state (`gpu_pstate`), and VPU metrics (`vpu_utilization_percent`, `vpu_encoder_utilization_percent`, `vpu_decoder_utilization_percent`, `vpu_clock_mhz`).
+
+- **EnablePCIe**: Controls collection of PCIe link metrics.
+
+  Default: false. When enabled, collects: current PCIe link speed and width (`pcie_link_speed_gt_per_sec`, `pcie_link_width_lanes`), max capability (`pcie_link_max_speed_gt_per_sec`, `pcie_link_max_width_lanes`), and replay counter (`pcie_replay_total`).
+
+- **EnableMTLink**: Controls collection of MtLink interconnect metrics.
+
+  Default: false. When enabled, collects: device-level static specs (per-link bandwidth `mtlink_link_bandwidth_gb_s` and link count `mtlink_link_count`) and per-link state (`mtlink_state`).
+
+**Library discovery**: At startup, the collector searches for `libmtml.so.2` then `libmtml.so` via the system dynamic linker (respecting `LD_LIBRARY_PATH` and `/etc/ld.so.cache`). If no library is found, the collector logs a warning and is disabled for the lifetime of the process. Library discovery is performed only at startup: changing `LD_LIBRARY_PATH` or installing a new MTML version also requires a restart.
+
+**Hot-reload semantics**: `EnableHealth`, `EnablePCIe`, and `EnableMTLink` are read from the latest config snapshot on every scrape, so toggling them takes effect on the next Prometheus scrape without restarting `huatuo-bamai`. A `false → true → false` transition emits and suppresses the corresponding metric groups on the next scrape after each change.
+
+Note: enabling the collector itself (i.e. removing `mthreads_gpu` from `BlackList` after the process has already started with the collector disabled because `libmtml.so` was missing at startup) requires a restart. The collector factory runs only during initialization, so a successful late library load will not register a new collector.
 
 ### 10. Pod
 

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -23,12 +23,12 @@ weight: 4
 # - BlackList
 # Global blacklist for tracing and metrics.
 #
-BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
+BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit", "mthreads_gpu"]
 ```
 
 - **BlackList**：全局追踪与指标黑名单。
 
-  用于排除特定模块的追踪和指标采集，避免无关噪声或高开销探针。默认值为 `["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]`，即全局禁用网络设备硬件层（netdev_hw）、Metax GPU、Ascend NPU、基于 procfs 的磁盘 I/O 指标和 TCP 重传追踪。需要启用磁盘 I/O 指标时从黑名单中移除 `diskio`；需要启用 TCP 重传追踪及其丢包关联缓存时移除 `tcp_retransmit`。
+  用于排除特定模块的追踪和指标采集，避免无关噪声或高开销探针。默认值为 `["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit", "mthreads_gpu"]`，即全局禁用网络设备硬件层（netdev_hw）、队列调度统计（netdev_qdisc）、Metax GPU、Ascend NPU、基于 procfs 的磁盘 I/O 指标、TCP 重传追踪和摩尔线程 GPU 监控。需要启用磁盘 I/O 指标时从黑名单中移除 `diskio`；需要启用 TCP 重传追踪及其丢包关联缓存时移除 `tcp_retransmit`；需要启用摩尔线程 GPU 指标采集时移除 `mthreads_gpu`（要求已安装 MTML 库）。
 
   **说明**：添加黑名单项可有效降低资源消耗，尤其在特定硬件环境中；支持数组格式，可根据实际业务扩展。
 
@@ -1022,6 +1022,53 @@ BlackList = ["netdev_hw", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
 - **MountPointsIncluded**：采集挂载点统计的路径正则。默认示例含 /、/home、/boot。
 
   **说明**：用于监控关键文件系统使用情况。
+
+#### 9.7 摩尔线程 GPU 指标
+
+```bash
+# MetricCollector.Mthreads
+#
+# 通过 MTML（摩尔线程管理库）共享库采集摩尔线程 GPU 指标。
+# 库文件在启动时通过系统动态链接器按 SONAME 顺序自动发现
+# （libmtml.so.2，然后 libmtml.so），无需硬编码路径。
+#
+# 从 BlackList 中移除 "mthreads_gpu" 以启用此采集器。
+#
+# - EnableHealth
+# 启用健康指标：温度、功耗、利用率、时钟、风扇、pstate、VPU。
+# 默认值：true
+#
+# - EnablePCIe
+# 启用 PCIe 链路指标：当前速率/宽度和重放计数器。
+# 默认值：false
+#
+# - EnableMTLink
+# 启用 MtLink 互连指标：每链路状态和带宽。
+# 默认值：false
+#
+[MetricCollector.Mthreads]
+    # EnableHealth = true
+    # EnablePCIe = false
+    # EnableMTLink = false
+```
+
+- **EnableHealth**：控制健康相关指标的采集。
+
+  默认值：true。启用后采集：GPU/内存温度（`gpu_temperature_celsius`、`memory_temperature_celsius`）、功耗及限制（`device_power_watts`、`gpu_power_limit_watts`、`gpu_power_default_limit_watts`）、GPU/内存利用率（`gpu_utilization_percent`、`memory_utilization_percent`）、时钟频率（`gpu_clock_mhz`、`gpu_max_clock_mhz`、`memory_clock_mhz`、`memory_max_clock_mhz`）、电压（`gpu_voltage_volts`）、内存容量（`memory_total_bytes`、`memory_used_bytes`）、风扇转速（`fan_rpm`、`fan_speed_percent`）、性能状态（`gpu_pstate`）以及 VPU 指标（`vpu_utilization_percent`、`vpu_encoder_utilization_percent`、`vpu_decoder_utilization_percent`、`vpu_clock_mhz`）。
+
+- **EnablePCIe**：控制 PCIe 链路指标的采集。
+
+  默认值：false。启用后采集：当前 PCIe 链路速率和宽度（`pcie_link_speed_gt_per_sec`、`pcie_link_width_lanes`）、最大能力值（`pcie_link_max_speed_gt_per_sec`、`pcie_link_max_width_lanes`）以及重放计数器（`pcie_replay_total`）。
+
+- **EnableMTLink**：控制 MtLink 互连指标的采集。
+
+  默认值：false。启用后采集：设备级静态规格（每链路带宽 `mtlink_link_bandwidth_gb_s` 和链路数 `mtlink_link_count`）以及每链路状态（`mtlink_state`）。
+
+**库发现机制**：启动时，采集器通过系统动态链接器（遵循 `LD_LIBRARY_PATH` 和 `/etc/ld.so.cache`）依次搜索 `libmtml.so.2` 和 `libmtml.so`。如果未找到库文件，采集器记录警告并在进程生命周期内保持禁用状态。库发现仅在启动时执行；更改 `LD_LIBRARY_PATH` 或安装新的 MTML 版本需要重启。
+
+**热更新语义**：`EnableHealth`、`EnablePCIe`、`EnableMTLink` 在每次 scrape 时从最新配置快照中读取，因此切换这些开关后下一个 Prometheus scrape 即可生效，无需重启 `huatuo-bamai`。`false → true → false` 的转换会在每次变更后的下一个 scrape 上按预期发布或停止发布对应的指标组。
+
+注意：在进程已经启动且因 `libmtml.so` 缺失导致采集器被禁用的情况下，要启用该采集器（即把 `mthreads_gpu` 从 `BlackList` 中移除）需要重启进程。采集器工厂只在初始化时运行，运行时即使库被加载成功也不会注册新的采集器。
 
 ### 10. Pod 配置
 

--- a/docs/key-feature/kernel-wide-insight_en.md
+++ b/docs/key-feature/kernel-wide-insight_en.md
@@ -1254,3 +1254,48 @@ huatuo_bamai_hungtask_total{host="hostname",region="dev"} 0
 |metax_gpu_dpm_performance_level|GPU DPM performance level.|-|gpu, die, ip|sml.GetDieDPMPerformanceLevel|
 |metax_gpu_ecc_memory_errors_total|GPU ECC memory errors count.|count|gpu, die, memory_type, error_type|sml.GetDieECCMemoryInfo|
 |metax_gpu_ecc_memory_retired_pages_total|GPU ECC memory retired pages count.|count|gpu, die|sml.GetDieECCMemoryInfo|
+
+- Moore Threads (MThreads)
+
+MThreads GPU monitoring via the MTML (Moore Threads Management Library). The library is discovered automatically at startup using SONAME search (`libmtml.so.2` then `libmtml.so`) through the system dynamic linker. Static device info is cached and only rebuilt on re-init; dynamic metrics are collected on every scrape.
+
+Configuration: remove `mthreads_gpu` from `BlackList` to enable. Metric groups are controlled by `[MetricCollector.Mthreads]` toggles (`EnableHealth`, `EnablePCIe`, `EnableMTLink`).
+
+|Metric|Description|Unit|Labels|Source|
+|----|---|---|---|---|
+|huatuo_bamai_mthreads_gpu_library_info|MTML library info.|-|version|mtml.LibraryVersion|
+|huatuo_bamai_mthreads_gpu_device_info|GPU info.|-|gpu, name, brand, serial|mtml.Device.Name/Brand/SerialNumber|
+|huatuo_bamai_mthreads_gpu_device_pci_info|GPU PCI info.|-|gpu, sbdf|mtml.Device.PciSbdf|
+|huatuo_bamai_mthreads_gpu_device_spec|GPU spec.|-|gpu, cores|mtml.Device.GpuCores|
+|huatuo_bamai_mthreads_gpu_device_bios_version|GPU BIOS version.|-|gpu, bios|mtml.Device.BiosVersion|
+|huatuo_bamai_mthreads_gpu_device_musa_capability|GPU MUSA compute capability.|-|gpu, musa_capability|mtml.Device.MusaComputeCapability|
+|huatuo_bamai_mthreads_gpu_memory_info|GPU memory info.|-|gpu, type, vendor, bus_width|mtml.Device.InitMemory|
+|huatuo_bamai_mthreads_gpu_pcie_link_max_speed_gt_per_sec|GPU PCIe max link speed in GT/s (hardware capability).|GT/s|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_pcie_link_max_width_lanes|GPU PCIe max link width in lanes (hardware capability).|lanes|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_device_power_watts|GPU device power in watts.|W|gpu|mtml.Device.PowerUsage|
+|huatuo_bamai_mthreads_gpu_gpu_temperature_celsius|GPU temperature.|°C|gpu|mtml.Gpu.Temperature|
+|huatuo_bamai_mthreads_gpu_memory_temperature_celsius|GPU memory temperature.|°C|gpu|mtml.Memory.Temperature|
+|huatuo_bamai_mthreads_gpu_gpu_utilization_percent|GPU utilization (0-100).|%|gpu|mtml.Gpu.Utilization|
+|huatuo_bamai_mthreads_gpu_memory_utilization_percent|GPU memory utilization (0-100).|%|gpu|mtml.Memory.Utilization|
+|huatuo_bamai_mthreads_gpu_memory_total_bytes|Total GPU memory in bytes.|bytes|gpu|mtml.Memory.Total|
+|huatuo_bamai_mthreads_gpu_memory_used_bytes|Used GPU memory in bytes.|bytes|gpu|mtml.Memory.Used|
+|huatuo_bamai_mthreads_gpu_gpu_clock_mhz|GPU clock in MHz.|MHz|gpu|mtml.Gpu.Clock|
+|huatuo_bamai_mthreads_gpu_gpu_max_clock_mhz|GPU max clock in MHz.|MHz|gpu|mtml.Gpu.MaxClock|
+|huatuo_bamai_mthreads_gpu_memory_clock_mhz|GPU memory clock in MHz.|MHz|gpu|mtml.Memory.Clock|
+|huatuo_bamai_mthreads_gpu_memory_max_clock_mhz|GPU memory max clock in MHz.|MHz|gpu|mtml.Memory.MaxClock|
+|huatuo_bamai_mthreads_gpu_gpu_voltage_volts|GPU voltage in volts.|V|gpu|mtml.Gpu.Voltage|
+|huatuo_bamai_mthreads_gpu_gpu_power_limit_watts|GPU enforced power limit in watts.|W|gpu|mtml.Gpu.EnforcedPowerLimit|
+|huatuo_bamai_mthreads_gpu_gpu_power_default_limit_watts|GPU default power management limit in watts.|W|gpu|mtml.Gpu.PowerManagementDefaultLimit|
+|huatuo_bamai_mthreads_gpu_fan_rpm|GPU fan speed in RPM.|RPM|gpu, fan|mtml.Device.FanRpm|
+|huatuo_bamai_mthreads_gpu_fan_speed_percent|GPU fan speed percent.|%|gpu, fan|mtml.Device.FanSpeed|
+|huatuo_bamai_mthreads_gpu_gpu_pstate|GPU performance state (0=P0).|-|gpu|mtml.Device.PerformanceState|
+|huatuo_bamai_mthreads_gpu_vpu_utilization_percent|GPU VPU utilization (0-100).|%|gpu|mtml.Vpu.Utilization|
+|huatuo_bamai_mthreads_gpu_vpu_encoder_utilization_percent|GPU VPU encoder utilization (0-100).|%|gpu|mtml.Vpu.Utilization|
+|huatuo_bamai_mthreads_gpu_vpu_decoder_utilization_percent|GPU VPU decoder utilization (0-100).|%|gpu|mtml.Vpu.Utilization|
+|huatuo_bamai_mthreads_gpu_vpu_clock_mhz|GPU VPU clock in MHz.|MHz|gpu|mtml.Vpu.Clock|
+|huatuo_bamai_mthreads_gpu_pcie_link_speed_gt_per_sec|GPU PCIe current link speed in GT/s.|GT/s|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_pcie_link_width_lanes|GPU PCIe current link width in lanes.|lanes|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_pcie_replay_total|GPU PCIe replay counter.|count|gpu|mtml.Device.PcieReplayCounter|
+|huatuo_bamai_mthreads_gpu_mtlink_state|GPU MtLink state (0=DOWN,1=UP,2=DOWNGRADE).|-|gpu, link|mtml.Device.MtLinkState|
+|huatuo_bamai_mthreads_gpu_mtlink_link_bandwidth_gb_s|GPU MtLink per-link max bandwidth (device static spec, not live throughput).|GB/s|gpu|mtml.Device.MtLinkSpec|
+|huatuo_bamai_mthreads_gpu_mtlink_link_count|GPU MtLink max number of supported links (device static spec).|links|gpu|mtml.Device.MtLinkSpec|

--- a/docs/key-feature/kernel-wide-insight_zh.md
+++ b/docs/key-feature/kernel-wide-insight_zh.md
@@ -1335,3 +1335,48 @@ huatuo_bamai_hungtask_total{host="hostname",region="dev"} 0
 |metax_gpu_dpm_performance_level|GPU DPM 性能等级|-|gpu, die, ip|sml.GetDieDPMPerformanceLevel|
 |metax_gpu_ecc_memory_errors_total|GPU ECC 内存错误次数|计数|gpu, die, memory_type, error_type|sml.GetDieECCMemoryInfo|
 |metax_gpu_ecc_memory_retired_pages_total|GPU ECC 内存退役页数|计数|gpu, die|sml.GetDieECCMemoryInfo|
+
+- 摩尔线程 (MThreads)
+
+摩尔线程 GPU 监控通过 MTML（摩尔线程管理库）实现。库文件在启动时通过 SONAME 搜索（`libmtml.so.2` 然后 `libmtml.so`）自动发现。静态设备信息会被缓存，仅在重新初始化时重建；动态指标在每次抓取时采集。
+
+配置：从 `BlackList` 中移除 `mthreads_gpu` 以启用。指标组由 `[MetricCollector.Mthreads]` 开关控制（`EnableHealth`、`EnablePCIe`、`EnableMTLink`）。
+
+|指标|描述|单位|标签|来源|
+|----|---|---|---|---|
+|huatuo_bamai_mthreads_gpu_library_info|MTML 库信息|-|version|mtml.LibraryVersion|
+|huatuo_bamai_mthreads_gpu_device_info|GPU 信息|-|gpu, name, brand, serial|mtml.Device.Name/Brand/SerialNumber|
+|huatuo_bamai_mthreads_gpu_device_pci_info|GPU PCI 信息|-|gpu, sbdf|mtml.Device.PciSbdf|
+|huatuo_bamai_mthreads_gpu_device_spec|GPU 规格|-|gpu, cores|mtml.Device.GpuCores|
+|huatuo_bamai_mthreads_gpu_device_bios_version|GPU BIOS 版本|-|gpu, bios|mtml.Device.BiosVersion|
+|huatuo_bamai_mthreads_gpu_device_musa_capability|GPU MUSA 计算能力|-|gpu, musa_capability|mtml.Device.MusaComputeCapability|
+|huatuo_bamai_mthreads_gpu_memory_info|GPU 内存信息|-|gpu, type, vendor, bus_width|mtml.Device.InitMemory|
+|huatuo_bamai_mthreads_gpu_pcie_link_max_speed_gt_per_sec|GPU PCIe 最大链路速率（硬件能力）|GT/s|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_pcie_link_max_width_lanes|GPU PCIe 最大链路宽度（硬件能力）|lanes|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_device_power_watts|GPU 设备功耗|W|gpu|mtml.Device.PowerUsage|
+|huatuo_bamai_mthreads_gpu_gpu_temperature_celsius|GPU 温度|°C|gpu|mtml.Gpu.Temperature|
+|huatuo_bamai_mthreads_gpu_memory_temperature_celsius|GPU 内存温度|°C|gpu|mtml.Memory.Temperature|
+|huatuo_bamai_mthreads_gpu_gpu_utilization_percent|GPU 利用率（0-100）|%|gpu|mtml.Gpu.Utilization|
+|huatuo_bamai_mthreads_gpu_memory_utilization_percent|GPU 内存利用率（0-100）|%|gpu|mtml.Memory.Utilization|
+|huatuo_bamai_mthreads_gpu_memory_total_bytes|GPU 总内存|bytes|gpu|mtml.Memory.Total|
+|huatuo_bamai_mthreads_gpu_memory_used_bytes|GPU 已使用内存|bytes|gpu|mtml.Memory.Used|
+|huatuo_bamai_mthreads_gpu_gpu_clock_mhz|GPU 时钟频率|MHz|gpu|mtml.Gpu.Clock|
+|huatuo_bamai_mthreads_gpu_gpu_max_clock_mhz|GPU 最大时钟频率|MHz|gpu|mtml.Gpu.MaxClock|
+|huatuo_bamai_mthreads_gpu_memory_clock_mhz|GPU 内存时钟频率|MHz|gpu|mtml.Memory.Clock|
+|huatuo_bamai_mthreads_gpu_memory_max_clock_mhz|GPU 内存最大时钟频率|MHz|gpu|mtml.Memory.MaxClock|
+|huatuo_bamai_mthreads_gpu_gpu_voltage_volts|GPU 电压|V|gpu|mtml.Gpu.Voltage|
+|huatuo_bamai_mthreads_gpu_gpu_power_limit_watts|GPU 强制功耗限制|W|gpu|mtml.Gpu.EnforcedPowerLimit|
+|huatuo_bamai_mthreads_gpu_gpu_power_default_limit_watts|GPU 默认功耗管理限制|W|gpu|mtml.Gpu.PowerManagementDefaultLimit|
+|huatuo_bamai_mthreads_gpu_fan_rpm|GPU 风扇转速|RPM|gpu, fan|mtml.Device.FanRpm|
+|huatuo_bamai_mthreads_gpu_fan_speed_percent|GPU 风扇速度百分比|%|gpu, fan|mtml.Device.FanSpeed|
+|huatuo_bamai_mthreads_gpu_gpu_pstate|GPU 性能状态（0=P0）|-|gpu|mtml.Device.PerformanceState|
+|huatuo_bamai_mthreads_gpu_vpu_utilization_percent|GPU VPU 利用率（0-100）|%|gpu|mtml.Vpu.Utilization|
+|huatuo_bamai_mthreads_gpu_vpu_encoder_utilization_percent|GPU VPU 编码器利用率（0-100）|%|gpu|mtml.Vpu.Utilization|
+|huatuo_bamai_mthreads_gpu_vpu_decoder_utilization_percent|GPU VPU 解码器利用率（0-100）|%|gpu|mtml.Vpu.Utilization|
+|huatuo_bamai_mthreads_gpu_vpu_clock_mhz|GPU VPU 时钟频率|MHz|gpu|mtml.Vpu.Clock|
+|huatuo_bamai_mthreads_gpu_pcie_link_speed_gt_per_sec|GPU PCIe 当前链路速率|GT/s|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_pcie_link_width_lanes|GPU PCIe 当前链路宽度|lanes|gpu|mtml.Device.PciInfo|
+|huatuo_bamai_mthreads_gpu_pcie_replay_total|GPU PCIe 重放计数器|count|gpu|mtml.Device.PcieReplayCounter|
+|huatuo_bamai_mthreads_gpu_mtlink_state|GPU MtLink 状态（0=DOWN,1=UP,2=DOWNGRADE）|-|gpu, link|mtml.Device.MtLinkState|
+|huatuo_bamai_mthreads_gpu_mtlink_link_bandwidth_gb_s|GPU MtLink 每链路最大带宽（设备静态规格，非实时吞吐）|GB/s|gpu|mtml.Device.MtLinkSpec|
+|huatuo_bamai_mthreads_gpu_mtlink_link_count|GPU MtLink 最大支持链路数（设备静态规格）|links|gpu|mtml.Device.MtLinkSpec|

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -3,7 +3,7 @@
 # - BlackList
 # Global blacklist for tracing and metrics.
 #
-BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit"]
+BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "tcp_retransmit", "mthreads_gpu"]
 
 # Log Configuration
 [Log]
@@ -496,6 +496,25 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
         # EnableDCMI = true
         # EnablePCIe = false
         # EnableHCCN = false
+
+    # Moore Threads (MTT) GPU fine-grained toggles
+    #
+    # - EnableHealth
+    # Enable health metrics: temperature, power, voltage, utilization, memory,
+    # clocks, fans, pstate, VPU. Default: true
+    #
+    # - EnablePCIe
+    # Enable PCIe link metrics: current/max speed and width, replay counter.
+    # Default: false
+    #
+    # - EnableMTLink
+    # Enable MtLink interconnect metrics: per-link state and bandwidth.
+    # Default: false
+    #
+    [MetricCollector.Mthreads]
+        # EnableHealth = true
+        # EnablePCIe = false
+        # EnableMTLink = false
 
     # Netdev statistic
     #


### PR DESCRIPTION
**Description**
Implement Moore Threads GPU collector via purego-bound MTML C library. Collect static device info (model/brand/serial/PCI/BIOS/MUSA/memory spec) and dynamic metrics (temperature/power/voltage/utilization/clocks/fans/ pstate/VPU/PCIe link/MtLink interconnect) per device. Static info is cached and only rebuilt on re-init. Health, PCIe, and MtLink metric groups are independently toggleable via config.

**Usage**
1. Check Environment: 
    Ensure that the /usr/lib/libmtml.so file exists.
2. Modify Configuration: 
    Edit /opt/huatuo-bamai/conf/huatuo-bamai.conf with the following adjustments:
    2.1 Under the [BlackList] section, ensure that mthreads_gpu is not added to the blacklist.
    2.2 Under the [MetricCollector.Mthreads] section, configure the desired metric groups as needed. Set the value to true to enable monitoring, or false to disable it.
3. Verify Metrics:
    After starting the huatuo-bamai service, access the Prometheus metrics endpoint. You should be able to see mthreads_gpu related metrics, such as huatuo_bamai_mthreads_gpu_device_info.
Note: If you do not see any mthreads_gpu_ related metrics after startup, check the huatuo-bamai logs for the error message: "mthreads: GPU collector disabled".