### PR TITLE
fix(metrics): refresh RDMA links per scrape

### DIFF
--- a/core/metrics/netdev_rdma_link.go
+++ b/core/metrics/netdev_rdma_link.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,26 +29,30 @@ func init() {
 }
 
 type rdmaLink struct {
-	rdmaList []*netlink.RdmaLink
+	listLinks  func() ([]*netlink.RdmaLink, error)
+	statistics func(*netlink.RdmaLink) (*netlink.RdmaDeviceStatistic, error)
 }
 
 func newRdmaLink() (*tracing.EventTracingAttr, error) {
-	lists, err := netlink.RdmaLinkList()
-	if err != nil {
-		return nil, err
-	}
-
 	return &tracing.EventTracingAttr{
-		TracingData: &rdmaLink{rdmaList: lists},
-		Flag:        tracing.FlagMetric,
+		TracingData: &rdmaLink{
+			listLinks:  netlink.RdmaLinkList,
+			statistics: netlink.RdmaStatistic,
+		},
+		Flag: tracing.FlagMetric,
 	}, nil
 }
 
 func (r *rdmaLink) Update() ([]*metric.Data, error) {
+	rdmaList, err := r.listLinks()
+	if err != nil {
+		return nil, fmt.Errorf("list RDMA links: %w", err)
+	}
+
 	var data []*metric.Data
 
-	for _, rdma := range r.rdmaList {
-		stats, err := netlink.RdmaStatistic(rdma)
+	for _, rdma := range rdmaList {
+		stats, err := r.statistics(rdma)
 		if err != nil {
 			continue
 		}

--- a/core/metrics/netdev_rdma_link_test.go
+++ b/core/metrics/netdev_rdma_link_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestRdmaLinkUpdateRefreshesDeviceList(t *testing.T) {
+	updates := [][]*netlink.RdmaLink{
+		{{Attrs: netlink.RdmaLinkAttrs{Index: 1, Name: "rdma0", NumPorts: 1}}},
+		{{Attrs: netlink.RdmaLinkAttrs{Index: 2, Name: "rdma1", NumPorts: 1}}},
+	}
+	call := 0
+	collector := &rdmaLink{
+		listLinks: func() ([]*netlink.RdmaLink, error) {
+			links := updates[call]
+			call++
+			return links, nil
+		},
+		statistics: func(link *netlink.RdmaLink) (*netlink.RdmaDeviceStatistic, error) {
+			return &netlink.RdmaDeviceStatistic{
+				RdmaPortStatistics: []*netlink.RdmaPortStatistic{
+					{PortIndex: 1, Statistics: map[string]uint64{"packets": uint64(link.Attrs.Index)}},
+				},
+			}, nil
+		},
+	}
+
+	for i, wantDevice := range []string{"rdma0", "rdma1"} {
+		metrics, err := collector.Update()
+		if err != nil {
+			t.Fatalf("Update() call %d error = %v", i+1, err)
+		}
+		if len(metrics) != 1 {
+			t.Fatalf("Update() call %d returned %d metrics, want 1", i+1, len(metrics))
+		}
+		if got := metrics[0].Labels()["device"]; got != wantDevice {
+			t.Errorf("Update() call %d device = %q, want %q", i+1, got, wantDevice)
+		}
+	}
+}
+
+func TestRdmaLinkUpdateReturnsDiscoveryError(t *testing.T) {
+	collector := &rdmaLink{
+		listLinks: func() ([]*netlink.RdmaLink, error) {
+			return nil, errors.New("netlink unavailable")
+		},
+	}
+
+	_, err := collector.Update()
+	if err == nil || !strings.Contains(err.Error(), "list RDMA links") {
+		t.Fatalf("Update() error = %v, want RDMA discovery context", err)
+	}
+}


### PR DESCRIPTION
## Summary

- discover RDMA links on every collector update instead of only at construction
- allow later scrapes to recover from transient link-discovery failures
- add regression coverage for device hotplug and discovery errors

## Why

The collector cached the RDMA device list when it was created. Devices added afterward never appeared, while removed devices stayed in the list. Refreshing the kernel link view per scrape keeps the exported series aligned with current hardware.

## Validation

- `gofmt` completed for the changed Go files
- `git diff --check` passed
- the targeted Go test was attempted, but this metrics package depends on Linux-only files that are excluded by the Windows build; the repository CI should run the Linux build and tests