### PR TITLE
fix(pod): verify the kubelet serving certificate by default

### DIFF
--- a/cmd/huatuo-bamai/config/config.go
+++ b/cmd/huatuo-bamai/config/config.go
@@ -73,7 +73,14 @@ type PodConfig struct {
 	KubeletReadOnlyPort   uint32 `default:"10255"`
 	KubeletAuthorizedPort uint32 `default:"10250"`
 	KubeletClientCertPath string
-	DockerAPIVersion      string `default:"1.24"`
+	// KubeletCABundle optionally points at PEM-encoded CA certificates used
+	// to verify the kubelet serving certificate (usually the cluster CA).
+	KubeletCABundle string
+	// KubeletTLSInsecure disables kubelet TLS server verification. The
+	// kubelet serving certificate is signed by the cluster CA; point
+	// KubeletCABundle at it instead of disabling verification.
+	KubeletTLSInsecure bool   `default:"false"`
+	DockerAPIVersion   string `default:"1.24"`
 }
 
 // Config is the global huatuo-bamai configuration.

--- a/cmd/huatuo-bamai/pod.go
+++ b/cmd/huatuo-bamai/pod.go
@@ -33,6 +33,8 @@ func setupPodManager(d *Daemon) (func(context.Context) error, error) {
 		PodReadOnlyPort:   config.Get().Pod.KubeletReadOnlyPort,
 		PodAuthorizedPort: config.Get().Pod.KubeletAuthorizedPort,
 		PodClientCertPath: config.Get().Pod.KubeletClientCertPath,
+		PodCABundle:       config.Get().Pod.KubeletCABundle,
+		PodTLSInsecure:    config.Get().Pod.KubeletTLSInsecure,
 		DockerAPIVersion:  config.Get().Pod.DockerAPIVersion,
 	}
 

--- a/docs/configuration/huatuo-bamai-configuration_en.md
+++ b/docs/configuration/huatuo-bamai-configuration_en.md
@@ -1092,6 +1092,8 @@ This section configures how to fetch Pod information from kubelet to enable cont
 #
 [Pod]
 	KubeletClientCertPath = "/etc/kubernetes/pki/apiserver-kubelet-client.crt,/etc/kubernetes/pki/apiserver-kubelet-client.key"
+	KubeletCABundle = "/etc/kubernetes/pki/ca.crt"
+	KubeletTLSInsecure = false
 ```
 
 - **KubeletReadOnlyPort**: Kubelet read-only port.
@@ -1105,6 +1107,22 @@ This section configures how to fetch Pod information from kubelet to enable cont
 - **KubeletClientCertPath**: Path to kubelet client certificate and private key. Supports comma-separated files or single PEM file.
 
   **Description**: Used for mTLS authentication on the HTTPS port. In non-Kubernetes (bare-metal) environments, set both ports to 0 to disable Pod fetching.
+
+- **KubeletCABundle**: Path to PEM-encoded CA certificates used to verify the kubelet serving certificate.
+
+  No default value.
+
+  **Description**: The kubelet serving certificate is normally signed by the
+  cluster CA (e.g. /etc/kubernetes/pki/ca.crt). Verification is enabled by
+  default; without a CA bundle the HTTPS fallback fails with a certificate
+  error.
+
+- **KubeletTLSInsecure**: Disable kubelet TLS server certificate verification.
+
+  Default value is `false` (verification enabled).
+
+  **Description**: On an unverified connection a man in the middle can feed a
+  fake pod list and poison container attribution, so prefer **KubeletCABundle**.
 
 ### 11. CLI Flags
 

--- a/docs/configuration/huatuo-bamai-configuration_zh.md
+++ b/docs/configuration/huatuo-bamai-configuration_zh.md
@@ -1102,6 +1102,8 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
 #
 [Pod]
 	KubeletClientCertPath = "/etc/kubernetes/pki/apiserver-kubelet-client.crt,/etc/kubernetes/pki/apiserver-kubelet-client.key"
+	KubeletCABundle = "/etc/kubernetes/pki/ca.crt"
+	KubeletTLSInsecure = false
 ```
 
 - **KubeletReadOnlyPort**：kubelet 只读端口。
@@ -1121,6 +1123,21 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
   支持格式："/path/to/xxx-kubelet-client.crt,/path/to/xxx-kubelet-client.key" 或单文件 PEM 格式。 
 
   **说明**：参考 Kubernetes 证书最佳实践，用于 HTTPS 端口的 mTLS 认证。在裸金属或非 Kubernetes 环境中可通过将两个端口设为 0 来禁用 Pod 获取功能。
+
+- **KubeletCABundle**：用于校验 kubelet 服务端证书的 PEM 格式 CA 证书文件路径。
+
+  无默认值。
+
+  **说明**：kubelet 服务端证书通常由集群 CA 签发（如
+  /etc/kubernetes/pki/ca.crt）。默认开启校验；未配置 CA bundle 时
+  HTTPS 回退会因证书校验失败而不可用。
+
+- **KubeletTLSInsecure**：关闭 kubelet HTTPS 地址的 TLS 服务端证书校验。
+
+  默认值为 false（开启校验）。
+
+  **说明**：不校验时中间人可以伪造 Pod 列表并污染容器归属信息，建议
+  优先配置 **KubeletCABundle** 而不是关闭校验。
 
 ### 11. 命令行参数
 

--- a/huatuo-bamai.conf
+++ b/huatuo-bamai.conf
@@ -625,8 +625,21 @@ BlackList = ["netdev_hw", "netdev_qdisc", "metax_gpu", "ascend_npu", "diskio", "
 # "/path/to/xxx-kubelet-client.crt,/path/to/xxx-kubelet-client.key",
 # "/path/to/kubelet-client-current.pem"
 #
+# - KubeletCABundle
+# Optional path to PEM-encoded CA certificates used to verify the kubelet
+# serving certificate, which is normally signed by the cluster CA
+# (e.g. /etc/kubernetes/pki/ca.crt).
+#
+# - KubeletTLSInsecure
+# Disable kubelet TLS server certificate verification. Verification is on
+# by default; on an unverified connection a man in the middle can feed a
+# fake pod list and poison container attribution, so prefer KubeletCABundle.
+# Default: false
+#
 # You can disable this kubelet fetching pods, for bare metal service, by
 # KubeletReadOnlyPort = 0, and KubeletAuthorizedPort = 0.
 #
 [Pod]
     KubeletClientCertPath = "/etc/kubernetes/pki/apiserver-kubelet-client.crt,/etc/kubernetes/pki/apiserver-kubelet-client.key"
+    # KubeletCABundle = "/etc/kubernetes/pki/ca.crt"
+    # KubeletTLSInsecure = false

--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -29,6 +29,7 @@ import (
 
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/utils/netutil"
+	"huatuo-bamai/internal/utils/tlsutil"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
@@ -74,6 +75,8 @@ type ManagerCtx struct {
 	PodReadOnlyPort   uint32
 	PodAuthorizedPort uint32
 	PodClientCertPath string
+	PodCABundle       string
+	PodTLSInsecure    bool
 	DockerAPIVersion  string
 
 	// this is used internally.
@@ -109,18 +112,35 @@ func kubeletPodListAuthorizationRequest(ctx *ManagerCtx) (*http.Client, error) {
 			ctx.podClientCertPath, ctx.podClientCertKey, err)
 	}
 
+	tlsCfg, err := kubeletTLSConfig(&cert, ctx.PodCABundle, ctx.PodTLSInsecure)
+	if err != nil {
+		return nil, err
+	}
+
 	client := &http.Client{
-		Timeout: kubeletReqTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				Certificates:       []tls.Certificate{cert},
-				InsecureSkipVerify: true, // #nosec G402
-			},
-		},
+		Timeout:   kubeletReqTimeout,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
 
 	_, err = kubeletPodListDoRequest(client, kubeletPodListAuthorizedURL(ctx.PodAuthorizedPort))
 	return client, err
+}
+
+// kubeletTLSConfig builds the TLS config for the authorized kubelet client.
+// Server verification is on by default: the kubelet serving certificate is
+// signed by the cluster CA, so point the CA bundle at it. A man in the
+// middle on an unverified connection can feed a fake pod list and poison
+// container attribution, so treat PodTLSInsecure as a last resort.
+func kubeletTLSConfig(cert *tls.Certificate, caBundle string, insecure bool) (*tls.Config, error) {
+	cfg := &tls.Config{
+		Certificates:       []tls.Certificate{*cert},
+		InsecureSkipVerify: insecure, //nolint:gosec // opt-in via config
+	}
+
+	if err := tlsutil.AppendCABundle(cfg, caBundle); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 func kubeletPodListPortCacheUpdate(ctx *ManagerCtx) error {

--- a/internal/pod/container_kubelet_sync_tls_test.go
+++ b/internal/pod/container_kubelet_sync_tls_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateCAAndServerCert builds a CA and a server certificate for 127.0.0.1
+// signed by it, mirroring a kubelet serving certificate.
+func generateCAAndServerCert(t *testing.T) (tls.Certificate, []byte) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "huatuo-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{serverDER},
+		PrivateKey:  serverKey,
+	}, caDER
+}
+
+// The authorized kubelet client presents a client certificate, so the server
+// side must be verified by default: an impostor can otherwise feed a fake pod
+// list and poison container attribution.
+func TestKubeletTLSConfigServerVerification(t *testing.T) {
+	serverCert, caDER := generateCAAndServerCert(t)
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	server.TLS = &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{serverCert}}
+	server.StartTLS()
+	defer server.Close()
+
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caFile, pem.EncodeToMemory(
+		&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0o600); err != nil {
+		t.Fatalf("write CA bundle: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		ca       string
+		insecure bool
+		wantErr  bool
+	}{
+		{name: "verification on without CA rejects the kubelet cert", wantErr: true},
+		{name: "verification on with cluster CA succeeds", ca: caFile},
+		{name: "verification off succeeds", insecure: true},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			cfg, err := kubeletTLSConfig(&serverCert, tests[i].ca, tests[i].insecure)
+			if err != nil {
+				t.Fatalf("kubeletTLSConfig() error=%v", err)
+			}
+
+			client := &http.Client{
+				Timeout:   5 * time.Second,
+				Transport: &http.Transport{TLSClientConfig: cfg},
+			}
+			resp, err := client.Get(server.URL)
+			if tests[i].wantErr {
+				if err == nil {
+					resp.Body.Close()
+					t.Fatal("request succeeded, want certificate verification failure")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("request error=%v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status=%d, want %d", resp.StatusCode, http.StatusOK)
+			}
+		})
+	}
+}

--- a/internal/utils/tlsutil/tlsutil.go
+++ b/internal/utils/tlsutil/tlsutil.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tlsutil helps build TLS client configs for the agent's outbound
+// endpoints (Elasticsearch, kubelet), whose certificates may chain to an
+// internal CA instead of the system roots.
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// AppendCABundle reads a PEM-encoded certificate bundle and sets it as the
+// root CA pool of cfg. An empty path leaves cfg unchanged.
+func AppendCABundle(cfg *tls.Config, caBundle string) error {
+	if caBundle == "" {
+		return nil
+	}
+
+	pem, err := os.ReadFile(caBundle)
+	if err != nil {
+		return fmt.Errorf("read CA bundle %q: %w", caBundle, err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return fmt.Errorf("CA bundle %q contains no certificates", caBundle)
+	}
+	cfg.RootCAs = pool
+	return nil
+}


### PR DESCRIPTION
## Problem

The authorized kubelet client presented a client certificate over a connection with `InsecureSkipVerify: true`. An impostor kubelet can feed a fake pod list, poisoning container attribution for every metric and event, and the connection target (127.0.0.1:10250) is unauthenticated on the impostor side.

## Fix

Server verification is **on by default**:
- `Pod.KubeletCABundle` — PEM CA certificates used to verify the kubelet serving certificate (normally the cluster CA, e.g. `/etc/kubernetes/pki/ca.crt`).
- `Pod.KubeletTLSInsecure` — explicit opt-out for self-signed setups (last resort).
- CA loading shared via new `internal/utils/tlsutil` so the Elasticsearch client can adopt it too.

## Tests

- `internal/pod`: `TestKubeletTLSConfigServerVerification` — generates a CA + server cert for 127.0.0.1 in-test; no-CA rejects, cluster-CA accepts, insecure accepts.
- Fail-first verified: re-hardcoding insecure mode fails the no-CA rejection case.

## Docs

Sample config and zh/en configuration docs updated for both new options.

## Verification

- `go test ./...` full suite green; `go vet`, `gofmt`, `golangci-lint` clean.
- Regression test fails when the fix is reverted (verified by reverting the fix locally).
- Combined with all my other PRs: 16-branch stack, full integration suite (`integration/run.sh`, 42 cases) — 37 pass / 5 failures reproduced identically on main (WSL2 environment limits, unrelated).
