### PR TITLE
feat: support ebpf runtime profiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ vendor:
 
 clean:
 	@rm -rf _output
-	@find . \( -name "*.o" -o -name "mock_*.go" -o -name "*.capnp.go" \) \
+	@find . \( -name "*.o" -o -name "mock_*.go" -o -name "*.capnp.go" -o -name "*_types_generated.go" \) \
 		$(FIND_EXCLUDE_PATHS) \
 		-delete
 

--- a/bpf/bpf_prog_runtime.c
+++ b/bpf/bpf_prog_runtime.c
@@ -1,0 +1,48 @@
+#include "vmlinux.h"
+
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#include "bpf_common.h"
+#include "abi/bpf_prog_runtime_types.h"
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, u32);
+	__type(value, struct bpf_prog_runtime_value);
+	__uint(max_entries, 1);
+} profile_stats SEC(".maps");
+
+SEC("fentry/XXX")
+int BPF_PROG(profile_fentry)
+{
+	u32 key = 0;
+	struct bpf_prog_runtime_value *value;
+
+	value = bpf_map_lookup_elem(&profile_stats, &key);
+	if (value)
+		value->start_time_ns = bpf_ktime_get_ns();
+
+	return 0;
+}
+
+SEC("fexit/XXX")
+int BPF_PROG(profile_fexit)
+{
+	u64 end_time_ns = bpf_ktime_get_ns();
+	u32 key = 0;
+	struct bpf_prog_runtime_value *value;
+
+	value = bpf_map_lookup_elem(&profile_stats, &key);
+	if (!value || !value->start_time_ns ||
+	    end_time_ns < value->start_time_ns)
+		return 0;
+
+	value->run_time_ns += end_time_ns - value->start_time_ns;
+	value->run_count++;
+	value->start_time_ns = 0;
+
+	return 0;
+}

--- a/bpf/include/abi/bpf_prog_runtime_types.h
+++ b/bpf/include/abi/bpf_prog_runtime_types.h
@@ -1,0 +1,28 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __BPF_ABI_PROG_RUNTIME_H__
+#define __BPF_ABI_PROG_RUNTIME_H__
+
+#include "bpf_abi.h"
+
+struct bpf_prog_runtime_value {
+	u64 start_time_ns;
+	u64 run_time_ns;
+	u64 run_count;
+};
+
+BPF_ABI_EXPORT(bpf_prog_runtime_value);
+
+#endif /* __BPF_ABI_PROG_RUNTIME_H__ */

--- a/build/docker/grafana/dashboards/metrics-host.json
+++ b/build/docker/grafana/dashboards/metrics-host.json
@@ -7159,6 +7159,507 @@
       ],
       "title": "🐳 HuaTuo-Bamai",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "huatuo-bamai-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 89,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "huatuo-bamai-prom"
+          },
+          "description": "1 = all currently loaded instances are profiled; 0 = no active target instance or at least one instance is not profiled.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "type": "value",
+                  "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "DOWN"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "UP"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 91,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "textOrientation": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "huatuo-bamai-prom"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "huatuo_bamai_bpf_prog_runtime_up{host=~\"$host\",region=~\"$region\"}",
+              "legendFormat": "{{region}}/{{host}} · {{program}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Profiler Up per Program",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "huatuo-bamai-prom"
+          },
+          "description": "Approximate target BPF program runtime as a fraction of total online logical CPU capacity. 100% means aggregate runtime is approximately equal to all online CPUs being continuously busy. Interrupt time between entry and exit may be included.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 92,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "width": 300
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "huatuo-bamai-prom"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (region, host, program) (rate(huatuo_bamai_bpf_prog_runtime_runtime_seconds_total{host=~\"$host\",region=~\"$region\"}[$__rate_interval]))\n/ on (region, host) group_left\nmax by (region, host) (huatuo_bamai_bpf_prog_runtime_online_cores{host=~\"$host\",region=~\"$region\"})",
+              "legendFormat": "{{region}}/{{host}} · {{program}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Profiled BPF Program CPU Utilization",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "huatuo-bamai-prom"
+          },
+          "description": "Approximate elapsed time between profiler entry and exit timestamps per target BPF program invocation.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 93,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "width": 300
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "huatuo-bamai-prom"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (region, host, program) (rate(huatuo_bamai_bpf_prog_runtime_runtime_seconds_total{host=~\"$host\",region=~\"$region\"}[$__rate_interval]))\n/\nclamp_min(sum by (region, host, program) (rate(huatuo_bamai_bpf_prog_runtime_runs_total{host=~\"$host\",region=~\"$region\"}[$__rate_interval])), 1e-9)",
+              "legendFormat": "{{region}}/{{host}} · {{program}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Average Run Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "huatuo-bamai-prom"
+          },
+          "description": "Invocations of the traced BPF program per second.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 94,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "width": 300
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "huatuo-bamai-prom"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum by (region, host, program) (rate(huatuo_bamai_bpf_prog_runtime_runs_total{host=~\"$host\",region=~\"$region\"}[$__rate_interval]))",
+              "legendFormat": "{{region}}/{{host}} · {{program}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Run Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "huatuo-bamai-prom"
+          },
+          "description": "Cumulative failed profiler attachment attempts per program. Check agent logs for the exact cause.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 95,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "width": 300
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "huatuo-bamai-prom"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "max by (region, host, program) (huatuo_bamai_bpf_prog_runtime_attach_failures_total{host=~\"$host\",region=~\"$region\"})",
+              "legendFormat": "{{region}}/{{host}} · {{program}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Attach Failures",
+          "type": "timeseries"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "huatuo-bamai-prom"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "🐳 BPF Profiler",
+      "type": "row"
     }
   ],
   "refresh": "",

--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -26,6 +26,7 @@ import (
 	"huatuo-bamai/core/autotracing"
 	"huatuo-bamai/core/events"
 	collector "huatuo-bamai/core/metrics"
+	"huatuo-bamai/internal/bpf"
 	internalconfig "huatuo-bamai/internal/config"
 	"huatuo-bamai/internal/matcher"
 )
@@ -155,6 +156,15 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("validating event tracing config: %w", err)
 	}
 	return nil
+}
+
+func (c *Config) BPFProgRuntimeOptions() bpf.ProgRuntimeOptions {
+	profiler := c.MetricCollector.BPFProgRuntime
+	inBlacklist := slices.Contains(c.BlackList, bpf.ProgRuntimeProfilerName)
+	return bpf.ProgRuntimeOptions{
+		Enabled: profiler.Enabled && !inBlacklist,
+		Targets: profiler.Targets,
+	}
 }
 
 // Validate rejects unsupported log levels.

--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -320,6 +320,45 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func TestBPFProgRuntimeOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		enabled   bool
+		blacklist []string
+		want      bool
+	}{
+		{name: "disabled by config"},
+		{name: "enabled", enabled: true, want: true},
+		{
+			name:      "unrelated blacklist",
+			enabled:   true,
+			blacklist: []string{"netdev_hw"},
+			want:      true,
+		},
+		{
+			name:      "collector blacklisted",
+			enabled:   true,
+			blacklist: []string{"bpf_prog_runtime"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{BlackList: tt.blacklist}
+			cfg.MetricCollector.BPFProgRuntime.Enabled = tt.enabled
+			cfg.MetricCollector.BPFProgRuntime.Targets = []string{"target"}
+
+			got := cfg.BPFProgRuntimeOptions()
+			if got.Enabled != tt.want {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, tt.want)
+			}
+			if len(got.Targets) != 1 || got.Targets[0] != "target" {
+				t.Fatalf("options = %+v, want targets preserved", got)
+			}
+		})
+	}
+}
+
 func TestLoadRejectsInvalidIssuesListExpression(t *testing.T) {
 	path := writeConfigFile(t, t.TempDir(), "huatuo-bamai.conf", `
 [EventTracing]

--- a/cmd/huatuo-bamai/tracing.go
+++ b/cmd/huatuo-bamai/tracing.go
@@ -26,7 +26,9 @@ import (
 )
 
 func setupBPF(_ *Daemon) (func(context.Context) error, error) {
-	if err := bpf.Init(&bpf.Option{}); err != nil {
+	if err := bpf.Init(&bpf.Option{
+		ProgRuntime: config.Get().BPFProgRuntimeOptions(),
+	}); err != nil {
 		return nil, fmt.Errorf("init bpf: %w", err)
 	}
 

--- a/core/metrics/bpf_prog_runtime.go
+++ b/core/metrics/bpf_prog_runtime.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/utils/cpuutil"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+//go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/bpf_prog_runtime.c -o $BPF_DIR/bpf_prog_runtime.o
+
+type bpfProgRuntimeCollector struct{}
+
+var readProgRuntimeData = bpf.ReadBPFProgRuntimeData
+
+func init() {
+	tracing.RegisterEventTracing(bpf.ProgRuntimeProfilerName, newBPFProgRuntimeCollector)
+}
+
+func newBPFProgRuntimeCollector() (*tracing.EventTracingAttr, error) {
+	cfg := configSnapshot()
+	if !cfg.BPFProgRuntime.Enabled {
+		return nil, types.ErrNotSupported
+	}
+
+	return &tracing.EventTracingAttr{
+		TracingData: &bpfProgRuntimeCollector{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+func (c *bpfProgRuntimeCollector) Update() ([]*metric.Data, error) {
+	metrics := []*metric.Data{}
+	if onlineCPUs, err := cpuutil.ParseOnlineCores(cpuutil.SystemCPUOnlinePath); err == nil {
+		metrics = append(metrics, metric.NewGaugeData(
+			"online_cores",
+			float64(onlineCPUs),
+			"number of online logical cpus on the host.",
+			nil,
+		))
+	}
+
+	for _, profile := range readProgRuntimeData() {
+		labels := map[string]string{"program": profile.ProgramName}
+		up := float64(0)
+		if profile.Up {
+			up = 1
+		}
+		metrics = append(metrics,
+			metric.NewGaugeData(
+				"up",
+				up,
+				"whether all current bpf program instances are profiled.",
+				labels,
+			),
+			metric.NewCounterData(
+				"attach_failures_total",
+				float64(profile.AttachFailures),
+				"target bpf program profiler attach failures.",
+				labels,
+			),
+			metric.NewCounterData(
+				"runs_total",
+				float64(profile.RunCount),
+				"cumulative target bpf program executions.",
+				labels,
+			),
+			metric.NewCounterData(
+				"runtime_seconds_total",
+				float64(profile.RunTimeNS)/1e9,
+				"cumulative target bpf program runtime in seconds, excluding profiler overhead.",
+				labels,
+			),
+		)
+	}
+	return metrics, nil
+}

--- a/core/metrics/bpf_prog_runtime_test.go
+++ b/core/metrics/bpf_prog_runtime_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/types"
+)
+
+func TestNewBPFProgRuntimeCollectorDisabled(t *testing.T) {
+	originalConfig := configSnapshot()
+	t.Cleanup(func() { Set(originalConfig) })
+	Set(&Config{})
+
+	if _, err := newBPFProgRuntimeCollector(); !errors.Is(err, types.ErrNotSupported) {
+		t.Fatalf("newBPFProgRuntimeCollector() error = %v, want ErrNotSupported", err)
+	}
+}
+
+func TestBPFProgRuntimeCollectorUpdate(t *testing.T) {
+	originalRead := readProgRuntimeData
+	readProgRuntimeData = func() []bpf.ProgRuntimeMetric {
+		return []bpf.ProgRuntimeMetric{{
+			ProgramName:    "target",
+			RunTimeNS:      2_500_000_000,
+			RunCount:       7,
+			Up:             true,
+			AttachFailures: 3,
+		}}
+	}
+	t.Cleanup(func() { readProgRuntimeData = originalRead })
+
+	data, err := (&bpfProgRuntimeCollector{}).Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if got := len(data); got < 4 || got > 5 {
+		t.Fatalf("metric count = %d, want 4 profile metrics and optional online_cores", got)
+	}
+
+	byName := make(map[string]*metric.Data, 4)
+	for _, item := range data {
+		if item.Name() == "online_cores" {
+			if item.Type() != metric.MetricTypeGauge || item.Value < 1 {
+				t.Fatalf("online_cores = type %d, value %v; want positive gauge", item.Type(), item.Value)
+			}
+			continue
+		}
+		if _, exists := byName[item.Name()]; exists {
+			t.Fatalf("duplicate metric %q", item.Name())
+		}
+		byName[item.Name()] = item
+	}
+
+	tests := []struct {
+		name  string
+		value float64
+		typ   int
+	}{
+		{name: "up", value: 1, typ: metric.MetricTypeGauge},
+		{name: "attach_failures_total", value: 3, typ: metric.MetricTypeCounter},
+		{name: "runs_total", value: 7, typ: metric.MetricTypeCounter},
+		{name: "runtime_seconds_total", value: 2.5, typ: metric.MetricTypeCounter},
+	}
+	for _, tt := range tests {
+		item, ok := byName[tt.name]
+		if !ok {
+			t.Errorf("metric %q is missing", tt.name)
+			continue
+		}
+		if item.Value != tt.value || item.Type() != tt.typ {
+			t.Errorf("%s = value %v, type %d; want value %v, type %d",
+				tt.name, item.Value, item.Type(), tt.value, tt.typ)
+		}
+		if got := item.Labels()["program"]; got != "target" {
+			t.Errorf("%s program label = %q, want target", tt.name, got)
+		}
+		if item.Help() == "" {
+			t.Errorf("%s help is empty", tt.name)
+		}
+	}
+}
+
+func BenchmarkBPFProgRuntimeCollectorUpdate(b *testing.B) {
+	originalRead := readProgRuntimeData
+	readProgRuntimeData = func() []bpf.ProgRuntimeMetric {
+		return []bpf.ProgRuntimeMetric{{ProgramName: "target", Up: true}}
+	}
+	b.Cleanup(func() { readProgRuntimeData = originalRead })
+
+	collector := &bpfProgRuntimeCollector{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := collector.Update(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/core/metrics/config.go
+++ b/core/metrics/config.go
@@ -72,6 +72,11 @@ type Config struct {
 	MountPointStat struct {
 		MountPointsIncluded string
 	}
+
+	BPFProgRuntime struct {
+		Enabled bool `default:"false"`
+		Targets []string
+	}
 }
 
 var currentConfig atomic.Pointer[Config]
@@ -98,5 +103,6 @@ func (c *Config) Clone() *Config {
 	dst := *c
 	dst.NetdevDCB.DeviceList = slices.Clone(c.NetdevDCB.DeviceList)
 	dst.NetdevHW.DeviceList = slices.Clone(c.NetdevHW.DeviceList)
+	dst.BPFProgRuntime.Targets = slices.Clone(c.BPFProgRuntime.Targets)
 	return &dst
 }

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -1060,6 +1060,28 @@ This section defines collection rules for various system and network metrics. Al
 
 Note: enabling the collector itself (i.e. removing `mthreads_gpu` from `BlackList` after the process has already started with the collector disabled because `libmtml.so` was missing at startup) requires a restart. The collector factory runs only during initialization, so a successful late library load will not register a new collector.
 
+#### 9.8 BPF Program Runtime Profiler
+
+```bash
+# Metric Collector
+[MetricCollector]
+    # Targeted BPF program runtime profiler
+    #
+    # Attaches fentry/fexit probes to managed BPF programs as they are loaded
+    # and exports cumulative run count and runtime per program.
+    # An empty Targets list profiles every managed program; otherwise only the
+    # named programs are profiled. Default: disabled.
+    #
+    [MetricCollector.BPFProgRuntime]
+        # Enabled = false
+        # Targets = ["bpf_anyfs_file_read_iter"]
+```
+
+- **Enabled**: Master switch. Default false. No hot reload.
+- **Targets**: Empty profiles all managed BPF programs; otherwise only the named programs are profiled. No hot reload. Metrics: `up`, `runs_total`, `runtime_seconds_total`, `attach_failures_total`, and a host `online_cores` gauge.
+
+  **Description**: Only managed BPF programs are profiled. Tail-called programs are not profiled separately; same-name programs share one metric series. Runtime is measured from fentry to fexit and may include interrupt, softirq, or NMI time. Nested or unmatched samples are skipped. Targets require BTF metadata and BPF-to-BPF fentry/fexit support. Unsupported targets report `up=0` and `attach_failures_total` without blocking program loading.
+
 ### 10. Pod
 
 This section configures how to fetch Pod information from kubelet to enable container/Pod-level labeling and metric isolation.

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -1070,6 +1070,29 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
 
 注意：在进程已经启动且因 `libmtml.so` 缺失导致采集器被禁用的情况下，要启用该采集器（即把 `mthreads_gpu` 从 `BlackList` 中移除）需要重启进程。采集器工厂只在初始化时运行，运行时即使库被加载成功也不会注册新的采集器。
 
+#### 9.8 BPF 程序运行时 Profiler
+
+```bash
+# Metric Collector
+[MetricCollector]
+    # Targeted BPF program runtime profiler
+    #
+    # Attaches fentry/fexit probes to managed BPF programs as they are loaded
+    # and exports cumulative run count and runtime per program.
+    # An empty Targets list profiles every managed program; otherwise only the
+    # named programs are profiled. Default: disabled.
+    #
+    [MetricCollector.BPFProgRuntime]
+        # Enabled = false
+        # Targets = ["bpf_anyfs_file_read_iter"]
+```
+
+- **Enabled**：总开关。默认 `false`，不支持配置热变更。
+- **Targets**：空列表表示剖析全部托管 BPF 程序；否则仅剖析列出的程序，不支持配置热变更。指标包括 `up`、`runs_total`、`runtime_seconds_total`、`attach_failures_total`，以及宿主机 `online_cores`。
+
+  **说明**：仅托管 BPF 加载器加载的程序可被剖析。尾调用进入的程序不会单独生成指标；同名程序聚合为同一条指标序列。统计值是 fentry 到 fexit 之间的单调时钟经过时间，期间发生的硬中断、软中断或 NMI 处理时间可能包含在运行时中。
+  单个 per-CPU 起始槽假设同一目标不会在同一 CPU 上嵌套执行。嵌套或入口不匹配的样本会被跳过而非误计。对累计监控预计影响很小，但不承诺严格的误差上界。目标程序必须带 BTF 函数元数据，且内核支持 BPF-to-BPF fentry/fexit 的tracing link。不支持的目标以 `up=0` 和 `attach_failures_total` 暴露，不阻止真实目标程序加载。
+
 ### 10. Pod 配置
 
 该 section 用于从 kubelet 获取 Pod 信息，实现容器与 Pod 级别的标签关联和指标隔离。

--- a/docs/key-feature/kernel-wide-insight_en.md
+++ b/docs/key-feature/kernel-wide-insight_en.md
@@ -100,6 +100,38 @@ huatuo_bamai_cpu_util_container_usr{container_host="coredns-855c4dd65d-8v5kg",co
 |cpu_util_container_usr| Container CPU user time %|%|Container|container_host,container_hostnamespace,container_level,container_name,container_type,host,region |
 |cpu_util_container_total| Container CPU total %|%|Container|container_host,container_hostnamespace,container_level,container_name,container_type,host,region |
 
+### BPF Program Runtime
+
+Runtime and attachment status of selected managed BPF programs:
+
+```bash
+# HELP huatuo_bamai_bpf_prog_runtime_online_cores number of online logical cpus on the host.
+# TYPE huatuo_bamai_bpf_prog_runtime_online_cores gauge
+huatuo_bamai_bpf_prog_runtime_online_cores{host="hostname",region="dev"} 64
+# HELP huatuo_bamai_bpf_prog_runtime_up whether all current bpf program instances are profiled.
+# TYPE huatuo_bamai_bpf_prog_runtime_up gauge
+huatuo_bamai_bpf_prog_runtime_up{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 1
+# HELP huatuo_bamai_bpf_prog_runtime_attach_failures_total target bpf program profiler attach failures.
+# TYPE huatuo_bamai_bpf_prog_runtime_attach_failures_total counter
+huatuo_bamai_bpf_prog_runtime_attach_failures_total{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 0
+# HELP huatuo_bamai_bpf_prog_runtime_runs_total cumulative target bpf program executions.
+# TYPE huatuo_bamai_bpf_prog_runtime_runs_total counter
+huatuo_bamai_bpf_prog_runtime_runs_total{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 18540
+# HELP huatuo_bamai_bpf_prog_runtime_runtime_seconds_total cumulative target bpf program runtime in seconds, excluding profiler overhead.
+# TYPE huatuo_bamai_bpf_prog_runtime_runtime_seconds_total counter
+huatuo_bamai_bpf_prog_runtime_runtime_seconds_total{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 0.7314
+```
+
+|Metric|Description|Unit|Target|Labels|
+|---|---|---|---|---|
+|bpf_prog_runtime_online_cores|Online logical CPU count|cores|Host|host, region|
+|bpf_prog_runtime_up|Whether all active same-name instances are profiled|`0`/`1`|BPF program|host, program, region|
+|bpf_prog_runtime_attach_failures_total|Cumulative attachment failures|count|BPF program|host, program, region|
+|bpf_prog_runtime_runs_total|Cumulative executions|count|BPF program|host, program, region|
+|bpf_prog_runtime_runtime_seconds_total|Cumulative runtime|seconds|BPF program|host, program, region|
+
+> Requires managed programs with BTF and BPF-to-BPF fentry/fexit support. Configuration changes require an agent restart.
+
 ### Allocation
 
 Container CPU resource configuration:

--- a/docs/key-feature/kernel-wide-insight_zh.md
+++ b/docs/key-feature/kernel-wide-insight_zh.md
@@ -99,6 +99,38 @@ huatuo_bamai_cpu_util_container_usr{container_host="coredns-855c4dd65d-8v5kg",co
 |cpu_util_container_usr| CPU 用户态利用率|%|容器|container_host,container_hostnamespace,container_level,container_name,container_type,host,region |
 |cpu_util_container_total| CPU 总利用率|%|容器|container_host,container_hostnamespace,container_level,container_name,container_type,host,region |
 
+### BPF 程序运行时
+
+选中托管 BPF 程序的运行时和附着状态：
+
+```bash
+# HELP huatuo_bamai_bpf_prog_runtime_online_cores number of online logical cpus on the host.
+# TYPE huatuo_bamai_bpf_prog_runtime_online_cores gauge
+huatuo_bamai_bpf_prog_runtime_online_cores{host="hostname",region="dev"} 64
+# HELP huatuo_bamai_bpf_prog_runtime_up whether all current bpf program instances are profiled.
+# TYPE huatuo_bamai_bpf_prog_runtime_up gauge
+huatuo_bamai_bpf_prog_runtime_up{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 1
+# HELP huatuo_bamai_bpf_prog_runtime_attach_failures_total target bpf program profiler attach failures.
+# TYPE huatuo_bamai_bpf_prog_runtime_attach_failures_total counter
+huatuo_bamai_bpf_prog_runtime_attach_failures_total{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 0
+# HELP huatuo_bamai_bpf_prog_runtime_runs_total cumulative target bpf program executions.
+# TYPE huatuo_bamai_bpf_prog_runtime_runs_total counter
+huatuo_bamai_bpf_prog_runtime_runs_total{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 18540
+# HELP huatuo_bamai_bpf_prog_runtime_runtime_seconds_total cumulative target bpf program runtime in seconds, excluding profiler overhead.
+# TYPE huatuo_bamai_bpf_prog_runtime_runtime_seconds_total counter
+huatuo_bamai_bpf_prog_runtime_runtime_seconds_total{host="hostname",program="bpf_anyfs_file_read_iter",region="dev"} 0.7314
+```
+
+|指标|意义|单位|对象|标签|
+|---|---|---|---|---|
+|bpf_prog_runtime_online_cores|在线逻辑 CPU 数量|核|物理机|host, region|
+|bpf_prog_runtime_up|同名活跃实例是否均被剖析|`0`/`1`|BPF 程序|host, program, region|
+|bpf_prog_runtime_attach_failures_total|附着失败累计次数|计数|BPF 程序|host, program, region|
+|bpf_prog_runtime_runs_total|累计执行次数|计数|BPF 程序|host, program, region|
+|bpf_prog_runtime_runtime_seconds_total|累计运行时间|秒|BPF 程序|host, program, region|
+
+> 仅支持带 BTF 且内核支持 BPF-to-BPF fentry/fexit 的托管程序；配置修改后需要重启 Agent。
+
 ### 资源配置
 
 通过如下指标可以了解容器 CPU 资源配置情况，prometheus 指标格式：

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -478,6 +478,17 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
 
 # Metric Collector
 [MetricCollector]
+    # Targeted BPF program runtime profiler
+    #
+    # Attaches fentry/fexit probes to managed BPF programs as they are loaded
+    # and exports cumulative run count and runtime per program.
+    # An empty Targets list profiles every managed program; otherwise only the
+    # named programs are profiled. Default: disabled.
+    #
+    [MetricCollector.BPFProgRuntime]
+        # Enabled = false
+        # Targets = ["bpf_anyfs_file_read_iter"]
+
     # Ascend NPU fine-grained toggles
     #
     # - EnableDCMI

--- a/integration/test_bpf_debug_macro.sh
+++ b/integration/test_bpf_debug_macro.sh
@@ -35,11 +35,11 @@ WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/bpf-debug.XXXXXX")
 
 # expect_marker <obj> <"has"|"missing"> <marker>: single source of truth
 # for the strings(1)-based assertion. `strings -a` scans the whole file
-# (section layout varies by binutils version); `grep -Fq` makes the match
-# literal and silent.
+# (section layout varies by binutils version); `grep -F` consumes the full
+# stream so `pipefail` does not turn grep's early match into SIGPIPE.
 expect_marker() {
 	local obj=$1 mode=$2 marker=$3
-	if strings -a "${obj}" | grep -Fq -- "${marker}"; then
+	if strings -a "${obj}" | grep -F -- "${marker}" > /dev/null; then
 		[[ "${mode}" == "has" ]] && return 0
 		fatal "marker '${marker}' must NOT appear in $(basename "${obj}")"
 	fi

--- a/integration/test_metrics_include_filter.sh
+++ b/integration/test_metrics_include_filter.sh
@@ -29,7 +29,7 @@ check_metrics "include filter" \
 	"memory_vmstat_pgfault" \
 	"netstat_Tcp_RetransSegs" "netstat_TcpExt_TCPLostRetransmit" \
 	'netdev_.*device="eth0"' \
-	'mountpoint_perm_ro{.*mountpoint="/boot"' \
+	'mountpoint_perm_ro\{.*mountpoint="/boot"' \
 	-- \
 	"memory_vmstat_thp_zero_page_alloc" "memory_vmstat_thp_swpout" \
 	"memory_vmstat_balloon_inflate" "memory_vmstat_balloon_deflate" \
@@ -37,5 +37,5 @@ check_metrics "include filter" \
 	"netstat_Tcp_ActiveOpens" "netstat_TcpExt_TCPAutoCorking" \
 	"netstat_TcpExt_TCPTimeouts" "netstat_Tcp_CurrEstab" \
 	'netdev_.*device="eth1"' 'netdev_.*device="docker0"' \
-	'mountpoint_perm_ro{.*mountpoint="/sys/fs/cgroup"' \
-	'mountpoint_perm_ro{.*mountpoint="/home/root/containers'
+	'mountpoint_perm_ro\{.*mountpoint="/sys/fs/cgroup"' \
+	'mountpoint_perm_ro\{.*mountpoint="/home/root/containers'

--- a/internal/bpf/bpf_default.go
+++ b/internal/bpf/bpf_default.go
@@ -36,11 +36,19 @@ import (
 var DefaultObjDir = "bpf"
 
 // Init initializes package-level BPF resources.
-func Init(_ *Option) error {
-	return unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
+func Init(opt *Option) error {
+	if err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
 		Cur: unix.RLIM_INFINITY,
 		Max: unix.RLIM_INFINITY,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if opt == nil {
+		return nil
+	}
+
+	return setProgRuntimeProfiler(opt.ProgRuntime)
 }
 
 // Shutdown releases package-level BPF resources.
@@ -72,6 +80,7 @@ type defaultBPF struct {
 	mapIDsByName     map[string]uint32
 	programIDsByName map[string]uint32
 	perfEvent        *perfEventAttach
+	progProfiles     []*bpfProgRuntimeInstance
 	isClosed         bool
 }
 
@@ -209,10 +218,16 @@ func loadBPFFromCollectionSpec(bpfName string, specs *ebpf.CollectionSpec, const
 	}
 
 	b.programIDsByName = make(map[string]uint32, len(b.programsByID))
+	programsInfo := make([]ProgramInfo, 0, len(b.programsByID))
 	for id, p := range b.programsByID {
 		b.programIDsByName[p.name] = id
+		programsInfo = append(programsInfo, ProgramInfo{
+			ID:          id,
+			Name:        p.name,
+			SectionName: p.sectionName,
+		})
 	}
-
+	b.progProfiles = startBPFProgRuntimeProfiles(programsInfo)
 	log.WithField("bpf", b.name).
 		WithField("map_count", len(b.mapIDsByName)).
 		WithField("program_count", len(b.programIDsByName)).
@@ -332,6 +347,10 @@ func (b *defaultBPF) Close() error {
 				}
 			}
 		}
+	}
+
+	if err := stopBPFProgRuntimeProfiles(b.progProfiles); err != nil {
+		closeErrs = append(closeErrs, fmt.Errorf("stop BPF program runtime profiles: %w", err))
 	}
 
 	for _, p := range b.programsByID {

--- a/internal/bpf/bpf_types.go
+++ b/internal/bpf/bpf_types.go
@@ -29,6 +29,13 @@ var (
 
 type Option struct {
 	KeepaliveTimeout int
+	ProgRuntime      ProgRuntimeOptions
+}
+
+// ProgRuntimeOptions selects loaded BPF programs for profiling.
+type ProgRuntimeOptions struct {
+	Enabled bool
+	Targets []string
 }
 
 // AttachOption is an option for attaching a program.

--- a/internal/bpf/prog_runtime_integration_test.go
+++ b/internal/bpf/prog_runtime_integration_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+)
+
+func TestProgRuntimeIntegration(t *testing.T) {
+	if os.Getenv("BPF_PROG_RUNTIME_INTEGRATION") != "1" {
+		t.Skip("set BPF_PROG_RUNTIME_INTEGRATION=1 and run as root")
+	}
+	if err := Init(&Option{}); err != nil {
+		t.Fatalf("initialize BPF manager: %v", err)
+	}
+
+	targetFunc := &btf.Func{
+		Name: "profile_test_target",
+		Type: &btf.FuncProto{
+			Return: &btf.Int{Name: "int", Size: 4, Encoding: btf.Signed},
+			Params: []btf.FuncParam{
+				{
+					Name: "ctx",
+					Type: &btf.Pointer{Target: &btf.Struct{Name: "xdp_md"}},
+				},
+			},
+		},
+		Linkage: btf.GlobalFunc,
+	}
+	target, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "profile_test_ta",
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			btf.WithFuncMetadata(asm.Mov.Imm(asm.R0, 2), targetFunc),
+			asm.Return(),
+		},
+		License: "GPL",
+	})
+	if err != nil {
+		t.Fatalf("load target program: %v", err)
+	}
+	defer target.Close()
+
+	info, err := target.Info()
+	if err != nil {
+		t.Fatalf("get target info: %v", err)
+	}
+	programID, ok := info.ID()
+	if !ok {
+		t.Fatal("target program has no ID")
+	}
+
+	profile, err := newBPFProgRuntimeByID(uint32(programID), filepath.Join("..", "..", "bpf", progRuntimeObjectName))
+	if err != nil {
+		t.Fatalf("attach profiler: %v", err)
+	}
+
+	const runs = 5
+	for i := 0; i < runs; i++ {
+		if _, _, err := target.Test(make([]byte, 64)); err != nil {
+			_ = profile.Close()
+			t.Fatalf("run target program: %v", err)
+		}
+	}
+
+	stats, err := profile.Read()
+	if err != nil {
+		_ = profile.Close()
+		t.Fatalf("read profiler: %v", err)
+	}
+	if stats.RunCount != runs {
+		_ = profile.Close()
+		t.Fatalf("RunCount = %d, want %d", stats.RunCount, runs)
+	}
+	if stats.RunTimeNS == 0 {
+		_ = profile.Close()
+		t.Fatal("RunTimeNS = 0, want greater than zero")
+	}
+
+	if err := profile.Close(); err != nil {
+		t.Fatalf("close profiler: %v", err)
+	}
+	if _, err := profile.Read(); !errors.Is(err, errProgRuntimeClosed) {
+		t.Fatalf("Read() after Close error = %v, want errProgRuntimeClosed", err)
+	}
+	if err := profile.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestManagedProgRuntimeReloadIntegration(t *testing.T) {
+	if os.Getenv("BPF_PROG_RUNTIME_INTEGRATION") != "1" {
+		t.Skip("set BPF_PROG_RUNTIME_INTEGRATION=1 and run as root")
+	}
+	if err := Init(&Option{}); err != nil {
+		t.Fatalf("initialize BPF manager: %v", err)
+	}
+
+	originalObjectDir := DefaultObjDir
+	DefaultObjDir = filepath.Join("..", "..", "bpf")
+	t.Cleanup(func() {
+		DefaultObjDir = originalObjectDir
+		// A failed attach leaves an active placeholder; drop it so the
+		// shared manager can be reconfigured by later tests.
+		progRuntime.Lock()
+		progRuntime.active = map[*bpfProgRuntimeInstance]struct{}{}
+		progRuntime.Unlock()
+		if err := progRuntime.configure(false, false, nil); err != nil {
+			t.Errorf("reset BPF program runtime profiler: %v", err)
+		}
+	})
+	if err := progRuntime.configure(true, true, nil); err != nil {
+		t.Fatalf("configure BPF program runtime profiler: %v", err)
+	}
+
+	first := loadManagedProgRuntimeTarget(t, "profile_reload_first")
+	runManagedProgRuntimeTarget(t, first, 5)
+	assertManagedProgRuntimeMetric(t, 5, true)
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first target: %v", err)
+	}
+	assertManagedProgRuntimeMetric(t, 5, false)
+
+	second := loadManagedProgRuntimeTarget(t, "profile_reload_second")
+	runManagedProgRuntimeTarget(t, second, 3)
+	assertManagedProgRuntimeMetric(t, 8, true)
+
+	third := loadManagedProgRuntimeTarget(t, "profile_reload_third")
+	runManagedProgRuntimeTarget(t, third, 2)
+	assertManagedProgRuntimeMetric(t, 10, true)
+	if err := second.Close(); err != nil {
+		t.Fatalf("close second target: %v", err)
+	}
+	assertManagedProgRuntimeMetric(t, 10, true)
+
+	runManagedProgRuntimeTarget(t, third, 1)
+	assertManagedProgRuntimeMetric(t, 11, true)
+	if err := third.Close(); err != nil {
+		t.Fatalf("close third target: %v", err)
+	}
+	assertManagedProgRuntimeMetric(t, 11, false)
+
+	if err := progRuntime.configure(true, true, nil); err != nil {
+		t.Fatalf("reconfigure BPF program runtime profiler: %v", err)
+	}
+	DefaultObjDir = t.TempDir()
+	failedProfile := loadManagedProgRuntimeTarget(t, "profile_attach_failure")
+	if err := failedProfile.Close(); err != nil {
+		t.Fatalf("close target after profiler attach failure: %v", err)
+	}
+	metrics := ReadBPFProgRuntimeData()
+	if len(metrics) != 1 || metrics[0].Up || metrics[0].AttachFailures != 1 {
+		t.Fatalf("failed attach metric = %+v, want up=false and attach_failures=1", metrics)
+	}
+}
+
+func loadManagedProgRuntimeTarget(t *testing.T, name string) BPF {
+	t.Helper()
+	targetFunc := &btf.Func{
+		Name: "profile_reload_target",
+		Type: &btf.FuncProto{
+			Return: &btf.Int{Name: "int", Size: 4, Encoding: btf.Signed},
+			Params: []btf.FuncParam{{
+				Name: "ctx",
+				Type: &btf.Pointer{Target: &btf.Struct{Name: "xdp_md"}},
+			}},
+		},
+		Linkage: btf.GlobalFunc,
+	}
+	spec := &ebpf.CollectionSpec{Programs: map[string]*ebpf.ProgramSpec{
+		"profile_reload": {
+			Name: "profile_reload",
+			Type: ebpf.XDP,
+			Instructions: asm.Instructions{
+				btf.WithFuncMetadata(asm.Mov.Imm(asm.R0, 2), targetFunc),
+				asm.Return(),
+			},
+			License: "GPL",
+		},
+	}}
+	target, err := loadBPFFromCollectionSpec(name, spec, nil)
+	if err != nil {
+		t.Fatalf("load managed target %q: %v", name, err)
+	}
+	return target
+}
+
+func runManagedProgRuntimeTarget(t *testing.T, target BPF, runs int) {
+	t.Helper()
+	managed := target.(*defaultBPF)
+	id := managed.ProgramIDByName("profile_reload")
+	program := managed.programsByID[id].handle
+	for i := 0; i < runs; i++ {
+		if _, _, err := program.Test(make([]byte, 64)); err != nil {
+			t.Fatalf("run managed target: %v", err)
+		}
+	}
+}
+
+func assertManagedProgRuntimeMetric(t *testing.T, runCount uint64, up bool) {
+	t.Helper()
+	metrics := ReadBPFProgRuntimeData()
+	if len(metrics) != 1 {
+		t.Fatalf("ReadBPFProgRuntimeData() returned %d metrics, want 1: %+v", len(metrics), metrics)
+	}
+	metric := metrics[0]
+	if metric.ProgramName != "profile_reload" || metric.RunCount != runCount || metric.RunTimeNS == 0 || metric.Up != up {
+		t.Fatalf("profile metric = %+v, want name=profile_reload run_count=%d runtime>0 up=%v", metric, runCount, up)
+	}
+}

--- a/internal/bpf/prog_runtime_profiler.go
+++ b/internal/bpf/prog_runtime_profiler.go
@@ -1,0 +1,465 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"huatuo-bamai/internal/bpf/abi"
+	"huatuo-bamai/internal/log"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+const (
+	// ProgRuntimeProfilerName is the tracer name.
+	ProgRuntimeProfilerName = "bpf_prog_runtime"
+
+	// progRuntimeObjectName is the compiled profiler BPF object name.
+	progRuntimeObjectName     = "bpf_prog_runtime.o"
+	progRuntimeStatsMapName   = "profile_stats"
+	progRuntimeFentryProgName = "profile_fentry"
+	progRuntimeFexitProgName  = "profile_fexit"
+)
+
+var errProgRuntimeClosed = errors.New("bpf: program runtime profiler is closed")
+
+// progRuntimeStats contains cumulative statistics for one target BPF program.
+type progRuntimeStats struct {
+	RunTimeNS uint64
+	RunCount  uint64
+}
+
+type progRuntimeProfiler struct {
+	mu         sync.RWMutex
+	closed     bool
+	target     *ebpf.Program
+	collection *ebpf.Collection
+	statsMap   *ebpf.Map
+	fentryLink link.Link
+	fexitLink  link.Link
+}
+
+func newBPFProgRuntimeByID(programID uint32, objectPath string) (*progRuntimeProfiler, error) {
+	if programID == 0 {
+		return nil, fmt.Errorf("program ID must be greater than zero")
+	}
+	if objectPath == "" {
+		return nil, fmt.Errorf("profiler object path must not be empty")
+	}
+
+	target, err := ebpf.NewProgramFromID(ebpf.ProgramID(programID))
+	if err != nil {
+		return nil, fmt.Errorf("open target BPF program %d: %w", programID, err)
+	}
+	progName, err := targetProgramName(target)
+	if err != nil {
+		_ = target.Close()
+		return nil, fmt.Errorf("resolve target BPF program %d: %w", programID, err)
+	}
+	return newProgRuntimeProfiler(target, ebpf.ProgramID(programID), progName, objectPath)
+}
+
+func newProgRuntimeProfiler(target *ebpf.Program, programID ebpf.ProgramID, progName, objectPath string) (*progRuntimeProfiler, error) {
+	var collection *ebpf.Collection
+	var fentryLink link.Link
+	var fexitLink link.Link
+	loaded := false
+	defer func() {
+		if loaded {
+			return
+		}
+		if fexitLink != nil {
+			_ = fexitLink.Close()
+		}
+		if fentryLink != nil {
+			_ = fentryLink.Close()
+		}
+		if collection != nil {
+			collection.Close()
+		}
+		_ = target.Close()
+	}()
+
+	spec, err := ebpf.LoadCollectionSpec(objectPath)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", progRuntimeObjectName, err)
+	}
+
+	for _, name := range []string{progRuntimeFentryProgName, progRuntimeFexitProgName} {
+		program, ok := spec.Programs[name]
+		if !ok {
+			return nil, fmt.Errorf("load %s: program %q not found", progRuntimeObjectName, name)
+		}
+		program.AttachTarget = target
+		program.AttachTo = progName
+	}
+
+	collection, err = ebpf.NewCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("load targeted profiler for program %d: %w", programID, err)
+	}
+
+	statsMap, ok := collection.Maps[progRuntimeStatsMapName]
+	if !ok {
+		return nil, fmt.Errorf("load %s: map %q not found", progRuntimeObjectName, progRuntimeStatsMapName)
+	}
+
+	fentryProgram, ok := collection.Programs[progRuntimeFentryProgName]
+	if !ok {
+		return nil, fmt.Errorf("load %s: program %q not found", progRuntimeObjectName, progRuntimeFentryProgName)
+	}
+	fexitProgram, ok := collection.Programs[progRuntimeFexitProgName]
+	if !ok {
+		return nil, fmt.Errorf("load %s: program %q not found", progRuntimeObjectName, progRuntimeFexitProgName)
+	}
+
+	fentryLink, err = link.AttachTracing(link.TracingOptions{
+		Program:    fentryProgram,
+		AttachType: ebpf.AttachTraceFEntry,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attach fentry to program %d: %w", programID, err)
+	}
+
+	fexitLink, err = link.AttachTracing(link.TracingOptions{
+		Program:    fexitProgram,
+		AttachType: ebpf.AttachTraceFExit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attach fexit to program %d: %w", programID, err)
+	}
+
+	profiler := &progRuntimeProfiler{
+		target:     target,
+		collection: collection,
+		statsMap:   statsMap,
+		fentryLink: fentryLink,
+		fexitLink:  fexitLink,
+	}
+	loaded = true
+	return profiler, nil
+}
+
+func targetProgramName(target *ebpf.Program) (string, error) {
+	info, err := target.Info()
+	if err != nil {
+		return "", fmt.Errorf("get program info: %w", err)
+	}
+	if _, ok := info.BTFID(); !ok {
+		return "", fmt.Errorf("target program has no BTF information")
+	}
+
+	instructions, err := info.Instructions()
+	if err != nil {
+		return "", fmt.Errorf("get program function info: %w", err)
+	}
+	if name := instructions.Name(); name != "" {
+		return name, nil
+	}
+
+	return "", fmt.Errorf("target program function name is empty")
+}
+
+// Read aggregates per-CPU counters.
+func (p *progRuntimeProfiler) Read() (progRuntimeStats, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.closed {
+		return progRuntimeStats{}, errProgRuntimeClosed
+	}
+
+	key := uint32(0)
+	var values []abi.BPFProgRuntimeValue
+	if err := p.statsMap.Lookup(&key, &values); err != nil {
+		return progRuntimeStats{}, fmt.Errorf("read profile stats: %w", err)
+	}
+
+	return aggregateProgRuntimeStats(values), nil
+}
+
+func aggregateProgRuntimeStats(values []abi.BPFProgRuntimeValue) progRuntimeStats {
+	var stats progRuntimeStats
+	for _, value := range values {
+		stats = addProgRuntimeStats(stats, progRuntimeStats{
+			RunTimeNS: value.RunTimeNS,
+			RunCount:  value.RunCount,
+		})
+	}
+	return stats
+}
+
+func addProgRuntimeStats(total, delta progRuntimeStats) progRuntimeStats {
+	total.RunTimeNS = saturatingAdd(total.RunTimeNS, delta.RunTimeNS)
+	total.RunCount = saturatingAdd(total.RunCount, delta.RunCount)
+	return total
+}
+
+func saturatingAdd(a, b uint64) uint64 {
+	if b > math.MaxUint64-a {
+		return math.MaxUint64
+	}
+	return a + b
+}
+
+// Close detaches the profiler and releases all kernel resources.
+func (p *progRuntimeProfiler) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	err := errors.Join(p.fentryLink.Close(), p.fexitLink.Close())
+	p.collection.Close()
+	err = errors.Join(err, p.target.Close())
+	return err
+}
+
+type progRuntimeProfile interface {
+	Read() (progRuntimeStats, error)
+	Close() error
+}
+
+type bpfProgRuntimeInstance struct {
+	name    string
+	profile progRuntimeProfile
+	last    progRuntimeStats
+}
+
+// ProgRuntimeMetric is one sample exported for a known BPF program.
+type ProgRuntimeMetric struct {
+	ProgramName    string
+	RunTimeNS      uint64
+	RunCount       uint64
+	Up             bool
+	AttachFailures uint64
+}
+
+type progRuntimeManager struct {
+	sync.Mutex
+	enabled        bool
+	all            bool
+	targets        map[string]struct{}
+	knownNames     map[string]struct{}
+	active         map[*bpfProgRuntimeInstance]struct{}
+	history        map[string]progRuntimeStats
+	attachFailures map[string]uint64
+	newProfile     func(uint32, string) (progRuntimeProfile, error)
+}
+
+func newProgRuntimeManager(newProfile func(uint32, string) (progRuntimeProfile, error)) *progRuntimeManager {
+	return &progRuntimeManager{
+		targets:        make(map[string]struct{}),
+		knownNames:     make(map[string]struct{}),
+		active:         make(map[*bpfProgRuntimeInstance]struct{}),
+		history:        make(map[string]progRuntimeStats),
+		attachFailures: make(map[string]uint64),
+		newProfile:     newProfile,
+	}
+}
+
+var progRuntime = newProgRuntimeManager(func(programID uint32, objectPath string) (progRuntimeProfile, error) {
+	return newBPFProgRuntimeByID(programID, objectPath)
+})
+
+func setProgRuntimeProfiler(opts ProgRuntimeOptions) error {
+	if !opts.Enabled {
+		return progRuntime.configure(false, false, nil)
+	}
+
+	programNames, err := normalizeProgRuntimeTargets(opts.Targets)
+	if err != nil {
+		return err
+	}
+	return progRuntime.configure(true, len(programNames) == 0, programNames)
+}
+
+func normalizeProgRuntimeTargets(targets []string) ([]string, error) {
+	names := make([]string, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for i, target := range targets {
+		name := strings.TrimSpace(target)
+		if name == "" {
+			return nil, fmt.Errorf("%s: target %d program name must not be empty", ProgRuntimeProfilerName, i)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("%s: duplicate program name %q", ProgRuntimeProfilerName, name)
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func (m *progRuntimeManager) configure(enabled, all bool, programNames []string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	if len(m.active) != 0 {
+		return fmt.Errorf("cannot configure BPF program runtime profiler while programs are active")
+	}
+
+	m.enabled = enabled
+	m.all = all
+	m.targets = make(map[string]struct{}, len(programNames))
+	m.knownNames = make(map[string]struct{}, len(programNames))
+	m.history = make(map[string]progRuntimeStats)
+	m.attachFailures = make(map[string]uint64)
+	for _, name := range programNames {
+		m.targets[name] = struct{}{}
+		m.knownNames[name] = struct{}{}
+	}
+	return nil
+}
+
+func (m *progRuntimeManager) selected(name string) bool {
+	if !m.enabled {
+		return false
+	}
+	if m.all {
+		return true
+	}
+	_, ok := m.targets[name]
+	return ok
+}
+
+func startBPFProgRuntimeProfiles(programs []ProgramInfo) []*bpfProgRuntimeInstance {
+	return progRuntime.start(programs, filepath.Join(DefaultObjDir, progRuntimeObjectName))
+}
+
+func stopBPFProgRuntimeProfiles(instances []*bpfProgRuntimeInstance) error {
+	return progRuntime.stop(instances)
+}
+
+func (m *progRuntimeManager) start(programs []ProgramInfo, objectPath string) []*bpfProgRuntimeInstance {
+	m.Lock()
+	defer m.Unlock()
+
+	instances := make([]*bpfProgRuntimeInstance, 0, len(programs))
+	for _, program := range programs {
+		if !m.selected(program.Name) {
+			continue
+		}
+
+		instance := &bpfProgRuntimeInstance{name: program.Name}
+		m.knownNames[program.Name] = struct{}{}
+		profile, err := m.newProfile(program.ID, objectPath)
+		if err != nil {
+			m.attachFailures[program.Name]++
+			log.Errorf("%s: attach target BPF program %q (ID %d): %v", ProgRuntimeProfilerName, program.Name, program.ID, err)
+		} else {
+			instance.profile = profile
+		}
+		m.active[instance] = struct{}{}
+		instances = append(instances, instance)
+	}
+	return instances
+}
+
+func (m *progRuntimeManager) stop(instances []*bpfProgRuntimeInstance) error {
+	m.Lock()
+	defer m.Unlock()
+
+	var errs []error
+	for _, instance := range instances {
+		if _, ok := m.active[instance]; !ok {
+			continue
+		}
+		delete(m.active, instance)
+		if instance.profile == nil {
+			continue
+		}
+
+		stats, err := instance.profile.Read()
+		if err != nil {
+			stats = instance.last
+			errs = append(errs, fmt.Errorf("final read of target BPF program %q: %w", instance.name, err))
+		}
+		m.history[instance.name] = addProgRuntimeStats(
+			m.history[instance.name],
+			stats,
+		)
+		if err := instance.profile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close profiler for target BPF program %q: %w", instance.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func ReadBPFProgRuntimeData() []ProgRuntimeMetric {
+	return progRuntime.getData()
+}
+
+func (m *progRuntimeManager) getData() []ProgRuntimeMetric {
+	m.Lock()
+	defer m.Unlock()
+
+	totals := make(map[string]progRuntimeStats, len(m.knownNames))
+	up := make(map[string]bool, len(m.knownNames))
+	active := make(map[string]int, len(m.knownNames))
+	for name := range m.knownNames {
+		totals[name] = m.history[name]
+	}
+
+	for instance := range m.active {
+		active[instance.name]++
+		if active[instance.name] == 1 {
+			up[instance.name] = true
+		}
+		if instance.profile == nil {
+			up[instance.name] = false
+			continue
+		}
+
+		stats, err := instance.profile.Read()
+		if err != nil {
+			stats = instance.last
+			up[instance.name] = false
+			log.Errorf("%s: read target BPF program %q: %v", ProgRuntimeProfilerName, instance.name, err)
+		} else {
+			instance.last = stats
+		}
+		totals[instance.name] = addProgRuntimeStats(
+			totals[instance.name],
+			stats,
+		)
+	}
+
+	names := slices.Sorted(maps.Keys(m.knownNames))
+
+	data := make([]ProgRuntimeMetric, 0, len(names))
+	for _, name := range names {
+		data = append(data, ProgRuntimeMetric{
+			ProgramName:    name,
+			RunTimeNS:      totals[name].RunTimeNS,
+			RunCount:       totals[name].RunCount,
+			Up:             active[name] != 0 && up[name],
+			AttachFailures: m.attachFailures[name],
+		})
+	}
+	return data
+}

--- a/internal/bpf/prog_runtime_profiler_test.go
+++ b/internal/bpf/prog_runtime_profiler_test.go
@@ -1,0 +1,478 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bpf
+
+import (
+	"errors"
+	"math"
+	"slices"
+	"sync"
+	"testing"
+
+	"huatuo-bamai/internal/bpf/abi"
+)
+
+type fakeProgRuntimeProfile struct {
+	stats      progRuntimeStats
+	readErr    error
+	closeErr   error
+	closeCount int
+}
+
+func (f *fakeProgRuntimeProfile) Read() (progRuntimeStats, error) {
+	return f.stats, f.readErr
+}
+
+func (f *fakeProgRuntimeProfile) Close() error {
+	f.closeCount++
+	return f.closeErr
+}
+
+func TestDefaultBPFCloseStopsProfiles(t *testing.T) {
+	originalManager := progRuntime
+	manager := newProgRuntimeManager(func(uint32, string) (progRuntimeProfile, error) {
+		return &fakeProgRuntimeProfile{}, nil
+	})
+	progRuntime = manager
+	t.Cleanup(func() { progRuntime = originalManager })
+
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("configure profiler: %v", err)
+	}
+	profile := &fakeProgRuntimeProfile{}
+	manager.newProfile = func(uint32, string) (progRuntimeProfile, error) { return profile, nil }
+	instances := manager.start([]ProgramInfo{{ID: 1, Name: "test"}}, progRuntimeObjectName)
+	b := &defaultBPF{progProfiles: instances}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if profile.closeCount != 1 {
+		t.Fatalf("profile close count = %d, want 1", profile.closeCount)
+	}
+	metrics := manager.getData()
+	if len(metrics) != 1 || metrics[0].Up {
+		t.Fatalf("metrics after Close() = %+v, want one inactive metric", metrics)
+	}
+}
+
+func TestDefaultBPFCloseReturnsProfileCloseError(t *testing.T) {
+	closeErr := errors.New("close failed")
+	manager := newProgRuntimeManager(func(uint32, string) (progRuntimeProfile, error) {
+		return &fakeProgRuntimeProfile{closeErr: closeErr}, nil
+	})
+	originalManager := progRuntime
+	progRuntime = manager
+	t.Cleanup(func() { progRuntime = originalManager })
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("configure profiler: %v", err)
+	}
+	instances := manager.start([]ProgramInfo{{ID: 1, Name: "test"}}, progRuntimeObjectName)
+
+	b := &defaultBPF{progProfiles: instances}
+	if err := b.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close() error = %v, want %v", err, closeErr)
+	}
+}
+
+func TestNewBPFProgRuntimeByIDValidatesArguments(t *testing.T) {
+	tests := []struct {
+		name       string
+		programID  uint32
+		objectPath string
+	}{
+		{name: "zero program ID", objectPath: progRuntimeObjectName},
+		{name: "empty object path", programID: 337},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := newBPFProgRuntimeByID(tt.programID, tt.objectPath); err == nil {
+				t.Fatal("newBPFProgRuntimeByID() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+func TestAggregateProgRuntimeStats(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []abi.BPFProgRuntimeValue
+		want   progRuntimeStats
+	}{
+		{
+			name: "no CPUs",
+		},
+		{
+			name: "one CPU",
+			values: []abi.BPFProgRuntimeValue{
+				{StartTimeNS: 99, RunTimeNS: 100, RunCount: 2},
+			},
+			want: progRuntimeStats{RunTimeNS: 100, RunCount: 2},
+		},
+		{
+			name: "all CPUs",
+			values: []abi.BPFProgRuntimeValue{
+				{RunTimeNS: 100, RunCount: 2},
+				{RunTimeNS: 250, RunCount: 3},
+				{RunTimeNS: 50, RunCount: 1},
+			},
+			want: progRuntimeStats{RunTimeNS: 400, RunCount: 6},
+		},
+		{
+			name: "saturates overflow",
+			values: []abi.BPFProgRuntimeValue{
+				{RunTimeNS: math.MaxUint64, RunCount: math.MaxUint64},
+				{RunTimeNS: 1, RunCount: 1},
+			},
+			want: progRuntimeStats{
+				RunTimeNS: math.MaxUint64,
+				RunCount:  math.MaxUint64,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aggregateProgRuntimeStats(tt.values)
+			if got != tt.want {
+				t.Fatalf("aggregateProgRuntimeStats() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetProgRuntimeProfilerFromOptions(t *testing.T) {
+	t.Cleanup(func() {
+		if err := progRuntime.configure(false, false, nil); err != nil {
+			t.Errorf("reset BPF program runtime profiler: %v", err)
+		}
+	})
+
+	tests := []struct {
+		name           string
+		opts           ProgRuntimeOptions
+		wantEnabled    bool
+		wantAll        bool
+		wantTargetName string
+	}{
+		{name: "disabled"},
+		{
+			name:        "empty targets profile all",
+			opts:        ProgRuntimeOptions{Enabled: true},
+			wantEnabled: true,
+			wantAll:     true,
+		},
+		{
+			name: "targets select allowlist",
+			opts: ProgRuntimeOptions{
+				Enabled: true,
+				Targets: []string{" read "},
+			},
+			wantEnabled:    true,
+			wantTargetName: "read",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := setProgRuntimeProfiler(tt.opts); err != nil {
+				t.Fatalf("configureProgRuntime() error = %v", err)
+			}
+
+			progRuntime.Lock()
+			defer progRuntime.Unlock()
+			if progRuntime.enabled != tt.wantEnabled || progRuntime.all != tt.wantAll {
+				t.Fatalf("policy = enabled:%v all:%v, want enabled:%v all:%v", progRuntime.enabled, progRuntime.all, tt.wantEnabled, tt.wantAll)
+			}
+			if tt.wantTargetName != "" {
+				if _, ok := progRuntime.targets[tt.wantTargetName]; !ok {
+					t.Fatalf("targets = %v, want %q", progRuntime.targets, tt.wantTargetName)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeProgRuntimeTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty profiles all"},
+		{
+			name:    "trims names",
+			targets: []string{" read ", "write"},
+			want:    []string{"read", "write"},
+		},
+		{name: "empty name", targets: []string{""}, wantErr: true},
+		{
+			name:    "duplicate name",
+			targets: []string{"read", " read "},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeProgRuntimeTargets(tt.targets)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeProgRuntimeTargets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("normalizeProgRuntimeTargets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProgRuntimeManagerAllowlistAndNewGeneration(t *testing.T) {
+	attachErr := errors.New("attach failed")
+	profiles := make(map[uint32]*fakeProgRuntimeProfile)
+	attachCalls := make(map[uint32]int)
+	manager := newProgRuntimeManager(func(programID uint32, objectPath string) (progRuntimeProfile, error) {
+		attachCalls[programID]++
+		if objectPath != progRuntimeObjectName {
+			t.Fatalf("objectPath = %q", objectPath)
+		}
+		if programID == 2 {
+			return nil, attachErr
+		}
+		profile := &fakeProgRuntimeProfile{stats: progRuntimeStats{RunCount: uint64(programID)}}
+		profiles[programID] = profile
+		return profile, nil
+	})
+	if err := manager.configure(true, false, []string{"read", "write"}); err != nil {
+		t.Fatalf("configure() error = %v", err)
+	}
+
+	instances := manager.start([]ProgramInfo{
+		{ID: 1, Name: "read"},
+		{ID: 2, Name: "write"},
+		{ID: 3, Name: "ignored"},
+	}, progRuntimeObjectName)
+	if len(instances) != 2 {
+		t.Fatalf("start() returned %d instances, want 2", len(instances))
+	}
+	if attachCalls[1] != 1 || attachCalls[2] != 1 || attachCalls[3] != 0 {
+		t.Fatalf("attach calls = %v", attachCalls)
+	}
+
+	metrics := manager.getData()
+	if len(metrics) != 2 {
+		t.Fatalf("metrics() returned %d programs, want 2", len(metrics))
+	}
+	if metrics[0].ProgramName != "read" || !metrics[0].Up || metrics[0].RunCount != 1 {
+		t.Fatalf("read metric = %+v", metrics[0])
+	}
+	if metrics[1].ProgramName != "write" || metrics[1].Up || metrics[1].AttachFailures != 1 {
+		t.Fatalf("write metric = %+v", metrics[1])
+	}
+	_ = manager.getData()
+	if attachCalls[2] != 1 {
+		t.Fatalf("failed instance attach calls = %d, want exactly 1", attachCalls[2])
+	}
+
+	if err := manager.stop(instances); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+	if profiles[1].closeCount != 1 {
+		t.Fatalf("read close count = %d, want 1", profiles[1].closeCount)
+	}
+
+	// A new load is a new instance and is evaluated once even when the old ID failed.
+	reloaded := manager.start([]ProgramInfo{{ID: 4, Name: "write"}}, progRuntimeObjectName)
+	if attachCalls[4] != 1 {
+		t.Fatalf("new generation attach calls = %d, want 1", attachCalls[4])
+	}
+	metrics = manager.getData()
+	if !metrics[1].Up || metrics[1].AttachFailures != 1 || metrics[1].RunCount != 4 {
+		t.Fatalf("reloaded write metric = %+v", metrics[1])
+	}
+	if err := manager.stop(reloaded); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+}
+
+func TestProgRuntimeManagerAllProgramsAndAttachIsolation(t *testing.T) {
+	manager := newProgRuntimeManager(func(programID uint32, _ string) (progRuntimeProfile, error) {
+		if programID == 2 {
+			return nil, errors.New("attach failed")
+		}
+		return &fakeProgRuntimeProfile{stats: progRuntimeStats{RunCount: 3}}, nil
+	})
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("configure() error = %v", err)
+	}
+	instances := manager.start([]ProgramInfo{
+		{ID: 1, Name: "same"},
+		{ID: 2, Name: "same"},
+	}, progRuntimeObjectName)
+
+	metrics := manager.getData()
+	if len(metrics) != 1 || metrics[0].Up || metrics[0].AttachFailures != 1 || metrics[0].RunCount != 3 {
+		t.Fatalf("metrics() = %+v, want partial counters and up=0", metrics)
+	}
+	if err := manager.stop(instances); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+}
+
+func TestProgRuntimeManagerCounterContinuity(t *testing.T) {
+	profiles := make(map[uint32]*fakeProgRuntimeProfile)
+	manager := newProgRuntimeManager(func(programID uint32, _ string) (progRuntimeProfile, error) {
+		profile := &fakeProgRuntimeProfile{}
+		profiles[programID] = profile
+		return profile, nil
+	})
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("configure() error = %v", err)
+	}
+
+	first := manager.start([]ProgramInfo{{ID: 1, Name: "read"}}, progRuntimeObjectName)
+	profiles[1].stats = progRuntimeStats{RunCount: 5, RunTimeNS: 500}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", Up: true, RunCount: 5, RunTimeNS: 500,
+	})
+	if err := manager.stop(first); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", RunCount: 5, RunTimeNS: 500,
+	})
+
+	second := manager.start([]ProgramInfo{{ID: 2, Name: "read"}}, progRuntimeObjectName)
+	profiles[2].stats = progRuntimeStats{RunCount: 3, RunTimeNS: 300}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", Up: true, RunCount: 8, RunTimeNS: 800,
+	})
+
+	third := manager.start([]ProgramInfo{{ID: 3, Name: "read"}}, progRuntimeObjectName)
+	profiles[3].stats = progRuntimeStats{RunCount: 2, RunTimeNS: 200}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", Up: true, RunCount: 10, RunTimeNS: 1000,
+	})
+	if err := manager.stop(second); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", Up: true, RunCount: 10, RunTimeNS: 1000,
+	})
+
+	profiles[3].stats = progRuntimeStats{RunCount: 4, RunTimeNS: 400}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", Up: true, RunCount: 12, RunTimeNS: 1200,
+	})
+	if err := manager.stop(third); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+	_ = manager.stop(third) // idempotent: second call must be a no-op.
+	if profiles[3].closeCount != 1 {
+		t.Fatalf("third close count = %d, want 1", profiles[3].closeCount)
+	}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", RunCount: 12, RunTimeNS: 1200,
+	})
+}
+
+func TestProgRuntimeManagerReadFailureUsesLastSnapshot(t *testing.T) {
+	readErr := errors.New("read failed")
+	profile := &fakeProgRuntimeProfile{stats: progRuntimeStats{RunCount: 7, RunTimeNS: 700}}
+	manager := newProgRuntimeManager(func(uint32, string) (progRuntimeProfile, error) { return profile, nil })
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("configure() error = %v", err)
+	}
+	instances := manager.start([]ProgramInfo{{ID: 1, Name: "read"}}, progRuntimeObjectName)
+	_ = manager.getData()
+
+	profile.readErr = readErr
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", RunCount: 7, RunTimeNS: 700,
+	})
+	// The final read fails by design; stop reports it while keeping the
+	// last snapshot, so only the error is asserted here.
+	stopErr := manager.stop(instances)
+	if stopErr == nil || !errors.Is(stopErr, readErr) {
+		t.Fatalf("stop() error = %v, want wrapped readErr", stopErr)
+	}
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", RunCount: 7, RunTimeNS: 700,
+	})
+}
+
+func TestProgRuntimeManagerConfiguration(t *testing.T) {
+	manager := newProgRuntimeManager(func(uint32, string) (progRuntimeProfile, error) {
+		return &fakeProgRuntimeProfile{}, nil
+	})
+	if err := manager.configure(false, false, nil); err != nil {
+		t.Fatalf("disabled configure() error = %v", err)
+	}
+	if got := manager.start([]ProgramInfo{{ID: 1, Name: "read"}}, progRuntimeObjectName); len(got) != 0 {
+		t.Fatalf("disabled start() returned %d instances", len(got))
+	}
+
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("enabled configure() error = %v", err)
+	}
+	instances := manager.start([]ProgramInfo{{ID: 1, Name: "read"}}, progRuntimeObjectName)
+	if err := manager.configure(true, true, nil); err == nil {
+		t.Fatal("configure() while active error = nil, want non-nil")
+	}
+	if err := manager.stop(instances); err != nil {
+		t.Fatalf("stop() error = %v", err)
+	}
+}
+
+func TestProgRuntimeManagerConcurrentReadAndStop(t *testing.T) {
+	profile := &fakeProgRuntimeProfile{stats: progRuntimeStats{RunCount: 1, RunTimeNS: 10}}
+	manager := newProgRuntimeManager(func(uint32, string) (progRuntimeProfile, error) { return profile, nil })
+	if err := manager.configure(true, true, nil); err != nil {
+		t.Fatalf("configure() error = %v", err)
+	}
+	instances := manager.start([]ProgramInfo{{ID: 1, Name: "read"}}, progRuntimeObjectName)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = manager.getData()
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := manager.stop(instances); err != nil {
+			t.Errorf("stop() error = %v", err)
+		}
+	}()
+	wg.Wait()
+
+	assertProgRuntimeMetric(t, manager.getData(), ProgRuntimeMetric{
+		ProgramName: "read", RunCount: 1, RunTimeNS: 10,
+	})
+	if profile.closeCount != 1 {
+		t.Fatalf("close count = %d, want 1", profile.closeCount)
+	}
+}
+
+func assertProgRuntimeMetric(t *testing.T, got []ProgRuntimeMetric, want ProgRuntimeMetric) {
+	t.Helper()
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("metrics() = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Closes #670 

背景：

Huatuo 会加载多个 eBPF 程序，用于 OOM、内存回收、网络、文件系统和硬件异常等观测。为了对 Huatuo 自身的 eBPF 程序进行探针，并且不干扰系统其他组件的 eBPF 程序，防止探测造成的系统开销，需要指标满足：

1. 哪个 Huatuo 自身加载的目标 BPF 程序正在消耗 CPU？
2. 某个程序的执行次数、累计运行时间或 attach 状态是否异常？

原理：

* Huatuo 每加载一个目标 BPF 程序时，根据配置决定是否为其挂载 profiler。
* profiler 通过 fentry/fexit 挂到目标程序：fentry 记录本次执行开始时间；fexit 计算执行耗时，并累计执行次数与运行时间。
* 统计数据保存在 per-CPU BPF map，用户态 scrape 时汇总各 CPU 数据并导出指标。
* BPF 程序卸载时保留已累计的历史统计，确保 counter 连续。

注意：

当前实现每个 CPU 只有一个 start_time_ns。外层程序执行中若被 IRQ/NMI 打断并在同 CPU 再次进入，内层 fentry 覆盖外层时间；内层 fexit 计数后清零，外层 fexit 看到 0 直接跳过。考虑到该探针运行时间极短，无需支持 nest，和官方工具 profiler.bpf.c（[https://github.com/libbpf/bpftool/blob/main/src/skeleton/profiler.bpf.c#L20-L123）实现逻辑保持一致，不为精确而引入复杂逻辑和过度性能开销，仅需粗略估计即可，并且增加 nest 可能导致不同内核版本的 verifier 校验兼容性而加载失败。还有一点，当前实现没有使用 bpftool 的硬件计数方案，因为 bpftool 拿到的数据需要额外的 CPU 频率支持才能计算 cpu 损耗，考虑到宿主机 cpu 频率不固定且需要单独获取，暂时就使用 bpftop 的类似开启全局 bpf stat 的方案，但是影响范围更小，仅针对感兴趣的 ebpf 程序句柄去监测。也有开关，可控制仅测试环境去 attach。

开销计算： 

```math
\text{CPU 利用率}(\%) =
\frac{
  \Delta \mathtt{runtime\_seconds\_total}
}{
  \Delta t \times \mathtt{online\_cores}
}
\times 100\%
```

- `Detla runtime_seconds_total`：两个样本之间的累计运行时间差，即
- `Delta t`：两个真实采样时间点之间的秒数；
- `online_cores`：同一节点的 `bpf_profile_online_cores`。

所有 active programs 的 runtime 差值求和后，可得到 Huatuo 被 profile 的目标 BPF programs 合计 CPU 占比：

```math
\text{Huatuo BPF 合计 CPU 利用率}(\%) =
\frac{
  \sum \Delta \mathtt{runtime\_seconds\_total}
}{
  \Delta t \times \mathtt{online\_cores}
}
\times 100\%
```