### PR TITLE
fix(profiler): propagate off-CPU drain failures instead of spinning

### DIFF
--- a/cmd/profiler/provider/native_offcpu_profiler.go
+++ b/cmd/profiler/provider/native_offcpu_profiler.go
@@ -154,6 +154,12 @@ func (p *cpuNativeProfiler) readOffCPUDataLoop(
 			if errors.Is(err, types.ErrExitByCancelCtx) {
 				return nil
 			}
+			// ReadBatch joins read/decode failures with the lost-samples
+			// count. Retrying forever on a real failure would silently
+			// produce an empty profile.
+			if !isOnlyLostSamples(err) {
+				return err
+			}
 		}
 
 		if len(batch) == 0 {
@@ -165,6 +171,29 @@ func (p *cpuNativeProfiler) readOffCPUDataLoop(
 			}
 		}
 	}
+}
+
+// isOnlyLostSamples reports whether err carries nothing but lost-sample
+// information. ReadBatch joins every failure with a lost-samples error, so
+// a bare error means a pure loss while a joined error also contains a real
+// read or decode failure.
+func isOnlyLostSamples(err error) bool {
+	var lostErr *bpf.PerfEventSamplesLostError
+	if !errors.As(err, &lostErr) {
+		return false
+	}
+
+	var joined interface{ Unwrap() []error }
+	if !errors.As(err, &joined) {
+		return true
+	}
+	for _, part := range joined.Unwrap() {
+		var partLost *bpf.PerfEventSamplesLostError
+		if !errors.As(part, &partLost) {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *ringBufferContext) aggregateOffCPUBatch(batch []any, enqueue func(any)) {

--- a/cmd/profiler/provider/native_offcpu_profiler_test.go
+++ b/cmd/profiler/provider/native_offcpu_profiler_test.go
@@ -17,6 +17,7 @@ package provider
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 	"unsafe"
@@ -231,4 +232,44 @@ func TestOffCPUProfileTypeUsesNanosecondsWithoutSampleRate(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, opt.SampleRate)
 	require.Equal(t, "process_offcpu:offcpu:nanoseconds:offcpu:nanoseconds", profileType)
+}
+
+func TestIsOnlyLostSamples(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "pure lost samples",
+			err:  &bpf.PerfEventSamplesLostError{Count: 7},
+			want: true,
+		},
+		{
+			name: "real read failure",
+			err:  fmt.Errorf("read: %w", errors.New("bad fd")),
+			want: false,
+		},
+		{
+			name: "read failure joined with lost samples",
+			err: errors.Join(
+				fmt.Errorf("read: %w", errors.New("bad fd")),
+				&bpf.PerfEventSamplesLostError{Count: 3},
+			),
+			want: false,
+		},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			if got := isOnlyLostSamples(tests[i].err); got != tests[i].want {
+				t.Errorf("isOnlyLostSamples(%v) = %v, want %v", tests[i].err, got, tests[i].want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

The off-CPU profiler drain loop retried `ReadBatch` forever on any error that was neither lost-samples nor the exit marker — without logging. A permanently broken reader or an ABI-drift decode failure produced an empty profile with no signal. `ReadBatch` joins real failures with the lost-samples count, so `errors.As(err, &lostErr)` is true even for real failures and the check was insufficient.

## Fix

Return the error unless it carries nothing but lost-sample information (`isOnlyLostSamples` helper unwraps joined errors).

## Tests

- `cmd/profiler/provider`: `TestIsOnlyLostSamples` — nil, pure loss, real failure, and failure-joined-with-loss cases.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
