### PR TITLE
fix(toolstream): close connections accepted concurrently with Close

### DIFF
--- a/internal/toolstream/transport/server.go
+++ b/internal/toolstream/transport/server.go
@@ -32,9 +32,13 @@ type Server struct {
 	mutex       sync.Mutex
 	waitGroup   sync.WaitGroup
 	connections map[net.Conn]struct{}
+	closed      bool
 	listener    net.Listener
 	handler     func(*Session, ChunkMsg)
 	cancel      context.CancelFunc
+	// acceptHook is a test seam invoked between Accept and connection
+	// registration; production code leaves it nil.
+	acceptHook func()
 }
 
 // Serve starts accepting connections from l in the background.
@@ -73,7 +77,21 @@ func (s *Server) acceptLoop(ctx context.Context) {
 			continue
 		}
 
+		if s.acceptHook != nil {
+			s.acceptHook()
+		}
+
+		// Register and check closed under one lock: either Close() sees the
+		// connection in its snapshot and closes it, or the accept loop sees
+		// closed and discards the connection. Otherwise a connection accepted
+		// while Close() is running escapes both, leaving its handler stuck in
+		// a read forever and Close() blocked in waitGroup.Wait().
 		s.mutex.Lock()
+		if s.closed {
+			s.mutex.Unlock()
+			_ = conn.Close()
+			return
+		}
 		s.connections[conn] = struct{}{}
 		s.mutex.Unlock()
 
@@ -99,6 +117,10 @@ func (s *Server) acceptLoop(ctx context.Context) {
 }
 
 func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
+	if ctx.Err() != nil {
+		return
+	}
+
 	frameDecoder := capnp.NewDecoder(conn)
 
 	firstMsg, err := frameDecoder.Decode()
@@ -229,8 +251,12 @@ func (s *Server) Close() error {
 		errs = append(errs, err)
 	}
 
-	// snapshot under lock, close outside to avoid holding the lock during I/O
+	// snapshot under lock, close outside to avoid holding the lock during I/O.
+	// Setting closed in the same critical section makes a connection accepted
+	// concurrently with Close() either enter this snapshot or be discarded by
+	// the accept loop; it can never escape both.
 	s.mutex.Lock()
+	s.closed = true
 	conns := make([]net.Conn, 0, len(s.connections))
 
 	for c := range s.connections {

--- a/internal/toolstream/transport/server_test.go
+++ b/internal/toolstream/transport/server_test.go
@@ -15,6 +15,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -395,5 +396,78 @@ func TestClientRoundTrip(t *testing.T) {
 	}
 	if !got[1].End {
 		t.Errorf("second chunk End=false want true")
+	}
+}
+
+// A connection accepted while Close() is running must not escape the close:
+// either Close() closes it from its snapshot, or the accept loop discards it.
+// Otherwise its handler blocks in a read forever and Close() never returns.
+func TestCloseClosesConcurrentlyAcceptedConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan struct{})
+	release := make(chan struct{})
+	srv := &Server{
+		listener:    listener,
+		connections: make(map[net.Conn]struct{}),
+		handler:     func(*Session, ChunkMsg) {},
+		acceptHook: func() {
+			close(accepted)
+			<-release
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv.cancel = cancel
+	srv.waitGroup.Add(1)
+	go func() {
+		defer srv.waitGroup.Done()
+		srv.acceptLoop(ctx)
+	}()
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not accept the connection")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- srv.Close()
+	}()
+
+	// Give Close() time to finish its connection snapshot (cancel, listener
+	// close, snapshot) and park in waitGroup.Wait() while the connection is
+	// still parked in the accept hook. Releasing the hook must then make the
+	// accept loop discard the connection, unblocking Close().
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() error=%v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not return; concurrently accepted connection escaped the close")
+	}
+
+	// The client side must observe the server-side close.
+	if err := client.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	one := make([]byte, 1)
+	if _, err := client.Read(one); err == nil {
+		t.Error("client still readable; server-side connection was never closed")
 	}
 }


### PR DESCRIPTION
## Problem

A connection accepted between `Close()` taking its snapshot and the accept loop registering it escaped both: `Close()` never closed it and its handler blocked in the first `Decode()` (which only checked the context after the read). `Close()` then blocked in `waitGroup.Wait()` until the silent client sent a frame or disconnected — hanging daemon shutdown.

## Reproduction (before fix)

A regression test with an accept hook parks a connection between Accept and registration; `Close()` never returns (`Close() did not return; concurrently accepted connection escaped the close`).

## Fix

Register the connection and check the `closed` flag under one mutex (it either enters the snapshot or is discarded by the accept loop), check the context before the first Decode, and add the hook-based deterministic test.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
