### PR TITLE
fix(profiler): reject malformed BPF counter values

### DIFF
--- a/internal/profiler/bpfmap/bpfmap.go
+++ b/internal/profiler/bpfmap/bpfmap.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 
 	"github.com/cilium/ebpf"
 
@@ -53,11 +54,18 @@ func ReadUint64(b bpf.BPF, mapID, idx uint32) (uint64, error) {
 		return 0, err
 	}
 
-	if len(val) < 8 {
-		return 0, nil
+	value, err := decodeUint64MapValue(val)
+	if err != nil {
+		return 0, fmt.Errorf("read uint64 map %d index %d: %w", mapID, idx, err)
 	}
+	return value, nil
+}
 
-	return binary.LittleEndian.Uint64(val), nil
+func decodeUint64MapValue(value []byte) (uint64, error) {
+	if len(value) != 8 {
+		return 0, fmt.Errorf("value has %d bytes, want 8", len(value))
+	}
+	return binary.LittleEndian.Uint64(value), nil
 }
 
 // WriteUint64 stores a uint64 value at a uint32-indexed cell in a BPF map.

--- a/internal/profiler/bpfmap/bpfmap_test.go
+++ b/internal/profiler/bpfmap/bpfmap_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpfmap
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+)
+
+type readMapBPF struct {
+	bpf.BPF
+	value []byte
+}
+
+func (b *readMapBPF) ReadMap(_ uint32, _ []byte) ([]byte, error) {
+	return b.value, nil
+}
+
+func TestReadUint64RejectsMalformedValues(t *testing.T) {
+	var valid [8]byte
+	binary.LittleEndian.PutUint64(valid[:], 42)
+
+	tests := []struct {
+		name    string
+		value   []byte
+		want    uint64
+		wantErr string
+	}{
+		{name: "valid", value: valid[:], want: 42},
+		{name: "empty", wantErr: "has 0 bytes, want 8"},
+		{name: "truncated", value: valid[:7], wantErr: "has 7 bytes, want 8"},
+		{name: "oversized", value: append(valid[:], 0), wantErr: "has 9 bytes, want 8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadUint64(&readMapBPF{value: tt.value}, 7, 3)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ReadUint64() error = %v, want %q", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), "map 7 index 3") {
+					t.Errorf("ReadUint64() error = %q, want map and index context", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadUint64() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ReadUint64() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- require profiler state-map values to match their eight-byte ABI
- report the map name and state index when a value is malformed
- cover valid, empty, truncated, and oversized values with regression tests

## Why

`ReadUint64` previously returned `0, nil` for short values. That turns map corruption or an ABI mismatch into a valid-looking counter and can silently lose profiler samples during state transfer.

## Validation

- `gofmt` completed for the changed Go files
- `git diff --check` passed
- `go test ./internal/profiler/bpfmap` was attempted, but this Windows checkout does not contain the generated Linux BPF ABI package required during package setup; the repository CI should run the Linux build and tests