### PR TITLE
fix(profiler): prevent physical memory profile overcounting

### DIFF
--- a/cmd/profiler/provider/native_bpf_context.go
+++ b/cmd/profiler/provider/native_bpf_context.go
@@ -168,16 +168,10 @@ func (r *ringBufferContext) advanceSwapParity() (frozenRingBuffer, error) {
 	return ring, nil
 }
 
-// drainFrozenRingBuffer drains events from the frozen ring buffer and aggregates stack traces.
+// drainFrozenRingBuffer drains events from the frozen ring buffer and aggregates raw values by stack.
 // This unified method works for both CPU and Memory profilers.
-//
-// Parameters:
-// - enqueue: callback to emit aggregated records
-// - newEvent: factory function to create event struct from batch data
-// - convertValue: optional function to convert raw value (nil for CPU, non-nil for Memory)
 func (r *ringBufferContext) drainFrozenRingBuffer(
 	newEvent func() any,
-	convertValue func(int64) int64,
 ) (map[processKey]map[rawStackIDs]int64, frozenRingBuffer, error) {
 	ring, err := r.advanceSwapParity()
 	if err != nil {
@@ -213,11 +207,9 @@ func (r *ringBufferContext) drainFrozenRingBuffer(
 				continue
 			}
 
-			// Get value directly from base (CPU: 1, Memory: page/byte delta)
+			// Keep the BPF-provided unit until final aggregation (CPU: samples,
+			// virtual memory: bytes, physical memory: pages).
 			value := base.Value
-			if convertValue != nil {
-				value = convertValue(value)
-			}
 			if value == 0 {
 				continue
 			}

--- a/cmd/profiler/provider/native_mem_profiler.go
+++ b/cmd/profiler/provider/native_mem_profiler.go
@@ -283,8 +283,7 @@ func (p *memNativeProfiler) ReadDataLoop(ctx context.Context, enqueue func(any))
 		// Use unified drainFrozenRingBuffer with Memory event factory
 		sampleCountsByProcess, ring, err := ringCtx.drainFrozenRingBuffer(
 			func() any { return &abi.ProfilerEventBase{} },
-			p.convertValueToBytes,
-		) // Convert pages to bytes
+		)
 		if err != nil {
 			if errors.Is(err, types.ErrExitByCancelCtx) {
 				return nil

--- a/cmd/profiler/provider/native_mem_profiler_test.go
+++ b/cmd/profiler/provider/native_mem_profiler_test.go
@@ -15,12 +15,119 @@
 package provider
 
 import (
+	"encoding/binary"
 	"reflect"
 	"testing"
 
 	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/bpf/abi"
 	"huatuo-bamai/pkg/profiling"
 )
+
+type memoryPipelineBPFStub struct {
+	bpf.BPF
+	state [3]uint64
+}
+
+func (s *memoryPipelineBPFStub) ReadMap(mapID uint32, key []byte) ([]byte, error) {
+	if mapID != 1 {
+		return nil, nil
+	}
+
+	idx := binary.LittleEndian.Uint32(key)
+	value := make([]byte, 8)
+	binary.LittleEndian.PutUint64(value, s.state[idx])
+	return value, nil
+}
+
+func (s *memoryPipelineBPFStub) WriteMapItems(mapID uint32, items []bpf.MapItem) error {
+	if mapID != 1 {
+		return nil
+	}
+
+	for _, item := range items {
+		idx := binary.LittleEndian.Uint32(item.Key)
+		s.state[idx] = binary.LittleEndian.Uint64(item.Value)
+	}
+	return nil
+}
+
+type memoryPipelineReaderStub struct {
+	batch []any
+}
+
+func (s *memoryPipelineReaderStub) ReadInto(any) error {
+	return nil
+}
+
+func (s *memoryPipelineReaderStub) ReadBatch(func() any) ([]any, error) {
+	batch := s.batch
+	s.batch = nil
+	return batch, nil
+}
+
+func (s *memoryPipelineReaderStub) Close() error {
+	return nil
+}
+
+func TestMemoryValueConvertedOnceAfterAggregation(t *testing.T) {
+	const pageSize = int64(4096)
+
+	tests := []struct {
+		name string
+		mode profiling.MemoryMode
+		raw  int64
+		want int64
+	}{
+		{name: "physical alloc page", mode: profiling.MemoryModePhysicalAlloc, raw: 1, want: pageSize},
+		{name: "physical usage freed page", mode: profiling.MemoryModePhysicalUsage, raw: -1, want: -pageSize},
+		{name: "virtual alloc bytes", mode: profiling.MemoryModeVirtualAlloc, raw: 1234, want: 1234},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &memoryPipelineBPFStub{state: [3]uint64{0, 1, 0}}
+			reader := &memoryPipelineReaderStub{batch: []any{
+				&abi.ProfilerEventBase{
+					PIDTGID:   uint64(123) << 32,
+					Kernstack: 0,
+					Userstack: -1,
+					Value:     tt.raw,
+				},
+			}}
+			ringCtx := &ringBufferContext{
+				bpf:                b,
+				readerA:            reader,
+				transferStateMapID: 1,
+				stackMapAID:        2,
+			}
+			profiler := &memNativeProfiler{
+				internalMode: tt.mode,
+				probability:  100,
+				pageSize:     pageSize,
+			}
+
+			counts, ring, err := ringCtx.drainFrozenRingBuffer(
+				func() any { return &abi.ProfilerEventBase{} },
+			)
+			if err != nil {
+				t.Fatalf("drainFrozenRingBuffer() error = %v", err)
+			}
+
+			var samples []*stackSample
+			ringCtx.aggregateStacksAndEnqueue(counts, ring, func(record any) {
+				samples = append(samples, record.(*stackSample))
+			}, profiler.convertValueToBytes)
+
+			if len(samples) != 1 {
+				t.Fatalf("sample count = %d, want 1", len(samples))
+			}
+			if got := samples[0].Value; got != tt.want {
+				t.Fatalf("sample value = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestNewBpfLoadConfigAttachOpts(t *testing.T) {
 	tests := []struct {

--- a/cmd/profiler/provider/native_oncpu_profiler.go
+++ b/cmd/profiler/provider/native_oncpu_profiler.go
@@ -227,8 +227,7 @@ func (p *cpuNativeProfiler) readOnCPUDataLoop(ctx context.Context, enqueue func(
 		// Use unified drainFrozenRingBuffer with CPU event factory
 		sampleCountsByProcess, ring, err := ringCtx.drainFrozenRingBuffer(
 			func() any { return &abi.ProfilerOnCPUEvent{} },
-			nil,
-		) // No value conversion needed for CPU profiler
+		)
 		if err != nil {
 			if errors.Is(err, types.ErrExitByCancelCtx) {
 				return nil


### PR DESCRIPTION
## 背景

内存 profiler 的 `physical_alloc` 和 `physical_usage` 事件由 BPF 上报物理页数。用户态在输出 profile 前，根据页面大小和采样率将页数换算成字节数。当前处理流程在读取事件时执行了一次换算，在堆栈聚合完成后又执行了一次相同换算，导致物理内存数值被重复放大。

以 4 KiB 页面为例：

- 100% 采样时，结果是正确值的 4,096 倍；
- 1% 采样时，结果是正确值的 409,600 倍。

该问题影响所有已输出的 `physical_alloc` 和 `physical_usage` 样本，使物理内存 profile 无法用于可靠的内存分配、驻留量和泄漏分析。

## 根因

`drainFrozenRingBuffer` 接收了 `convertValue` 回调，并在读取每条 BPF 事件时调用 `convertValueToBytes`。

事件按进程和堆栈聚合后，`aggregateStacksAndEnqueue` 在输出样本时又调用了一次 `convertValueToBytes`，因此物理页数被重复换算。

## 修改方案

从 `drainFrozenRingBuffer` 中移除数值转换逻辑，只负责读取和聚合原始值，物理内存页数只在 `aggregateStacksAndEnqueue` 输出样本时换算一次，同步调整 native memory 和 on-CPU profiler 的调用方式，保持不同 profiler 的数据单位不变。