### PR TITLE
fix(container): bound container API responses

### DIFF
--- a/internal/command/container/body.go
+++ b/internal/command/container/body.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import "io"
+
+const (
+	maxContainerResponseBytes = 32 << 20
+	maxContainerErrorBytes    = 8 << 10
+)
+
+func readBoundedBody(body io.Reader, limit int64) ([]byte, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > limit {
+		return data[:limit], true, nil
+	}
+	return data, false, nil
+}

--- a/internal/command/container/body_test.go
+++ b/internal/command/container/body_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadBoundedBody(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		limit         int64
+		want          string
+		wantTruncated bool
+	}{
+		{name: "below limit", body: "short", limit: 8, want: "short"},
+		{name: "exact limit", body: "12345678", limit: 8, want: "12345678"},
+		{name: "over limit", body: "1234567890", limit: 8, want: "12345678", wantTruncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, truncated, err := readBoundedBody(strings.NewReader(tt.body), tt.limit)
+			if err != nil {
+				t.Fatalf("readBoundedBody() error = %v", err)
+			}
+			if string(got) != tt.want || truncated != tt.wantTruncated {
+				t.Fatalf("readBoundedBody() = (%q, %t), want (%q, %t)",
+					got, truncated, tt.want, tt.wantTruncated)
+			}
+		})
+	}
+}
+
+func TestReadBoundedBodyPreservesReadError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	_, _, err := readBoundedBody(io.MultiReader(strings.NewReader("ok"), errorReader{err: wantErr}), 8)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("readBoundedBody() error = %v, want %v", err, wantErr)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}

--- a/internal/command/container/container.go
+++ b/internal/command/container/container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 package container
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -47,11 +47,18 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		body, truncated, err := readBoundedBody(resp.Body, maxContainerErrorBytes)
 		if err != nil {
 			return nil, fmt.Errorf("get container failed, status code: %d, read body: %w", resp.StatusCode, err)
 		}
-		return nil, fmt.Errorf("get container failed, status code: %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		detail := strings.TrimSpace(string(body))
+		if truncated {
+			detail += " [truncated]"
+		}
+		return nil, fmt.Errorf("get container failed, status code: %d, body: %s", resp.StatusCode, detail)
+	}
+	if resp.ContentLength > maxContainerResponseBytes {
+		return nil, fmt.Errorf("get container failed: response exceeds %d bytes", maxContainerResponseBytes)
 	}
 
 	type containersResp struct {
@@ -60,8 +67,16 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 		Data    []pod.Container `json:"data"`
 	}
 
+	body, truncated, err := readBoundedBody(resp.Body, maxContainerResponseBytes)
+	if err != nil {
+		return nil, fmt.Errorf("containersResp read failed: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("get container failed: response exceeds %d bytes", maxContainerResponseBytes)
+	}
+
 	var ctResp containersResp
-	if err := json.NewDecoder(resp.Body).Decode(&ctResp); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&ctResp); err != nil {
 		return nil, fmt.Errorf("containersResp decode failed: %w", err)
 	}
 

--- a/internal/command/container/container_test.go
+++ b/internal/command/container/container_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -37,6 +38,38 @@ func TestGetContainersIncludesErrorBody(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "backend unavailable") {
 		t.Fatalf("getContainers() error = %q, want response body", err)
+	}
+}
+
+func TestGetContainersTruncatesErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = fmt.Fprint(w, strings.Repeat("x", maxContainerErrorBytes+1024))
+	}))
+	defer server.Close()
+
+	_, err := getContainers(strings.TrimPrefix(server.URL, "http://"), "")
+	if err == nil {
+		t.Fatal("getContainers() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "[truncated]") {
+		t.Fatalf("getContainers() error = %q, want truncation marker", err)
+	}
+	if len(err.Error()) > maxContainerErrorBytes+256 {
+		t.Fatalf("getContainers() error length = %d, want bounded preview", len(err.Error()))
+	}
+}
+
+func TestGetContainersRejectsDeclaredOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.FormatInt(maxContainerResponseBytes+1, 10))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, err := getContainers(strings.TrimPrefix(server.URL, "http://"), "")
+	if err == nil || !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("getContainers() error = %v, want response limit error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- cap successful container API responses at 32 MiB
- keep at most 8 KiB of an error response and mark truncation
- add regression coverage for limits, truncation, and read errors

## Why

The local container API response was read without a byte limit. A malfunctioning endpoint could therefore grow the agent's memory use without bound.

## Validation

- `go test -mod=vendor internal/command/container/body.go internal/command/container/body_test.go -count=1`
- `git diff --check`
- Full package tests and `make check` could not run on this Windows host because the generated Linux BPF ABI is absent and `make` is unavailable; GitHub CI is expected to run the repository checks.

Fixes #692