### PR TITLE
fix(daemon): preserve shutdown dependency boundaries

### DIFF
--- a/cmd/huatuo-bamai/handlers/tracer.go
+++ b/cmd/huatuo-bamai/handlers/tracer.go
@@ -80,6 +80,7 @@ func tracerAPIError(err error) error {
 		return response.ErrNotFound.WithMessage(err.Error())
 	case errors.Is(err, tracing.ErrTracerAlreadyRunning),
 		errors.Is(err, tracing.ErrTracerNotRunning),
+		errors.Is(err, tracing.ErrTracerRunErrorPending),
 		errors.Is(err, tracing.ErrManagerClosed):
 		return response.ErrConflict.WithMessage(err.Error())
 	case errors.Is(err, context.Canceled):

--- a/cmd/huatuo-bamai/handlers/tracer_test.go
+++ b/cmd/huatuo-bamai/handlers/tracer_test.go
@@ -47,6 +47,11 @@ func TestTracerAPIError(t *testing.T) {
 			httpStatus: http.StatusConflict,
 		},
 		{
+			name:       "run error pending",
+			err:        tracing.ErrTracerRunErrorPending,
+			httpStatus: http.StatusConflict,
+		},
+		{
 			name:       "manager closed",
 			err:        tracing.ErrManagerClosed,
 			httpStatus: http.StatusConflict,

--- a/cmd/huatuo-bamai/main.go
+++ b/cmd/huatuo-bamai/main.go
@@ -80,6 +80,40 @@ type Daemon struct {
 	tracer  *tracing.Manager
 }
 
+type cleanupStep struct {
+	name               string
+	cleanup            func(context.Context) error
+	requires           cleanupDependency
+	blocksOnIncomplete cleanupDependency
+}
+
+type cleanupDependency uint8
+
+const (
+	dependencyTracingStopped cleanupDependency = 1 << iota
+	dependencyToolstreamStopped
+)
+
+type daemonSetupStep struct {
+	name               string
+	setup              func(*Daemon) (func(context.Context) error, error)
+	requires           cleanupDependency
+	blocksOnIncomplete cleanupDependency
+}
+
+// cleanupBoundaryError records which later cleanup is unsafe after a failed
+// cleanup. Its Error omits this internal control state.
+type cleanupBoundaryError struct {
+	err     error
+	blocked cleanupDependency
+}
+
+func (e *cleanupBoundaryError) Error() string { return e.err.Error() }
+func (e *cleanupBoundaryError) Unwrap() error { return e.err }
+func (e *cleanupBoundaryError) blockedCleanupDependencies() cleanupDependency {
+	return e.blocked
+}
+
 func NewDaemon(opts *Options) *Daemon {
 	return &Daemon{opts: opts}
 }
@@ -89,52 +123,41 @@ func NewDaemon(opts *Options) *Daemon {
 // signal arrives and runs the stack in reverse. A setup failure tears
 // down whatever already came up before returning the original error.
 func (d *Daemon) Run(ctx context.Context) error {
-	var cleanups []func(context.Context) error
+	var cleanups []cleanupStep
 
-	shutdown := func() error {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-
-		var errs []error
-		for i := len(cleanups) - 1; i >= 0; i-- {
-			if err := cleanups[i](shutdownCtx); err != nil {
-				errs = append(errs, err)
-			}
-		}
-
-		return errors.Join(errs...)
+	steps := []daemonSetupStep{
+		{name: "pidfile", setup: lockPidfile},
+		{name: "cgroup", setup: setupCgroup},
+		{
+			name:     "storage",
+			setup:    setupStorage,
+			requires: dependencyTracingStopped | dependencyToolstreamStopped,
+		},
+		{name: "bpf", setup: setupBPF, requires: dependencyTracingStopped},
+		{name: "pod", setup: setupPodManager, requires: dependencyTracingStopped},
+		{name: "metrics", setup: setupMetrics},
+		{
+			name:               "toolstream",
+			setup:              startToolstream,
+			requires:           dependencyTracingStopped,
+			blocksOnIncomplete: dependencyToolstreamStopped,
+		},
+		{
+			name:               "tracing",
+			setup:              startTracing,
+			blocksOnIncomplete: dependencyTracingStopped,
+		},
+		{name: "handlers", setup: startHandlers},
+		{name: "cgroup-cpu-quota", setup: applyCgroupCPUQuota},
 	}
-
-	run := func(name string, setup func(*Daemon) (func(context.Context) error, error)) error {
-		cleanup, err := setup(d)
-		if err != nil {
-			_ = shutdown()
-			return fmt.Errorf("%s: %w", name, err)
-		}
-		if cleanup != nil {
-			cleanups = append(cleanups, cleanup)
-		}
-
-		return nil
-	}
-
-	steps := []struct {
-		name  string
-		setup func(*Daemon) (func(context.Context) error, error)
-	}{
-		{"pidfile", lockPidfile},
-		{"cgroup", setupCgroup},
-		{"storage", setupStorage},
-		{"bpf", setupBPF},
-		{"pod", setupPodManager},
-		{"metrics", setupMetrics},
-		{"toolstream", startToolstream},
-		{"tracing", startTracing},
-		{"handlers", startHandlers},
-		{"cgroup-cpu-quota", applyCgroupCPUQuota},
-	}
-	for _, s := range steps {
-		if err := run(s.name, s.setup); err != nil {
+	for _, step := range steps {
+		if err := runSetupStep(
+			ctx,
+			d,
+			&cleanups,
+			step,
+			shutdownTimeout,
+		); err != nil {
 			return err
 		}
 	}
@@ -143,11 +166,71 @@ func (d *Daemon) Run(ctx context.Context) error {
 	s := d.waitForSignal(ctx)
 	log.Infof("huatuo-bamai received signal %v, shutting down", s)
 
-	if err := shutdown(); err != nil {
-		log.Warnf("shutdown completed with errors: %v", err)
+	if err := runCleanups(ctx, cleanups, shutdownTimeout); err != nil {
+		return fmt.Errorf("shutdown: %w", err)
 	}
 
 	return nil
+}
+
+func runSetupStep(
+	ctx context.Context,
+	d *Daemon,
+	cleanups *[]cleanupStep,
+	step daemonSetupStep,
+	rollbackTimeout time.Duration,
+) error {
+	cleanup, setupErr := step.setup(d)
+	if setupErr != nil {
+		rollbackErr := runCleanups(ctx, *cleanups, rollbackTimeout)
+		return errors.Join(
+			fmt.Errorf("%s: %w", step.name, setupErr),
+			rollbackErr,
+		)
+	}
+	if cleanup != nil {
+		*cleanups = append(*cleanups, cleanupStep{
+			name:               step.name,
+			cleanup:            cleanup,
+			requires:           step.requires,
+			blocksOnIncomplete: step.blocksOnIncomplete,
+		})
+	}
+
+	return nil
+}
+
+func runCleanups(ctx context.Context, cleanups []cleanupStep, stepTimeout time.Duration) error {
+	var errs []error
+	var blocked cleanupDependency
+
+	for i := len(cleanups) - 1; i >= 0; i-- {
+		step := cleanups[i]
+		if step.requires&blocked != 0 {
+			continue
+		}
+		stepCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stepTimeout)
+		err := step.cleanup(stepCtx)
+		incomplete := stepCtx.Err() != nil
+		cancel()
+		if err == nil {
+			continue
+		}
+
+		errs = append(errs, fmt.Errorf("%s cleanup: %w", step.name, err))
+		var boundary interface {
+			blockedCleanupDependencies() cleanupDependency
+		}
+		if errors.As(err, &boundary) {
+			blocked |= boundary.blockedCleanupDependencies()
+			continue
+		}
+		if incomplete {
+			blocked |= step.blocksOnIncomplete
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (d *Daemon) waitForSignal(ctx context.Context) os.Signal {

--- a/cmd/huatuo-bamai/main_test.go
+++ b/cmd/huatuo-bamai/main_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/toolstream"
+)
+
+func TestRunCleanupsPreservesDependenciesAfterTimeout(t *testing.T) {
+	called := make([]string, 0, 7)
+	steps := []cleanupStep{
+		{
+			name: "pidfile",
+			cleanup: func(context.Context) error {
+				called = append(called, "pidfile")
+				return nil
+			},
+		},
+		{
+			name: "cgroup",
+			cleanup: func(context.Context) error {
+				called = append(called, "cgroup")
+				return nil
+			},
+		},
+		{
+			name:     "storage",
+			requires: dependencyTracingStopped | dependencyToolstreamStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "storage")
+				return nil
+			},
+		},
+		{
+			name:     "bpf",
+			requires: dependencyTracingStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "bpf")
+				return nil
+			},
+		},
+		{
+			name:     "pod",
+			requires: dependencyTracingStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "pod")
+				return nil
+			},
+		},
+		{
+			name:               "toolstream",
+			requires:           dependencyTracingStopped,
+			blocksOnIncomplete: dependencyToolstreamStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "toolstream")
+				return nil
+			},
+		},
+		{
+			name:               "tracing",
+			blocksOnIncomplete: dependencyTracingStopped,
+			cleanup: func(ctx context.Context) error {
+				called = append(called, "tracing")
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		},
+	}
+
+	err := runCleanups(t.Context(), steps, time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runCleanups() error = %v, want deadline exceeded", err)
+	}
+	if want := []string{"tracing", "cgroup", "pidfile"}; !slices.Equal(called, want) {
+		t.Fatalf("cleanup calls = %v, want %v", called, want)
+	}
+}
+
+func TestRunSetupStepJoinsSetupAndRollbackErrors(t *testing.T) {
+	setupErr := errors.New("setup failed")
+	rollbackErr := errors.New("rollback failed")
+	cleanups := []cleanupStep{{
+		name: "existing",
+		cleanup: func(context.Context) error {
+			return rollbackErr
+		},
+	}}
+	step := daemonSetupStep{
+		name: "next",
+		setup: func(*Daemon) (func(context.Context) error, error) {
+			return nil, setupErr
+		},
+	}
+
+	err := runSetupStep(
+		t.Context(),
+		&Daemon{},
+		&cleanups,
+		step,
+		time.Second,
+	)
+	if !errors.Is(err, setupErr) {
+		t.Errorf("runSetupStep() error = %v, want setup error", err)
+	}
+	if !errors.Is(err, rollbackErr) {
+		t.Errorf("runSetupStep() error = %v, want rollback error", err)
+	}
+	if !strings.Contains(err.Error(), "existing cleanup") {
+		t.Errorf("runSetupStep() error = %q, want cleanup step name", err)
+	}
+}
+
+func TestRunCleanupsContinuesAfterCompletedError(t *testing.T) {
+	wantErr := errors.New("tracing stopped with an error")
+	called := make([]string, 0, 2)
+	steps := []cleanupStep{
+		{
+			name:     "storage",
+			requires: dependencyToolstreamStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "storage")
+				return nil
+			},
+		},
+		{
+			name: "tracing",
+			cleanup: func(context.Context) error {
+				called = append(called, "tracing")
+				return wantErr
+			},
+		},
+	}
+
+	err := runCleanups(t.Context(), steps, time.Second)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runCleanups() error = %v, want %v", err, wantErr)
+	}
+	if want := []string{"tracing", "storage"}; !slices.Equal(called, want) {
+		t.Fatalf("cleanup calls = %v, want %v", called, want)
+	}
+}
+
+func TestRunCleanupsIgnoresParentCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	called := false
+	err := runCleanups(ctx, []cleanupStep{{
+		name: "storage",
+		cleanup: func(cleanupCtx context.Context) error {
+			called = true
+			return cleanupCtx.Err()
+		},
+	}}, time.Second)
+	if err != nil {
+		t.Fatalf("runCleanups() error = %v, want nil", err)
+	}
+	if !called {
+		t.Fatal("cleanup was not called")
+	}
+}
+
+func TestRunCleanupsContinuesWhenToolstreamForcedCloseIsSafe(t *testing.T) {
+	called := make([]string, 0, 2)
+	steps := []cleanupStep{
+		{
+			name: "storage",
+			cleanup: func(context.Context) error {
+				called = append(called, "storage")
+				return nil
+			},
+		},
+		{
+			name: "toolstream",
+			cleanup: func(ctx context.Context) error {
+				called = append(called, "toolstream")
+				<-ctx.Done()
+				return closeToolstream(ctx, &fakeToolstreamServer{drainErr: ctx.Err()})
+			},
+		},
+	}
+
+	err := runCleanups(t.Context(), steps, time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runCleanups() error = %v, want deadline exceeded", err)
+	}
+	if want := []string{"toolstream", "storage"}; !slices.Equal(called, want) {
+		t.Fatalf("cleanup calls = %v, want %v", called, want)
+	}
+}
+
+func TestRunCleanupsStopsWhileToolstreamHandlerIsActive(t *testing.T) {
+	called := make([]string, 0, 3)
+	steps := []cleanupStep{
+		{
+			name: "cgroup",
+			cleanup: func(context.Context) error {
+				called = append(called, "cgroup")
+				return nil
+			},
+		},
+		{
+			name:     "storage",
+			requires: dependencyToolstreamStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "storage")
+				return nil
+			},
+		},
+		{
+			name: "toolstream",
+			cleanup: func(ctx context.Context) error {
+				called = append(called, "toolstream")
+				return closeToolstream(ctx, &fakeToolstreamServer{
+					closeErr: toolstream.ErrHandlersActive,
+				})
+			},
+		},
+	}
+
+	err := runCleanups(t.Context(), steps, time.Second)
+	if !errors.Is(err, toolstream.ErrHandlersActive) {
+		t.Fatalf("runCleanups() error = %v, want ErrHandlersActive", err)
+	}
+	if want := []string{"toolstream", "cgroup"}; !slices.Equal(called, want) {
+		t.Fatalf("cleanup calls = %v, want %v", called, want)
+	}
+}
+
+func TestRunCleanupsRetriesToolstreamBeforeStorage(t *testing.T) {
+	called := make([]string, 0, 2)
+	retryStarted := make(chan struct{})
+	handlerReleased := make(chan struct{})
+	srv := &fakeToolstreamServer{
+		drainErrs: []error{
+			errors.Join(toolstream.ErrDrainTimeout, context.DeadlineExceeded),
+			nil,
+		},
+		closeErrs: []error{toolstream.ErrHandlersActive, nil},
+		onDrain: func(_ context.Context, call int) {
+			if call != 1 {
+				return
+			}
+			close(retryStarted)
+			<-handlerReleased
+		},
+	}
+	go func() {
+		<-retryStarted
+		close(handlerReleased)
+	}()
+	steps := []cleanupStep{
+		{
+			name:     "storage",
+			requires: dependencyToolstreamStopped,
+			cleanup: func(context.Context) error {
+				called = append(called, "storage")
+				return nil
+			},
+		},
+		{
+			name:               "toolstream",
+			blocksOnIncomplete: dependencyToolstreamStopped,
+			cleanup: func(ctx context.Context) error {
+				called = append(called, "toolstream")
+				return closeToolstream(ctx, srv)
+			},
+		},
+	}
+
+	if err := runCleanups(t.Context(), steps, time.Minute); err != nil {
+		t.Fatalf("runCleanups() error = %v, want recovered shutdown", err)
+	}
+	if want := []string{"toolstream", "storage"}; !slices.Equal(called, want) {
+		t.Fatalf("cleanup calls = %v, want %v", called, want)
+	}
+}

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -33,7 +33,10 @@ func setupStorage(d *Daemon) (func(context.Context) error, error) {
 		return nil, nil
 	}
 
-	return nil, initStorage(d.opts.Region, config.Get())
+	if err := initStorage(d.opts.Region, config.Get()); err != nil {
+		return nil, err
+	}
+	return tracing.CloseStores, nil
 }
 
 func initStorage(storageRegion string, cfg *config.BamaiConfig) error {

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -16,7 +16,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"huatuo-bamai/cmd/huatuo-bamai/config"
 	"huatuo-bamai/cmd/huatuo-bamai/handlers"
@@ -24,6 +26,11 @@ import (
 	"huatuo-bamai/internal/toolstream"
 	"huatuo-bamai/pkg/tracing"
 )
+
+type toolstreamServer interface {
+	QuiesceAndDrain(ctx context.Context) error
+	Close() error
+}
 
 func setupBPF(_ *Daemon) (func(context.Context) error, error) {
 	if err := bpf.Init(&bpf.Option{}); err != nil {
@@ -46,7 +53,60 @@ func startToolstream(_ *Daemon) (func(context.Context) error, error) {
 		return nil, fmt.Errorf("start: %w", err)
 	}
 
-	return func(context.Context) error { return srv.Close() }, nil
+	return func(ctx context.Context) error {
+		return closeToolstream(ctx, srv)
+	}, nil
+}
+
+func closeToolstream(ctx context.Context, srv toolstreamServer) error {
+	initialDrainCtx, cancelInitialDrain := initialToolstreamDrainContext(ctx)
+	drainErr := srv.QuiesceAndDrain(initialDrainCtx)
+	cancelInitialDrain()
+	closeErr := srv.Close()
+	if errors.Is(closeErr, toolstream.ErrHandlersActive) && ctx.Err() == nil {
+		retryDrainErr := srv.QuiesceAndDrain(ctx)
+		retryCloseErr := srv.Close()
+		if retryDrainErr == nil && retryCloseErr == nil {
+			return nil
+		}
+		drainErr = errors.Join(drainErr, retryDrainErr)
+		closeErr = errors.Join(closeErr, retryCloseErr)
+		if !errors.Is(retryCloseErr, toolstream.ErrHandlersActive) {
+			return &cleanupBoundaryError{err: errors.Join(drainErr, closeErr)}
+		}
+	}
+
+	err := errors.Join(drainErr, closeErr)
+	if err == nil {
+		return nil
+	}
+
+	// Close without ErrHandlersActive establishes that dispatch cannot enter a
+	// handler again, so storage cleanup is safe even if draining timed out.
+	var blocked cleanupDependency
+	if errors.Is(closeErr, toolstream.ErrHandlersActive) {
+		blocked = dependencyToolstreamStopped
+	}
+	return &cleanupBoundaryError{
+		err:     err,
+		blocked: blocked,
+	}
+}
+
+func initialToolstreamDrainContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return context.WithCancel(ctx)
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return context.WithCancel(ctx)
+	}
+
+	// Leave half of the cleanup budget for a handler that owns a decoded frame
+	// after the initial drain force-closes idle connections.
+	return context.WithTimeout(ctx, remaining/2)
 }
 
 func startTracing(d *Daemon) (func(context.Context) error, error) {
@@ -60,13 +120,9 @@ func startTracing(d *Daemon) (func(context.Context) error, error) {
 	}
 
 	d.tracer = mgr
-	// Stop collectors first, then drain bulk-buffered writes before BPF teardown.
 	return func(ctx context.Context) error {
 		if err := mgr.Close(ctx); err != nil {
 			return fmt.Errorf("stop: %w", err)
-		}
-		if err := tracing.CloseStores(ctx); err != nil {
-			return fmt.Errorf("close stores: %w", err)
 		}
 		return nil
 	}, nil

--- a/cmd/huatuo-bamai/tracing_test.go
+++ b/cmd/huatuo-bamai/tracing_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/toolstream"
+)
+
+type fakeToolstreamServer struct {
+	drainErr   error
+	closeErr   error
+	drainErrs  []error
+	closeErrs  []error
+	drainCalls int
+	closeCalls int
+	calls      []string
+	onDrain    func(context.Context, int)
+}
+
+func (s *fakeToolstreamServer) QuiesceAndDrain(ctx context.Context) error {
+	s.calls = append(s.calls, "drain")
+	call := s.drainCalls
+	s.drainCalls++
+	if s.onDrain != nil {
+		s.onDrain(ctx, call)
+	}
+	if call < len(s.drainErrs) {
+		return s.drainErrs[call]
+	}
+	return s.drainErr
+}
+
+func (s *fakeToolstreamServer) Close() error {
+	s.calls = append(s.calls, "close")
+	call := s.closeCalls
+	s.closeCalls++
+	if call < len(s.closeErrs) {
+		return s.closeErrs[call]
+	}
+	return s.closeErr
+}
+
+func TestCloseToolstreamAlwaysCloses(t *testing.T) {
+	drainErr := errors.New("drain failed")
+	closeErr := errors.New("close failed")
+	srv := &fakeToolstreamServer{drainErr: drainErr, closeErr: closeErr}
+
+	err := closeToolstream(t.Context(), srv)
+	if !errors.Is(err, drainErr) {
+		t.Fatalf("closeToolstream error = %v, want drain error", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("closeToolstream error = %v, want close error", err)
+	}
+	if want := []string{"drain", "close"}; !slices.Equal(srv.calls, want) {
+		t.Fatalf("calls = %v, want %v", srv.calls, want)
+	}
+}
+
+func TestCloseToolstreamReservesRetryBudget(t *testing.T) {
+	firstDrainErr := errors.Join(toolstream.ErrDrainTimeout, context.DeadlineExceeded)
+	var initialDeadline, retryDeadline time.Time
+	srv := &fakeToolstreamServer{
+		drainErrs: []error{firstDrainErr, nil},
+		closeErrs: []error{toolstream.ErrHandlersActive, nil},
+		onDrain: func(ctx context.Context, call int) {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatalf("drain call %d has no deadline", call)
+			}
+			if call == 0 {
+				initialDeadline = deadline
+				return
+			}
+			retryDeadline = deadline
+		},
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	if err := closeToolstream(ctx, srv); err != nil {
+		t.Fatalf("closeToolstream() error = %v, want recovered shutdown", err)
+	}
+	if !initialDeadline.Before(retryDeadline) {
+		t.Fatalf(
+			"initial drain deadline = %v, retry deadline = %v; want reserved retry budget",
+			initialDeadline,
+			retryDeadline,
+		)
+	}
+	if want := []string{"drain", "close", "drain", "close"}; !slices.Equal(srv.calls, want) {
+		t.Fatalf("calls = %v, want %v", srv.calls, want)
+	}
+}

--- a/docs/CHANGELOG_en.md
+++ b/docs/CHANGELOG_en.md
@@ -6,3 +6,11 @@ author: HUATUO Team
 date: 2026-03-29
 weight: 50
 ---
+
+## Unreleased
+
+### Changed
+
+- Daemon shutdown now waits for tracing and active toolstream handlers before
+  closing dependent BPF and storage resources. Terminal shutdown errors are
+  returned while cleanup of independent resources continues.

--- a/internal/toolstream/server.go
+++ b/internal/toolstream/server.go
@@ -16,6 +16,7 @@
 package toolstream
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +42,10 @@ var (
 	ErrNotInitialized = errors.New("toolstream: server not initialized")
 	// ErrAlreadyStarted is returned by Start when the server is already running.
 	ErrAlreadyStarted = errors.New("toolstream: server already started")
+	// ErrDrainTimeout means active streams did not finish before the drain context.
+	ErrDrainTimeout = transport.ErrDrainTimeout
+	// ErrHandlersActive means network resources are closed but a handler has not returned.
+	ErrHandlersActive = transport.ErrHandlersActive
 )
 
 var (
@@ -147,8 +152,27 @@ func (s *Server) Start() error {
 	return nil
 }
 
-// Close shuts down the server and waits for all goroutines to finish.
-// Calling Close more than once is safe and a no-op after the first call.
+// QuiesceAndDrain rejects new connections and waits for active streams.
+func (s *Server) QuiesceAndDrain(ctx context.Context) error {
+	if s == nil || s.sockPath == "" {
+		return ErrNotInitialized
+	}
+
+	s.innerMu.Lock()
+	inner := s.inner
+	s.innerMu.Unlock()
+	if inner == nil {
+		return nil
+	}
+
+	if err := inner.QuiesceAndDrain(ctx); err != nil {
+		return fmt.Errorf("toolstream: quiesce and drain: %w", err)
+	}
+	return nil
+}
+
+// Close shuts down the server. A handler that has not returned is reported so
+// callers do not close storage that the handler may still use.
 func (s *Server) Close() error {
 	if s == nil {
 		return ErrNotInitialized
@@ -161,8 +185,11 @@ func (s *Server) Close() error {
 		return nil
 	}
 	inner := s.inner
-	s.inner = nil
-	return inner.Close()
+	err := inner.Close()
+	if !errors.Is(err, transport.ErrHandlersActive) {
+		s.inner = nil
+	}
+	return err
 }
 
 func (s *Server) dispatch(tsess *transport.Session, chunk transport.ChunkMsg) {

--- a/internal/toolstream/server_test.go
+++ b/internal/toolstream/server_test.go
@@ -15,7 +15,10 @@
 package toolstream_test
 
 import (
+	"context"
 	"errors"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -217,6 +220,94 @@ func TestMultipleChunksThenEnd(t *testing.T) {
 			t.Errorf("event %d: ID=%d want %d", i, g.event.ID, i)
 		}
 	}
+}
+
+func TestQuiesceAndDrainCanResumeAfterHandlerTimeout(t *testing.T) {
+	srv, sockPath := newTestServer(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(unblock)
+
+	toolstream.Register(srv, "blocked-tool", func(_ *toolstream.Session, _ testEvent) error {
+		close(started)
+		<-release
+		return nil
+	})
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client, err := toolstream.NewClient(toolstream.ClientOptions{
+		SockPath: sockPath,
+		ToolName: "blocked-tool",
+		Version:  "1.0",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if err := client.Send(testEvent{ID: 1}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not start")
+	}
+	if err := client.End(); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+
+	waitersBefore := drainWaiterCount()
+	for range 8 {
+		drainCtx, cancel := context.WithCancel(t.Context())
+		cancel()
+		err = srv.QuiesceAndDrain(drainCtx)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("QuiesceAndDrain error = %v, want context canceled", err)
+		}
+		if !errors.Is(err, toolstream.ErrDrainTimeout) {
+			t.Fatalf("QuiesceAndDrain error = %v, want ErrDrainTimeout", err)
+		}
+	}
+	runtime.Gosched()
+	if waitersAfter := drainWaiterCount(); waitersAfter != waitersBefore {
+		t.Fatalf("QuiesceAndDrain waiter goroutines = %d, want %d", waitersAfter, waitersBefore)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- srv.Close()
+	}()
+	select {
+	case err := <-closeDone:
+		if !errors.Is(err, toolstream.ErrHandlersActive) {
+			t.Fatalf("Close error = %v, want ErrHandlersActive", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked on an active handler")
+	}
+
+	unblock()
+	retryCtx, retryCancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer retryCancel()
+	if err := srv.QuiesceAndDrain(retryCtx); err != nil {
+		t.Fatalf("second QuiesceAndDrain: %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close after handler returned: %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("repeated Close: %v", err)
+	}
+}
+
+func drainWaiterCount() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), ".QuiesceAndDrain.func")
 }
 
 func TestStartNilServer(t *testing.T) {

--- a/internal/toolstream/transport/server.go
+++ b/internal/toolstream/transport/server.go
@@ -29,13 +29,30 @@ import (
 
 // Server accepts connections and dispatches ChunkMsg events to a caller-supplied handler.
 type Server struct {
-	mutex       sync.Mutex
-	waitGroup   sync.WaitGroup
-	connections map[net.Conn]struct{}
-	listener    net.Listener
-	handler     func(*Session, ChunkMsg)
-	cancel      context.CancelFunc
+	mutex          sync.Mutex
+	connectionWG   sync.WaitGroup
+	connections    map[net.Conn]struct{}
+	listener       net.Listener
+	handler        func(*Session, ChunkMsg)
+	cancel         context.CancelFunc
+	acceptDone     chan struct{}
+	drainDone      chan struct{}
+	handlersDone   chan struct{}
+	listenerOnce   sync.Once
+	listenerErr    error
+	accepting      bool
+	forceClosing   bool
+	activeHandlers int
 }
+
+var (
+	// ErrDrainTimeout reports that active streams did not drain before the
+	// caller's context expired; their sockets have been force-closed.
+	ErrDrainTimeout = errors.New("transport: drain timed out")
+	// ErrHandlersActive reports that Close released network resources while a
+	// caller-owned handler was still running.
+	ErrHandlersActive = errors.New("transport: close incomplete: handlers still active")
+)
 
 // Serve starts accepting connections from l in the background.
 func Serve(l net.Listener, handler func(*Session, ChunkMsg)) (*Server, error) {
@@ -44,28 +61,125 @@ func Serve(l net.Listener, handler func(*Session, ChunkMsg)) (*Server, error) {
 	}
 
 	srv := &Server{
-		listener:    l,
-		connections: make(map[net.Conn]struct{}),
-		handler:     handler,
+		listener:     l,
+		connections:  make(map[net.Conn]struct{}),
+		handler:      handler,
+		accepting:    true,
+		acceptDone:   make(chan struct{}),
+		drainDone:    make(chan struct{}),
+		handlersDone: make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	srv.cancel = cancel
-	srv.waitGroup.Add(1)
-
 	go func() {
-		defer srv.waitGroup.Done()
+		defer close(srv.acceptDone)
 		srv.acceptLoop(ctx)
+	}()
+	go func() {
+		// Waiting for acceptDone first guarantees that no Add can race with Wait.
+		<-srv.acceptDone
+		srv.connectionWG.Wait()
+		close(srv.drainDone)
 	}()
 
 	return srv, nil
+}
+
+// QuiesceAndDrain stops accepting connections and waits for active streams.
+func (s *Server) QuiesceAndDrain(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("transport: drain context must not be nil")
+	}
+
+	listenerErr := s.stopAccepting()
+
+	select {
+	case <-s.drainDone:
+		return listenerErr
+	case <-ctx.Done():
+		closeErr, _ := s.forceCloseConnections()
+		return errors.Join(
+			listenerErr,
+			closeErr,
+			ErrDrainTimeout,
+			fmt.Errorf("transport: drain active streams: %w", ctx.Err()),
+		)
+	}
+}
+
+// Close releases network resources. It returns ErrHandlersActive rather than
+// waiting indefinitely for a handler that does not honor shutdown.
+func (s *Server) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	listenerErr := s.stopAccepting()
+	closeErr, activeHandlers := s.forceCloseConnections()
+	if activeHandlers > 0 {
+		select {
+		case <-s.handlersDone:
+			return errors.Join(listenerErr, closeErr)
+		default:
+			return errors.Join(listenerErr, closeErr, ErrHandlersActive)
+		}
+	}
+
+	// forceClosing prevents decoded frames from starting new handlers. Connection
+	// goroutines may still be unwinding, but none can reach caller-owned storage.
+	<-s.handlersDone
+	return errors.Join(listenerErr, closeErr)
+}
+
+func (s *Server) stopAccepting() error {
+	s.mutex.Lock()
+	s.accepting = false
+	s.mutex.Unlock()
+
+	s.listenerOnce.Do(func() {
+		s.listenerErr = s.listener.Close()
+		if errors.Is(s.listenerErr, net.ErrClosed) {
+			s.listenerErr = nil
+		}
+	})
+	return s.listenerErr
+}
+
+func (s *Server) forceCloseConnections() (error, int) {
+	s.mutex.Lock()
+	if !s.forceClosing {
+		s.forceClosing = true
+		if s.activeHandlers == 0 {
+			close(s.handlersDone)
+		}
+	}
+	activeHandlers := s.activeHandlers
+	conns := make([]net.Conn, 0, len(s.connections))
+	for conn := range s.connections {
+		conns = append(conns, conn)
+		delete(s.connections, conn)
+	}
+	s.mutex.Unlock()
+
+	var errs []error
+	for _, conn := range conns {
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			errs = append(errs, fmt.Errorf("transport: close connection: %w", err))
+		}
+	}
+
+	return errors.Join(errs...), activeHandlers
 }
 
 func (s *Server) acceptLoop(ctx context.Context) {
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
-			if ctx.Err() != nil {
+			s.mutex.Lock()
+			accepting := s.accepting
+			s.mutex.Unlock()
+			if ctx.Err() != nil || !accepting || errors.Is(err, net.ErrClosed) {
 				return
 			}
 
@@ -74,10 +188,15 @@ func (s *Server) acceptLoop(ctx context.Context) {
 		}
 
 		s.mutex.Lock()
+		if !s.accepting {
+			s.mutex.Unlock()
+			_ = conn.Close()
+			continue
+		}
 		s.connections[conn] = struct{}{}
 		s.mutex.Unlock()
 
-		s.waitGroup.Add(1)
+		s.connectionWG.Add(1)
 
 		go func() {
 			defer func() {
@@ -90,7 +209,7 @@ func (s *Server) acceptLoop(ctx context.Context) {
 					_ = conn.Close()
 				}
 
-				s.waitGroup.Done()
+				s.connectionWG.Done()
 			}()
 
 			s.handleConn(ctx, conn)
@@ -148,7 +267,9 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 			return
 		}
 
-		s.handler(sess, chunk)
+		if !s.callHandler(sess, chunk) {
+			return
+		}
 
 		if chunk.End {
 			return
@@ -217,37 +338,24 @@ func parseChunk(msg *capnp.Message) (ChunkMsg, error) {
 	}, nil
 }
 
-// Close shuts down the server and waits for all goroutines to finish.
-func (s *Server) Close() error {
-	if s.cancel != nil {
-		s.cancel()
-	}
-
-	var errs []error
-
-	if err := s.listener.Close(); err != nil {
-		errs = append(errs, err)
-	}
-
-	// snapshot under lock, close outside to avoid holding the lock during I/O
+func (s *Server) callHandler(sess *Session, chunk ChunkMsg) bool {
 	s.mutex.Lock()
-	conns := make([]net.Conn, 0, len(s.connections))
-
-	for c := range s.connections {
-		conns = append(conns, c)
-		delete(s.connections, c)
+	if s.forceClosing {
+		s.mutex.Unlock()
+		return false
 	}
-
+	s.activeHandlers++
 	s.mutex.Unlock()
 
-	// closing each conn unblocks handleConn goroutines stuck in Decode
-	for _, c := range conns {
-		if err := c.Close(); err != nil {
-			errs = append(errs, err)
+	defer func() {
+		s.mutex.Lock()
+		s.activeHandlers--
+		if s.forceClosing && s.activeHandlers == 0 {
+			close(s.handlersDone)
 		}
-	}
+		s.mutex.Unlock()
+	}()
 
-	s.waitGroup.Wait()
-
-	return errors.Join(errs...)
+	s.handler(sess, chunk)
+	return true
 }

--- a/internal/toolstream/transport/server_test.go
+++ b/internal/toolstream/transport/server_test.go
@@ -15,6 +15,8 @@
 package transport
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -395,5 +397,95 @@ func TestClientRoundTrip(t *testing.T) {
 	}
 	if !got[1].End {
 		t.Errorf("second chunk End=false want true")
+	}
+}
+
+func TestQuiesceAndDrainForceClosesIdleConnections(t *testing.T) {
+	tests := []struct {
+		name      string
+		handshake bool
+	}{
+		{name: "before handshake"},
+		{name: "after handshake", handshake: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sockPath := t.TempDir() + "/test.sock"
+			handled := make(chan struct{}, 1)
+			listener, err := ListenUDS(sockPath)
+			if err != nil {
+				t.Fatalf("ListenUDS: %v", err)
+			}
+			srv, err := Serve(listener, func(*Session, ChunkMsg) {
+				handled <- struct{}{}
+			})
+			if err != nil {
+				t.Fatalf("Serve: %v", err)
+			}
+			t.Cleanup(func() { _ = srv.Close() })
+
+			client, err := DialUDS(sockPath)
+			if err != nil {
+				t.Fatalf("DialUDS: %v", err)
+			}
+			t.Cleanup(func() { _ = client.Close() })
+			if tt.handshake {
+				encoder := capnp.NewEncoder(client)
+				if err := handshake(
+					t,
+					encoder,
+					client,
+					"idle-tool",
+					"1.0",
+					"",
+				); err != nil {
+					t.Fatalf("handshake: %v", err)
+				}
+				if err := sendChunk(t, encoder, []byte(`{}`), false, false, ""); err != nil {
+					t.Fatalf("sendChunk: %v", err)
+				}
+				select {
+				case <-handled:
+				case <-time.After(2 * time.Second):
+					t.Fatal("post-handshake chunk was not handled")
+				}
+			}
+			waitForConnectionCount(t, srv, 1)
+
+			drainCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+			err = srv.QuiesceAndDrain(drainCtx)
+			cancel()
+			if !errors.Is(err, ErrDrainTimeout) {
+				t.Fatalf("QuiesceAndDrain error = %v, want ErrDrainTimeout", err)
+			}
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("QuiesceAndDrain error = %v, want deadline exceeded", err)
+			}
+			if err := srv.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+			if err := srv.Close(); err != nil {
+				t.Fatalf("repeated Close: %v", err)
+			}
+		})
+	}
+}
+
+func waitForConnectionCount(t *testing.T, srv *Server, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		srv.mutex.Lock()
+		got := len(srv.connections)
+		srv.mutex.Unlock()
+		if got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("active connections = %d, want %d", got, want)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/pkg/tracing/errors.go
+++ b/pkg/tracing/errors.go
@@ -26,6 +26,9 @@ var (
 	ErrTracerAlreadyRunning = errors.New("tracer already running")
 	// ErrTracerNotRunning indicates that a tracer is inactive.
 	ErrTracerNotRunning = errors.New("tracer not running")
+	// ErrTracerRunErrorPending indicates that a completed run error has not
+	// yet been collected by StopByName or Close.
+	ErrTracerRunErrorPending = errors.New("tracer run error pending")
 	// ErrInvalidTracer indicates that a tracing registration is invalid.
 	ErrInvalidTracer = errors.New("invalid tracer")
 	// ErrManagerClosed indicates that the manager no longer accepts starts.
@@ -38,4 +41,16 @@ func newTracerStateError(err error, name string) error {
 
 func newTracerContextError(operation, name string, err error) error {
 	return fmt.Errorf("%s %q: %w", operation, name, err)
+}
+
+func newTracerRunError(name string, err error) error {
+	return fmt.Errorf("tracer %q: %w", name, err)
+}
+
+func newTracerRunErrorPending(name string) error {
+	return fmt.Errorf(
+		"%q: %w; stop the tracer to collect the previous error before restarting",
+		name,
+		ErrTracerRunErrorPending,
+	)
 }

--- a/pkg/tracing/manager.go
+++ b/pkg/tracing/manager.go
@@ -118,26 +118,28 @@ func (m *Manager) Close(ctx context.Context) error {
 	m.isClosed = true
 
 	type pendingStop struct {
-		name string
-		done <-chan struct{}
+		runner      *eventRunner
+		completions []*runCompletion
 	}
 
 	pending := make([]pendingStop, 0, len(m.runners))
 	var errs []error
-	for name, runner := range m.runners {
-		done, err := runner.cancelRun()
-		if err != nil && !errors.Is(err, ErrTracerNotRunning) {
-			errs = append(errs, err)
-			continue
+	for _, runner := range m.runners {
+		cancel, completions := runner.prepareStop()
+		if cancel != nil {
+			cancel()
 		}
-		if done != nil {
-			pending = append(pending, pendingStop{name: name, done: done})
+		if len(completions) != 0 {
+			pending = append(pending, pendingStop{
+				runner:      runner,
+				completions: completions,
+			})
 		}
 	}
 	m.mu.Unlock()
 
-	for _, runner := range pending {
-		if err := waitForRunner(ctx, runner.name, runner.done); err != nil {
+	for _, stop := range pending {
+		if err := stop.runner.waitForCompletions(ctx, stop.completions); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -149,12 +151,23 @@ func (m *Manager) Close(ctx context.Context) error {
 func (m *Manager) StopByName(ctx context.Context, name string) error {
 	m.mu.RLock()
 	runner, ok := m.runners[name]
-	m.mu.RUnlock()
 	if !ok {
+		m.mu.RUnlock()
 		return newTracerStateError(ErrTracerNotFound, name)
 	}
+	managerClosed := m.isClosed
+	cancel, completions := runner.prepareStop()
+	m.mu.RUnlock()
 
-	return runner.stop(ctx)
+	if len(completions) == 0 {
+		if managerClosed {
+			// Close has already accounted for every generation and prevents new ones.
+			return nil
+		}
+		return newTracerStateError(ErrTracerNotRunning, name)
+	}
+
+	return runner.stopCompletions(ctx, cancel, completions)
 }
 
 // Snapshots returns lifecycle snapshots for all registered tracers.

--- a/pkg/tracing/manager_test.go
+++ b/pkg/tracing/manager_test.go
@@ -23,6 +23,22 @@ import (
 	pkgtypes "huatuo-bamai/pkg/types"
 )
 
+type stopMatchingError struct {
+	err error
+}
+
+func (e *stopMatchingError) Error() string {
+	return e.err.Error()
+}
+
+func (e *stopMatchingError) Unwrap() error {
+	return e.err
+}
+
+func (e *stopMatchingError) Is(target error) bool {
+	return target == pkgtypes.ErrNotSupported
+}
+
 func TestNewManager(t *testing.T) {
 	resetRegisterState()
 	t.Cleanup(resetRegisterState)
@@ -194,4 +210,335 @@ func TestManagerCloseWaitsForAllRunners(t *testing.T) {
 	if err := manager.Close(t.Context()); err != nil {
 		t.Errorf("second Manager.Close() error = %v, want nil", err)
 	}
+}
+
+func TestManagerCloseReportsShutdownErrors(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	tests := []struct {
+		name       string
+		startErr   func(context.Context) error
+		wantErr    error
+		wantCancel bool
+	}{
+		{
+			name: "cleanup error",
+			startErr: func(context.Context) error {
+				return cleanupErr
+			},
+			wantErr: cleanupErr,
+		},
+		{
+			name: "cancellation joined with cleanup error",
+			startErr: func(ctx context.Context) error {
+				return errors.Join(ctx.Err(), cleanupErr)
+			},
+			wantErr:    cleanupErr,
+			wantCancel: true,
+		},
+		{
+			name: "pure context cancellation",
+			startErr: func(ctx context.Context) error {
+				return ctx.Err()
+			},
+		},
+		{
+			name: "pure project stop sentinel",
+			startErr: func(context.Context) error {
+				return pkgtypes.ErrExitByCancelCtx
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			started := make(chan struct{})
+			runner := newEventRunner(
+				"shutdown",
+				&starterStub{
+					startFunc: func(ctx context.Context) error {
+						close(started)
+						<-ctx.Done()
+						return tt.startErr(ctx)
+					},
+				},
+				time.Hour,
+				FlagTracing,
+			)
+			manager := &Manager{
+				runners: map[string]*eventRunner{"shutdown": runner},
+			}
+
+			if err := manager.Start(t.Context()); err != nil {
+				t.Fatalf("Manager.Start() error = %v, want nil", err)
+			}
+			<-started
+
+			err := manager.Close(t.Context())
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("Manager.Close() error = %v, want %v", err, tt.wantErr)
+			}
+			if got := errors.Is(err, context.Canceled); got != tt.wantCancel {
+				t.Errorf(
+					"errors.Is(Manager.Close(), context.Canceled) = %t, want %t",
+					got,
+					tt.wantCancel,
+				)
+			}
+		})
+	}
+}
+
+func TestManagerStopByNameReportsShutdownError(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	started := make(chan struct{})
+	runner := newEventRunner(
+		"stop",
+		&starterStub{
+			startFunc: func(ctx context.Context) error {
+				close(started)
+				<-ctx.Done()
+				return cleanupErr
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"stop": runner},
+	}
+
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Manager.Start() error = %v, want nil", err)
+	}
+	<-started
+	if err := manager.StopByName(t.Context(), "stop"); !errors.Is(err, cleanupErr) {
+		t.Errorf("Manager.StopByName() error = %v, want %v", err, cleanupErr)
+	}
+	if err := manager.StopByName(t.Context(), "stop"); !errors.Is(err, ErrTracerNotRunning) {
+		t.Errorf("second Manager.StopByName() error = %v, want ErrTracerNotRunning", err)
+	}
+}
+
+func TestManagerRequiresCompletedErrorClaimBeforeRestart(t *testing.T) {
+	firstErr := errors.New("first cleanup failed")
+	secondErr := errors.New("second cleanup failed")
+	errs := []error{firstErr, secondErr}
+	nextErr := 0
+	runner := newEventRunner(
+		"completed",
+		&starterStub{
+			startFunc: func(context.Context) error {
+				err := errs[nextErr]
+				nextErr++
+				return errors.Join(pkgtypes.ErrNotSupported, err)
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"completed": runner},
+	}
+
+	if err := manager.StartByName(t.Context(), "completed"); err != nil {
+		t.Fatalf("first Manager.StartByName() error = %v, want nil", err)
+	}
+	waitForLatestGeneration(t, runner)
+	if err := manager.StartByName(t.Context(), "completed"); !errors.Is(err, ErrTracerRunErrorPending) {
+		t.Fatalf("second Manager.StartByName() error = %v, want pending run error", err)
+	}
+	if err := manager.StopByName(t.Context(), "completed"); !errors.Is(err, firstErr) {
+		t.Fatalf("Manager.StopByName() error = %v, want %v", err, firstErr)
+	}
+	if err := manager.StartByName(t.Context(), "completed"); err != nil {
+		t.Fatalf("third Manager.StartByName() error = %v, want nil", err)
+	}
+	waitForLatestGeneration(t, runner)
+
+	err := manager.Close(t.Context())
+	if !errors.Is(err, secondErr) {
+		t.Errorf("Manager.Close() error = %v, want %v", err, secondErr)
+	}
+	if err := manager.Close(t.Context()); err != nil {
+		t.Errorf("second Manager.Close() error = %v, want nil", err)
+	}
+}
+
+func TestManagerCompletedStopSentinelsRemainBounded(t *testing.T) {
+	const generations = 2048
+
+	runner := newEventRunner(
+		"unsupported",
+		&starterStub{
+			startFunc: func(context.Context) error {
+				return pkgtypes.ErrNotSupported
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"unsupported": runner},
+	}
+
+	for generation := 0; generation < generations; generation++ {
+		if err := manager.StartByName(t.Context(), "unsupported"); err != nil {
+			t.Fatalf("Manager.StartByName(%d) error = %v", generation, err)
+		}
+		waitForLatestGeneration(t, runner)
+
+		runner.mu.RLock()
+		retained := len(runner.completions)
+		runner.mu.RUnlock()
+		if retained > 1 {
+			t.Fatalf("retained completions after generation %d = %d, want at most 1", generation, retained)
+		}
+	}
+}
+
+func TestManagerCloseIgnoresCompletedStopSentinel(t *testing.T) {
+	runner := newEventRunner(
+		"unsupported",
+		&starterStub{
+			startFunc: func(context.Context) error {
+				return pkgtypes.ErrNotSupported
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"unsupported": runner},
+	}
+
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Manager.Start() error = %v, want nil", err)
+	}
+	waitForLatestGeneration(t, runner)
+	if err := manager.Close(t.Context()); err != nil {
+		t.Errorf("Manager.Close() error = %v, want nil", err)
+	}
+}
+
+func TestManagerCloseRetainsErrorWrappedByStopMatchingError(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	runner := newEventRunner(
+		"wrapped",
+		&starterStub{
+			startFunc: func(context.Context) error {
+				return &stopMatchingError{err: cleanupErr}
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"wrapped": runner},
+	}
+
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Manager.Start() error = %v, want nil", err)
+	}
+	waitForLatestGeneration(t, runner)
+	if err := manager.Close(t.Context()); !errors.Is(err, cleanupErr) {
+		t.Errorf("Manager.Close() error = %v, want %v", err, cleanupErr)
+	}
+}
+
+func TestManagerCloseRetainsCompletionAfterWaitTimeout(t *testing.T) {
+	cleanupErr := errors.New("delayed cleanup failed")
+	started := make(chan struct{})
+	release := make(chan struct{})
+	runner := newEventRunner(
+		"delayed",
+		&starterStub{
+			startFunc: func(ctx context.Context) error {
+				close(started)
+				<-ctx.Done()
+				<-release
+				return cleanupErr
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"delayed": runner},
+	}
+
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Manager.Start() error = %v, want nil", err)
+	}
+	<-started
+
+	stopCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := manager.Close(stopCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Manager.Close() error = %v, want context.Canceled", err)
+	}
+
+	close(release)
+	waitForLatestGeneration(t, runner)
+	if err := manager.Close(t.Context()); !errors.Is(err, cleanupErr) {
+		t.Errorf("second Manager.Close() error = %v, want %v", err, cleanupErr)
+	}
+}
+
+func TestManagerCloseAndStopConsumeTerminalErrorOnce(t *testing.T) {
+	cleanupErr := errors.New("cleanup failed")
+	started := make(chan struct{})
+	runner := newEventRunner(
+		"concurrent",
+		&starterStub{
+			startFunc: func(ctx context.Context) error {
+				close(started)
+				<-ctx.Done()
+				return cleanupErr
+			},
+		},
+		time.Hour,
+		FlagTracing,
+	)
+	manager := &Manager{
+		runners: map[string]*eventRunner{"concurrent": runner},
+	}
+
+	if err := manager.Start(t.Context()); err != nil {
+		t.Fatalf("Manager.Start() error = %v, want nil", err)
+	}
+	<-started
+
+	results := make(chan error, 2)
+	go func() {
+		results <- manager.Close(t.Context())
+	}()
+	go func() {
+		results <- manager.StopByName(t.Context(), "concurrent")
+	}()
+
+	seen := 0
+	for range 2 {
+		err := <-results
+		if errors.Is(err, ErrTracerNotRunning) {
+			t.Errorf("concurrent stop error = %v, want nil or cleanup error", err)
+		}
+		if errors.Is(err, cleanupErr) {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("cleanup error returned %d times, want 1", seen)
+	}
+	if err := manager.StopByName(t.Context(), "concurrent"); err != nil {
+		t.Errorf("StopByName() after Close error = %v, want nil", err)
+	}
+}
+
+func waitForLatestGeneration(t *testing.T, runner *eventRunner) {
+	t.Helper()
+
+	runner.mu.RLock()
+	completion := runner.completions[len(runner.completions)-1]
+	runner.mu.RUnlock()
+	<-completion.done
 }

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -35,10 +35,16 @@ type eventRunner struct {
 	restartInterval time.Duration
 	roles           uint32
 
-	mu       sync.RWMutex
-	cancel   context.CancelFunc
-	done     <-chan struct{}
-	runCount int
+	mu          sync.RWMutex
+	cancel      context.CancelFunc
+	active      *runCompletion
+	completions []*runCompletion
+	runCount    int
+}
+
+type runCompletion struct {
+	done        chan struct{}
+	terminalErr error
 }
 
 func newEventRunner(
@@ -61,31 +67,56 @@ func (r *eventRunner) start(ctx context.Context) error {
 	}
 
 	r.mu.Lock()
-	if r.done != nil {
+	if r.active != nil {
 		r.mu.Unlock()
 		return newTracerStateError(ErrTracerAlreadyRunning, r.name)
 	}
+	r.discardSuccessfulCompletionsLocked()
+	if len(r.completions) != 0 {
+		r.mu.Unlock()
+		return newTracerRunErrorPending(r.name)
+	}
 
 	runCtx, cancel := context.WithCancel(ctx)
-	done := make(chan struct{})
+	completion := &runCompletion{done: make(chan struct{})}
 	r.cancel = cancel
-	r.done = done
+	r.active = completion
+	r.completions = append(r.completions, completion)
 	r.mu.Unlock()
 
-	go r.run(runCtx, done)
+	go r.run(runCtx, completion)
 
 	return nil
 }
 
-func (r *eventRunner) run(ctx context.Context, done chan<- struct{}) {
+func (r *eventRunner) discardSuccessfulCompletionsLocked() {
+	live := r.completions[:0]
+	for _, completion := range r.completions {
+		if completion.terminalErr != nil {
+			live = append(live, completion)
+		}
+	}
+	clear(r.completions[len(live):])
+	r.completions = live
+}
+
+func (r *eventRunner) run(ctx context.Context, completion *runCompletion) {
 	log.WithField("tracer", r.name).Info("tracer started")
-	defer r.finish(done)
+	var terminalErr error
+	defer func() {
+		r.finish(completion, terminalErr)
+	}()
 
 	for {
 		err := r.starter.Start(ctx)
 		r.incrementRunCount()
 
-		if ctx.Err() != nil || errors.Is(err, types.ErrNotSupported) {
+		if ctx.Err() != nil {
+			terminalErr = unexpectedStopError(err)
+			return
+		}
+		if errors.Is(err, types.ErrNotSupported) {
+			terminalErr = unexpectedStopError(err)
 			return
 		}
 
@@ -108,14 +139,62 @@ func (r *eventRunner) run(ctx context.Context, done chan<- struct{}) {
 	}
 }
 
-func (r *eventRunner) finish(done chan<- struct{}) {
+func (r *eventRunner) finish(completion *runCompletion, terminalErr error) {
 	r.mu.Lock()
-	close(done)
-	r.cancel = nil
-	r.done = nil
+	completion.terminalErr = terminalErr
+	if r.active == completion {
+		r.cancel = nil
+		r.active = nil
+	}
+	close(completion.done)
 	r.mu.Unlock()
 
 	log.WithField("tracer", r.name).Info("tracer stopped")
+}
+
+func unexpectedStopError(err error) error {
+	if err == nil || containsOnlyStopErrors(err) {
+		return nil
+	}
+	return err
+}
+
+func containsOnlyStopErrors(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	var multiple interface{ Unwrap() []error }
+	if errors.As(err, &multiple) {
+		errs := multiple.Unwrap()
+		if len(errs) == 0 {
+			return isStopError(err)
+		}
+		for _, unwrapped := range errs {
+			if !containsOnlyStopErrors(unwrapped) {
+				return false
+			}
+		}
+		return true
+	}
+
+	var single interface{ Unwrap() error }
+	if errors.As(err, &single) {
+		unwrapped := single.Unwrap()
+		if unwrapped != nil {
+			return containsOnlyStopErrors(unwrapped)
+		}
+	}
+
+	return isStopError(err)
+}
+
+func isStopError(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, types.ErrExitByCancelCtx) ||
+		errors.Is(err, types.ErrDisconnectedHuatuo) ||
+		errors.Is(err, types.ErrNotSupported)
 }
 
 func (r *eventRunner) incrementRunCount() {
@@ -125,28 +204,72 @@ func (r *eventRunner) incrementRunCount() {
 }
 
 func (r *eventRunner) stop(ctx context.Context) error {
-	done, err := r.cancelRun()
-	if err != nil {
-		return err
+	cancel, completions := r.prepareStop()
+	if len(completions) == 0 {
+		return newTracerStateError(ErrTracerNotRunning, r.name)
 	}
 
-	return waitForRunner(ctx, r.name, done)
+	return r.stopCompletions(ctx, cancel, completions)
 }
 
-func (r *eventRunner) cancelRun() (<-chan struct{}, error) {
-	r.mu.RLock()
-	if r.done == nil {
-		r.mu.RUnlock()
-		return nil, newTracerStateError(ErrTracerNotRunning, r.name)
+func (r *eventRunner) stopCompletions(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	completions []*runCompletion,
+) error {
+	if cancel != nil {
+		cancel()
 	}
 
+	return r.waitForCompletions(ctx, completions)
+}
+
+func (r *eventRunner) prepareStop() (context.CancelFunc, []*runCompletion) {
+	r.mu.RLock()
 	cancel := r.cancel
-	done := r.done
+	completions := append([]*runCompletion(nil), r.completions...)
 	r.mu.RUnlock()
 
-	cancel()
+	return cancel, completions
+}
 
-	return done, nil
+func (r *eventRunner) waitForCompletions(
+	ctx context.Context,
+	completions []*runCompletion,
+) error {
+	var errs []error
+	for _, completion := range completions {
+		if err := waitForRunner(ctx, r.name, completion.done); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		terminalErr, ok := r.consumeCompletion(completion)
+		if ok && terminalErr != nil {
+			errs = append(errs, newTracerRunError(r.name, terminalErr))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (r *eventRunner) consumeCompletion(completion *runCompletion) (error, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i, pending := range r.completions {
+		if pending != completion {
+			continue
+		}
+
+		terminalErr := pending.terminalErr
+		copy(r.completions[i:], r.completions[i+1:])
+		r.completions[len(r.completions)-1] = nil
+		r.completions = r.completions[:len(r.completions)-1]
+		return terminalErr, true
+	}
+
+	return nil, false
 }
 
 func waitForRunner(ctx context.Context, name string, done <-chan struct{}) error {
@@ -178,7 +301,7 @@ func (r *eventRunner) snapshot() LifecycleSnapshot {
 
 	return LifecycleSnapshot{
 		Name:            r.name,
-		IsRunning:       r.done != nil,
+		IsRunning:       r.active != nil,
 		RunCount:        r.runCount,
 		RestartInterval: int(r.restartInterval / time.Second),
 		Roles:           r.roles,

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -130,7 +130,7 @@ func TestEventRunnerStopHonorsContext(t *testing.T) {
 	<-started
 
 	runner.mu.RLock()
-	done := runner.done
+	done := runner.active.done
 	runner.mu.RUnlock()
 
 	stopCtx, cancel := context.WithCancel(t.Context())
@@ -203,7 +203,7 @@ func TestEventRunnerNotSupportedStops(t *testing.T) {
 	<-started
 
 	runner.mu.RLock()
-	done := runner.done
+	done := runner.active.done
 	runner.mu.RUnlock()
 	close(release)
 	<-done


### PR DESCRIPTION
## What

- Model daemon cleanup steps with explicit dependency boundaries.
- Quiesce toolstream before shutdown, force-close stalled transports, and track
  active handlers before releasing dependent resources.
- Preserve terminal errors reported by `pkg/tracing`.
- Retain setup errors together with rollback failures.
- Make the storage setup step own store cleanup so shutdown follows producer,
  transport, then storage order.

## Why

A timed-out cleanup did not prove that all dependent work had stopped. Continuing
could close storage or tracing resources while handlers still used them, while
stopping all cleanup leaked independent resources. Explicit boundaries allow safe
cleanup to continue and block only resources that may still be in use.

## Scope

This generic lifecycle fix was split from #553. It contains no TCP
retransmit/dropwatch correlation code; #553 retains only the feature-specific
child-process final drain and can rebase after this PR lands.

## Testing

- Affected package unit tests
- Affected package tests with the race detector
- `make check`
