### PR TITLE
fix(server): rate limit before authentication

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -40,6 +40,16 @@ func buildMiddlewareChain(cfg *Config) []httpGin.HandlerFunc {
 	if cfg.PromReg != nil {
 		chain = append(chain, newHTTPMetricsMiddleware(cfg.PromReg))
 	}
+	// Rate limiting must run before authentication, otherwise the 401/403
+	// responses abort the chain and leave token brute force unthrottled.
+	// Pre-authentication the user id is unknown, so clients are keyed by
+	// source address.
+	if cfg.RateLimit != nil {
+		chain = append(chain, newRateLimitMiddleware(
+			rate.Limit(cfg.RateLimit.RequestsPerSecond),
+			cfg.RateLimit.Burst,
+		))
+	}
 	if cfg.RequireAuth || len(cfg.AuthUsers) > 0 {
 		authService := NewAuthService(cfg.AuthUsers)
 		publicPaths := append(
@@ -54,12 +64,6 @@ func buildMiddlewareChain(cfg *Config) []httpGin.HandlerFunc {
 			chain,
 			wrapHandler(NewAuthMiddleware(authService, publicPaths, adminPaths)),
 		)
-	}
-	if cfg.RateLimit != nil {
-		chain = append(chain, newRateLimitMiddleware(
-			rate.Limit(cfg.RateLimit.RequestsPerSecond),
-			cfg.RateLimit.Burst,
-		))
 	}
 	return chain
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -267,6 +267,43 @@ func TestNewRateLimitMiddleware(t *testing.T) {
 	}
 }
 
+// Rate limiting must run before authentication so that rejected
+// authentication attempts are throttled too.
+func TestRateLimitThrottlesFailedAuth(t *testing.T) {
+	httpGin.SetMode(httpGin.TestMode)
+
+	chain := buildMiddlewareChain(&Config{
+		RequireAuth: true,
+		AuthUsers: []UserConfig{
+			{ID: "admin-2026", BearerToken: "admin-secret", IsAdmin: true},
+		},
+		RateLimit: &RateLimitConfig{RequestsPerSecond: 1, Burst: 2},
+	})
+
+	engine := httpGin.New()
+	engine.Use(chain...)
+	engine.GET("/v1/tasks", func(c *httpGin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	sawTooManyRequests := false
+	for i := 0; i < 4; i++ {
+		request := httptest.NewRequest(http.MethodGet, "/v1/tasks", http.NoBody)
+		request.Header.Set("Authorization", "Bearer wrong-token")
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, request)
+
+		if recorder.Code == http.StatusTooManyRequests {
+			sawTooManyRequests = true
+		} else if recorder.Code != http.StatusUnauthorized {
+			t.Errorf("request %d status = %d, want 401 or 429", i+1, recorder.Code)
+		}
+	}
+	if !sawTooManyRequests {
+		t.Error("no 429 observed for repeated invalid bearer tokens; auth is not rate limited")
+	}
+}
+
 func TestNewServerRateLimit(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
## Problem

`buildMiddlewareChain` appended the rate-limit middleware **after** auth (`internal/server/middleware.go`). Gin executes the chain in order; on 401/403 the auth middleware calls `ctx.Abort()`, so rejected requests never reach the limiter. An attacker can guess bearer tokens at full line rate on the apiserver (no 429 ever appears).

## Reproduction (before fix)

`TestRateLimitThrottlesFailedAuth` (added in this PR) fails on the old order with:
`no 429 observed for repeated invalid bearer tokens; auth is not rate limited` — verified by moving the limiter back behind auth.

## Fix

Move the rate-limit middleware ahead of authentication. Pre-auth the user id is unknown, so clients are keyed by source address (exactly the key needed to throttle brute force).

## Tests

- `internal/server`: `TestRateLimitThrottlesFailedAuth` — 4 invalid-token requests against a burst-2 limiter must produce a 429.
- Fail-first verified (reverting the order fails the test).

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
