### PR TITLE
fix(storage): verify Elasticsearch TLS by default and stop logging payloads

### DIFF
--- a/cmd/huatuo-apiserver/profiling.go
+++ b/cmd/huatuo-apiserver/profiling.go
@@ -33,6 +33,9 @@ func setupProfileQueryService(ctx context.Context, d *Daemon) (func(context.Cont
 		Username: d.opts.Config.Elasticsearch.Username,
 		Password: d.opts.Config.Elasticsearch.Password,
 		Index:    d.opts.Config.Elasticsearch.Index,
+
+		InsecureSkipVerify: d.opts.Config.Elasticsearch.InsecureSkipVerify,
+		CABundle:           d.opts.Config.Elasticsearch.CABundle,
 	}
 	profileQueryService, err := service.NewService(ctx, esConfig)
 	if err != nil {

--- a/cmd/huatuo-bamai/storage.go
+++ b/cmd/huatuo-bamai/storage.go
@@ -47,6 +47,9 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 			ESUsername:  cfg.Storage.Elasticsearch.Username,
 			ESPassword:  cfg.Storage.Elasticsearch.Password,
 			ESIndex:     cfg.Storage.Elasticsearch.Index,
+
+			ESInsecureSkipVerify: cfg.Storage.Elasticsearch.InsecureSkipVerify,
+			ESCABundle:           cfg.Storage.Elasticsearch.CABundle,
 		}, tracing.DocumentCollection, tracing.DocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("new tracing document store (elasticsearch): %w", err)
@@ -87,6 +90,9 @@ func initStorage(storageRegion string, cfg *config.Config) error {
 			ESUsername:  cfg.Storage.Elasticsearch.Username,
 			ESPassword:  cfg.Storage.Elasticsearch.Password,
 			ESIndex:     cfg.Storage.Elasticsearch.Index,
+
+			ESInsecureSkipVerify: cfg.Storage.Elasticsearch.InsecureSkipVerify,
+			ESCABundle:           cfg.Storage.Elasticsearch.CABundle,
 		}, profiler.MetadataCollection, tracing.ProfileDocumentStoreMapper{})
 		if err != nil {
 			return fmt.Errorf("new profiling document store (elasticsearch): %w", err)

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -166,10 +166,12 @@ idle timeout; 15–60 seconds is typical.
     # all configured (enabled). Partial connection settings are invalid.
     #
     [Storage.Elasticsearch]
-        # Address = "http://127.0.0.1:9200"
+        # Address = "https://127.0.0.1:9200"
         # Index = "huatuo_bamai"
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
+        # InsecureSkipVerify = false
+        # CABundle = "/etc/huatuo/es-ca.pem"
 ```
 
 - **Address**: ElasticSearch/OpenSearch service address.
@@ -200,6 +202,24 @@ idle timeout; 15–60 seconds is typical.
   **Description**: Used together with the username. In production, use a strong password and enable TLS encryption.
 
 **Overall**: ES/OS storage persists kernel tracing and event data for later search and analysis.
+
+- **InsecureSkipVerify**: Disable TLS server certificate verification for
+  HTTPS addresses.
+
+  Default value is `false` (verification enabled).
+
+  **Description**: Basic-auth credentials are sent on every request, so a
+  man in the middle can capture them when verification is disabled. Opt out
+  only for self-signed deployments, preferably combined with **CABundle**.
+
+- **CABundle**: Path to PEM-encoded CA certificates used to verify the
+  Elasticsearch/OpenSearch server.
+
+  No default value.
+
+  **Description**: Use this when the server certificate does not chain to
+  the system roots, e.g. an internal CA. Ignored when
+  InsecureSkipVerify is true.
 
 #### 6.2 Local File Storage
 

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -166,10 +166,12 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
     # all configured (enabled). Partial connection settings are invalid.
     #
     [Storage.Elasticsearch]
-        # Address = "http://127.0.0.1:9200"
+        # Address = "https://127.0.0.1:9200"
         # Index = "huatuo_bamai"
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
+        # InsecureSkipVerify = false
+        # CABundle = "/etc/huatuo/es-ca.pem"
 ```
 
 - **Address**：ElasticSearch/OpenSearch 存储服务地址。 
@@ -197,6 +199,21 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
   无默认值。
 
   **说明**：配合用户名进行安全认证。生产环境强烈建议使用强密码并结合 TLS 加密传输。
+
+- **InsecureSkipVerify**：关闭 HTTPS 地址的 TLS 服务端证书校验。
+
+  默认值为 false（开启校验）。
+
+  **说明**：Basic Auth 凭证会随每次请求发送，关闭校验后中间人可以截获
+  这些凭证。仅为自签名证书的部署关闭校验，并建议配合 **CABundle** 使用。
+
+- **CABundle**：用于校验 Elasticsearch/OpenSearch 服务端证书的 PEM 格式
+  CA 证书文件路径。
+
+  无默认值。
+
+  **说明**：当服务端证书无法链接到系统根证书时（例如内部 CA 签发），
+  通过该选项指定信任的 CA。InsecureSkipVerify 为 true 时忽略。
 
 **整体说明**：ES/OS 存储用于持久化内核追踪和事件数据，便于后续检索与分析。如果用户不关心 Linux 内核事件、Autotracing 数据则可以关闭该配置。
 

--- a/huatuo-apiserver.conf
+++ b/huatuo-apiserver.conf
@@ -115,7 +115,22 @@
     # Index containing huatuo-bamai profiling data.
     # Default: "huatuo_bamai"
     #
-    # Address = "http://127.0.0.1:9200"
+    # - InsecureSkipVerify
+    # Disable TLS server certificate verification for HTTPS addresses.
+    # Verification is on by default; opt out only for self-signed
+    # deployments, because a man in the middle can otherwise capture the
+    # basic-auth credentials sent on every request.
+    # Default: false
+    #
+    # InsecureSkipVerify = false
+    #
+    # - CABundle
+    # Optional path to PEM-encoded CA certificates used to verify the
+    # server when it does not chain to the system roots.
+    #
+    # CABundle = "/etc/huatuo/es-ca.pem"
+    #
+    # Address = "https://127.0.0.1:9200"
     # Username = "elastic"
     # Password = "REPLACE_WITH_PASSWORD"
     # Index = "huatuo_bamai"

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -95,10 +95,25 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
     # There are no default connection credentials.
     #
     [Storage.Elasticsearch]
-        # Address = "http://127.0.0.1:9200"
+        # Address = "https://127.0.0.1:9200"
         # Index = "huatuo_bamai"
         # Username = "elastic"
         # Password = "REPLACE_WITH_PASSWORD"
+        #
+        # - InsecureSkipVerify
+        # Disable TLS server certificate verification for HTTPS addresses.
+        # Verification is on by default; opt out only for self-signed
+        # deployments, because a man in the middle can otherwise capture the
+        # basic-auth credentials sent on every request.
+        # Default: false
+        #
+        # InsecureSkipVerify = false
+        #
+        # - CABundle
+        # Optional path to PEM-encoded CA certificates used to verify the
+        # server when it does not chain to the system roots.
+        #
+        # CABundle = "/etc/huatuo/es-ca.pem"
 
     # LocalFile Storage
     #

--- a/internal/config/elasticsearch.go
+++ b/internal/config/elasticsearch.go
@@ -28,17 +28,25 @@ type ElasticsearchConfig struct {
 	Username string
 	Password string
 	Index    string `default:"huatuo_bamai"`
+	// InsecureSkipVerify disables TLS certificate verification. Verification
+	// is on by default; opt out only for self-signed deployments, because a
+	// man in the middle can otherwise capture the basic-auth credentials
+	// sent on every request.
+	InsecureSkipVerify bool `default:"false"`
+	// CABundle is an optional path to PEM-encoded CA certificates used to
+	// verify the server when it does not chain to the system roots.
+	CABundle string
 }
 
 // Enabled reports whether all connection fields opt in to Elasticsearch.
-func (c ElasticsearchConfig) Enabled() bool {
+func (c *ElasticsearchConfig) Enabled() bool {
 	return strings.TrimSpace(c.Address) != "" &&
 		strings.TrimSpace(c.Username) != "" &&
 		strings.TrimSpace(c.Password) != ""
 }
 
 // Validate accepts either a complete connection or no connection fields.
-func (c ElasticsearchConfig) Validate() error {
+func (c *ElasticsearchConfig) Validate() error {
 	fields := []string{c.Address, c.Username, c.Password}
 	configured := 0
 	for _, field := range fields {

--- a/internal/profiler/service/flamegraph.go
+++ b/internal/profiler/service/flamegraph.go
@@ -34,6 +34,10 @@ import (
 
 type ElasticSearchConfig struct {
 	Address, Username, Password, Index string
+	// InsecureSkipVerify disables TLS certificate verification (default off).
+	InsecureSkipVerify bool
+	// CABundle optionally points at PEM-encoded CA certificates.
+	CABundle string
 }
 
 // Service provides profile query operations.
@@ -49,6 +53,8 @@ func NewService(ctx context.Context, esConfig *ElasticSearchConfig) (*Service, e
 		esConfig.Username,
 		esConfig.Password,
 		esConfig.Index,
+		esConfig.InsecureSkipVerify,
+		esConfig.CABundle,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/profiler/service/storage.go
+++ b/internal/profiler/service/storage.go
@@ -109,11 +109,11 @@ type profileDocumentMapper struct{}
 
 // NewProfileStorage creates a profiling storage.
 func NewProfileStorage(address, username, password, index string) (*ProfileStorage, error) {
-	return NewProfileStorageContext(context.Background(), address, username, password, index)
+	return NewProfileStorageContext(context.Background(), address, username, password, index, false, "")
 }
 
 // NewProfileStorageContext creates profiling storage with caller-owned cancellation.
-func NewProfileStorageContext(ctx context.Context, address, username, password, index string) (*ProfileStorage, error) {
+func NewProfileStorageContext(ctx context.Context, address, username, password, index string, insecureSkipVerify bool, caBundle string) (*ProfileStorage, error) {
 	if index == "" {
 		index = defaultESIndex
 	}
@@ -124,6 +124,9 @@ func NewProfileStorageContext(ctx context.Context, address, username, password, 
 		ESUsername:  username,
 		ESPassword:  password,
 		ESIndex:     index,
+
+		ESInsecureSkipVerify: insecureSkipVerify,
+		ESCABundle:           caBundle,
 	}, profileMetadataCollection, profileDocumentMapper{})
 	if err != nil {
 		return nil, err

--- a/internal/storage/driver/types.go
+++ b/internal/storage/driver/types.go
@@ -57,6 +57,10 @@ type Config struct {
 	ESUsername  string
 	ESPassword  string
 	ESIndex     string
+	// ESInsecureSkipVerify disables TLS certificate verification; ESCABundle
+	// optionally points at PEM-encoded CA certificates for server verification.
+	ESInsecureSkipVerify bool
+	ESCABundle           string
 }
 
 // Op is a storage query operator.

--- a/internal/storage/elasticsearch/client.go
+++ b/internal/storage/elasticsearch/client.go
@@ -16,16 +16,29 @@ package elasticsearch
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	elasticsearch "github.com/elastic/go-elasticsearch/v8"
 )
 
-// defaultTransport is sized to keep TLS handshake cost off the hot path.
+// tlsOptions controls server certificate verification for the ES transport.
+type tlsOptions struct {
+	// InsecureSkipVerify disables certificate verification. Verification is
+	// on by default: a man in the middle can otherwise capture the basic-auth
+	// credentials sent on every request.
+	InsecureSkipVerify bool
+	// CABundle optionally points at a file with PEM-encoded CA certificates
+	// used to verify servers that do not chain to the system roots.
+	CABundle string
+}
+
+// newTransport is sized to keep TLS handshake cost off the hot path.
 // Under FIPS, each fresh handshake spends several ms on RSA-PSS verification;
 // a small idle pool turned bursty writes into per-request handshakes and
 // dominated CPU. The idle/total caps below let concurrent writers reuse
@@ -34,23 +47,39 @@ import (
 // ClientSessionCache enables TLS 1.3 PSK resumption: when the server (or an
 // intermediate proxy) silently closes an idle connection, the next handshake
 // reuses a ticket instead of doing full RSA-PSS verification.
-var defaultTransport http.RoundTripper = &http.Transport{
-	MaxIdleConns:        200,
-	MaxIdleConnsPerHost: 100,
-	MaxConnsPerHost:     200,
-	// Keep below typical server-side idle timeouts (ES/nginx/LB ~60s) so the
-	// client closes first. If the server closes a connection we still hold,
-	// the next request races into a stale conn and triggers a fresh handshake.
-	IdleConnTimeout:       50 * time.Second,
-	ResponseHeaderTimeout: 10 * time.Second,
-	DialContext: (&net.Dialer{
-		Timeout:   10 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	TLSClientConfig: &tls.Config{
-		InsecureSkipVerify: true, // #nosec G402
+func newTransport(opts tlsOptions) (http.RoundTripper, error) {
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: opts.InsecureSkipVerify, //nolint:gosec // opt-in via config
 		ClientSessionCache: tls.NewLRUClientSessionCache(64),
-	},
+	}
+
+	if opts.CABundle != "" {
+		pem, err := os.ReadFile(opts.CABundle)
+		if err != nil {
+			return nil, fmt.Errorf("read CA bundle %q: %w", opts.CABundle, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("CA bundle %q contains no certificates", opts.CABundle)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return &http.Transport{
+		MaxIdleConns:        200,
+		MaxIdleConnsPerHost: 100,
+		MaxConnsPerHost:     200,
+		// Keep below typical server-side idle timeouts (ES/nginx/LB ~60s) so the
+		// client closes first. If the server closes a connection we still hold,
+		// the next request races into a stale conn and triggers a fresh handshake.
+		IdleConnTimeout:       50 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSClientConfig: tlsCfg,
+	}, nil
 }
 
 // productHeaderTransport injects X-Elastic-Product: Elasticsearch into
@@ -88,13 +117,18 @@ func (t *productHeaderTransport) RoundTrip(req *http.Request) (*http.Response, e
 //   - ES v7 ≥ 7.14: CompatibilityMode headers + native product header.
 //   - ES v7 < 7.14: CompatibilityMode headers + injected product header.
 //   - OpenSearch:    returns X-Elastic-Product natively; no separate client needed.
-func newCompatClient(addresses []string, username, password string) (*elasticsearch.Client, error) {
+func newCompatClient(addresses []string, username, password string, opts tlsOptions) (*elasticsearch.Client, error) {
+	transport, err := newTransport(opts)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
 		Addresses:               addresses,
 		Username:                username,
 		Password:                password,
 		EnableCompatibilityMode: true,
-		Transport:               &productHeaderTransport{inner: defaultTransport},
+		Transport:               &productHeaderTransport{inner: transport},
 		// Whole-batch retry: covers transport failures and 429/5xx returned for
 		// the entire bulk request. Per-item failures inside a 200 response are
 		// surfaced through BulkIndexerItem.OnFailure instead.

--- a/internal/storage/elasticsearch/client_test.go
+++ b/internal/storage/elasticsearch/client_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elasticsearch
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The basic-auth credentials travel on every request, so the transport must
+// verify server certificates by default and only trust an explicitly
+// configured CA bundle.
+func TestNewTransportServerVerification(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("NewRequest() error=%v", err)
+	}
+
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caFile, encodeCertPEM(server.Certificate()), 0o600); err != nil {
+		t.Fatalf("WriteFile(CA bundle) error=%v", err)
+	}
+
+	tests := []struct {
+		name    string
+		opts    tlsOptions
+		wantErr bool
+	}{
+		{
+			name:    "verification on without CA rejects the self-signed server",
+			opts:    tlsOptions{},
+			wantErr: true,
+		},
+		{
+			name:    "verification on with the server CA succeeds",
+			opts:    tlsOptions{CABundle: caFile},
+			wantErr: false,
+		},
+		{
+			name:    "verification off succeeds",
+			opts:    tlsOptions{InsecureSkipVerify: true},
+			wantErr: false,
+		},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			transport, err := newTransport(tests[i].opts)
+			if err != nil {
+				t.Fatalf("newTransport() error=%v", err)
+			}
+
+			client := &http.Client{Transport: transport}
+			resp, err := client.Do(request.Clone(request.Context()))
+			if tests[i].wantErr {
+				if err == nil {
+					resp.Body.Close()
+					t.Fatal("request succeeded, want certificate verification failure")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("request error=%v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status=%d, want %d", resp.StatusCode, http.StatusOK)
+			}
+		})
+	}
+}
+
+func TestNewTransportInvalidCABundle(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.pem")
+	if _, err := newTransport(tlsOptions{CABundle: missing}); err == nil {
+		t.Error("newTransport() with missing CA bundle error=nil, want error")
+	}
+
+	empty := filepath.Join(t.TempDir(), "empty.pem")
+	if err := os.WriteFile(empty, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error=%v", err)
+	}
+	if _, err := newTransport(tlsOptions{CABundle: empty}); err == nil {
+		t.Error("newTransport() with garbage CA bundle error=nil, want error")
+	}
+}
+
+func encodeCertPEM(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}

--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -54,6 +54,11 @@ type Config struct {
 	Username  string
 	Password  string
 	Index     string
+	// InsecureSkipVerify disables TLS certificate verification (default off).
+	InsecureSkipVerify bool
+	// CABundle optionally points at PEM-encoded CA certificates used to
+	// verify the server when it does not chain to the system roots.
+	CABundle string
 }
 
 // Storage stores records in Elasticsearch, OpenSearch, or any compatible backend.
@@ -74,10 +79,12 @@ var _ driver.Backend = (*Storage)(nil)
 func init() {
 	factory := func(cfg *driver.Config) (driver.Backend, error) {
 		return NewBackend(&Config{
-			Addresses: cfg.ESAddresses,
-			Username:  cfg.ESUsername,
-			Password:  cfg.ESPassword,
-			Index:     cfg.ESIndex,
+			Addresses:          cfg.ESAddresses,
+			Username:           cfg.ESUsername,
+			Password:           cfg.ESPassword,
+			Index:              cfg.ESIndex,
+			InsecureSkipVerify: cfg.ESInsecureSkipVerify,
+			CABundle:           cfg.ESCABundle,
 		})
 	}
 	driver.RegisterBackend("elasticsearch", factory)
@@ -90,7 +97,10 @@ func NewBackend(cfg *Config) (*Storage, error) {
 	if prefix == "" {
 		prefix = defaultIndex
 	}
-	client, err := newCompatClient(cfg.Addresses, cfg.Username, cfg.Password)
+	client, err := newCompatClient(cfg.Addresses, cfg.Username, cfg.Password, tlsOptions{
+		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		CABundle:           cfg.CABundle,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +161,9 @@ func (s *Storage) Save(ctx context.Context, rec driver.Record) error {
 	if err := s.bulk.Add(driver.WithContext(ctx), item); err != nil {
 		return fmt.Errorf("elasticsearch backend save %s: %w", s.index, err)
 	}
-	log.Debugf("elasticsearch bulk queued index=%s id=%s data=%s", s.index, rec.ID, rec.Data)
+	// Trace and profile documents may contain tenant-identifying content;
+	// log only the size, never the payload.
+	log.Debugf("elasticsearch bulk queued index=%s id=%s data_bytes=%d", s.index, rec.ID, len(rec.Data))
 	return nil
 }
 


### PR DESCRIPTION
## Problem

The Elasticsearch client hard-coded `InsecureSkipVerify: true` while sending basic-auth credentials on every request — a man in the middle between node and ES/LB captures the storage credentials and can read or poison all observability data. The bulk debug log also wrote full trace/profile documents (tenant symbol names, hostnames, container IDs) into node logs.

## Fix

- Certificate verification is **on by default**. Two config knobs:
  - `Storage.Elasticsearch.InsecureSkipVerify` — opt-out for self-signed deployments (documented migration: set it to preserve the old behavior).
  - `Storage.Elasticsearch.CABundle` — PEM CA certificates for internal CAs.
- The apiserver profile query service honors the same options.
- The debug log now records the payload size, never the payload (Beats CVE-2023-49922 class).

## Tests

- `internal/storage/elasticsearch`: `TestNewTransportServerVerification` (real HTTPS round trip against `httptest.NewTLSServer`: no-CA rejects, server-CA accepts, insecure accepts), `TestNewTransportInvalidCABundle` (missing/garbage bundle errors).
- Fail-first verified: re-hardcoding insecure mode fails the no-CA rejection case.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
