### PR TITLE
fix(metrics): keep netdev_hw scrape alive across device churn

### DIFF
--- a/core/metrics/netdev_hw.go
+++ b/core/metrics/netdev_hw.go
@@ -45,6 +45,9 @@ type netdevHw struct {
 	ifaceList             map[string]*ethtool.DrvInfo
 	sysNetPath            string
 	mutex                 sync.Mutex
+	// interfaceByIndex is a seam for tests; production code uses
+	// net.InterfaceByIndex.
+	interfaceByIndex func(int) (*net.Interface, error)
 }
 
 //go:generate $BPF_COMPILE $BPF_INCLUDE -s $BPF_DIR/netdev_hw.c -o $BPF_DIR/netdev_hw.o
@@ -96,6 +99,7 @@ func newNetdevHw() (*tracing.EventTracingAttr, error) {
 			ifaceList:             ifaceList,
 			ifaceSwDroppedCounter: ifaceSwCounter,
 			sysNetPath:            sysfs.Path("class/net"),
+			interfaceByIndex:      net.InterfaceByIndex,
 		},
 		Interval: 10,
 		Flag:     tracing.FlagTracing | tracing.FlagMetric,
@@ -118,26 +122,33 @@ func (netdev *netdevHw) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
+	return netdev.collectData(), nil
+}
+
+// collectData builds one sample per tracked interface. A failed sysfs read
+// skips the interface instead of exporting zero: the metric is a counter,
+// and a fabricated reset makes Prometheus rate() report a phantom spike.
+func (netdev *netdevHw) collectData() []*metric.Data {
 	data := []*metric.Data{}
 	for iface, drv := range netdev.ifaceList {
-		counters := map[string]uint64{
-			"rx_dropped":       0,
-			"rx_missed_errors": 0,
+		rxDropped, err := netdev.readSysNetclassStat(iface, "rx_dropped")
+		if err != nil {
+			log.Debugf("skip %s sample: read rx_dropped: %v", iface, err)
+			continue
+		}
+		rxMissed, err := netdev.readSysNetclassStat(iface, "rx_missed_errors")
+		if err != nil {
+			log.Debugf("skip %s sample: read rx_missed_errors: %v", iface, err)
+			continue
 		}
 
-		for name := range counters {
-			counters[name], _ = netdev.readSysNetclassStat(iface, name)
-		}
-
-		count := counters["rx_missed_errors"]
+		count := rxMissed
 		// 1. No packet loss
 		// 2. rx_missed_errors of the driver is not used.
 		if count == 0 {
 			// hardware drop = rx_dropped - software_drops
-			if sw, ok := netdev.ifaceSwDroppedCounter[iface]; ok {
-				if counters["rx_dropped"] >= sw {
-					count = counters["rx_dropped"] - sw
-				}
+			if sw, ok := netdev.ifaceSwDroppedCounter[iface]; ok && rxDropped >= sw {
+				count = rxDropped - sw
 			}
 		}
 
@@ -148,7 +159,7 @@ func (netdev *netdevHw) Update() ([]*metric.Data, error) {
 		))
 	}
 
-	return data, nil
+	return data
 }
 
 func (netdev *netdevHw) readSysNetclassStat(iface, stat string) (uint64, error) {
@@ -167,6 +178,12 @@ func (netdev *netdevHw) updateIfaceSwDroppedStat(object bpf.BPF) error {
 		return err
 	}
 
+	return netdev.applySwDroppedItems(items)
+}
+
+// applySwDroppedItems consumes one dumped rx_sw_dropped_stats map item per
+// call slice entry, keyed by ifindex.
+func (netdev *netdevHw) applySwDroppedItems(items []bpf.MapItem) error {
 	for _, v := range items {
 		var (
 			ifidx   uint32
@@ -180,9 +197,13 @@ func (netdev *netdevHw) updateIfaceSwDroppedStat(object bpf.BPF) error {
 			return fmt.Errorf("read map value: %w", err)
 		}
 
-		ifi, err := net.InterfaceByIndex(int(ifidx))
+		ifi, err := netdev.interfaceByIndex(int(ifidx))
 		if err != nil {
-			return err
+			// The interface may have been removed while its key is still
+			// in the BPF map; skip it so one stale key cannot abort the
+			// whole scrape.
+			log.Debugf("[rx_sw_dropped_stats] skip ifindex %d: %v", ifidx, err)
+			continue
 		}
 
 		// iface can be dynamically added while huatuo is running.

--- a/core/metrics/netdev_hw_test.go
+++ b/core/metrics/netdev_hw_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+
+	"github.com/safchain/ethtool"
+)
+
+func newTestNetdevHw(sysNetPath string, ifaces map[string]string) *netdevHw {
+	ifaceList := make(map[string]*ethtool.DrvInfo, len(ifaces))
+	for iface, driver := range ifaces {
+		ifaceList[iface] = &ethtool.DrvInfo{Driver: driver}
+	}
+	swCounter := make(map[string]uint64, len(ifaces))
+	for iface := range ifaces {
+		swCounter[iface] = 0
+	}
+	return &netdevHw{
+		ifaceList:             ifaceList,
+		ifaceSwDroppedCounter: swCounter,
+		sysNetPath:            sysNetPath,
+		interfaceByIndex: func(int) (*net.Interface, error) {
+			return nil, errors.New("not wired")
+		},
+	}
+}
+
+func writeIfaceStat(t *testing.T, sysNetPath, iface, stat, value string) {
+	t.Helper()
+	dir := filepath.Join(sysNetPath, iface, "statistics")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error=%v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, stat), []byte(value), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error=%v", stat, err)
+	}
+}
+
+func TestNetdevHwCollectDataSkipsFailedStatRead(t *testing.T) {
+	sysNetPath := t.TempDir()
+	// eth0 is complete, eth1 misses rx_missed_errors.
+	writeIfaceStat(t, sysNetPath, "eth0", "rx_dropped", "7")
+	writeIfaceStat(t, sysNetPath, "eth0", "rx_missed_errors", "0")
+	writeIfaceStat(t, sysNetPath, "eth1", "rx_dropped", "9")
+
+	netdev := newTestNetdevHw(sysNetPath, map[string]string{
+		"eth0": "mlx5_core",
+		"eth1": "mlx5_core",
+	})
+
+	data := netdev.collectData()
+	if len(data) != 1 {
+		t.Fatalf("collectData() emitted %d samples, want 1 (eth1 must be skipped)", len(data))
+	}
+	if got := data[0].Value; got != 7 {
+		t.Errorf("eth0 rx_dropped_total=%v, want 7", got)
+	}
+}
+
+func TestNetdevHwCollectDataSubtractsSoftwareDrops(t *testing.T) {
+	sysNetPath := t.TempDir()
+	writeIfaceStat(t, sysNetPath, "eth0", "rx_dropped", "10")
+	writeIfaceStat(t, sysNetPath, "eth0", "rx_missed_errors", "0")
+
+	netdev := newTestNetdevHw(sysNetPath, map[string]string{"eth0": "mlx5_core"})
+	netdev.ifaceSwDroppedCounter["eth0"] = 4
+
+	data := netdev.collectData()
+	if len(data) != 1 {
+		t.Fatalf("collectData() emitted %d samples, want 1", len(data))
+	}
+	if got := data[0].Value; got != 6 {
+		t.Errorf("rx_dropped_total=%v, want 6 (10 - 4 software drops)", got)
+	}
+}
+
+func TestNetdevHwApplySwDroppedItemsToleratesStaleIfindex(t *testing.T) {
+	encodeItem := func(ifidx uint32, counter uint64) bpf.MapItem {
+		key := make([]byte, 4)
+		value := make([]byte, 8)
+		binary.LittleEndian.PutUint32(key, ifidx)
+		binary.LittleEndian.PutUint64(value, counter)
+		return bpf.MapItem{Key: key, Value: value}
+	}
+
+	sysNetPath := t.TempDir()
+	netdev := newTestNetdevHw(sysNetPath, map[string]string{"eth0": "mlx5_core"})
+	lookups := 0
+	netdev.interfaceByIndex = func(ifindex int) (*net.Interface, error) {
+		lookups++
+		if ifindex == 101 {
+			// Stale key: the interface no longer exists.
+			return nil, errors.New("route ip+net: no such network interface")
+		}
+		return &net.Interface{Name: "eth0"}, nil
+	}
+
+	items := []bpf.MapItem{
+		encodeItem(101, 111), // stale, must be skipped
+		encodeItem(102, 222), // eth0, must be applied
+	}
+	if err := netdev.applySwDroppedItems(items); err != nil {
+		t.Fatalf("applySwDroppedItems() error=%v, want stale key tolerated", err)
+	}
+	if lookups != 2 {
+		t.Errorf("interface lookups=%d, want 2 (loop must continue past stale keys)", lookups)
+	}
+	if got := netdev.ifaceSwDroppedCounter["eth0"]; got != 222 {
+		t.Errorf("ifaceSwDroppedCounter[eth0]=%d, want 222", got)
+	}
+}


### PR DESCRIPTION
## Problem

Two defects in the `netdev_hw` collector turned a single transient device failure into a permanent outage or corrupted data:

1. `updateIfaceSwDroppedStat` returned the error from `net.InterfaceByIndex` for every dumped `rx_sw_dropped_stats` map key. When an interface is removed (SR-IOV VF churn, bond failover) its stale key stays in the BPF map forever → every later scrape fails and all netdev_hw metrics disappear until restart.
2. The sysfs statistics reads swallowed errors and exported 0. `rx_dropped_total` is a Prometheus counter, so a fabricated zero looks like a counter reset and `rate()` reports a phantom spike on the next interval.

## Fix

Skip stale ifindex keys (log + continue) and skip the interface sample on sysfs read failure. Both paths get a test seam (`interfaceByIndex`, extracted `collectData`/`applySwDroppedItems`), same style as the qdisc collector's `readStats`.

## Tests

- `core/metrics`: `TestNetdevHwCollectDataSkipsFailedStatRead` (healthy iface survives a broken sibling), `TestNetdevHwCollectDataSubtractsSoftwareDrops`, `TestNetdevHwApplySwDroppedItemsToleratesStaleIfindex` (stale key skipped, fresh key applied, loop continues).

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
