### PR TITLE
fix(cgroup): resolve controller IDs from BTF

### DIFF
--- a/bpf/cgroup_css_events.c
+++ b/bpf/cgroup_css_events.c
@@ -22,6 +22,7 @@ bpf_cgroup_event_class_prog(struct bpf_raw_tracepoint_args *ctx, u64 type)
 	struct cgroup *cgrp		= (void *)ctx->args[0];
 	struct cgroup_css_event data = {};
 	int knode_len;
+	u32 css_size;
 
 	/* knode name */
 	knode_len =
@@ -35,8 +36,10 @@ bpf_cgroup_event_class_prog(struct bpf_raw_tracepoint_args *ctx, u64 type)
 	data.cgroup_root  = BPF_CORE_READ(cgrp, root, hierarchy_id);
 	data.cgroup_level = BPF_CORE_READ(cgrp, level);
 
-	bpf_probe_read(&data.css, sizeof(u64) * CGROUP_SUBSYS_COUNT,
-		       BPF_CORE_READ(cgrp, subsys));
+	css_size = bpf_core_field_size(cgrp->subsys);
+	if (css_size > sizeof(data.css))
+		css_size = sizeof(data.css);
+	bpf_probe_read(&data.css, css_size, BPF_CORE_READ(cgrp, subsys));
 
 	bpf_perf_event_output(ctx, &cgroup_perf_events, COMPAT_BPF_F_CURRENT_CPU,
 			      &data, sizeof(data));

--- a/bpf/cgroup_css_sync.c
+++ b/bpf/cgroup_css_sync.c
@@ -22,6 +22,7 @@ int bpf_cgroup_subsys_state_prog(struct pt_regs *ctx)
 	struct cgroup *cgrp		= BPF_CORE_READ(css, cgroup);
 	struct cgroup_css_event data = {};
 	int knode_len;
+	u32 css_size;
 
 	/* knode name */
 	knode_len =
@@ -36,8 +37,10 @@ int bpf_cgroup_subsys_state_prog(struct pt_regs *ctx)
 	data.cgroup_level = BPF_CORE_READ(cgrp, level);
 
 	/* css */
-	bpf_probe_read(&data.css, sizeof(u64) * CGROUP_SUBSYS_COUNT,
-		       BPF_CORE_READ(cgrp, subsys));
+	css_size = bpf_core_field_size(cgrp->subsys);
+	if (css_size > sizeof(data.css))
+		css_size = sizeof(data.css);
+	bpf_probe_read(&data.css, css_size, BPF_CORE_READ(cgrp, subsys));
 
 	/* output */
 	bpf_perf_event_output(ctx, &cgroup_perf_events, COMPAT_BPF_F_CURRENT_CPU,

--- a/bpf/include/bpf_cgroup.h
+++ b/bpf/include/bpf_cgroup.h
@@ -2,21 +2,23 @@
 #define __BPF_CGROUP_H__
 
 #include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
 
 static __always_inline u64 current_task_cpu_css_addr(void)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-
-	return (u64)BPF_CORE_READ(task, cgroups, subsys[cpu_cgrp_id]);
+	u64 cpu_cgrp_id_val =
+		bpf_core_enum_value(enum cgroup_subsys_id, cpu_cgrp_id);
+	return (u64)BPF_CORE_READ(task, cgroups, subsys[cpu_cgrp_id_val]);
 }
 
 static __always_inline u64 current_task_memory_css_addr(void)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
-
-	return (u64)BPF_CORE_READ(task, cgroups, subsys[memory_cgrp_id]);
+	u64 memory_cgrp_id_val =
+		bpf_core_enum_value(enum cgroup_subsys_id, memory_cgrp_id);
+	return (u64)BPF_CORE_READ(task, cgroups, subsys[memory_cgrp_id_val]);
 }
 
 /* skb_memcg_css_addr returns the memory cgroup subsystem state address for the

--- a/bpf/memory_reclaim.c
+++ b/bpf/memory_reclaim.c
@@ -4,6 +4,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
+#include "bpf_cgroup.h"
 #include "bpf_common.h"
 #include "vmlinux_sched.h"
 
@@ -32,7 +33,7 @@ int tracepoint_vmscan_mm_vmscan_memcg_reclaim_begin(struct pt_regs *ctx)
 	if (BPF_CORE_READ(task, flags) & PF_KSWAPD)
 		return 0;
 
-	css  = BPF_CORE_READ(task, cgroups, subsys[memory_cgrp_id]);
+	css = (struct cgroup_subsys_state *)current_task_memory_css_addr();
 	valp = bpf_map_lookup_elem(&memory_cgroup_allocpages_stall, &css);
 	if (!valp) {
 		struct mem_cgroup_metric new = {

--- a/bpf/memory_reclaim_events.c
+++ b/bpf/memory_reclaim_events.c
@@ -4,6 +4,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
+#include "bpf_cgroup.h"
 #include "bpf_common.h"
 #include "bpf_func_trace.h"
 #include "bpf_ratelimit.h"
@@ -30,19 +31,15 @@ SEC("kretprobe/try_to_free_pages")
 int kretprobe_try_to_free_pages(struct pt_regs *ctx)
 {
 	struct trace_entry_ctx *entry;
-	struct task_struct *task;
 
 	entry = func_trace_end(bpf_get_current_pid_tgid());
 	if (!entry)
 		return 0;
 
 	if (entry->delta_ns > deltath) {
-		task = (struct task_struct *)bpf_get_current_task();
-
 		struct memory_reclaim_event data = {
 			.pid	    = entry->id,
-			.css	    = (u64)BPF_CORE_READ(task, cgroups,
-							 subsys[cpu_cgrp_id]),
+			.css	    = current_task_cpu_css_addr(),
 			.delta_time = entry->delta_ns,
 		};
 

--- a/bpf/oom.c
+++ b/bpf/oom.c
@@ -23,6 +23,7 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 {
 	struct oom_event info = {};
 	struct task_struct *trigger_task, *victim_task;
+	u64 memory_cgrp_id_val;
 
 	if (bpf_ratelimited_in_map(ctx, rate))
 		return 0;
@@ -37,10 +38,12 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 	BPF_CORE_READ_STR_INTO(&info.trigger_comm, trigger_task, comm);
 	BPF_CORE_READ_STR_INTO(&info.victim_comm, victim_task, comm);
 
+	memory_cgrp_id_val =
+		bpf_core_enum_value(enum cgroup_subsys_id, memory_cgrp_id);
 	info.victim_memcg_css =
-	    (u64)BPF_CORE_READ(victim_task, cgroups, subsys[memory_cgrp_id]);
+	    (u64)BPF_CORE_READ(victim_task, cgroups, subsys[memory_cgrp_id_val]);
 	info.trigger_memcg_css =
-	    (u64)BPF_CORE_READ(trigger_task, cgroups, subsys[memory_cgrp_id]);
+	    (u64)BPF_CORE_READ(trigger_task, cgroups, subsys[memory_cgrp_id_val]);
 
 	info.mem_limit_pages = BPF_CORE_READ(oc, totalpages);
 	struct mem_cgroup *memcg = BPF_CORE_READ(oc, memcg);

--- a/bpf/perf.c
+++ b/bpf/perf.c
@@ -4,6 +4,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
+#include "bpf_cgroup.h"
 #include "bpf_common.h"
 #include "bpf_ratelimit.h"
 
@@ -33,8 +34,7 @@ struct {
 SEC("perf_event/software/cpu_clock")
 int perf_event_sw_cpu_clock(struct pt_regs *ctx)
 {
-	struct task_struct *curr = (struct task_struct *)bpf_get_current_task();
-	u64 cpu_css = (u64)BPF_CORE_READ(curr, cgroups, subsys[cpu_cgrp_id]);
+	u64 cpu_css = current_task_cpu_css_addr();
 	if (css != 0 && css != cpu_css)
 		return 0;
 

--- a/internal/pod/container_css_default.go
+++ b/internal/pod/container_css_default.go
@@ -17,7 +17,6 @@
 package pod
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -38,6 +37,7 @@ import (
 	"huatuo-bamai/internal/utils/bytesutil"
 	"huatuo-bamai/pkg/types"
 
+	"github.com/cilium/ebpf/btf"
 	mapset "github.com/deckarep/golang-set"
 )
 
@@ -248,26 +248,43 @@ func cgroupCssNotifyFile() {
 }
 
 func cgroupInitSubSysIDs() error {
-	file, err := os.Open("/proc/cgroups")
+	spec, err := btf.LoadSpec("/sys/kernel/btf/vmlinux")
+	if err != nil {
+		return fmt.Errorf("load kernel BTF: %w", err)
+	}
+
+	var subsystems *btf.Enum
+	if err := spec.TypeByName("cgroup_subsys_id", &subsystems); err != nil {
+		return fmt.Errorf("find cgroup_subsys_id in kernel BTF: %w", err)
+	}
+
+	ids, err := cgroupSubSysIDNameMap(subsystems.Values)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
+	cgroupCssID2SubSysNameMap = ids
+	return nil
+}
 
-	// skip frst head
-	scanner.Scan()
-
-	ssid := 0
-	for scanner.Scan() {
-		arr := strings.SplitN(scanner.Text(), "\t", 2)
-		cgroupCssID2SubSysNameMap[ssid] = arr[0]
-		ssid++
+func cgroupSubSysIDNameMap(values []btf.EnumValue) (map[int]string, error) {
+	ids := make(map[int]string, len(values))
+	for _, value := range values {
+		name, ok := strings.CutSuffix(value.Name, "_cgrp_id")
+		if !ok {
+			continue
+		}
+		if value.Value >= uint64(len(containerCssPerfEvent{}.CSS)) {
+			continue
+		}
+		ids[int(value.Value)] = name
 	}
 
-	return nil
+	if len(ids) == 0 {
+		return nil, errors.New("cgroup_subsys_id has no subsystem values")
+	}
+
+	return ids, nil
 }
 
 func cgroupCssInitEventSync() error {

--- a/internal/pod/container_css_default_test.go
+++ b/internal/pod/container_css_default_test.go
@@ -19,7 +19,31 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cilium/ebpf/btf"
 )
+
+func TestCgroupSubSysIDNameMap(t *testing.T) {
+	ids, err := cgroupSubSysIDNameMap([]btf.EnumValue{
+		{Name: "cpuset_cgrp_id", Value: 0},
+		{Name: "cpu_cgrp_id", Value: 1},
+		{Name: "memory_cgrp_id", Value: 4},
+		{Name: "CGROUP_SUBSYS_COUNT", Value: 13},
+		{Name: "future_cgrp_id", Value: 13},
+	})
+	if err != nil {
+		t.Fatalf("cgroupSubSysIDNameMap() error = %v", err)
+	}
+
+	for id, want := range map[int]string{0: "cpuset", 1: "cpu", 4: "memory"} {
+		if got := ids[id]; got != want {
+			t.Errorf("ids[%d] = %q, want %q", id, got, want)
+		}
+	}
+	if _, ok := ids[13]; ok {
+		t.Error("controllers outside the CSS event ABI must not be mapped")
+	}
+}
 
 func TestExtractContainerID(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -192,7 +192,9 @@ func InitManager(ctx *ManagerCtx) error {
 				if err := kubeletPodListPortCacheUpdate(ctx); err == nil {
 					log.Infof("kubelet is running now")
 					_ = kubeletConfigCacheMustUpdate(ctx)
-					_ = containerCgroupCssInit()
+					if err := containerCgroupCssInit(); err != nil {
+						log.Errorf("initialize container cgroup CSS: %v", err)
+					}
 					t.Stop()
 					return
 				}


### PR DESCRIPTION
Closes #645 

Huatuo 当前按 `/proc/cgroups` 的文本行序推导 `cgroup->subsys[]` 下标。在 cgroup v2 内核中，该行序不保证与内核 `enum cgroup_subsys_id` 一致（cgroupv2 不能用 v1 接口去判断，后续高版本内核均存在兼容性问题，就算不是高版本内核，如果 v1 后续手动编译去除某些 controller，会导致 v2 下获取不到 id，指标丢失）。这会导致 CPU/memory CSS 被错误识别，进而使 memory reclaim、OOM、perf 及 native profiler 的容器归属缺失或错误。

修复方案：

- 从目标内核 BTF 的 `enum cgroup_subsys_id` 获取 controller ID；
- 所有 BPF 中 CPU/memory 的 `subsys[]` 访问使用该 ID；
- 保持现有 CSS event ABI，并兼容 cgroup v1、v2 和 hybrid 模式。