### PR TITLE
fix(profiler): passes offcpu reader failures to the outer caller

### DIFF
--- a/cmd/profiler/provider/native_offcpu_profiler.go
+++ b/cmd/profiler/provider/native_offcpu_profiler.go
@@ -147,12 +147,20 @@ func (p *cpuNativeProfiler) readOffCPUDataLoop(
 		ringCtx.aggregateOffCPUBatch(batch, enqueue)
 
 		if err != nil {
-			var lostErr *bpf.PerfEventSamplesLostError
-			if errors.As(err, &lostErr) {
-				log.Warnf("off-CPU perf event samples lost: %d", lostErr.Count)
-			}
 			if errors.Is(err, types.ErrExitByCancelCtx) {
 				return nil
+			}
+
+			var lostErr *bpf.PerfEventSamplesLostError
+			if !errors.As(err, &lostErr) {
+				return fmt.Errorf("read off-CPU perf event batch: %w", err)
+			}
+
+			log.Warnf("off-CPU perf event samples lost: %d", lostErr.Count)
+			// ReadBatch joins sample loss with read or decode failures.
+			var joinedErr interface{ Unwrap() []error }
+			if errors.As(err, &joinedErr) {
+				return fmt.Errorf("read off-CPU perf event batch: %w", err)
 			}
 		}
 

--- a/cmd/profiler/provider/native_offcpu_profiler_test.go
+++ b/cmd/profiler/provider/native_offcpu_profiler_test.go
@@ -15,6 +15,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"math"
@@ -60,6 +61,98 @@ type stackLookupMissBPF struct {
 
 func (stackLookupMissBPF) ReadMap(uint32, []byte) ([]byte, error) {
 	return nil, ebpf.ErrKeyNotExist
+}
+
+type offCPUReaderStub struct {
+	readBatch func() ([]any, error)
+}
+
+func (*offCPUReaderStub) ReadInto(any) error {
+	return nil
+}
+
+func (r *offCPUReaderStub) ReadBatch(func() any) ([]any, error) {
+	return r.readBatch()
+}
+
+func (*offCPUReaderStub) Close() error {
+	return nil
+}
+
+type offCPUReaderBPFStub struct {
+	bpf.BPF
+	reader bpf.PerfEventReader
+}
+
+func (*offCPUReaderBPFStub) MapIDByName(name string) uint32 {
+	if name == "stack_map_a" {
+		return 1
+	}
+	return 0
+}
+
+func (b *offCPUReaderBPFStub) EventPipeByName(
+	context.Context,
+	string,
+	uint32,
+) (bpf.PerfEventReader, error) {
+	return b.reader, nil
+}
+
+func TestReadOffCPUDataLoopReturnsReaderErrors(t *testing.T) {
+	readErr := errors.New("read failed")
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "read error", err: readErr},
+		{
+			name: "read error with lost samples",
+			err: errors.Join(
+				readErr,
+				&bpf.PerfEventSamplesLostError{Count: 7},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			calls := 0
+			reader := &offCPUReaderStub{readBatch: func() ([]any, error) {
+				calls++
+				if calls == 2 {
+					cancel()
+				}
+				return nil, tt.err
+			}}
+			profiler := &cpuNativeProfiler{bpf: &offCPUReaderBPFStub{reader: reader}}
+
+			err := profiler.readOffCPUDataLoop(ctx, func(any) {})
+			require.ErrorIs(t, err, readErr)
+			require.Equal(t, 1, calls)
+		})
+	}
+}
+
+func TestReadOffCPUDataLoopContinuesAfterSamplesLost(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	calls := 0
+	reader := &offCPUReaderStub{readBatch: func() ([]any, error) {
+		calls++
+		if calls == 2 {
+			cancel()
+		}
+		return nil, &bpf.PerfEventSamplesLostError{Count: 7}
+	}}
+	profiler := &cpuNativeProfiler{bpf: &offCPUReaderBPFStub{reader: reader}}
+
+	require.NoError(t, profiler.readOffCPUDataLoop(ctx, func(any) {}))
+	require.Equal(t, 2, calls)
 }
 
 func TestAggregateOffCPUBatch(t *testing.T) {


### PR DESCRIPTION
## 问题背景

offcpu profiler 的事件读取循环没有正确处理 `ReadBatch` 返回的真实 reader 错误。

除 context 取消外，原实现会继续执行读取循环。当 perf reader 持续发生读取或事件解码错误时，profiler 仍然表现为正在运行，但无法持续产出有效的 off-CPU 采样结果，上层调用者也无法感知失败。由于空 batch 会立即进入下一次读取，持续错误还可能造成紧循环重试。

此外，`ReadBatch` 可能通过 `errors.Join` 同时返回真实读取错误和 `PerfEventSamplesLostError`。原实现只能识别并记录 samples lost，仍会吞掉其中需要终止 profiler 的真实错误。

## 根因

读取循环将非取消错误都当作可恢复错误处理，没有区分以下情况：

1. context 取消；
2. 单纯的 perf event samples lost；
3. 普通 reader 错误；
4. reader 错误与 samples lost 组成的 joined error。

其中只有单纯的 samples lost 可以安全地记录告警后继续采集。普通错误和 joined error 都需要返回给 profiler 调用者。

## 修改内容

- context 取消时保持原有正常退出行为；
- 单纯发生 perf event samples lost 时记录丢失数量并继续读取；
- 普通读取或解码错误立即返回给上层；
- 同时包含真实错误和 samples lost 的 joined error 在记录丢失数量后返回；
- 增加回归测试，覆盖普通错误、joined error 和纯 samples lost 三条路径。

本次修改不改变 BPF 事件格式、off-CPU 数据聚合逻辑和正常采样行为。

## 修复效果

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| context 取消 | 正常退出 | 正常退出 |
| 纯 samples lost | 告警后继续 | 告警后继续 |
| 普通 reader 错误 | 错误被吞掉并继续读取 | 返回错误，调用者可感知失败 |
| reader 错误与 samples lost 同时发生 | 只记录丢失，真实错误被吞掉 | 记录丢失并返回真实错误 |
| 持续 reader 错误 | 可能无有效输出并紧循环重试 | 首次错误即终止并向上返回 |

## 测试结果

以下检查均已通过：

```bash
go test ./cmd/profiler/provider -run TestReadOffCPUDataLoop -count=1
go test -race ./cmd/profiler/provider -count=1
go vet ./cmd/profiler/provider ./cmd/profiler
go test ./cmd/profiler -count=1
golangci-lint run ./... --timeout=5m --config .golangci.yaml
make -B _output/bin/profiler
make unit
make check
sudo -n bash integration/run.sh test_profiler_native_cpu_offcpu.sh