### PR TITLE
fix(metrics): convert tcp memory pages with the kernel page size

### DIFF
--- a/core/metrics/net_tcp_memory.go
+++ b/core/metrics/net_tcp_memory.go
@@ -76,7 +76,7 @@ func parseTcpMemory() (*tcpMemoryStat, error) {
 		if p.Mem != nil {
 			return &tcpMemoryStat{
 				memoryPages: float64(*p.Mem),
-				memoryBytes: float64(*p.Mem * 4096),
+				memoryBytes: float64(*p.Mem) * float64(defaultHostPageSize),
 				memoryLimit: float64(values[2]), // tcpMemLimit
 			}, nil
 		}


### PR DESCRIPTION
## Problem

`tcp_memory` hardcoded 4 KiB when converting the sockstat TCP `mem` field to bytes (`*p.Mem * 4096`). The kernel reports `mem` in native pages, so on hosts whose kernel uses larger pages (64 KiB is common on aarch64: RHEL/Amazon Linux arm, Kunpeng, Phytium) `usage_bytes` is wrong by 16x — silently, corrupting dashboards and alerts.

## Fix

Convert with `os.Getpagesize()` (hoisted into a package var for tests), matching the pending sockstat fix. Also converts to float64 before multiplying, avoiding int overflow on 32-bit builds.

## Tests

- `core/metrics`: `TestParseTcpMemoryUsesKernelPageSize` — fixture procfs tree (`tcp_mem` + `sockstat`), page size overridden to 64 KiB; asserts pages/bytes/limit and that bytes track the configured page size, not 4096.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
