### PR TITLE
fix(iolatency): propagate container metric errors

### DIFF
--- a/core/metrics/iolatency_collector.go
+++ b/core/metrics/iolatency_collector.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -31,14 +32,10 @@ func (c *iolatencyTracing) Update() ([]*metric.Data, error) {
 	}
 	defer lease.Release()
 
-	containers, _ := c.fetchContainerIOlatency(lease.BPF)
+	containers, containerErr := c.fetchContainerIOlatency(lease.BPF)
+	blkio, blkioErr := c.fetchBlkDiskIOlatency(lease.BPF)
 
-	blkio, err := c.fetchBlkDiskIOlatency(lease.BPF)
-	if err != nil {
-		return containers, err
-	}
-
-	return append(containers, blkio...), nil
+	return append(containers, blkio...), errors.Join(containerErr, blkioErr)
 }
 
 func (c *iolatencyTracing) fetchContainerIOlatency(object bpf.BPF) ([]*metric.Data, error) {

--- a/core/metrics/iolatency_collector_test.go
+++ b/core/metrics/iolatency_collector_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+)
+
+type iolatencyBPFStub struct {
+	bpf.BPF
+	containerErr error
+}
+
+func (s *iolatencyBPFStub) DumpMapByName(name string) ([]bpf.MapItem, error) {
+	if name == blkContainerLatencyMap {
+		return nil, s.containerErr
+	}
+
+	return nil, nil
+}
+
+func (s *iolatencyBPFStub) Close() error {
+	return nil
+}
+
+func TestIOLatencyUpdateReturnsContainerCollectionError(t *testing.T) {
+	expectedErr := errors.New("container latency map unavailable")
+	collector := &iolatencyTracing{}
+	if err := collector.bpfObject.Publish(&iolatencyBPFStub{
+		containerErr: expectedErr,
+	}); err != nil {
+		t.Fatalf("publish BPF stub: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := collector.bpfObject.UnPublish(); err != nil {
+			t.Errorf("unpublish BPF stub: %v", err)
+		}
+	})
+
+	metrics, err := collector.Update()
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("Update() error = %v, want %v", err, expectedErr)
+	}
+	if len(metrics) != 0 {
+		t.Fatalf("Update() returned %d metrics, want 0", len(metrics))
+	}
+}


### PR DESCRIPTION
## 背景

iolatency 采集器同时读取两个独立的 BPF map：

- `blkcg_map`：容器级 q2c/d2c 延迟指标
- `blkdisk_map`：磁盘级 q2c/d2c/freeze 指标

原实现忽略了 `fetchContainerIOlatency()` 返回的错误。当 `blkcg_map` 读取失败或 map value 解码失败时，容器级延迟指标会静默缺失，但采集器仍可能返回成功状态。

## 影响

该问题会导致：

1. 容器级 I/O 延迟指标静默丢失；
2. 宿主机磁盘级指标仍然存在，容易掩盖容器指标采集异常；
3. `scrape_success` 可能错误地保持为 1；
4. 容器存储尾延迟分析、异常定位和相关告警出现不完整或误判。

这会降低 iolatency 对容器级存储问题的发现和定位能力。

## 修改

参考其他 metrics 的实现，将错误以及将 metrics data 合并，作为最终结果返回。补充测试用例。