### PR TITLE
fix(profiling): bound duration_seconds before overflow-prone checks

### DIFF
--- a/cmd/huatuo-apiserver/handlers/profiling/request.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request.go
@@ -75,6 +75,12 @@ func buildCreateProfilingJobRequest(
 	if err != nil {
 		return nil, err
 	}
+	// Bound the value itself before any arithmetic: at math.MaxInt64 the
+	// interval-sum comparison below overflows negative and bypasses the cap.
+	const maxDurationSeconds = 3599
+	if req.DurationSeconds <= 0 || req.DurationSeconds > maxDurationSeconds {
+		return nil, fmt.Errorf("duration_seconds must be between 1 and %d seconds", maxDurationSeconds)
+	}
 	if req.DurationSeconds < taskReq.Interval*2 {
 		return nil, errors.New("duration_seconds must cover at least two profiling intervals")
 	}

--- a/cmd/huatuo-apiserver/handlers/profiling/request_test.go
+++ b/cmd/huatuo-apiserver/handlers/profiling/request_test.go
@@ -15,6 +15,7 @@
 package profiling
 
 import (
+	"math"
 	"slices"
 	"testing"
 
@@ -88,6 +89,35 @@ func TestBuildCreateProfilingJobRequest(t *testing.T) {
 				DurationSeconds: 19,
 			},
 			wantErr: "duration_seconds must cover at least two profiling intervals",
+		},
+		{
+			// MaxInt64+interval overflows negative, which previously
+			// bypassed the 3600-second cap.
+			name: "duration at int64 max overflows the cap check",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: math.MaxInt64,
+			},
+			wantErr: "duration_seconds must be between 1 and 3599 seconds",
+		},
+		{
+			name: "duration above the hard cap",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: 3600,
+			},
+			wantErr: "duration_seconds must be between 1 and 3599 seconds",
+		},
+		{
+			name: "negative duration",
+			req: v1.CreateProfilingJobRequest{
+				ProfilingType:   "cpu",
+				Language:        "go",
+				DurationSeconds: -5,
+			},
+			wantErr: "duration_seconds must be between 1 and 3599 seconds",
 		},
 	}
 


### PR DESCRIPTION
## Problem

`buildCreateProfilingJobRequest` validated `duration_seconds` with `req.DurationSeconds + taskReq.Interval >= 3600`. At `math.MaxInt64` the sum overflows negative, bypassing the cap, and a negative `TraceTimeout`/`Duration` reaches the node agent — whose negative timeout context expires instantly, churning jobs and spawning agent processes per request.

## Reproduction (before fix)

Table case `duration at int64 max overflows the cap check` passes validation on the unfixed code and yields `TraceTimeout < 0` (verified by reverting the fix).

## Fix

Bound the request value itself (`1 <= duration_seconds <= 3599`) before any arithmetic; the two existing interval/cap checks remain for their specific messages.

## Tests

- `cmd/huatuo-apiserver/handlers/profiling`: MaxInt64, 3600, and negative-duration table cases.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
