### PR TITLE
fix(profiler): bound speedscope memory against untrusted sample counts

### DIFF
--- a/internal/profiler/output/speedscope/speedscope.go
+++ b/internal/profiler/output/speedscope/speedscope.go
@@ -54,7 +54,8 @@ type sampledProfile struct {
 type threadState struct {
 	name    string
 	samples [][]int
-	total   int64 // total sample count
+	weights []float64 // per-sample weight in seconds
+	total   int64     // total sample count
 }
 
 // Formatter accumulates samples and writes Speedscope JSON.
@@ -82,7 +83,9 @@ func New(sampleRateHz float64) *Formatter {
 
 func (f *Formatter) Name() string { return "speedscope" }
 
-// Add incorporates one sample. Batch samples (Count > 1) are expanded inline.
+// Add incorporates one sample. Batch samples (Count > 1) are stored as one
+// entry weighted by their duration: expanding them would multiply memory by
+// the caller-supplied count, which is untrusted input from collapsed files.
 func (f *Formatter) Add(s *output.Sample) error {
 	if len(s.Frames) == 0 {
 		return nil
@@ -106,10 +109,9 @@ func (f *Formatter) Add(s *output.Sample) error {
 	if count <= 0 {
 		count = 1
 	}
-	for i := int64(0); i < count; i++ {
-		ts.samples = append(ts.samples, indices)
-		ts.total++
-	}
+	ts.samples = append(ts.samples, indices)
+	ts.weights = append(ts.weights, float64(count)*f.sampleDuration)
+	ts.total += count
 	return nil
 }
 
@@ -117,10 +119,6 @@ func (f *Formatter) Write(w io.Writer) error {
 	profiles := make([]sampledProfile, 0, len(f.threadOrder))
 	for _, key := range f.threadOrder {
 		ts := f.threads[key]
-		weights := make([]float64, len(ts.samples))
-		for i := range weights {
-			weights[i] = f.sampleDuration
-		}
 		profiles = append(profiles, sampledProfile{
 			Type:       "sampled",
 			Name:       ts.name,
@@ -128,7 +126,7 @@ func (f *Formatter) Write(w io.Writer) error {
 			StartValue: 0,
 			EndValue:   float64(ts.total) * f.sampleDuration,
 			Samples:    ts.samples,
-			Weights:    weights,
+			Weights:    ts.weights,
 		})
 	}
 

--- a/internal/profiler/output/speedscope/speedscope_test.go
+++ b/internal/profiler/output/speedscope/speedscope_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package speedscope
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"huatuo-bamai/internal/profiler/output"
+)
+
+// Batch samples with huge counts come from collapsed files, which may be
+// produced by the profiled tenant container. The formatter must stay
+// memory-bounded per sample instead of expanding Count entries.
+func TestAddHugeCountStaysBounded(t *testing.T) {
+	f := New(100) // 10ms per sample
+
+	const hugeCount = int64(1_000_000_000)
+	if err := f.Add(&output.Sample{Frames: []string{"a", "b"}, Count: hugeCount}); err != nil {
+		t.Fatalf("Add() error=%v", err)
+	}
+
+	ts := f.threads["default"]
+	if len(ts.samples) != 1 {
+		t.Fatalf("samples=%d, want 1 weighted entry", len(ts.samples))
+	}
+	if got := ts.weights[0]; got != float64(hugeCount)*f.sampleDuration {
+		t.Errorf("weight=%v, want %v", got, float64(hugeCount)*f.sampleDuration)
+	}
+	if ts.total != hugeCount {
+		t.Errorf("total=%d, want %d", ts.total, hugeCount)
+	}
+
+	var buf bytes.Buffer
+	if err := f.Write(&buf); err != nil {
+		t.Fatalf("Write() error=%v", err)
+	}
+
+	var file struct {
+		Profiles []struct {
+			EndValue float64   `json:"endValue"`
+			Samples  [][]int   `json:"samples"`
+			Weights  []float64 `json:"weights"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &file); err != nil {
+		t.Fatalf("output is not valid speedscope JSON: %v", err)
+	}
+	if len(file.Profiles) != 1 {
+		t.Fatalf("profiles=%d, want 1", len(file.Profiles))
+	}
+	profile := file.Profiles[0]
+	if want := float64(hugeCount) * f.sampleDuration; profile.EndValue != want {
+		t.Errorf("endValue=%v, want %v", profile.EndValue, want)
+	}
+	if len(profile.Samples) != 1 || len(profile.Weights) != 1 {
+		t.Errorf("samples=%d weights=%d, want 1/1", len(profile.Samples), len(profile.Weights))
+	}
+}
+
+func TestAddSingleSampleDefaultWeight(t *testing.T) {
+	f := New(100)
+
+	if err := f.Add(&output.Sample{Frames: []string{"a"}}); err != nil {
+		t.Fatalf("Add() error=%v", err)
+	}
+
+	ts := f.threads["default"]
+	if len(ts.samples) != 1 || len(ts.weights) != 1 {
+		t.Fatalf("samples=%d weights=%d, want 1/1", len(ts.samples), len(ts.weights))
+	}
+	if got := ts.weights[0]; got != f.sampleDuration {
+		t.Errorf("weight=%v, want %v", got, f.sampleDuration)
+	}
+}


### PR DESCRIPTION
## Problem

The speedscope formatter expanded every batch sample into `Count` copied entries. Counts come from collapsed files, which can be produced inside the profiled tenant container, so one planted line with a huge count (`a;b 900000000000`) attempted terabytes of appends and OOM-killed the root agent (chrometrace already uses the count arithmetically).

## Fix

Store one weighted sample: the speedscope sampled format carries a per-sample weight, so total time and rendering are unchanged while memory no longer depends on the count.

## Tests

- `internal/profiler/output/speedscope`: `TestAddHugeCountStaysBounded` (1e9-count sample: one weighted entry, valid JSON, correct endValue/weight), `TestAddSingleSampleDefaultWeight`.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
