### PR TITLE
fix(job): make active recovery transactional

### DIFF
--- a/internal/job/manager.go
+++ b/internal/job/manager.go
@@ -172,30 +172,57 @@ func (m *Manager) recoverJobs(ctx context.Context) error {
 		return err
 	}
 
+	prepared, hostCounts, err := m.prepareRecoveredJobs(jobs)
+	if err != nil {
+		return err
+	}
+
 	m.mu.Lock()
-	for _, recoveredJob := range jobs {
-		policy, policyErr := m.policyFor(recoveredJob.Type)
-		if policyErr != nil {
-			m.mu.Unlock()
-			return fmt.Errorf("job %s: %w", recoveredJob.ID, policyErr)
+	for _, recoveredJob := range prepared {
+		m.jobs[recoveredJob.ID] = recoveredJob
+	}
+	for hostKey, count := range hostCounts {
+		m.jobsByHost[hostKey] += count
+	}
+	m.monitorWG.Add(len(prepared))
+	m.recoveredJobs.Add(uint64(len(prepared)))
+	m.mu.Unlock()
+
+	for _, recoveredJob := range prepared {
+		go func(jobToMonitor *Job) {
+			defer m.monitorWG.Done()
+			m.monitorJob(context.WithoutCancel(ctx), jobToMonitor)
+		}(recoveredJob)
+	}
+
+	return nil
+}
+
+func (m *Manager) prepareRecoveredJobs(jobs []*Job) ([]*Job, map[string]int, error) {
+	prepared := make([]*Job, 0, len(jobs))
+	hostCounts := make(map[string]int)
+
+	for index, storedJob := range jobs {
+		if storedJob == nil {
+			return nil, nil, fmt.Errorf("job recovery row %d is nil", index)
+		}
+
+		recoveredJob := cloneJob(storedJob)
+		policy, err := m.policyFor(recoveredJob.Type)
+		if err != nil {
+			return nil, nil, fmt.Errorf("job %s: %w", recoveredJob.ID, err)
 		}
 		if recoveredJob.AgentTaskID == "" {
 			recoveredJob.AgentTaskID = recoveredJob.ID
 		}
 		recoveredJob.AgentTask.RequestID = recoveredJob.ID
 		recoveredJob.stopCh = make(chan struct{})
-		m.jobs[recoveredJob.ID] = recoveredJob
-		hostKey := quotaHostKey(recoveredJob.Hostname, policy.Group)
-		m.jobsByHost[hostKey]++
-		m.monitorWG.Add(1)
-		go func(jobToMonitor *Job) {
-			defer m.monitorWG.Done()
-			m.monitorJob(context.WithoutCancel(ctx), jobToMonitor)
-		}(recoveredJob)
+
+		prepared = append(prepared, recoveredJob)
+		hostCounts[quotaHostKey(recoveredJob.Hostname, policy.Group)]++
 	}
-	m.recoveredJobs.Add(uint64(len(jobs)))
-	m.mu.Unlock()
-	return nil
+
+	return prepared, hostCounts, nil
 }
 
 // ShutdownContext stops monitors without interrupting Agent tasks, then closes

--- a/internal/job/manager_test.go
+++ b/internal/job/manager_test.go
@@ -95,11 +95,12 @@ func (s *stubJobStore) List(_ context.Context, query *JobQuery) ([]*Job, error) 
 }
 
 type stubNodeAgent struct {
-	startTaskCalls    atomic.Int32
-	stopTaskCalls     atomic.Int32
-	startTaskFunc     func(host, container string, args *AgentTaskRequest) (string, error)
-	stopTaskFunc      func(host, taskID string, force bool) error
-	getTaskStatusFunc func(host, taskID string) (string, *Result, error)
+	startTaskCalls     atomic.Int32
+	stopTaskCalls      atomic.Int32
+	getTaskStatusCalls atomic.Int32
+	startTaskFunc      func(host, container string, args *AgentTaskRequest) (string, error)
+	stopTaskFunc       func(host, taskID string, force bool) error
+	getTaskStatusFunc  func(host, taskID string) (string, *Result, error)
 }
 
 func (s *stubNodeAgent) StartTask(host, container string, args *AgentTaskRequest) (string, error) {
@@ -119,6 +120,7 @@ func (s *stubNodeAgent) StopTask(host, taskID string, force bool) error {
 }
 
 func (s *stubNodeAgent) GetTaskStatus(host, taskID string) (string, *Result, error) {
+	s.getTaskStatusCalls.Add(1)
 	if s.getTaskStatusFunc != nil {
 		return s.getTaskStatusFunc(host, taskID)
 	}
@@ -448,6 +450,136 @@ func TestManagerRecoverJobsRestoresActiveQuota(t *testing.T) {
 	}
 	if err := manager.ShutdownContext(t.Context()); err != nil {
 		t.Fatalf("ShutdownContext() error=%v", err)
+	}
+}
+
+func TestManagerRecoverJobsValidatesBatchBeforePublishing(t *testing.T) {
+	valid := newRunningJob("job-valid-recovery-2026")
+	valid.AgentTaskID = ""
+	valid.AgentTask.RequestID = ""
+	valid.stopCh = nil
+
+	invalid := newRunningJob("job-invalid-recovery-2026")
+	invalid.Type = JobType("removed-job-type")
+
+	storage := &stubJobStore{listFunc: func(*JobQuery) ([]*Job, error) {
+		return []*Job{valid, invalid}, nil
+	}}
+	agent := &stubNodeAgent{}
+	manager := newTestManager(storage, agent)
+	manager.config.StatusPollInterval = time.Second
+	t.Cleanup(func() {
+		if err := manager.ShutdownContext(context.Background()); err != nil {
+			t.Errorf("ShutdownContext() error=%v", err)
+		}
+	})
+
+	err := manager.recoverJobs(context.Background())
+	if !errors.Is(err, ErrUnsupportedJobType) {
+		t.Fatalf("recoverJobs() error=%v, want ErrUnsupportedJobType", err)
+	}
+
+	manager.mu.RLock()
+	jobsCount := len(manager.jobs)
+	hostCounts := len(manager.jobsByHost)
+	manager.mu.RUnlock()
+	if jobsCount != 0 {
+		t.Fatalf("recovered jobs=%d, want 0 after validation failure", jobsCount)
+	}
+	if hostCounts != 0 {
+		t.Fatalf("recovered host quotas=%d, want 0 after validation failure", hostCounts)
+	}
+	if got := manager.recoveredJobs.Load(); got != 0 {
+		t.Fatalf("recoveredJobs=%d, want 0 after validation failure", got)
+	}
+
+	if valid.AgentTaskID != "" {
+		t.Fatalf("stored job AgentTaskID mutated to %q", valid.AgentTaskID)
+	}
+	if valid.AgentTask.RequestID != "" {
+		t.Fatalf("stored job RequestID mutated to %q", valid.AgentTask.RequestID)
+	}
+	if valid.stopCh != nil {
+		t.Fatal("stored job stop channel was initialized before validation completed")
+	}
+
+	// A monitor polls after one second with this test configuration. Waiting
+	// beyond that boundary proves failed recovery did not launch one.
+	time.Sleep(1200 * time.Millisecond)
+	if got := agent.getTaskStatusCalls.Load(); got != 0 {
+		t.Fatalf("GetTaskStatus() calls=%d, want 0 after validation failure", got)
+	}
+}
+
+func TestManagerRecoverJobsCommitsPreparedBatch(t *testing.T) {
+	cpuJob := newRunningJob("job-recovered-cpu-2026")
+	cpuJob.Type = JobTypeProfilingCPU
+	cpuJob.AgentTaskID = ""
+	cpuJob.AgentTask.RequestID = "stale-request"
+	cpuJob.stopCh = nil
+
+	memoryJob := newRunningJob("job-recovered-memory-2026")
+	memoryJob.Type = JobTypeProfilingMemory
+	memoryJob.AgentTaskID = "agent-memory-2026"
+	memoryJob.AgentTask.RequestID = "stale-request"
+	memoryJob.stopCh = nil
+
+	storage := &stubJobStore{listFunc: func(*JobQuery) ([]*Job, error) {
+		return []*Job{cpuJob, memoryJob}, nil
+	}}
+	policy := TypePolicy{Group: "profiling", MaxJobsPerHost: 4, MaxTotalJobs: 8}
+	manager := newManagerWithStore(storage, &stubNodeAgent{}, ManagerConfig{
+		TypePolicies: map[JobType]TypePolicy{
+			JobTypeProfilingCPU:    policy,
+			JobTypeProfilingMemory: policy,
+		},
+	})
+
+	if err := manager.recoverJobs(t.Context()); err != nil {
+		t.Fatalf("recoverJobs() error=%v", err)
+	}
+	t.Cleanup(func() {
+		if err := manager.ShutdownContext(context.Background()); err != nil {
+			t.Errorf("ShutdownContext() error=%v", err)
+		}
+	})
+
+	manager.mu.RLock()
+	recoveredCPU := manager.jobs[cpuJob.ID]
+	recoveredMemory := manager.jobs[memoryJob.ID]
+	hostQuota := manager.jobsByHost[quotaHostKey(cpuJob.Hostname, policy.Group)]
+	manager.mu.RUnlock()
+
+	if recoveredCPU == nil || recoveredMemory == nil {
+		t.Fatalf("recovered jobs=(%v,%v), want both jobs", recoveredCPU, recoveredMemory)
+	}
+	if recoveredCPU.AgentTaskID != cpuJob.ID {
+		t.Fatalf("CPU AgentTaskID=%q, want %q", recoveredCPU.AgentTaskID, cpuJob.ID)
+	}
+	if recoveredMemory.AgentTaskID != "agent-memory-2026" {
+		t.Fatalf("memory AgentTaskID=%q, want agent-memory-2026", recoveredMemory.AgentTaskID)
+	}
+	for _, recovered := range []*Job{recoveredCPU, recoveredMemory} {
+		if recovered.AgentTask.RequestID != recovered.ID {
+			t.Errorf("job %s RequestID=%q, want job ID", recovered.ID, recovered.AgentTask.RequestID)
+		}
+		if recovered.stopCh == nil {
+			t.Errorf("job %s stop channel is nil", recovered.ID)
+		}
+	}
+	if hostQuota != 2 {
+		t.Fatalf("profiling host quota=%d, want 2", hostQuota)
+	}
+	if got := manager.recoveredJobs.Load(); got != 2 {
+		t.Fatalf("recoveredJobs=%d, want 2", got)
+	}
+
+	// Preparation publishes clones, not partially normalized storage rows.
+	if cpuJob.AgentTaskID != "" || cpuJob.AgentTask.RequestID != "stale-request" || cpuJob.stopCh != nil {
+		t.Fatalf("CPU storage row mutated during recovery: %+v", cpuJob)
+	}
+	if memoryJob.AgentTask.RequestID != "stale-request" || memoryJob.stopCh != nil {
+		t.Fatalf("memory storage row mutated during recovery: %+v", memoryJob)
 	}
 }
 


### PR DESCRIPTION
## Summary

Make durable active-job recovery transactional before any jobs, quota counters, wait-group entries, or monitor goroutines become visible.

A recovery batch is now fully cloned, normalized, and validated first. Only a completely valid batch is committed to the manager and assigned monitors. An incompatible durable row can no longer leave partial manager state and background polling after `NewManager` returns an error.

## Problem

`Manager.recoverJobs` previously combined validation, state publication, and goroutine startup in one loop:

```go
for _, recoveredJob := range jobs {
    policy, err := m.policyFor(recoveredJob.Type)
    if err != nil {
        return err
    }
    m.jobs[recoveredJob.ID] = recoveredJob
    m.jobsByHost[hostKey]++
    m.monitorWG.Add(1)
    go m.monitorJob(context.WithoutCancel(ctx), recoveredJob)
}
```

If a valid durable row preceded a row whose job type was no longer configured, the valid row and its monitor were already active when recovery failed.

The production failure path is:

```text
cmd/huatuo-apiserver.setupJobManagers
  -> job.NewManager
  -> Manager.recoverJobs
  -> partial job/quota publication
  -> partial monitor startup
  -> unsupported later job type
  -> NewManager closes the store and returns nil manager
```

Because recovered monitors intentionally use `context.WithoutCancel`, cancellation of the startup context does not stop a partially launched monitor. The failed manager is not returned, so its `ShutdownContext` cannot be called. The monitor can continue polling through unreachable state after the job store has been closed.

## Root cause

Recovery had no preparation/commit boundary. Each row produced externally visible side effects before the remaining rows were known to be compatible with the current policy configuration.

Durable rows are expected to survive restarts, while policy configuration and supported job types can change between versions or deployments. A later incompatible row is therefore a normal upgrade/configuration boundary, not merely a synthetic request.

## Implementation

- Add `prepareRecoveredJobs` as a side-effect-free preparation phase.
- Clone every stored job before normalization, preserving the store's returned objects.
- Validate every job type against the complete current policy map.
- Restore fallback `AgentTaskID`, idempotent `AgentTask.RequestID`, and a fresh `stopCh` only on the prepared clone.
- Precompute grouped host quota increments without touching manager state.
- Return immediately on any validation failure with no prepared state published.
- Commit all prepared jobs and host quotas together under the manager mutex.
- Register the complete monitor count before releasing the commit boundary.
- Start monitors only for the successfully committed batch.
- Increment the recovered-job metric only after successful validation and commit.

## Error behavior

An unsupported durable job type still returns the existing wrapped `ErrUnsupportedJobType` error, including the affected job ID.

The difference is that the error now has no runtime side effects:

- `manager.jobs` is unchanged;
- `manager.jobsByHost` is unchanged;
- `recoveredJobs` is unchanged;
- no monitor is registered or started;
- no agent status polling occurs.

A nil row is also rejected before publication with its recovery-row index rather than causing a nil dereference during startup.

## Compatibility

- Valid pending/running jobs are still recovered.
- Empty `AgentTaskID` still falls back to the durable job ID.
- `AgentTask.RequestID` is still restored to the durable job ID for idempotent agent restart.
- Host quotas still use the configured policy group and aggregate jobs sharing a group.
- Successful monitors still use `context.WithoutCancel` and remain owned by `ShutdownContext`.
- No API, database schema, JSON representation, configuration, or job-status semantics change.

## Regression coverage

Added tests proving:

- a valid row followed by an unsupported row returns `ErrUnsupportedJobType`;
- failed recovery publishes zero jobs and zero host quotas;
- failed recovery leaves the recovered metric at zero;
- failed recovery does not mutate the valid store row's task ID, request ID, or stop channel;
- no status poll occurs after the failed batch, even after crossing the configured monitor polling interval;
- a fully valid CPU+memory profiling batch commits both jobs;
- fallback and existing agent task IDs are preserved correctly;
- idempotent request IDs and stop channels are restored on clones;
- grouped profiling host quota is committed as two;
- the recovered metric records the complete batch;
- original store rows remain unchanged after successful preparation.

The existing successful single-job recovery and shutdown test remains in place.

## Reproduction evidence

A test against the pre-fix `upstream/main` implementation used a valid active job followed by `removed-job-type`. It observed the monitor after recovery had already returned an error:

```text
=== RUN   TestReproducePartialRecoveryStartsMonitorBeforeValidationFailure
    monitor started for a partially recovered job
--- PASS: TestReproducePartialRecoveryStartsMonitorBeforeValidationFailure (1.00s)
PASS
```

The final regression test reverses that assertion: after waiting beyond the monitor polling boundary, the fixed implementation has zero status calls and no published state.

## Size

```text
Changed files: 2
Additions: 180
Deletions: 21
Total changed lines: 201
Generated/vendor-only lines: 0
```

## Validation

Passed:

```text
go test ./internal/job -count=1
go test -race ./internal/job -count=1
go vet ./internal/job
go test ./cmd/huatuo-apiserver/... ./internal/job -count=1
golangci-lint run -v ./internal/job --timeout=5m --config .golangci.yaml
golangci-lint run -v ./... --timeout=10m --config .golangci.yaml
make check
git diff --check
```

Package and full-repository lint completed with zero issues. `make check` completed successfully on a clean container-local copy using the intended patch as its baseline.

Fixes #655