### PR TITLE
fix(profiler): surface final export failures

### DIFF
--- a/internal/profiler/aggregator/pipeline.go
+++ b/internal/profiler/aggregator/pipeline.go
@@ -38,10 +38,13 @@ const (
 // aggregation via the embedded Aggregator, and routes output to the
 // configured backend (ES upload, file write, or SVG render).
 type Pipeline struct {
-	wg     sync.WaitGroup
-	stopCh chan struct{}
-	doneCh chan struct{}
-	state  atomic.Uint32
+	wg          sync.WaitGroup
+	stopCh      chan struct{}
+	doneCh      chan struct{}
+	state       atomic.Uint32
+	lifecycleMu sync.Mutex
+	stopOnce    sync.Once
+	finalErr    error
 
 	tracerID      string
 	aggrInterval  time.Duration
@@ -89,9 +92,13 @@ func resolveTracerID(configured string, allocate func() (string, error)) string 
 // Start launches the aggregation worker and periodic export schedule once.
 // It is a no-op after Stop starts; Pipeline instances are not restartable.
 func (p *Pipeline) Start() {
-	if !p.state.CompareAndSwap(pipelineStateIdle, pipelineStateRunning) {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+
+	if p.state.Load() != pipelineStateIdle {
 		return
 	}
+	p.state.Store(pipelineStateRunning)
 
 	p.wg.Add(1)
 	go p.runDequeueAndAggregate()
@@ -113,9 +120,7 @@ func (p *Pipeline) runAggregateSnapshot() {
 		if snapshotCtx != nil {
 			snapshotCtx = context.WithoutCancel(snapshotCtx)
 		}
-		if err := p.aggregateAndSnapshot(snapshotCtx, true); err != nil {
-			p.logAggregateExportError(err)
-		}
+		p.finalErr = p.aggregateAndSnapshot(snapshotCtx, true)
 
 		return
 	}
@@ -130,11 +135,15 @@ func (p *Pipeline) runAggregateSnapshot() {
 			}
 		case <-p.stopCh:
 			// Stop scheduling periodic snapshots; the final snapshot must observe
-			// all records accepted before shutdown.
+			// all records accepted before shutdown. The profiler context is canceled
+			// before Pipeline.Stop so sampling loops terminate; final persistence
+			// still needs a live context to flush the records they produced.
 			<-p.doneCh
-			if err := p.aggregateAndSnapshot(p.pctx.Ctx, true); err != nil {
-				p.logAggregateExportError(err)
+			snapshotCtx := p.pctx.Ctx
+			if snapshotCtx != nil {
+				snapshotCtx = context.WithoutCancel(snapshotCtx)
 			}
+			p.finalErr = p.aggregateAndSnapshot(snapshotCtx, true)
 
 			return
 		}
@@ -164,23 +173,29 @@ func (p *Pipeline) runDequeueAndAggregate() {
 	}
 }
 
-// Stop signals the pipeline to terminate and waits for all goroutines to exit.
-// Calls after the first one are no-ops. A stopped Pipeline cannot be restarted.
-func (p *Pipeline) Stop() {
-	for {
+// Stop signals the pipeline to terminate, waits for the final export, and
+// returns its result. Every caller waits for the same shutdown operation.
+// A stopped Pipeline cannot be restarted.
+func (p *Pipeline) Stop() error {
+	p.stopOnce.Do(func() {
+		// Start must finish registering both workers before Stop can wait on the
+		// WaitGroup. Without this boundary, a concurrent Stop could return while
+		// Start is between publishing the running state and calling Add.
+		p.lifecycleMu.Lock()
 		state := p.state.Load()
-		if state == pipelineStateStopped {
-			return
-		}
+		p.state.Store(pipelineStateStopped)
 
-		if p.state.CompareAndSwap(state, pipelineStateStopped) {
-			p.enqueueMutex.Lock()
-			close(p.stopCh)
-			p.enqueueMutex.Unlock()
+		p.enqueueMutex.Lock()
+		close(p.stopCh)
+		p.enqueueMutex.Unlock()
+		p.lifecycleMu.Unlock()
+
+		if state == pipelineStateRunning {
 			p.wg.Wait()
-			return
 		}
-	}
+	})
+
+	return p.finalErr
 }
 
 // Enqueue offers a record into the aggregation queue for async processing.

--- a/internal/profiler/aggregator/pipeline_test.go
+++ b/internal/profiler/aggregator/pipeline_test.go
@@ -17,11 +17,14 @@ package aggregator
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
 	profctx "huatuo-bamai/internal/profiler/context"
 	"huatuo-bamai/internal/profiler/output"
+
+	"github.com/stretchr/testify/mock"
 )
 
 func TestNewPipeline_DoesNotMutateContext(t *testing.T) {
@@ -90,7 +93,7 @@ func TestResolveTracerID(t *testing.T) {
 
 func TestPipelineStart_IsIdempotent(t *testing.T) {
 	aggr := NewMockAggregator(t)
-	aggr.On("OutputFormatter").Return(nil).Once()
+	aggr.On("OutputFormatter").Return(emptyFormatter{}).Once()
 
 	p := NewPipeline(&profctx.ProfilerContext{
 		Ctx:          context.Background(),
@@ -99,7 +102,9 @@ func TestPipelineStart_IsIdempotent(t *testing.T) {
 
 	p.Start()
 	p.Start()
-	p.Stop()
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
 }
 
 func TestPipelineStart_AfterStop(t *testing.T) {
@@ -110,7 +115,9 @@ func TestPipelineStart_AfterStop(t *testing.T) {
 		OutputFormat: output.FormatCollapsed,
 	}, aggr)
 
-	p.Stop()
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
 	p.Start()
 	p.Enqueue("ignored")
 
@@ -126,7 +133,9 @@ func TestPipelineEnqueue_AfterStop(t *testing.T) {
 		OutputFormat: output.FormatCollapsed,
 	}, aggr)
 
-	p.Stop()
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
 	p.Enqueue("ignored")
 
 	aggr.AssertNotCalled(t, "Aggregate")
@@ -136,7 +145,7 @@ func TestPipelineStop_DrainsAcceptedRecords(t *testing.T) {
 	aggr := NewMockAggregator(t)
 	aggr.On("Aggregate", "first").Once()
 	aggr.On("Aggregate", "second").Once()
-	aggr.On("OutputFormatter").Return(nil).Once()
+	aggr.On("OutputFormatter").Return(emptyFormatter{}).Once()
 
 	p := NewPipeline(&profctx.ProfilerContext{
 		Ctx:          t.Context(),
@@ -146,7 +155,9 @@ func TestPipelineStop_DrainsAcceptedRecords(t *testing.T) {
 	p.Enqueue("second")
 
 	p.Start()
-	p.Stop()
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
 }
 
 func TestPipelineEnqueue_CountsOverflow(t *testing.T) {
@@ -201,3 +212,184 @@ func TestPipelineAggregateAndExport_EmptyFormatter(t *testing.T) {
 
 	aggr.AssertNotCalled(t, "Reset")
 }
+
+func TestPipelineStop_ReturnsFinalExportError(t *testing.T) {
+	exportErr := errors.New("formatter write failed")
+	formatter := NewFormatter(t)
+	formatter.On("IsEmpty").Return(false).Once()
+	formatter.On("Write", mock.Anything).Return(exportErr).Once()
+
+	aggr := NewMockAggregator(t)
+	aggr.On("OutputFormatter").Return(formatter).Once()
+
+	p := NewPipeline(&profctx.ProfilerContext{
+		Ctx:          context.Background(),
+		IsOneShotAgg: true,
+		OutputFormat: output.FormatCollapsed,
+		OutputPath:   t.TempDir(),
+	}, aggr)
+	p.Start()
+
+	err := p.Stop()
+	if !errors.Is(err, exportErr) {
+		t.Fatalf("Stop error = %v, want %v", err, exportErr)
+	}
+	aggr.AssertNotCalled(t, "Reset")
+}
+
+func TestPipelineStop_RepeatedCallsReturnFinalExportError(t *testing.T) {
+	exportErr := errors.New("final export failed")
+	formatter := &blockingFormatter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     exportErr,
+	}
+	aggr := &formatterAggregator{formatter: formatter}
+
+	p := NewPipeline(&profctx.ProfilerContext{
+		Ctx:          context.Background(),
+		IsOneShotAgg: true,
+		OutputFormat: output.FormatCollapsed,
+		OutputPath:   t.TempDir(),
+	}, aggr)
+	p.Start()
+
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- p.Stop()
+	}()
+	<-formatter.started
+
+	secondResult := make(chan error, 1)
+	go func() {
+		secondResult <- p.Stop()
+	}()
+
+	select {
+	case err := <-secondResult:
+		t.Fatalf("concurrent Stop returned before final export: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(formatter.release)
+	for i, result := range []<-chan error{firstResult, secondResult} {
+		select {
+		case err := <-result:
+			if !errors.Is(err, exportErr) {
+				t.Fatalf("Stop result %d = %v, want %v", i, err, exportErr)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("Stop result %d did not wait for final export", i)
+		}
+	}
+
+	if err := p.Stop(); !errors.Is(err, exportErr) {
+		t.Fatalf("repeated Stop error = %v, want %v", err, exportErr)
+	}
+}
+
+func TestPipelineStop_SuccessfulExportReturnsNil(t *testing.T) {
+	formatter := NewFormatter(t)
+	formatter.On("IsEmpty").Return(false).Once()
+	formatter.On("Write", mock.Anything).Return(nil).Once()
+
+	aggr := NewMockAggregator(t)
+	aggr.On("OutputFormatter").Return(formatter).Once()
+	aggr.On("Reset").Once()
+
+	p := NewPipeline(&profctx.ProfilerContext{
+		Ctx:          context.Background(),
+		IsOneShotAgg: true,
+		OutputFormat: output.FormatCollapsed,
+		OutputPath:   t.TempDir(),
+	}, aggr)
+	p.Start()
+
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+}
+
+func TestPipelineStartAndStop_ConcurrentLifecycleIsSafe(t *testing.T) {
+	for range 100 {
+		p := NewPipeline(&profctx.ProfilerContext{
+			Ctx:          context.Background(),
+			IsOneShotAgg: true,
+			OutputFormat: output.FormatCollapsed,
+			OutputPath:   t.TempDir(),
+		}, &formatterAggregator{formatter: emptyFormatter{}})
+
+		startDone := make(chan struct{})
+		go func() {
+			p.Start()
+			close(startDone)
+		}()
+
+		stopDone := make(chan error, 1)
+		go func() {
+			stopDone <- p.Stop()
+		}()
+
+		select {
+		case <-startDone:
+		case <-time.After(time.Second):
+			t.Fatal("Start blocked during concurrent Stop")
+		}
+		select {
+		case err := <-stopDone:
+			if err != nil {
+				t.Fatalf("Stop returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Stop blocked during concurrent Start")
+		}
+	}
+}
+
+type formatterAggregator struct {
+	formatter output.Formatter
+}
+
+func (*formatterAggregator) Aggregate(any) {}
+
+func (*formatterAggregator) Snapshot(*profctx.ProfilerContext) (any, error) {
+	return nil, nil
+}
+
+func (*formatterAggregator) Reset() {}
+
+func (a *formatterAggregator) OutputFormatter() output.Formatter {
+	return a.formatter
+}
+
+type blockingFormatter struct {
+	started chan struct{}
+	release chan struct{}
+	err     error
+}
+
+func (*blockingFormatter) Name() string { return "blocking" }
+
+func (*blockingFormatter) Add(*output.Sample) error { return nil }
+
+func (f *blockingFormatter) Write(io.Writer) error {
+	close(f.started)
+	<-f.release
+	return f.err
+}
+
+func (*blockingFormatter) Reset() {}
+
+func (*blockingFormatter) IsEmpty() bool { return false }
+
+type emptyFormatter struct{}
+
+func (emptyFormatter) Name() string { return "empty" }
+
+func (emptyFormatter) Add(*output.Sample) error { return nil }
+
+func (emptyFormatter) Write(io.Writer) error { return nil }
+
+func (emptyFormatter) Reset() {}
+
+func (emptyFormatter) IsEmpty() bool { return true }

--- a/internal/profiler/registry/registry.go
+++ b/internal/profiler/registry/registry.go
@@ -16,6 +16,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -85,10 +86,13 @@ func Profile(pctx *pcontext.ProfilerContext, p ProfilerMeta) error {
 	log.Info("aggregator started")
 
 	if err := p.Impl.Start(pctx); err != nil {
-		pipe.Stop()
 		pctx.Cancel()
+		pipelineErr := pipe.Stop()
 
-		return fmt.Errorf("start profiler: %w", err)
+		return errors.Join(
+			fmt.Errorf("start profiler: %w", err),
+			wrapPipelineError(pipelineErr),
+		)
 	}
 
 	loopDone := make(chan error, 1)
@@ -135,11 +139,19 @@ func Profile(pctx *pcontext.ProfilerContext, p ProfilerMeta) error {
 		log.Errorf("profiler stop: %v", stopErr)
 	}
 
-	pipe.Stop()
+	pipelineErr := pipe.Stop()
 
 	if err == nil && loopErr != nil {
 		err = loopErr
 	}
 
-	return err
+	return errors.Join(err, wrapPipelineError(pipelineErr))
+}
+
+func wrapPipelineError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("finalize profiler output: %w", err)
 }

--- a/internal/profiler/registry/registry_test.go
+++ b/internal/profiler/registry/registry_test.go
@@ -16,6 +16,8 @@ package registry
 
 import (
 	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -27,19 +29,25 @@ import (
 
 // fakeProfiler satisfies Profiler with no behavior. Registry tests exercise
 // the lookup tables, not sampling, so a stub is enough.
-type fakeProfiler struct{}
+type fakeProfiler struct {
+	readErr error
+}
 
-func (fakeProfiler) Start(*pcontext.ProfilerContext) error         { return nil }
-func (fakeProfiler) ReadDataLoop(context.Context, func(any)) error { return nil }
-func (fakeProfiler) Stop(*pcontext.ProfilerContext) error          { return nil }
+func (fakeProfiler) Start(*pcontext.ProfilerContext) error { return nil }
+func (p fakeProfiler) ReadDataLoop(context.Context, func(any)) error {
+	return p.readErr
+}
+func (fakeProfiler) Stop(*pcontext.ProfilerContext) error { return nil }
 
 // fakeAggregator satisfies aggregator.Aggregator with no behavior.
-type fakeAggregator struct{}
+type fakeAggregator struct {
+	formatter output.Formatter
+}
 
 func (fakeAggregator) Aggregate(any)                                   {}
 func (fakeAggregator) Snapshot(*pcontext.ProfilerContext) (any, error) { return nil, nil }
 func (fakeAggregator) Reset()                                          {}
-func (fakeAggregator) OutputFormatter() output.Formatter               { return nil }
+func (a fakeAggregator) OutputFormatter() output.Formatter             { return a.formatter }
 
 func resetRegistry(t *testing.T) {
 	t.Helper()
@@ -111,3 +119,84 @@ func TestGetUnknownImplementation(t *testing.T) {
 		t.Fatal(`Get("unknown", "cpu") error = nil, want non-nil`)
 	}
 }
+
+func TestProfile_ReturnsFinalOutputError(t *testing.T) {
+	exportErr := errors.New("formatter export failed")
+	pctx := newProfileTestContext(t)
+	meta := profileTestMeta(fakeProfiler{}, failingFormatter{err: exportErr})
+
+	err := Profile(pctx, meta)
+	if !errors.Is(err, exportErr) {
+		t.Fatalf("Profile error = %v, want %v", err, exportErr)
+	}
+	if !strings.Contains(err.Error(), "finalize profiler output") {
+		t.Fatalf("Profile error = %q, want pipeline context", err)
+	}
+}
+
+func TestProfile_PreservesReadAndFinalOutputErrors(t *testing.T) {
+	readErr := errors.New("read loop failed")
+	exportErr := errors.New("formatter export failed")
+	pctx := newProfileTestContext(t)
+	meta := profileTestMeta(fakeProfiler{readErr: readErr}, failingFormatter{err: exportErr})
+
+	err := Profile(pctx, meta)
+	if !errors.Is(err, readErr) {
+		t.Fatalf("Profile error = %v, want read error %v", err, readErr)
+	}
+	if !errors.Is(err, exportErr) {
+		t.Fatalf("Profile error = %v, want export error %v", err, exportErr)
+	}
+}
+
+func TestProfile_SuccessfulFinalOutputReturnsNil(t *testing.T) {
+	pctx := newProfileTestContext(t)
+	meta := profileTestMeta(fakeProfiler{}, failingFormatter{})
+
+	if err := Profile(pctx, meta); err != nil {
+		t.Fatalf("Profile returned error: %v", err)
+	}
+}
+
+func newProfileTestContext(t *testing.T) *pcontext.ProfilerContext {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return &pcontext.ProfilerContext{
+		Ctx:          ctx,
+		Cancel:       cancel,
+		IsOneShotAgg: true,
+		OutputFormat: output.FormatCollapsed,
+		OutputPath:   t.TempDir(),
+	}
+}
+
+func profileTestMeta(profiler Profiler, formatter output.Formatter) ProfilerMeta {
+	return ProfilerMeta{
+		Impl: profiler,
+		NewAggregator: func(*pcontext.ProfilerContext) (aggregator.Aggregator, error) {
+			return fakeAggregator{formatter: formatter}, nil
+		},
+	}
+}
+
+type failingFormatter struct {
+	err error
+}
+
+func (failingFormatter) Name() string { return "test" }
+
+func (failingFormatter) Add(*output.Sample) error { return nil }
+
+func (f failingFormatter) Write(w io.Writer) error {
+	if _, err := io.WriteString(w, "profile\n"); err != nil {
+		return err
+	}
+	return f.err
+}
+
+func (failingFormatter) Reset() {}
+
+func (failingFormatter) IsEmpty() bool { return false }


### PR DESCRIPTION
## Summary

Propagate final profiler aggregation/export failures to the profiler caller instead of logging and discarding them.

The pipeline now exposes one terminal shutdown result, every `Stop` caller waits for that same result, and `registry.Profile` returns the export failure to `cmd/profiler`. A requested folded file, flame graph, or final remote snapshot can no longer fail while the profiler process reports success.

## Problem

The final export runs asynchronously in `Pipeline.runAggregateSnapshot`:

```go
if err := p.aggregateAndSnapshot(..., true); err != nil {
    p.logAggregateExportError(err)
}
```

`Pipeline.Stop` waited for the worker but returned no error. `registry.Profile` therefore had no way to distinguish a successful final export from a failed one and could return `nil`, causing the profiler CLI to exit with status 0 even though its requested output was missing.

This affects the normal production path:

```text
cmd/profiler/run.go
  -> registry.Profile
  -> Pipeline.Start
  -> Pipeline.Stop
  -> runAggregateSnapshot
  -> aggregateAndSnapshot
  -> writeFolded / writeFlameGraph / final remote save
```

## Root cause

The pipeline treated final persistence errors as logging-only events. Its lifecycle state also allowed later or concurrent `Stop` callers to return without receiving the first shutdown operation's result.

Sampling cancellation adds another boundary: `registry.Profile` cancels the profiler context before draining and exporting the final records. Reusing that canceled context for a final remote save can make shutdown persistence fail for the cancellation itself rather than for the storage operation.

## Implementation

- Change `Pipeline.Stop()` to return the final aggregation/export error.
- Retain the final `aggregateAndSnapshot(..., true)` result until all pipeline workers have exited.
- Use `sync.Once` so repeated and concurrent `Stop` calls join one shutdown operation and receive the same result.
- Serialize `Start` worker registration against `Stop` so shutdown cannot wait before the worker `WaitGroup` has been populated.
- Preserve the existing enqueue/close boundary: records accepted before shutdown are drained before the final snapshot.
- Use `context.WithoutCancel` for final persistence after the sampling context is canceled. Sampling remains stopped, while already-collected records still receive a usable persistence context.
- Propagate the pipeline result through `registry.Profile` with `errors.Join` so a read-loop or context error and a final export error are both retained.
- Preserve the start failure while also retaining any pipeline finalization failure.

## Error behavior

A final formatter, file, snapshot, or remote storage error is now returned as:

```text
finalize profiler output: <underlying export error>
```

`errors.Is` continues to match the underlying cause. If sampling already produced another error, both causes remain discoverable through the joined error.

Periodic aggregation failures continue to be logged and retried on later intervals. Only an unresolved final export result becomes the pipeline's terminal error.

## Compatibility

- Successful profiler runs still return `nil`.
- Empty final formatters still complete without producing an artifact or error.
- Existing output formats and filenames are unchanged.
- No public serialization, storage schema, CLI flag, or configuration format changes.
- `Pipeline` is internal; its only production caller has been updated.
- A previously silent final-output failure now correctly changes the profiler process exit status to non-zero.

## Regression coverage

Added coverage for:

- final formatter/export errors returned by `Pipeline.Stop`;
- successful final export returning `nil` and resetting the aggregator;
- repeated `Stop` calls returning the same terminal error;
- concurrent `Stop` calls waiting until a blocked final export completes;
- concurrent `Start`/`Stop` lifecycle registration under repeated execution;
- `registry.Profile` returning a final output error;
- retaining both read-loop and final output errors;
- successful `registry.Profile` finalization remaining error-free.

A negative mutation changed `Pipeline.Stop` to return `nil`. The new tests failed as intended:

```text
TestPipelineStop_ReturnsFinalExportError:
  Stop error = <nil>, want formatter write failed
TestPipelineStop_RepeatedCallsReturnFinalExportError:
  Stop result 0 = <nil>, want final export failed
```

Restoring the implementation made both tests pass.

## Size

```text
Changed files: 4
Additions: 348
Deletions: 40
Total changed lines: 388
Generated/vendor-only lines: 0
```

## Validation

Passed:

```text
go test ./internal/profiler/aggregator ./internal/profiler/registry -count=1
go test -race ./internal/profiler/aggregator ./internal/profiler/registry -count=1
go vet ./internal/profiler/aggregator ./internal/profiler/registry
go test ./cmd/profiler/... ./internal/profiler/... -count=1
golangci-lint run -v ./internal/profiler/aggregator ./internal/profiler/registry \
  --timeout=5m --config .golangci.yaml
golangci-lint run -v ./... --timeout=10m --config .golangci.yaml
make check
git diff --check
```

Both package and full-repository lint completed with zero issues. `make check` was run on a clean container-local copy with the intended patch as the baseline and completed successfully.

`make unit` was also executed in an unprivileged container. The changed profiler packages and the rest of the ordinary unit suite ran, but the target ended non-zero on two environment-dependent existing tests:

```text
internal/cgroups: systemd cgroup runtime requires /run/systemd/private
internal/pcapfilter: BPF map creation requires elevated MEMLOCK/BPF privileges
```

Neither failure exercises the modified profiler packages. The repository's privileged GitHub VM jobs remain the authoritative full-suite validation.

Fixes #653