### PR TITLE
fix(tracing): reject path traversal in task binary name

### DIFF
--- a/pkg/tracing/task.go
+++ b/pkg/tracing/task.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"sort"
 	"sync"
 	"time"
@@ -178,6 +179,9 @@ func NewTaskWithIDLimit(
 	if taskID == "" {
 		return "", errors.New("task id is required")
 	}
+	if err := validateTaskBinary(execBinary); err != nil {
+		return "", err
+	}
 	taskCreateMu.Lock()
 	defer taskCreateMu.Unlock()
 	if _, loaded := taskLifeTmpCache.Load(taskID); loaded {
@@ -219,6 +223,18 @@ func activeTaskCount() int {
 		return true
 	})
 	return count
+}
+
+// validateTaskBinary restricts the tracer name to a bare file name resolved
+// inside TaskBinDir. The task API is reachable without authentication, so a
+// caller-supplied name such as "../bin/bash" or "/bin/sh" must never reach
+// exec.CommandContext.
+func validateTaskBinary(execBinary string) error {
+	if execBinary == "" || execBinary == "." || execBinary == ".." ||
+		filepath.Base(execBinary) != execBinary {
+		return fmt.Errorf("task binary %q must be a bare file name within the tool directory", execBinary)
+	}
+	return nil
 }
 
 func runTask(ctx context.Context, task *task) {

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -116,6 +116,64 @@ func TestNewTaskWithIDLimitAllowsRetryButRejectsNewTask(t *testing.T) {
 	}
 }
 
+func TestValidateTaskBinary(t *testing.T) {
+	tests := []struct {
+		name       string
+		execBinary string
+		wantErr    bool
+	}{
+		{name: "bare file name", execBinary: "iotracing"},
+		{name: "empty name", execBinary: "", wantErr: true},
+		{name: "parent traversal", execBinary: "../../bin/bash", wantErr: true},
+		{name: "single parent", execBinary: "../escape", wantErr: true},
+		{name: "absolute path", execBinary: "/bin/sh", wantErr: true},
+		{name: "subdirectory", execBinary: "tools/iotracing", wantErr: true},
+		{name: "dot", execBinary: ".", wantErr: true},
+		{name: "double dot", execBinary: "..", wantErr: true},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			err := validateTaskBinary(tests[i].execBinary)
+			if tests[i].wantErr && err == nil {
+				t.Errorf("validateTaskBinary(%q) err=nil, want error", tests[i].execBinary)
+			}
+			if !tests[i].wantErr && err != nil {
+				t.Errorf("validateTaskBinary(%q) err=%v, want nil", tests[i].execBinary, err)
+			}
+		})
+	}
+}
+
+func TestNewTaskWithIDLimitRejectsPathTraversal(t *testing.T) {
+	clearTaskCache()
+	t.Cleanup(clearTaskCache)
+
+	binDir := t.TempDir()
+	outside := t.TempDir()
+	createExecutableScript(t, outside, "escape.sh", "#!/bin/sh\necho PWNED-ESCAPE\n")
+
+	origBinDir := TaskBinDir
+	TaskBinDir = binDir
+	t.Cleanup(func() { TaskBinDir = origBinDir })
+
+	rel, err := filepath.Rel(binDir, filepath.Join(outside, "escape.sh"))
+	if err != nil {
+		t.Fatalf("Rel() error=%v", err)
+	}
+
+	id, err := NewTaskWithIDLimit("escape-attempt-2026", rel, 2*time.Second, TaskStorageStdout, nil, 0)
+	if err == nil {
+		t.Fatalf("NewTaskWithIDLimit(%q) err=nil, want traversal rejection", rel)
+	}
+	if id != "" {
+		t.Errorf("NewTaskWithIDLimit(%q) id=%q, want empty", rel, id)
+	}
+	if _, ok := taskLifeTmpCache.Load("escape-attempt-2026"); ok {
+		t.Error("traversal task was stored and may have executed")
+	}
+}
+
 func TestResultNotFound(t *testing.T) {
 	clearTaskCache()
 


### PR DESCRIPTION
## Problem

`POST /tasks` forwards the caller-supplied `tracer_name` to `exec.CommandContext` via `path.Join(TaskBinDir, name)` (`pkg/tracing/task.go`) with no validation. `path.Join` cleans dot-dot segments away, so `../../bin/bash` resolves outside the tool directory. The agent HTTP API has no authentication (`huatuo-bamai` registers no `RequireAuth`), so this is unauthenticated arbitrary-command execution on a privileged node (the agent runs BPF), with output readable back through `GET /tasks/:id` (arbitrary file read, e.g. `../../bin/cat /etc/shadow`).

## Reproduction (before fix)

Unit PoC (verified locally, prior to the fix):

```
attacker tracer_name="../002/escape.sh" joins to "/tmp/.../002/escape.sh"
status=completed data="PWNED-ESCAPE\n"   <- executed binary outside TaskBinDir
```

## Fix

`validateTaskBinary` at the single task creation gate (`NewTaskWithIDLimit`): the name must be a bare file name inside the tool directory (`filepath.Base(name) == name`, rejecting empty/`.`/`..`/separators/absolute paths).

## Tests

- `pkg/tracing`: `TestValidateTaskBinary` (8 cases), `TestNewTaskWithIDLimitRejectsPathTraversal` (end-to-end rejection, asserts nothing executed).
- Fail-first verified: removing the validation makes the traversal test fail.

## End-to-end (real agent + curl, combined build)

| request | result |
|---|---|
| `{"tracer_name":"../../etc/passwd"}` | HTTP 400 `must be a bare file name within the tool directory` |
| `{"tracer_name":"/bin/echo"}` | HTTP 400 |
| `{"tracer_name":"sub/dir"}` | HTTP 400 |
| `{"tracer_name":"ok.sh"}` (legit) | task completed, output returned — no false positive |

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
