### PR TITLE
fix(ascend): retry incomplete topology discovery

### DIFF
--- a/core/metrics/ascend_npu.go
+++ b/core/metrics/ascend_npu.go
@@ -50,8 +50,25 @@ type npuCache struct {
 	devices []deviceKey
 }
 
+type ascendTopologyProvider interface {
+	cardList(ctx context.Context) ([]int32, error)
+	deviceCount(ctx context.Context, cardID int32) (int32, error)
+}
+
+type dcmiTopologyProvider struct{}
+
+func (dcmiTopologyProvider) cardList(ctx context.Context) ([]int32, error) {
+	_, cards, err := dcmi.DcGetCardList(ctx)
+	return cards, err
+}
+
+func (dcmiTopologyProvider) deviceCount(ctx context.Context, cardID int32) (int32, error) {
+	return dcmi.DcGetDeviceNumInCard(ctx, cardID)
+}
+
 type ascendNpuCollector struct {
-	cache atomic.Pointer[npuCache]
+	cache    atomic.Pointer[npuCache]
+	topology ascendTopologyProvider
 }
 
 func newAscendNpuCollector() (*tracing.EventTracingAttr, error) {
@@ -60,17 +77,31 @@ func newAscendNpuCollector() (*tracing.EventTracingAttr, error) {
 		return nil, types.ErrNotSupported
 	}
 
-	c := &ascendNpuCollector{}
-	c.refreshCache()
+	c := newAscendNpuCollectorWithTopology(dcmiTopologyProvider{})
 	return &tracing.EventTracingAttr{
 		TracingData: c,
 		Flag:        tracing.FlagMetric,
 	}, nil
 }
 
+func newAscendNpuCollectorWithTopology(topology ascendTopologyProvider) *ascendNpuCollector {
+	c := &ascendNpuCollector{topology: topology}
+	if _, err := c.refreshCache(context.Background()); err != nil {
+		// Keep the collector registered so a transient startup failure can be
+		// retried by the first metric scrape.
+		log.Errorf("ascend: failed to discover NPU topology: %v", err)
+	}
+	return c
+}
+
 func (a *ascendNpuCollector) Update() ([]*metric.Data, error) {
 	ctx := context.Background()
-	metrics, err := ascendCollectMetrics(ctx, a.getDevices())
+	devices, err := a.getDevices(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics, err := ascendCollectMetrics(ctx, devices)
 	if err != nil {
 		var dcmiErr *dcmi.Error
 		if ok := errors.As(err, &dcmiErr); ok {
@@ -80,7 +111,11 @@ func (a *ascendNpuCollector) Update() ([]*metric.Data, error) {
 				return nil, fmt.Errorf("failed to re-init dcmi: %w", err)
 			}
 			a.cache.Store(nil)
-			return ascendCollectMetrics(ctx, a.getDevices())
+			devices, discoveryErr := a.getDevices(ctx)
+			if discoveryErr != nil {
+				return nil, fmt.Errorf("rediscover NPU topology after DCMI re-init: %w", discoveryErr)
+			}
+			return ascendCollectMetrics(ctx, devices)
 		}
 
 		return nil, err
@@ -89,27 +124,24 @@ func (a *ascendNpuCollector) Update() ([]*metric.Data, error) {
 	return metrics, nil
 }
 
-func (a *ascendNpuCollector) getDevices() []deviceKey {
+func (a *ascendNpuCollector) getDevices(ctx context.Context) ([]deviceKey, error) {
 	if c := a.cache.Load(); c != nil {
-		return c.devices
+		return c.devices, nil
 	}
-	return a.refreshCache()
+	return a.refreshCache(ctx)
 }
 
-func (a *ascendNpuCollector) refreshCache() []deviceKey {
-	ctx := context.Background()
-	_, cardList, err := dcmi.DcGetCardList(ctx)
+func (a *ascendNpuCollector) refreshCache(ctx context.Context) ([]deviceKey, error) {
+	cardList, err := a.topology.cardList(ctx)
 	if err != nil {
-		log.Errorf("ascend: failed to get card list for cache: %v", err)
-		return nil
+		return nil, fmt.Errorf("discover Ascend card list: %w", err)
 	}
 
 	var devices []deviceKey
 	for _, cardId := range cardList {
-		deviceNum, err := dcmi.DcGetDeviceNumInCard(ctx, cardId)
+		deviceNum, err := a.topology.deviceCount(ctx, cardId)
 		if err != nil {
-			log.Errorf("ascend: failed to get device count for card %d: %v", cardId, err)
-			continue
+			return nil, fmt.Errorf("discover devices for Ascend card %d: %w", cardId, err)
 		}
 		for devId := int32(0); devId < deviceNum; devId++ {
 			devices = append(devices, deviceKey{uint32(cardId), uint32(devId)})
@@ -117,7 +149,7 @@ func (a *ascendNpuCollector) refreshCache() []deviceKey {
 	}
 
 	a.cache.Store(&npuCache{devices: devices})
-	return devices
+	return devices, nil
 }
 
 func ascendCollectMetrics(ctx context.Context, devices []deviceKey) ([]*metric.Data, error) {

--- a/core/metrics/ascend_npu_cache_test.go
+++ b/core/metrics/ascend_npu_cache_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var (
+	errCardListDiscovery = errors.New("card list unavailable")
+	errCardOneDiscovery  = errors.New("card 1 device count unavailable")
+)
+
+type recordingTopologyProvider struct {
+	mu sync.Mutex
+
+	cardListCalls    int
+	deviceCountCalls map[int32]int
+	cardListFn       func(int) ([]int32, error)
+	deviceCountFn    func(int32, int) (int32, error)
+}
+
+func (p *recordingTopologyProvider) cardList(context.Context) ([]int32, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.cardListCalls++
+	return p.cardListFn(p.cardListCalls)
+}
+
+func (p *recordingTopologyProvider) deviceCount(_ context.Context, cardID int32) (int32, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.deviceCountCalls == nil {
+		p.deviceCountCalls = make(map[int32]int)
+	}
+	p.deviceCountCalls[cardID]++
+	return p.deviceCountFn(cardID, p.deviceCountCalls[cardID])
+}
+
+func (p *recordingTopologyProvider) calls() (int, map[int32]int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	counts := make(map[int32]int, len(p.deviceCountCalls))
+	for cardID, count := range p.deviceCountCalls {
+		counts[cardID] = count
+	}
+	return p.cardListCalls, counts
+}
+
+func newRecordingTopologyProvider(
+	cardList func(int) ([]int32, error),
+	deviceCount func(int32, int) (int32, error),
+) *recordingTopologyProvider {
+	provider := &recordingTopologyProvider{
+		cardListFn:    cardList,
+		deviceCountFn: deviceCount,
+	}
+	return provider
+}
+
+func TestAscendRefreshCacheRejectsPartialTopology(t *testing.T) {
+	provider := newRecordingTopologyProvider(
+		func(int) ([]int32, error) { return []int32{0, 1}, nil },
+		func(cardID int32, _ int) (int32, error) {
+			if cardID == 1 {
+				return 0, errCardOneDiscovery
+			}
+			return 2, nil
+		},
+	)
+	collector := &ascendNpuCollector{topology: provider}
+
+	devices, err := collector.refreshCache(t.Context())
+	if !errors.Is(err, errCardOneDiscovery) {
+		t.Fatalf("refreshCache() error=%v, want card discovery cause", err)
+	}
+	if !strings.Contains(err.Error(), "Ascend card 1") {
+		t.Fatalf("refreshCache() error=%q, want affected card", err)
+	}
+	if devices != nil {
+		t.Fatalf("refreshCache() devices=%v, want nil after partial failure", devices)
+	}
+	if cached := collector.cache.Load(); cached != nil {
+		t.Fatalf("cache=%v, want no published partial topology", cached.devices)
+	}
+
+	cardCalls, deviceCalls := provider.calls()
+	if cardCalls != 1 || deviceCalls[0] != 1 || deviceCalls[1] != 1 {
+		t.Fatalf("discovery calls=(cards=%d devices=%v), want cards=1 and each device count=1",
+			cardCalls, deviceCalls)
+	}
+}
+
+func TestAscendGetDevicesRetriesIncompleteTopology(t *testing.T) {
+	provider := newRecordingTopologyProvider(
+		func(int) ([]int32, error) { return []int32{0, 1}, nil },
+		func(cardID int32, call int) (int32, error) {
+			if cardID == 1 && call == 1 {
+				return 0, errCardOneDiscovery
+			}
+			if cardID == 1 {
+				return 2, nil
+			}
+			return 1, nil
+		},
+	)
+	collector := &ascendNpuCollector{topology: provider}
+
+	if devices, err := collector.getDevices(t.Context()); !errors.Is(err, errCardOneDiscovery) {
+		t.Fatalf("first getDevices()=(%v, %v), want discovery failure", devices, err)
+	}
+	want := []deviceKey{
+		{cardId: 0, deviceId: 0},
+		{cardId: 1, deviceId: 0},
+		{cardId: 1, deviceId: 1},
+	}
+	got, err := collector.getDevices(t.Context())
+	if err != nil {
+		t.Fatalf("second getDevices() error=%v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("second getDevices()=%v, want %v", got, want)
+	}
+
+	got, err = collector.getDevices(t.Context())
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("cached getDevices()=(%v, %v), want (%v, nil)", got, err, want)
+	}
+	cardCalls, deviceCalls := provider.calls()
+	if cardCalls != 2 || deviceCalls[0] != 2 || deviceCalls[1] != 2 {
+		t.Fatalf("discovery calls after cache hit=(cards=%d devices=%v), want two attempts only",
+			cardCalls, deviceCalls)
+	}
+}
+
+func TestAscendRefreshCachePublishesCandidateAtomically(t *testing.T) {
+	provider := newRecordingTopologyProvider(
+		func(call int) ([]int32, error) {
+			if call == 1 {
+				return []int32{4}, nil
+			}
+			return []int32{5, 6}, nil
+		},
+		func(cardID int32, _ int) (int32, error) {
+			if cardID == 6 {
+				return 0, errCardOneDiscovery
+			}
+			return 1, nil
+		},
+	)
+	collector := &ascendNpuCollector{topology: provider}
+
+	initial, err := collector.refreshCache(t.Context())
+	if err != nil {
+		t.Fatalf("initial refreshCache() error=%v", err)
+	}
+	if _, err := collector.refreshCache(t.Context()); !errors.Is(err, errCardOneDiscovery) {
+		t.Fatalf("failed refreshCache() error=%v, want card discovery cause", err)
+	}
+
+	cached := collector.cache.Load()
+	if cached == nil || !reflect.DeepEqual(cached.devices, initial) {
+		t.Fatalf("cache after failed replacement=%v, want prior complete topology %v",
+			cached, initial)
+	}
+	cardCalls, _ := provider.calls()
+	if cardCalls != 2 {
+		t.Fatalf("card list calls=%d, want 2", cardCalls)
+	}
+}
+
+func TestAscendCollectorRetriesStartupTopologyFailure(t *testing.T) {
+	provider := newRecordingTopologyProvider(
+		func(call int) ([]int32, error) {
+			if call == 1 {
+				return nil, errCardListDiscovery
+			}
+			return []int32{2}, nil
+		},
+		func(int32, int) (int32, error) { return 1, nil },
+	)
+	collector := newAscendNpuCollectorWithTopology(provider)
+
+	if cached := collector.cache.Load(); cached != nil {
+		t.Fatalf("startup cache=%v, want nil after discovery failure", cached.devices)
+	}
+	got, err := collector.getDevices(t.Context())
+	if err != nil {
+		t.Fatalf("getDevices() retry error=%v", err)
+	}
+	want := []deviceKey{{cardId: 2, deviceId: 0}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("getDevices()=%v, want %v", got, want)
+	}
+	cardCalls, deviceCalls := provider.calls()
+	if cardCalls != 2 || deviceCalls[2] != 1 {
+		t.Fatalf("discovery calls=(cards=%d devices=%v), want startup failure plus one retry",
+			cardCalls, deviceCalls)
+	}
+}
+
+func TestAscendUpdateReturnsTopologyDiscoveryError(t *testing.T) {
+	provider := newRecordingTopologyProvider(
+		func(int) ([]int32, error) { return []int32{3}, nil },
+		func(int32, int) (int32, error) { return 0, errCardOneDiscovery },
+	)
+	collector := &ascendNpuCollector{topology: provider}
+
+	metrics, err := collector.Update()
+	if !errors.Is(err, errCardOneDiscovery) {
+		t.Fatalf("Update() error=%v, want topology discovery cause", err)
+	}
+	if metrics != nil {
+		t.Fatalf("Update() metrics=%v, want nil for incomplete topology", metrics)
+	}
+}
+
+func BenchmarkAscendGetDevicesCached(b *testing.B) {
+	collector := &ascendNpuCollector{}
+	collector.cache.Store(&npuCache{devices: []deviceKey{{cardId: 0, deviceId: 0}}})
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for range b.N {
+		devices, err := collector.getDevices(ctx)
+		if err != nil || len(devices) != 1 {
+			b.Fatalf("getDevices()=(%v, %v), want one cached device", devices, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- publish Ascend NPU topology only after every discovered card is enumerated;
- keep failed topology candidates uncached so later scrapes retry them;
- surface card-specific discovery errors while preserving their original causes;
- keep constructor discovery best-effort and preserve the atomic cache-hit path;
- add deterministic retry, atomic-publication, caller-error, and performance coverage.

## Problem

`ascendNpuCollector.refreshCache` previously skipped a card when
`DcGetDeviceNumInCard` failed, then stored the devices collected from the other
cards. `getDevices` treated that partial slice as a complete topology forever.

A transient error could therefore remove one card and all of its devices from
every later scrape. Because metrics for the remaining cards continued to be
returned, monitoring could look healthy while inventory, capacity, and alerts
were operating on an incomplete accelerator set.

The deterministic baseline reproduction used cards 0 and 1, made the first
card-1 device-count call fail, and made every later call succeed. The first
refresh stored card 0 alone. The second scrape reused that partial cache and
never issued the prepared successful retry for card 1.

## Root cause

The previous loop combined two incompatible decisions:

1. `continue` converted a failed per-card lookup into a partial candidate;
2. the unconditional `cache.Store` assigned complete-snapshot semantics to
   that candidate.

Card-list failures did not have this problem because they returned before the
store. Per-card failures therefore had a uniquely permanent failure mode.

## Implementation

The collector now uses an internal `ascendTopologyProvider` for the two DCMI
topology calls. The production provider delegates directly to
`DcGetCardList` and `DcGetDeviceNumInCard`; the interface provides a
deterministic seam for lifecycle tests without `libdcmi.so` or NPU hardware.

`refreshCache` now:

- accepts the caller context;
- builds a candidate device slice without mutating cache state;
- returns immediately if any card cannot be enumerated;
- wraps the error with the affected card ID while retaining the original cause;
- stores the candidate only after every card succeeds.

`getDevices` now returns `(devices, error)`. A complete cached snapshot still
uses one atomic pointer load. A cache miss performs discovery and leaves the
cache absent on failure, so the next scrape retries it.

Constructor-time discovery remains best-effort. The collector is still
registered after an initial topology error, but no partial cache is installed.
The first `Update` can therefore recover when the DCMI call succeeds later.

The DCMI reinitialization path also checks rediscovery separately and reports an
actionable error if rebuilding the topology fails after re-init.

## Error behavior

Before this change, a per-card error was logged once and hidden behind a
successful partial cache publication.

After this change:

- the current scrape returns no partial topology-derived metrics;
- the returned error identifies the affected Ascend card;
- `errors.Is` and `errors.As` still reach the original provider/DCMI cause;
- the next scrape retries discovery because no incomplete cache exists;
- an already complete cache is not replaced if an explicit refresh candidate
  fails.

## Compatibility

There are no changes to metric names, labels, configuration, DCMI APIs, or the
successful topology order. The steady-state cache path remains allocation-free.

Benchmark results on linux/amd64 with Go 1.24.13:

```text
BenchmarkAscendGetDevicesCached-20  1.300 ns/op  0 B/op  0 allocs/op
BenchmarkAscendGetDevicesCached-20  1.340 ns/op  0 B/op  0 allocs/op
BenchmarkAscendGetDevicesCached-20  1.346 ns/op  0 B/op  0 allocs/op
```

## Regression coverage

The new tests verify:

- a later card failure returns its original cause and publishes no partial
  snapshot;
- a subsequent cache miss retries the full topology and publishes all devices;
- the resulting complete cache prevents further provider calls;
- a failed replacement candidate preserves the previous complete cache;
- constructor-time card-list failure remains recoverable on the next request;
- `Update` returns a topology error instead of collecting from an incomplete
  inventory;
- the cached path remains allocation-free.

A negative mutation changed the per-card error path back to `continue`. The new
root-cause regression failed as expected:

```text
refreshCache() error=<nil>, want card discovery cause
```

Restoring the fix made the test pass.

## Validation

Passed on linux/amd64 with Go 1.24.13:

```text
go test ./core/metrics -count=1
go test -race ./core/metrics -count=1
go vet ./core/metrics
go test ./core/metrics -run '^$' \
  -bench BenchmarkAscendGetDevicesCached -benchmem -count=3
golangci-lint run -v ./core/metrics --timeout=5m --config .golangci.yaml
golangci-lint run -v ./... --timeout=10m --config .golangci.yaml
make check
git diff --check
```

Both package and full-repository lint completed with zero issues. `make check`
completed on a clean container-local copy containing the exact committed files.

`make unit` was also attempted in the unprivileged development container. The
suite reached the repository tests and failed only at two existing
host-integration assumptions unrelated to this change:

```text
internal/cgroups:
  dial unix /run/systemd/private: connect: no such file or directory
internal/pcapfilter:
  map create: operation not permitted (MEMLOCK may be too low)
```

The affected `core/metrics` package, its race run, vet, lint, and all new tests
passed independently.

Fixes #657
