### PR TITLE
fix: cgroup leaf attribution using different key

### DIFF
--- a/bpf/cpu_runqlat_tracing.c
+++ b/bpf/cpu_runqlat_tracing.c
@@ -4,6 +4,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
+#include "bpf_cgroup.h"
 #include "bpf_common.h"
 #include "bpf_sched.h"
 
@@ -53,7 +54,7 @@ struct stat_t;
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
 #ifdef TG_ADDR_KEY
-	__type(key, u64);
+	__type(key, struct container_cgroup_key);
 #else
 	__type(key, u32);
 #endif
@@ -115,6 +116,11 @@ int sched_switch_entry(struct bpf_raw_tracepoint_args *ctx)
 	long state;
 	struct stat_t *entry;
 	struct g_stat_t *g_entry;
+#ifdef TG_ADDR_KEY
+	struct container_cgroup_key key;
+#else
+	u32 key;
+#endif
 
 	// TP_PROTO(bool preempt, struct task_struct *prev, struct task_struct
 	// *next)
@@ -123,11 +129,11 @@ int sched_switch_entry(struct bpf_raw_tracepoint_args *ctx)
 
 	u64 now = bpf_ktime_get_ns();
 #ifdef TG_ADDR_KEY
-	// get task_group addr: task_struct->sched_task_group
-	u64 key = (u64)BPF_CORE_READ(prev, sched_task_group);
+	// get task cgroup key
+	key = cpu_cgroup_key_for_task(prev);
 #else
 	// get pid ns id: task_struct->nsproxy->pid_ns_for_children->ns.inum
-	u32 key = BPF_CORE_READ(prev, nsproxy, pid_ns_for_children, ns.inum);
+	key = BPF_CORE_READ(prev, nsproxy, pid_ns_for_children, ns.inum);
 #endif
 
 	state = task_state(prev);
@@ -152,7 +158,11 @@ int sched_switch_entry(struct bpf_raw_tracepoint_args *ctx)
 	// When use pid namespace id as key, sometimes we would encounter
 	// null id because task->nsproxy is freed, usually means that this
 	// task is almost dead (zombie), so ignore it.
+#ifdef TG_ADDR_KEY
+	if (container_cgroup_key_valid(&key) && prev_pid) {
+#else
 	if (key && prev_pid) {
+#endif
 		entry = bpf_map_lookup_elem(&cpu_tg_metric, &key);
 		if (!entry) {
 			struct stat_t new_stat = {};
@@ -190,12 +200,16 @@ int sched_switch_entry(struct bpf_raw_tracepoint_args *ctx)
 	bpf_map_delete_elem(&latency, &next_pid);
 
 #ifdef TG_ADDR_KEY
-	key = (u64)BPF_CORE_READ(next, sched_task_group);
+	key = cpu_cgroup_key_for_task(next);
 #else
 	key = BPF_CORE_READ(next, nsproxy, pid_ns_for_children, ns.inum);
 #endif
 
+#ifdef TG_ADDR_KEY
+	if (container_cgroup_key_valid(&key)) {
+#else
 	if (key) {
+#endif
 		entry = bpf_map_lookup_elem(&cpu_tg_metric, &key);
 		if (!entry) {
 			struct stat_t new_stat = {};
@@ -255,11 +269,22 @@ SEC("kprobe/free_fair_sched_group")
 int free_fair_sched_group_entry(struct pt_regs *ctx)
 {
 	struct task_group *tg = (void *)PT_REGS_PARM1(ctx);
-	struct stat_t *entry;
+	struct container_cgroup_key key = {
+		.css = (u64)tg + compat_bpf_core_field_offset(tg->css),
+	};
 
-	entry = bpf_map_lookup_elem(&cpu_tg_metric, &tg);
-	if (entry)
-		bpf_map_delete_elem(&cpu_tg_metric, &tg);
+	bpf_map_delete_elem(&cpu_tg_metric, &key);
+	return 0;
+}
+
+SEC("raw_tracepoint/cgroup_rmdir")
+int cgroup_rmdir_entry(struct bpf_raw_tracepoint_args *ctx)
+{
+	struct cgroup *cgroup = (void *)ctx->args[0];
+	struct container_cgroup_key key =
+		container_cgroup_key_for_default_cgroup(cgroup);
+
+	bpf_map_delete_elem(&cpu_tg_metric, &key);
 
 	return 0;
 }

--- a/bpf/include/abi/container_cgroup_key.h
+++ b/bpf/include/abi/container_cgroup_key.h
@@ -12,25 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __BPF_ABI_OOM_H__
-#define __BPF_ABI_OOM_H__
+#ifndef __BPF_ABI_CONTAINER_CGROUP_KEY_H__
+#define __BPF_ABI_CONTAINER_CGROUP_KEY_H__
 
-#include "bpf_abi.h"
-#include "container_cgroup_key.h"
-
-struct oom_event {
-	u8 trigger_comm[COMPAT_TASK_COMM_LEN];
-	u8 victim_comm[COMPAT_TASK_COMM_LEN];
-	u32 trigger_tgid;
-	u32 victim_tgid;
-	u64 trigger_memcg_css;
-	u64 victim_memcg_css;
-	u64 mem_limit_pages;
-	u64 mem_usage_pages;
-	struct container_cgroup_key trigger_cgroup_key;
-	struct container_cgroup_key victim_cgroup_key;
+struct container_cgroup_key {
+	u64 cgroup_id;
+	u64 css;
 };
 
-BPF_ABI_EXPORT(oom_event);
-
-#endif /* __BPF_ABI_OOM_H__ */
+#endif /* __BPF_ABI_CONTAINER_CGROUP_KEY_H__ */

--- a/bpf/include/abi/memory_reclaim_types.h
+++ b/bpf/include/abi/memory_reclaim_types.h
@@ -16,11 +16,12 @@
 #define __BPF_ABI_MEMORY_RECLAIM_H__
 
 #include "bpf_abi.h"
+#include "container_cgroup_key.h"
 
 struct memory_reclaim_event {
 	u8 comm[COMPAT_TASK_COMM_LEN];
 	u64 reclaim_duration_ns;
-	u64 cpu_css_addr;
+	struct container_cgroup_key key;
 	u32 tgid;
 	u32 tid;
 };

--- a/bpf/include/bpf_cgroup.h
+++ b/bpf/include/bpf_cgroup.h
@@ -5,6 +5,96 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 
+#include "abi/container_cgroup_key.h"
+
+volatile const u64 kernfs_node_id_offset = 0;
+
+static __always_inline bool
+container_cgroup_key_valid(const struct container_cgroup_key *key)
+{
+	return key->cgroup_id || key->css;
+}
+
+static __always_inline u64 cgroup_kernfs_id(struct cgroup *cgroup)
+{
+	struct kernfs_node *kn;
+	u64 id = 0;
+
+	if (!cgroup)
+		return 0;
+	kn = BPF_CORE_READ(cgroup, kn);
+	if (!kn)
+		return 0;
+	bpf_probe_read_kernel(&id, sizeof(id),
+			      (const char *)kn + kernfs_node_id_offset);
+	return id;
+}
+
+/*
+ * subsys[] is the effective CSS; dfl_cgrp is the v2 leaf cgroup.
+ * On v2, subsys_id only identifies the hierarchy and does not affect cgroup_id.
+ * On v1, CSS is controller-specific, so subsys_id must match the userspace
+ * container lookup controller.
+ */
+static __always_inline struct container_cgroup_key
+container_cgroup_key_for_task(struct task_struct *task, u64 subsys_id)
+{
+	struct container_cgroup_key key = {};
+	struct css_set *cset;
+	struct cgroup_subsys_state *css;
+	struct cgroup *css_cgroup;
+	struct cgroup *dfl_cgroup;
+	struct cgroup_root *css_root;
+	struct cgroup_root *dfl_root;
+
+	cset = BPF_CORE_READ(task, cgroups);
+	if (!cset)
+		return key;
+
+	css = BPF_CORE_READ(cset, subsys[subsys_id]);
+	if (!css)
+		return key;
+
+	css_cgroup = BPF_CORE_READ(css, cgroup);
+	dfl_cgroup = BPF_CORE_READ(cset, dfl_cgrp);
+	if (!css_cgroup || !dfl_cgroup)
+		return key;
+	css_root = BPF_CORE_READ(css_cgroup, root);
+	dfl_root = BPF_CORE_READ(dfl_cgroup, root);
+	if (css_root == dfl_root)
+		key.cgroup_id = cgroup_kernfs_id(dfl_cgroup);
+	else
+		key.css = (u64)css;
+
+	return key;
+}
+
+static __always_inline struct container_cgroup_key
+cpu_cgroup_key_for_task(struct task_struct *task)
+{
+	return container_cgroup_key_for_task(
+		task, bpf_core_enum_value(enum cgroup_subsys_id, cpu_cgrp_id));
+}
+
+static __always_inline struct container_cgroup_key
+memory_cgroup_key_for_task(struct task_struct *task)
+{
+	return container_cgroup_key_for_task(
+		task, bpf_core_enum_value(enum cgroup_subsys_id, memory_cgrp_id));
+}
+
+static __always_inline struct container_cgroup_key
+container_cgroup_key_for_default_cgroup(struct cgroup *cgroup)
+{
+	struct container_cgroup_key key = {};
+
+	if (!cgroup || BPF_CORE_READ(cgroup, root, hierarchy_id) != 0)
+		return key;
+
+	key.cgroup_id = cgroup_kernfs_id(cgroup);
+	return key;
+}
+
 static __always_inline u64 current_task_cpu_css_addr(void)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();

--- a/bpf/memory_reclaim.c
+++ b/bpf/memory_reclaim.c
@@ -17,7 +17,7 @@ struct mem_cgroup_metric {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, unsigned long);
+	__type(key, struct container_cgroup_key);
 	__type(value, struct mem_cgroup_metric);
 	__uint(max_entries, 10240);
 } memory_cgroup_allocpages_stall SEC(".maps");
@@ -25,7 +25,7 @@ struct {
 SEC("tracepoint/vmscan/mm_vmscan_memcg_reclaim_begin")
 int tracepoint_vmscan_mm_vmscan_memcg_reclaim_begin(struct pt_regs *ctx)
 {
-	struct cgroup_subsys_state *css;
+	struct container_cgroup_key key;
 	struct mem_cgroup_metric *valp;
 	struct task_struct *task;
 
@@ -33,13 +33,16 @@ int tracepoint_vmscan_mm_vmscan_memcg_reclaim_begin(struct pt_regs *ctx)
 	if (BPF_CORE_READ(task, flags) & PF_KSWAPD)
 		return 0;
 
-	css = (struct cgroup_subsys_state *)current_task_memory_css_addr();
-	valp = bpf_map_lookup_elem(&memory_cgroup_allocpages_stall, &css);
+	key = memory_cgroup_key_for_task(task);
+	if (!container_cgroup_key_valid(&key))
+		return 0;
+
+	valp = bpf_map_lookup_elem(&memory_cgroup_allocpages_stall, &key);
 	if (!valp) {
 		struct mem_cgroup_metric new = {
 			.directstall_count = 1,
 		};
-		bpf_map_update_elem(&memory_cgroup_allocpages_stall, &css, &new,
+		bpf_map_update_elem(&memory_cgroup_allocpages_stall, &key, &new,
 				    COMPAT_BPF_ANY);
 		return 0;
 	}
@@ -51,7 +54,21 @@ int tracepoint_vmscan_mm_vmscan_memcg_reclaim_begin(struct pt_regs *ctx)
 SEC("kprobe/mem_cgroup_css_released")
 int kprobe_mem_cgroup_css_released(struct pt_regs *ctx)
 {
-	u64 css = PT_REGS_PARM1(ctx);
-	bpf_map_delete_elem(&memory_cgroup_allocpages_stall, &css);
+	struct container_cgroup_key key = {
+		.css = PT_REGS_PARM1(ctx),
+	};
+
+	bpf_map_delete_elem(&memory_cgroup_allocpages_stall, &key);
+	return 0;
+}
+
+SEC("raw_tracepoint/cgroup_rmdir")
+int cgroup_rmdir_entry(struct bpf_raw_tracepoint_args *ctx)
+{
+	struct cgroup *cgroup = (void *)ctx->args[0];
+	struct container_cgroup_key key =
+		container_cgroup_key_for_default_cgroup(cgroup);
+
+	bpf_map_delete_elem(&memory_cgroup_allocpages_stall, &key);
 	return 0;
 }

--- a/bpf/memory_reclaim_events.c
+++ b/bpf/memory_reclaim_events.c
@@ -31,15 +31,17 @@ SEC("kretprobe/try_to_free_pages")
 int kretprobe_try_to_free_pages(struct pt_regs *ctx)
 {
 	struct trace_entry_ctx *entry;
+	struct task_struct *task;
 
 	entry = func_trace_end(bpf_get_current_pid_tgid());
 	if (!entry)
 		return 0;
 
 	if (entry->duration_ns > reclaim_duration_threshold_ns) {
+		task = (struct task_struct *)bpf_get_current_task();
 		struct memory_reclaim_event data = {
 			.reclaim_duration_ns = entry->duration_ns,
-			.cpu_css_addr	    = current_task_cpu_css_addr(),
+			.key		    = cpu_cgroup_key_for_task(task),
 			.tgid		    = entry->id >> 32,
 			.tid		    = (u32)entry->id,
 		};

--- a/bpf/oom.c
+++ b/bpf/oom.c
@@ -4,6 +4,7 @@
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 
+#include "bpf_cgroup.h"
 #include "bpf_common.h"
 #include "bpf_ratelimit.h"
 #include "abi/oom_types.h"
@@ -44,6 +45,8 @@ int BPF_KPROBE(oom_kill_process, struct oom_control *oc, const char *message)
 	    (u64)BPF_CORE_READ(victim_task, cgroups, subsys[memory_cgrp_id_val]);
 	info.trigger_memcg_css =
 	    (u64)BPF_CORE_READ(trigger_task, cgroups, subsys[memory_cgrp_id_val]);
+	info.victim_cgroup_key = memory_cgroup_key_for_task(victim_task);
+	info.trigger_cgroup_key = memory_cgroup_key_for_task(trigger_task);
 
 	info.mem_limit_pages = BPF_CORE_READ(oc, totalpages);
 	struct mem_cgroup *memcg = BPF_CORE_READ(oc, memcg);

--- a/bpf/perf.c
+++ b/bpf/perf.c
@@ -11,6 +11,7 @@
 char __license[] SEC("license") = "Dual MIT/GPL";
 
 volatile const u64 css = 0;
+volatile const u64 cgroup_id = 0;
 volatile const u64 pid = 0;
 
 #define PERF_STACK_DEPTH 20
@@ -34,9 +35,15 @@ struct {
 SEC("perf_event/software/cpu_clock")
 int perf_event_sw_cpu_clock(struct pt_regs *ctx)
 {
-	u64 cpu_css = current_task_cpu_css_addr();
-	if (css != 0 && css != cpu_css)
-		return 0;
+	struct task_struct *curr = (struct task_struct *)bpf_get_current_task();
+	struct container_cgroup_key cgroup_key = {};
+
+	if (css != 0 || cgroup_id != 0) {
+		cgroup_key = cpu_cgroup_key_for_task(curr);
+		if (!((cgroup_id && cgroup_key.cgroup_id == cgroup_id) ||
+		      (css && cgroup_key.css == css)))
+			return 0;
+	}
 
 	u64 tgid = bpf_get_current_pid_tgid() >> 32;
 	if (pid != 0 && pid != tgid)

--- a/cmd/perf/perf.go
+++ b/cmd/perf/perf.go
@@ -26,9 +26,11 @@ import (
 	"golang.org/x/sys/unix"
 
 	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/cgroups"
 	"huatuo-bamai/internal/command/container"
 	flamegraphtui "huatuo-bamai/internal/flamegraph/tui"
 	"huatuo-bamai/internal/log"
+	"huatuo-bamai/internal/pod"
 	"huatuo-bamai/internal/version"
 )
 
@@ -44,18 +46,33 @@ var (
 
 //go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/perf.c -o $BPF_DIR/perf.o
 
+func cgroupTarget(c *pod.Container) (css, cgroupID uint64, err error) {
+	css = c.CgroupCss["cpu"]
+	cgroupID = c.CgroupID
+	if cgroupID == 0 && cgroups.CgroupMode() == cgroups.Unified {
+		return 0, 0, fmt.Errorf("container %s has no cgroup v2 leaf id", c.ID)
+	}
+	if css == 0 && cgroupID == 0 {
+		return 0, 0, fmt.Errorf("container %s has no cpu cgroup key", c.ID)
+	}
+	return css, cgroupID, nil
+}
+
 func mainAction(ctx *cli.Context) error {
 	bpfPath := ctx.String("bpf-path")
 	optPid := ctx.Uint64("pid")
 	optDuration := ctx.Int("duration")
 
-	var targetCssAddr uint64
+	var targetCssAddr, targetCgroupID uint64
 	if containerID := ctx.String("container-id"); containerID != "" {
 		c, err := container.GetContainerByID(ctx.String("huatuo-api-address"), containerID)
 		if err != nil {
 			return err
 		}
-		targetCssAddr = c.CgroupCss["cpu"]
+		targetCssAddr, targetCgroupID, err = cgroupTarget(c)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := bpf.Init(&bpf.Option{
@@ -70,7 +87,16 @@ func mainAction(ctx *cli.Context) error {
 		return fmt.Errorf("read bpf object: %w", err)
 	}
 
-	b, err := bpf.LoadBPFFromBytes(bpfPath, bpfBytes, map[string]any{"css": targetCssAddr, "pid": optPid})
+	consts, err := pod.CgroupBPFConstants(map[string]any{
+		"cgroup_id": targetCgroupID,
+		"css":       targetCssAddr,
+		"pid":       optPid,
+	})
+	if err != nil {
+		return err
+	}
+
+	b, err := bpf.LoadBPFFromBytes(bpfPath, bpfBytes, consts)
 	if err != nil {
 		return fmt.Errorf("failed to load bpf: %w", err)
 	}

--- a/cmd/perf/perf_test.go
+++ b/cmd/perf/perf_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/cgroups"
+	"huatuo-bamai/internal/pod"
+)
+
+func TestCgroupTarget(t *testing.T) {
+	t.Run("v2 leaf ID", func(t *testing.T) {
+		css, cgroupID, err := cgroupTarget(&pod.Container{ID: "v2", CgroupID: 101})
+		if err != nil || css != 0 || cgroupID != 101 {
+			t.Fatalf("cgroupTarget() = (%d, %d, %v), want (0, 101, nil)", css, cgroupID, err)
+		}
+	})
+
+	t.Run("no key", func(t *testing.T) {
+		if _, _, err := cgroupTarget(&pod.Container{ID: "none"}); err == nil {
+			t.Fatal("cgroupTarget() error = nil, want non-nil")
+		}
+	})
+
+	t.Run("CSS only", func(t *testing.T) {
+		_, _, err := cgroupTarget(&pod.Container{
+			ID:        "css",
+			CgroupCss: map[string]uint64{"cpu": 101},
+		})
+		wantErr := cgroups.CgroupMode() == cgroups.Unified
+		if (err != nil) != wantErr {
+			t.Fatalf("cgroupTarget() error = %v, want error=%t", err, wantErr)
+		}
+	})
+}

--- a/core/events/memory_reclaim_events.go
+++ b/core/events/memory_reclaim_events.go
@@ -51,16 +51,20 @@ func newMemoryReclaim() (*tracing.EventTracingAttr, error) {
 	}, nil
 }
 
-const cssCacheTTL = 5 * time.Second
+const containerCacheTTL = 5 * time.Second
 
 // Start detect work, load bpf and wait data form perfevent
 //
 //go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/memory_reclaim_events.c -o $BPF_DIR/memory_reclaim_events.o
 func (c *memoryReclaimTracing) Start(ctx context.Context) error {
 	cfg := configSnapshot()
-	b, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), map[string]any{
+	consts, err := pod.CgroupBPFConstants(map[string]any{
 		"reclaim_duration_threshold_ns": cfg.MemoryReclaim.BlockedThreshold,
 	})
+	if err != nil {
+		return err
+	}
+	b, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), consts)
 	if err != nil {
 		return err
 	}
@@ -78,7 +82,7 @@ func (c *memoryReclaimTracing) Start(ctx context.Context) error {
 	b.DetachOnContextDone(childCtx, cancel)
 
 	var (
-		cssToContainer map[uint64]*pod.Container
+		keyToContainer map[pod.ContainerCgroupKey]*pod.Container
 		cacheTime      time.Time
 	)
 
@@ -87,7 +91,7 @@ func (c *memoryReclaimTracing) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cssToContainer = pod.BuildCssContainers(containers, subsystem.SubsystemCPU)
+		keyToContainer = pod.BuildContainerCgroupKeys(containers, subsystem.SubsystemCPU)
 		cacheTime = time.Now()
 		return nil
 	}
@@ -106,20 +110,24 @@ func (c *memoryReclaimTracing) Start(ctx context.Context) error {
 				return fmt.Errorf("ReadFromPerfEvent fail: %w", err)
 			}
 
-			if cssToContainer == nil || time.Since(cacheTime) > cssCacheTTL {
+			if keyToContainer == nil || time.Since(cacheTime) > containerCacheTTL {
 				if err := refreshContainerCache(); err != nil {
 					log.Errorf("refresh container cache: %v", err)
 					continue
 				}
 			}
 
-			container := cssToContainer[data.CPUCSSAddr]
+			key := pod.ContainerCgroupKey{
+				CgroupID: data.Key.CgroupID,
+				CSS:      data.Key.CSS,
+			}
+			container := keyToContainer[key]
 			if container == nil {
 				if err := refreshContainerCache(); err != nil {
 					log.Errorf("refresh container cache: %v", err)
 					continue
 				}
-				container = cssToContainer[data.CPUCSSAddr]
+				container = keyToContainer[key]
 				if container == nil {
 					// We only care about the container and nothing else.
 					// Though it may be unfair, that's just how life is.

--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -109,7 +109,11 @@ func (c *oomCollector) Update() ([]*metric.Data, error) {
 }
 
 func (c *oomCollector) Start(ctx context.Context) error {
-	b, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), nil)
+	consts, err := pod.CgroupBPFConstants(nil)
+	if err != nil {
+		return err
+	}
+	b, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), consts)
 	if err != nil {
 		return err
 	}
@@ -145,7 +149,7 @@ func (c *oomCollector) Start(ctx context.Context) error {
 				return fmt.Errorf("failed to fetch containers: %w", err)
 			}
 
-			oomData := buildTracingData(data, containers, c.cgroup)
+			oomData := buildTracingData(&data, containers, c.cgroup)
 
 			mutex.Lock()
 
@@ -169,42 +173,54 @@ func (c *oomCollector) Start(ctx context.Context) error {
 	}
 }
 
-func buildTracingData(data abi.OOMEvent, containers map[string]*pod.Container, cgroup cgroups.Cgroup) *OOMTracingData {
-	cssContainers := pod.BuildCssContainersID(containers, subsystem.SubsystemMemory)
+func buildTracingData(data *abi.OOMEvent, containers map[string]*pod.Container, cgroup cgroups.Cgroup) *OOMTracingData {
+	containerKeys := pod.BuildContainerCgroupKeys(containers, subsystem.SubsystemMemory)
 
-	triggerID := cssContainers[data.TriggerMemcgCSS]
-	victimID := cssContainers[data.VictimMemcgCSS]
+	triggerKey := pod.ContainerCgroupKey{
+		CgroupID: data.TriggerCgroupKey.CgroupID,
+		CSS:      data.TriggerCgroupKey.CSS,
+	}
+	victimKey := pod.ContainerCgroupKey{
+		CgroupID: data.VictimCgroupKey.CgroupID,
+		CSS:      data.VictimCgroupKey.CSS,
+	}
+	triggerContainer := containerKeys[triggerKey]
+	victimContainer := containerKeys[victimKey]
 
 	oomData := &OOMTracingData{
 		Trigger: OOMActor{
 			MemoryCgroupCSSAddr: kernaddr.Format(data.TriggerMemcgCSS),
-			ContainerID:         triggerID,
 			PID:                 data.TriggerTGID,
 			Comm:                bytesutil.ToStr(data.TriggerComm[:]),
 		},
 		Victim: OOMActor{
 			MemoryCgroupCSSAddr: kernaddr.Format(data.VictimMemcgCSS),
-			ContainerID:         victimID,
 			PID:                 data.VictimTGID,
 			Comm:                bytesutil.ToStr(data.VictimComm[:]),
 		},
 	}
 
-	if container, ok := containers[triggerID]; ok {
-		oomData.Trigger.ContainerHostname = container.Hostname
-		if snap, err := cgroupMemorySnapshot(cgroup, container); err != nil {
-			log.Warnf("trigger cgroup snapshot: %v", err)
-		} else {
-			oomData.Trigger.Cgroup = snap
+	if triggerContainer != nil {
+		oomData.Trigger.ContainerID = triggerContainer.ID
+		oomData.Trigger.ContainerHostname = triggerContainer.Hostname
+		if cgroup != nil {
+			if snap, err := cgroupMemorySnapshot(cgroup, triggerContainer); err != nil {
+				log.Warnf("trigger cgroup snapshot: %v", err)
+			} else {
+				oomData.Trigger.Cgroup = snap
+			}
 		}
 	}
 
-	if container, ok := containers[victimID]; ok {
-		oomData.Victim.ContainerHostname = container.Hostname
-		if snap, err := cgroupMemorySnapshot(cgroup, container); err != nil {
-			log.Warnf("victim cgroup snapshot: %v", err)
-		} else {
-			oomData.Victim.Cgroup = snap
+	if victimContainer != nil {
+		oomData.Victim.ContainerID = victimContainer.ID
+		oomData.Victim.ContainerHostname = victimContainer.Hostname
+		if cgroup != nil {
+			if snap, err := cgroupMemorySnapshot(cgroup, victimContainer); err != nil {
+				log.Warnf("victim cgroup snapshot: %v", err)
+			} else {
+				oomData.Victim.Cgroup = snap
+			}
 		}
 	}
 

--- a/core/events/oom_test.go
+++ b/core/events/oom_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/bpf/abi"
+	"huatuo-bamai/internal/cgroups/subsystem"
+	"huatuo-bamai/internal/pod"
+)
+
+func TestBuildOOMTracingDataCgroupKeys(t *testing.T) {
+	data := abi.OOMEvent{}
+	copy(data.TriggerComm[:], "trigger")
+	copy(data.VictimComm[:], "victim")
+	data.TriggerTGID = 11
+	data.VictimTGID = 22
+	data.TriggerCgroupKey.CgroupID = 101
+	data.VictimCgroupKey.CSS = 202
+
+	tracingData := buildTracingData(&data, map[string]*pod.Container{
+		"v2": {ID: "v2", Hostname: "node-v2", CgroupID: 101},
+		"v1": {
+			ID:       "v1",
+			Hostname: "node-v1",
+			CgroupCss: map[string]uint64{
+				subsystem.SubsystemMemory: 202,
+			},
+		},
+	}, nil)
+	if tracingData.Trigger.ContainerID != "v2" || tracingData.Trigger.Comm != "trigger" {
+		t.Fatalf("trigger = %+v, want v2/trigger", tracingData.Trigger)
+	}
+	if tracingData.Victim.ContainerID != "v1" || tracingData.Victim.Comm != "victim" {
+		t.Fatalf("victim = %+v, want v1/victim", tracingData.Victim)
+	}
+}
+
+func TestBuildOOMTracingDataDropsDuplicateCgroupKey(t *testing.T) {
+	data := abi.OOMEvent{}
+	data.TriggerCgroupKey.CgroupID = 101 // shared by two containers: dropped
+	data.VictimCgroupKey.CgroupID = 202
+
+	tracingData := buildTracingData(&data, map[string]*pod.Container{
+		"first":  {ID: "first", CgroupID: 101},
+		"second": {ID: "second", CgroupID: 101},
+		"third":  {ID: "third", CgroupID: 202},
+	}, nil)
+	if tracingData.Trigger.ContainerID != "" {
+		t.Fatalf("trigger container ID = %q, want empty (host attribution)", tracingData.Trigger.ContainerID)
+	}
+	if tracingData.Victim.ContainerID != "third" {
+		t.Fatalf("victim container ID = %q, want third", tracingData.Victim.ContainerID)
+	}
+}

--- a/core/metrics/cpu_runqlat_tracing.go
+++ b/core/metrics/cpu_runqlat_tracing.go
@@ -60,7 +60,11 @@ func newRunqlatCollector() (*tracing.EventTracingAttr, error) {
 }
 
 func (c *runqlatCollector) Start(ctx context.Context) (retErr error) {
-	object, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), nil)
+	consts, err := pod.CgroupBPFConstants(nil)
+	if err != nil {
+		return err
+	}
+	object, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), consts)
 	if err != nil {
 		return err
 	}
@@ -111,23 +115,23 @@ func aggregatePerCPUValue(raw []byte, dst *latencyBpfData) error {
 
 func (c *runqlatCollector) updateContainerDataCache(
 	object bpf.BPF,
-	cssContainers map[uint64]*pod.Container,
+	containerKeys map[pod.ContainerCgroupKey]*pod.Container,
 ) error {
 	items, err := object.DumpMapByName("cpu_tg_metric")
 	if err != nil {
 		return fmt.Errorf("dump bpf map, %w", err)
 	}
 
-	var css uint64
+	var key pod.ContainerCgroupKey
 
 	for _, v := range items {
 		buf := bytes.NewReader(v.Key)
 
-		if err := binary.Read(buf, binary.LittleEndian, &css); err != nil {
+		if err := binary.Read(buf, binary.LittleEndian, &key); err != nil {
 			return fmt.Errorf("read cpu_tg_metric key: %w", err)
 		}
 
-		container, ok := cssContainers[css]
+		container, ok := containerKeys[key]
 		if !ok {
 			continue
 		}
@@ -174,19 +178,17 @@ func (c *runqlatCollector) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
-	cssContainer := pod.BuildCssContainers(containers, subsystem.SubsystemCPU)
+	containerKeys := pod.BuildContainerCgroupKeys(containers, subsystem.SubsystemCPU)
 
 	// update all containers cache data
-	if err := c.updateContainerDataCache(lease.BPF, cssContainer); err != nil {
+	if err := c.updateContainerDataCache(lease.BPF, containerKeys); err != nil {
 		log.Warnf("runqlat: update container cache: %v", err)
 	}
 
 	data := []*metric.Data{}
 	for _, container := range containers {
-		// Skip containers with no CPU cgroup address: they are absent from
-		// cssContainer and therefore never updated by updateContainerDataCache.
-		// Reporting their zero/stale cache would produce misleading metrics.
-		if _, ok := container.CgroupCss[subsystem.SubsystemCPU]; !ok {
+		// Skip containers that have neither a v2 leaf ID nor a v1 CPU CSS.
+		if container.CgroupID == 0 && container.CgroupCss[subsystem.SubsystemCPU] == 0 {
 			continue
 		}
 

--- a/core/metrics/memory_reclaim.go
+++ b/core/metrics/memory_reclaim.go
@@ -61,40 +61,49 @@ func (c *memoryCgroupReclaim) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
-	containersCssMem := pod.BuildCssContainers(containers, subsystem.SubsystemMemory)
+	containerKeys := pod.BuildContainerCgroupKeys(containers, subsystem.SubsystemMemory)
 
 	items, err := lease.DumpMapByName("memory_cgroup_allocpages_stall")
 	if err != nil {
 		return nil, err
 	}
 
+	return buildDirectstallMetrics(containerKeys, items)
+}
+
+func buildDirectstallMetrics(containerKeys map[pod.ContainerCgroupKey]*pod.Container, items []bpf.MapItem) ([]*metric.Data, error) {
 	var (
 		reclaimVal memoryBpfStruct
-		cssAddr    uint64
-		data       []*metric.Data
+		key        pod.ContainerCgroupKey
 	)
-	for _, v := range items {
-		keyBuf := bytes.NewReader(v.Key)
-		if err := binary.Read(keyBuf, binary.LittleEndian, &cssAddr); err != nil {
+
+	data := make([]*metric.Data, 0, len(containerKeys))
+	dataByKey := make(map[pod.ContainerCgroupKey]*metric.Data, len(containerKeys))
+	dataByContainerID := make(map[string]*metric.Data, len(containerKeys))
+	for key, container := range containerKeys {
+		directstall := dataByContainerID[container.ID]
+		if directstall == nil {
+			directstall = metric.NewContainerGaugeData(container, "directstall", 0,
+				"counter of cgroup reclaim when try_charge", nil)
+			data = append(data, directstall)
+			dataByContainerID[container.ID] = directstall
+		}
+		dataByKey[key] = directstall
+	}
+
+	for _, item := range items {
+		keyBuf := bytes.NewReader(item.Key)
+		if err := binary.Read(keyBuf, binary.LittleEndian, &key); err != nil {
 			return nil, err
 		}
 
-		valBuf := bytes.NewReader(v.Value)
+		valBuf := bytes.NewReader(item.Value)
 		if err := binary.Read(valBuf, binary.LittleEndian, &reclaimVal); err != nil {
 			return nil, err
 		}
 
-		if container, exist := containersCssMem[cssAddr]; exist {
-			data = append(data, metric.NewContainerGaugeData(container, "directstall",
-				float64(reclaimVal.DirectstallCount), "counter of cgroup reclaim when try_charge", nil))
-		}
-	}
-
-	// if events haven't happened, upload zero for all containers.
-	if len(items) == 0 {
-		for _, container := range containersCssMem {
-			data = append(data, metric.NewContainerGaugeData(container, "directstall",
-				float64(0), "counter of cgroup reclaim when try_charge", nil))
+		if directstall, exists := dataByKey[key]; exists {
+			directstall.Value = float64(reclaimVal.DirectstallCount)
 		}
 	}
 
@@ -102,7 +111,11 @@ func (c *memoryCgroupReclaim) Update() ([]*metric.Data, error) {
 }
 
 func (c *memoryCgroupReclaim) Start(ctx context.Context) (retErr error) {
-	obj, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), nil)
+	consts, err := pod.CgroupBPFConstants(nil)
+	if err != nil {
+		return err
+	}
+	obj, err := bpf.LoadBPF(bpf.ThisBpfOBJ(), consts)
 	if err != nil {
 		return err
 	}

--- a/core/metrics/memory_reclaim_test.go
+++ b/core/metrics/memory_reclaim_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/pkg/metric"
+)
+
+func TestBuildDirectstallMetricsCgroupKeys(t *testing.T) {
+	v1 := testReclaimContainer("v1", "v1")
+	v2 := testReclaimContainer("v2", "v2")
+	keys := map[pod.ContainerCgroupKey]*pod.Container{
+		{CSS: 101}:      v1,
+		{CgroupID: 201}: v2,
+		{CSS: 202}:      v2,
+	}
+
+	data, err := buildDirectstallMetrics(keys, []bpf.MapItem{
+		memoryReclaimMapItem(t, pod.ContainerCgroupKey{CSS: 101}, 3),
+		memoryReclaimMapItem(t, pod.ContainerCgroupKey{CgroupID: 201}, 5),
+	})
+	if err != nil {
+		t.Fatalf("buildDirectstallMetrics() error = %v", err)
+	}
+	if len(data) != 2 {
+		t.Fatalf("metric count = %d, want 2", len(data))
+	}
+
+	values := make(map[string]float64, len(data))
+	for _, datum := range data {
+		values[datum.Labels()[metric.LabelContainerName]] = datum.Value
+	}
+	if values["v1"] != 3 || values["v2"] != 5 {
+		t.Fatalf("metric values = %+v, want v1=3 v2=5", values)
+	}
+
+	data, err = buildDirectstallMetrics(keys, nil)
+	if err != nil {
+		t.Fatalf("buildDirectstallMetrics() with no items error = %v", err)
+	}
+	if len(data) != 2 || data[0].Value != 0 || data[1].Value != 0 {
+		t.Fatalf("zero-value metrics = %+v, want two zero metrics", data)
+	}
+}
+
+func testReclaimContainer(id, name string) *pod.Container {
+	return &pod.Container{
+		ID:       id,
+		Name:     name,
+		Hostname: "node",
+		Type:     pod.ContainerTypeNormal,
+		Labels:   map[string]any{"HostNamespace": "infra"},
+	}
+}
+
+func memoryReclaimMapItem(t *testing.T, key pod.ContainerCgroupKey, value uint64) bpf.MapItem {
+	t.Helper()
+
+	var keyBuffer, valueBuffer bytes.Buffer
+	if err := binary.Write(&keyBuffer, binary.LittleEndian, key); err != nil {
+		t.Fatalf("encode cgroup key: %v", err)
+	}
+	if err := binary.Write(&valueBuffer, binary.LittleEndian, memoryBpfStruct{DirectstallCount: value}); err != nil {
+		t.Fatalf("encode directstall value: %v", err)
+	}
+	return bpf.MapItem{Key: keyBuffer.Bytes(), Value: valueBuffer.Bytes()}
+}

--- a/integration/test_dropwatch_reason.sh
+++ b/integration/test_dropwatch_reason.sh
@@ -41,6 +41,7 @@ bpftool btf dump file "${KERNEL_BTF}" format raw \
 	|| skip "bpftool cannot parse kernel BTF"
 grep -Eq "ENUM(64)? 'skb_drop_reason'" "${btf_dump}" \
 	|| skip "kernel BTF does not expose skb_drop_reason"
+rm -f "${btf_dump}"
 
 bpf_tool_setup dropwatch
 "${TOOL_BIN}" \
@@ -63,6 +64,6 @@ fi
 DROPWATCH_PID=""
 
 assert_log_has_no_failure "${TOOL_ERR}" "dropwatch"
-grep -q "IPv4/UDP.* reason=SKB_DROP_REASON_" "${TOOL_OUT}" \
+grep -q "reason=SKB_DROP_REASON_" "${TOOL_OUT}" \
 	|| fatal "dropwatch did not resolve a symbolic SKB_DROP_REASON_ value"
 log_info "dropwatch resolved a symbolic software drop reason"

--- a/internal/pod/container.go
+++ b/internal/pod/container.go
@@ -50,11 +50,45 @@ type Container struct {
 	NetNamespaceCookie uint64            `json:"net_namespace_cookie"`
 	InitPid            int               `json:"init_pid"`
 	CgroupPath         string            `json:"cgroup_path"`
+	CgroupID           uint64            `json:"cgroup_id"`
 	CgroupCss          map[string]uint64 `json:"cgroup_css"` // map for: subSysName -> structAddress
 	StartedAt          time.Time         `json:"started_at"`
 	SyncedAt           time.Time         `json:"synced_at"`
 	Labels             map[string]any    `json:"labels"` // custom labels
 	lifeResources      map[string]any
+}
+
+type ContainerCgroupKey struct {
+	CgroupID uint64
+	CSS      uint64
+}
+
+// BuildContainerCgroupKeys builds v1/v2 attribution keys.
+// Duplicate keys are dropped to avoid nondeterministic container attribution.
+func BuildContainerCgroupKeys(containers map[string]*Container, subsys string) map[ContainerCgroupKey]*Container {
+	keys := make(map[ContainerCgroupKey]*Container, len(containers))
+	dropped := make(map[ContainerCgroupKey]bool)
+	for _, container := range containers {
+		for _, key := range [...]ContainerCgroupKey{
+			{CgroupID: container.CgroupID},
+			{CSS: container.CgroupCss[subsys]},
+		} {
+			if key.CgroupID == 0 && key.CSS == 0 {
+				continue
+			}
+			if dropped[key] {
+				continue
+			}
+			if previous, exists := keys[key]; exists && previous.ID != container.ID {
+				log.Debugf("duplicate cgroup attribution key %+v shared by containers %s and %s, dropping it until next sync", key, previous.ID, container.ID)
+				dropped[key] = true
+				delete(keys, key)
+				continue
+			}
+			keys[key] = container
+		}
+	}
+	return keys
 }
 
 func (c *Container) String() string {

--- a/internal/pod/container_cgroup_path.go
+++ b/internal/pod/container_cgroup_path.go
@@ -15,18 +15,24 @@
 package pod
 
 import (
+	"encoding/binary"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"huatuo-bamai/internal/cgroups"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
 	defaultSystemdSuffix  = ".slice"
 	defaultNodeCgroupName = "kubepods"
+	cgroupV2HandleSize    = 8
 )
 
 // slices: {"kubepods", "burstable", "pod1234-abcd-5678-efgh"}
@@ -77,6 +83,102 @@ func (p cgroupPath) ToSystemd() string {
 
 func (p cgroupPath) ToCgroupfs() string {
 	return "/" + path.Join(p.slices...)
+}
+
+func defaultCgroupIDByPID(pid int) (uint64, error) {
+	paths, err := cgroups.PathsForPID(pid)
+	if err != nil {
+		return 0, err
+	}
+	if paths.Unified == "" {
+		return 0, nil
+	}
+
+	mountInfo, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return 0, err
+	}
+
+	path, err := cgroup2PathOnMount(string(mountInfo), paths.Unified)
+	if err != nil {
+		return 0, fmt.Errorf("resolve cgroup v2 path %q: %w", paths.Unified, err)
+	}
+
+	cgroupID, err := cgroupIDFromFileHandle(path)
+	if err != nil {
+		return 0, fmt.Errorf("get cgroup v2 id for %q: %w", path, err)
+	}
+	return cgroupID, nil
+}
+
+func cgroupIDFromFileHandle(cgroupPath string) (uint64, error) {
+	handle, _, err := unix.NameToHandleAt(unix.AT_FDCWD, cgroupPath, 0)
+	if err != nil {
+		return 0, fmt.Errorf("get cgroup file handle %q: %w", cgroupPath, err)
+	}
+	return cgroupIDFromHandleBytes(handle.Bytes())
+}
+
+func cgroupIDFromHandleBytes(handle []byte) (uint64, error) {
+	if len(handle) != cgroupV2HandleSize {
+		return 0, fmt.Errorf("unexpected cgroup file handle size %d", len(handle))
+	}
+	return binary.NativeEndian.Uint64(handle), nil
+}
+
+func cgroup2PathOnMount(mountInfo, cgroupPath string) (string, error) {
+	cgroupPath = filepath.Clean(cgroupPath)
+	if !strings.HasPrefix(cgroupPath, "/") {
+		return "", fmt.Errorf("invalid cgroup2 path %q", cgroupPath)
+	}
+
+	for _, line := range strings.Split(mountInfo, "\n") {
+		before, after, found := strings.Cut(line, " - ")
+		if !found {
+			continue
+		}
+		post := strings.Fields(after)
+		if len(post) == 0 || post[0] != "cgroup2" {
+			continue
+		}
+		pre := strings.Fields(before)
+		if len(pre) < 5 {
+			continue
+		}
+
+		root := unescapeMountInfoPath(pre[3])
+		mountPoint := unescapeMountInfoPath(pre[4])
+		relative, ok := cgroupPathRelativeToMountRoot(cgroupPath, root)
+		if !ok {
+			continue
+		}
+		return filepath.Join(mountPoint, relative), nil
+	}
+
+	return "", fmt.Errorf("cgroup2 mount for %q not found", cgroupPath)
+}
+
+func cgroupPathRelativeToMountRoot(cgroupPath, root string) (string, bool) {
+	root = filepath.Clean(root)
+	if root == "/" {
+		return strings.TrimPrefix(cgroupPath, "/"), true
+	}
+	if cgroupPath == root {
+		return "", true
+	}
+	if strings.HasPrefix(cgroupPath, root+"/") {
+		return strings.TrimPrefix(cgroupPath, root+"/"), true
+	}
+	return "", false
+}
+
+func unescapeMountInfoPath(value string) string {
+	return strings.NewReplacer(
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	).Replace(value)
 }
 
 func containerCgroupPathsByID(containerID string) (*cgroups.ProcessPaths, error) {

--- a/internal/pod/container_css_default.go
+++ b/internal/pod/container_css_default.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -248,7 +249,7 @@ func cgroupCssNotifyFile() {
 }
 
 func cgroupInitSubSysIDs() error {
-	spec, err := btf.LoadSpec("/sys/kernel/btf/vmlinux")
+	spec, err := btf.LoadKernelSpec()
 	if err != nil {
 		return fmt.Errorf("load kernel BTF: %w", err)
 	}
@@ -267,11 +268,83 @@ func cgroupInitSubSysIDs() error {
 	return nil
 }
 
+// CgroupBPFConstants adds the target kernel's kernfs cgroup ID offset.
+func CgroupBPFConstants(extra map[string]any) (map[string]any, error) {
+	spec, err := btf.LoadKernelSpec()
+	if err != nil {
+		return nil, fmt.Errorf("load kernel BTF: %w", err)
+	}
+
+	types, err := spec.AnyTypesByName("kernfs_node")
+	if err != nil {
+		return nil, fmt.Errorf("find kernfs_node in kernel BTF: %w", err)
+	}
+	offset, err := kernfsNodeIDOffsetFromTypes(types)
+	if err != nil {
+		return nil, err
+	}
+
+	consts := maps.Clone(extra)
+	if consts == nil {
+		consts = make(map[string]any, 1)
+	}
+	consts["kernfs_node_id_offset"] = offset
+	return consts, nil
+}
+
+// BTF can contain same-named structs from multiple compilation units.
+func kernfsNodeIDOffsetFromTypes(types []btf.Type) (uint64, error) {
+	var (
+		offset uint64
+		found  bool
+	)
+	for _, typ := range types {
+		kernfsNode, ok := typ.(*btf.Struct)
+		if !ok {
+			continue
+		}
+
+		candidate, err := kernfsNodeIDOffset(kernfsNode)
+		if err != nil {
+			continue
+		}
+		if found && offset != candidate {
+			return 0, fmt.Errorf("kernfs_node.id has conflicting offsets %d and %d", offset, candidate)
+		}
+		offset = candidate
+		found = true
+	}
+	if found {
+		return offset, nil
+	}
+	return 0, errors.New("compatible kernfs_node struct not found")
+}
+
+func kernfsNodeIDOffset(kernfsNode *btf.Struct) (uint64, error) {
+	for _, member := range kernfsNode.Members {
+		if member.Name != "id" {
+			continue
+		}
+		if member.Offset%8 != 0 {
+			return 0, fmt.Errorf("kernfs_node.id has unaligned offset %d", member.Offset)
+		}
+		size, err := btf.Sizeof(member.Type)
+		if err != nil {
+			return 0, fmt.Errorf("size kernfs_node.id: %w", err)
+		}
+		if size != 8 {
+			return 0, fmt.Errorf("kernfs_node.id has size %d, want 8", size)
+		}
+		return uint64(member.Offset.Bytes()), nil
+	}
+	return 0, errors.New("kernfs_node has no id field")
+}
+
 func cgroupSubSysIDNameMap(values []btf.EnumValue) (map[int]string, error) {
 	ids := make(map[int]string, len(values))
 	nameIDs := make(map[string]int, len(values))
 	for _, value := range values {
-		name, ok := strings.CutSuffix(value.Name, "_cgrp_id")
+		name, ok := containerCSSSubsysName(value.Name)
 		if !ok {
 			continue
 		}
@@ -312,6 +385,19 @@ func cgroupSubSysIDNameMap(values []btf.EnumValue) (map[int]string, error) {
 	}
 
 	return ids, nil
+}
+
+// containerCSSSubsysName returns the stable Container.CgroupCss key.
+// The kernel calls the v2 controller io, while the legacy key is blkio.
+func containerCSSSubsysName(enumName string) (string, bool) {
+	name, ok := strings.CutSuffix(enumName, "_cgrp_id")
+	if !ok {
+		return "", false
+	}
+	if name == "io" {
+		return subsystem.SubsystemBlkIO, true
+	}
+	return name, true
 }
 
 func cgroupCssInitEventSync() error {

--- a/internal/pod/container_css_default_test.go
+++ b/internal/pod/container_css_default_test.go
@@ -15,11 +15,14 @@
 package pod
 
 import (
+	"encoding/binary"
 	"maps"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"huatuo-bamai/internal/cgroups/subsystem"
 
 	"github.com/cilium/ebpf/btf"
 )
@@ -41,14 +44,16 @@ func TestCgroupSubSysIDNameMap(t *testing.T) {
 				{Name: "unrelated", Value: 2},
 				{Name: "io_cgrp_id", Value: 3},
 				{Name: "memory_cgrp_id", Value: 4},
+				{Name: "rdma_cgrp_id", Value: 12},
 				{Name: "CGROUP_SUBSYS_COUNT", Value: 13},
 				{Name: "future_cgrp_id", Value: 13},
 			},
 			want: map[int]string{
-				0: "cpuset",
-				1: "cpu",
-				3: "blkio",
-				4: "memory",
+				0:  "cpuset",
+				1:  "cpu",
+				3:  subsystem.SubsystemBlkIO,
+				4:  "memory",
+				12: "rdma",
 			},
 		},
 		{
@@ -174,5 +179,141 @@ func TestResolveCgroupFilesystemPathRejectsMissingNotificationFile(t *testing.T)
 	}
 	if !strings.Contains(err.Error(), filepath.Join(cgroupPath, cgroupv2NotifyFile)) {
 		t.Fatalf("resolveCgroupFilesystemPath() error = %q, want notification path", err)
+	}
+}
+
+func TestKernfsNodeIDOffset(t *testing.T) {
+	for _, typ := range []btf.Type{
+		&btf.Int{Name: "u64", Size: 8},
+		&btf.Union{Name: "kernfs_node_id", Size: 8},
+	} {
+		offset, err := kernfsNodeIDOffset(&btf.Struct{Members: []btf.Member{{
+			Name:   "id",
+			Type:   typ,
+			Offset: 192,
+		}}})
+		if err != nil || offset != 24 {
+			t.Fatalf("kernfsNodeIDOffset() = %d, %v; want 24, nil", offset, err)
+		}
+	}
+}
+
+func TestKernfsNodeIDOffsetFromTypes(t *testing.T) {
+	newKernfsNode := func(offset btf.Bits) *btf.Struct {
+		return &btf.Struct{Members: []btf.Member{{
+			Name:   "id",
+			Type:   &btf.Union{Name: "kernfs_node_id", Size: 8},
+			Offset: offset,
+		}}}
+	}
+
+	offset, err := kernfsNodeIDOffsetFromTypes([]btf.Type{
+		newKernfsNode(192),
+		newKernfsNode(192),
+	})
+	if err != nil || offset != 24 {
+		t.Fatalf("kernfsNodeIDOffsetFromTypes() = %d, %v; want 24, nil", offset, err)
+	}
+
+	_, err = kernfsNodeIDOffsetFromTypes([]btf.Type{
+		newKernfsNode(192),
+		newKernfsNode(256),
+	})
+	if err == nil {
+		t.Fatal("kernfsNodeIDOffsetFromTypes() error = nil, want non-nil")
+	}
+}
+
+func TestCgroup2PathOnMount(t *testing.T) {
+	mountInfo := "36 25 0:32 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n" +
+		"37 25 0:33 / /sys/fs/cgroup/cpu rw,nosuid,nodev,noexec,relatime - cgroup cgroup rw,cpu\n" //nolint:dupword // v1 fstype and mount source are both "cgroup"
+
+	path, err := cgroup2PathOnMount(mountInfo, "/kubepods/pod/container")
+	if err != nil {
+		t.Fatalf("cgroup2PathOnMount: %v", err)
+	}
+	if want := "/sys/fs/cgroup/kubepods/pod/container"; path != want {
+		t.Fatalf("cgroup2 path = %q, want %q", path, want)
+	}
+}
+
+func TestCgroup2PathOnMountWithSubtreeRoot(t *testing.T) {
+	mountInfo := "36 25 0:32 /delegated /cgroup2 rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n"
+
+	path, err := cgroup2PathOnMount(mountInfo, "/delegated/pod/container")
+	if err != nil {
+		t.Fatalf("cgroup2PathOnMount: %v", err)
+	}
+	if want := "/cgroup2/pod/container"; path != want {
+		t.Fatalf("cgroup2 path = %q, want %q", path, want)
+	}
+
+	if _, err := cgroup2PathOnMount(mountInfo, "/other/container"); err == nil {
+		t.Fatal("path outside cgroup2 mount root must fail")
+	}
+}
+
+func TestCgroupIDFromHandleBytes(t *testing.T) {
+	handle := make([]byte, cgroupV2HandleSize)
+	const want uint64 = 0x1020304050607080
+	binary.NativeEndian.PutUint64(handle, want)
+
+	got, err := cgroupIDFromHandleBytes(handle)
+	if err != nil || got != want {
+		t.Fatalf("cgroupIDFromHandleBytes() = (%#x, %v), want (%#x, nil)", got, err, want)
+	}
+
+	if _, err := cgroupIDFromHandleBytes(handle[:cgroupV2HandleSize-1]); err == nil {
+		t.Fatal("cgroupIDFromHandleBytes() error = nil, want non-nil for a short handle")
+	}
+}
+
+func TestBuildContainerCgroupKeys(t *testing.T) {
+	containers := map[string]*Container{
+		"v1": {ID: "v1", CgroupCss: map[string]uint64{subsystem.SubsystemMemory: 201}},
+		"v2": {ID: "v2", CgroupID: 102, CgroupCss: map[string]uint64{}},
+	}
+
+	keys := BuildContainerCgroupKeys(containers, subsystem.SubsystemMemory)
+	for key, want := range map[ContainerCgroupKey]string{
+		{CSS: 201}:      "v1",
+		{CgroupID: 102}: "v2",
+	} {
+		if got := keys[key]; got == nil || got.ID != want {
+			t.Fatalf("key %+v = %+v, want container %s", key, got, want)
+		}
+	}
+}
+
+func TestBuildContainerCgroupKeysDropsDuplicateKey(t *testing.T) {
+	containers := map[string]*Container{
+		"first":  {ID: "first", CgroupID: 101, CgroupCss: map[string]uint64{subsystem.SubsystemMemory: 301}},
+		"second": {ID: "second", CgroupID: 101, CgroupCss: map[string]uint64{subsystem.SubsystemMemory: 302}},
+		"third":  {ID: "third", CgroupID: 103, CgroupCss: map[string]uint64{subsystem.SubsystemMemory: 301}},
+	}
+
+	keys := BuildContainerCgroupKeys(containers, subsystem.SubsystemMemory)
+
+	for _, key := range []ContainerCgroupKey{
+		{CgroupID: 101}, // shared by first and second
+		{CSS: 301},      // shared by first and third
+	} {
+		if got := keys[key]; got != nil {
+			t.Fatalf("duplicate key %+v = %s, want it dropped", key, got.ID)
+		}
+	}
+	for key, want := range map[ContainerCgroupKey]string{
+		{CSS: 302}:      "second",
+		{CgroupID: 103}: "third", // third's CSS key was dropped, its ID key survives
+	} {
+		if got := keys[key]; got == nil || got.ID != want {
+			t.Fatalf("key %+v = %+v, want container %s", key, got, want)
+		}
+	}
+}
+
+func TestContainerCgroupKeyBinarySize(t *testing.T) {
+	if got, want := binary.Size(ContainerCgroupKey{}), 16; got != want {
+		t.Fatalf("ContainerCgroupKey size = %d, want %d", got, want)
 	}
 }

--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -388,6 +388,11 @@ func kubeletUpdateContainer(containerID string, container *corev1.Container, con
 		return fmt.Errorf("failed to get InitPid: %w", err)
 	}
 
+	cgroupID, err := defaultCgroupIDByPID(initPid)
+	if err != nil {
+		log.Warnf("failed to get dfl cgroup id for container %s: %v", containerID, err)
+	}
+
 	// net namespace
 	nsInum, err := netutil.NetNamespaceInumByPID(initPid)
 	if err != nil {
@@ -431,6 +436,7 @@ func kubeletUpdateContainer(containerID string, container *corev1.Container, con
 		NetNamespaceCookie: netNamespaceCookie,
 		InitPid:            initPid,
 		CgroupPath:         cgroupPath,
+		CgroupID:           cgroupID,
 		CgroupCss:          css,
 		StartedAt:          startedAt,
 		SyncedAt:           time.Now(),


### PR DESCRIPTION
Closes #648 

### 问题描述

在 cgroup v2 中，controller 可能只在 root cgroup 生效。Huatuo 同步容器时读取 leaf cgroup 的 direct CSS，而 reclaim、OOM、runqlat 和 perf 的 BPF 采样使用 task 的 effective CSS；在 cgroupv2 下两者可能指向不同层级，导致容器级指标/事件无法关联。

### 修改方案

1. 修复上一个 pr #646 的遗漏修改，从内核 BTF `cgroup_subsys_id` 解析 controller ID，并保留 io 到 blkio 的 v1 兼容（不过当前没用到）
2. 使用 cgroup key 进行判断，表示“这条 BPF 样本属于哪个容器”，同时兼容 v1、v2 和 hybrid
- cgroup v2 中，controller CSS 可能回退到 pod 或 root，不能可靠代表容器，因此用 leaf cgroup_id
- cgroup v1 中没有 default hierarchy leaf ID 这套语义，仍用 CPU/memory controller 的 CSS 地址
- hybrid 中按 controller 所属 hierarchy 自动选择其中一个字段
3. 将该 key 接入 memory reclaim 指标与事件、OOM、CPU runqlat、perf 容器过滤及生命周期清理

### 补充修复（本次提交 CI 有时候会失败， 顺便蹭个车修复）

1. dropwatch 的 CI 测试脚本在  Ubuntu 24.04 的 QEMU 会丢失 perf ring-buffer 样本，可能导致测试概率失败问题。


@hao022 @fanzu8 改动较多，请帮忙 review 下
