### PR TITLE
fix(storage): bound Elasticsearch response bodies

### DIFF
--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -39,6 +39,8 @@ import (
 const (
 	defaultIndex     = "huatuo_bamai"
 	defaultQuerySize = 10000
+	maxResponseBytes = 16 * 1024 * 1024
+	maxErrorBytes    = 4 * 1024
 
 	// Bulk indexer tuning. 5MB / 1s matches the upstream defaults and is a
 	// safe starting point for ES/OpenSearch single-node and small clusters.
@@ -171,7 +173,7 @@ func (s *Storage) Get(ctx context.Context, id string) (rec driver.Record, err er
 	}
 
 	var payload esget.Response
-	if err = json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err = decodeResponse(res.Body, &payload); err != nil {
 		return rec, fmt.Errorf("elasticsearch backend get %s/%s: decode: %w", s.index, id, err)
 	}
 	if !payload.Found {
@@ -219,7 +221,7 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 	}
 
 	var payload essearch.Response
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeResponse(res.Body, &payload); err != nil {
 		return nil, fmt.Errorf("elasticsearch backend query %s: decode: %w", s.index, err)
 	}
 	records := make([]driver.Record, 0, len(payload.Hits.Hits))
@@ -252,7 +254,7 @@ func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
 	}
 
 	var payload escount.Response
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeResponse(res.Body, &payload); err != nil {
 		return 0, fmt.Errorf("elasticsearch backend count %s: decode: %w", s.index, err)
 	}
 	return payload.Count, nil
@@ -276,7 +278,7 @@ func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size
 	}
 
 	var payload valuesResponse
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeResponse(res.Body, &payload); err != nil {
 		return nil, fmt.Errorf("elasticsearch backend terms %s/%s: decode: %w", s.index, field, err)
 	}
 	result := make([]string, 0, len(payload.Aggregations.Terms.Buckets))
@@ -287,9 +289,39 @@ func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size
 }
 
 func responseError(action, target string, res *esapi.Response) error {
-	body, err := io.ReadAll(res.Body)
+	body, truncated, err := readBoundedBody(res.Body, maxErrorBytes)
 	if err != nil {
 		return fmt.Errorf("elasticsearch %s %s: status %d: read body: %w", action, target, res.StatusCode, err)
 	}
-	return fmt.Errorf("elasticsearch %s %s: status %d: %s", action, target, res.StatusCode, strings.TrimSpace(string(body)))
+	diagnostic := strings.TrimSpace(string(body))
+	if truncated {
+		diagnostic += " (truncated)"
+	}
+	return fmt.Errorf("elasticsearch %s %s: status %d: %s", action, target, res.StatusCode, diagnostic)
+}
+
+func decodeResponse(body io.Reader, dst any) error {
+	return decodeResponseWithLimit(body, dst, maxResponseBytes)
+}
+
+func decodeResponseWithLimit(body io.Reader, dst any, limit int64) error {
+	data, truncated, err := readBoundedBody(body, limit)
+	if err != nil {
+		return err
+	}
+	if truncated {
+		return fmt.Errorf("response body exceeds %d bytes", limit)
+	}
+	return json.NewDecoder(bytes.NewReader(data)).Decode(dst)
+}
+
+func readBoundedBody(body io.Reader, limit int64) ([]byte, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) <= limit {
+		return data, false, nil
+	}
+	return data[:limit], true, nil
 }

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+
 	"huatuo-bamai/internal/storage/driver"
 )
 
@@ -1063,5 +1065,40 @@ func TestNewBackend_ServerError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "elasticsearch client info") {
 		t.Errorf("error = %q, want to contain \"elasticsearch client info\"", err.Error())
+	}
+}
+
+func TestDecodeResponseWithLimit(t *testing.T) {
+	var payload struct {
+		Value string `json:"value"`
+	}
+	if err := decodeResponseWithLimit(
+		strings.NewReader(`{"value":"ok"}`),
+		&payload,
+		32,
+	); err != nil {
+		t.Fatalf("decodeResponseWithLimit() error = %v", err)
+	}
+	if payload.Value != "ok" {
+		t.Fatalf("decoded value = %q, want %q", payload.Value, "ok")
+	}
+
+	err := decodeResponseWithLimit(strings.NewReader(`{"value":"too long"}`), &payload, 8)
+	if err == nil || !strings.Contains(err.Error(), "exceeds 8 bytes") {
+		t.Fatalf("oversized response error = %v", err)
+	}
+}
+
+func TestResponseErrorBoundsDiagnostic(t *testing.T) {
+	res := &esapi.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", maxErrorBytes+32))),
+	}
+	err := responseError("query", "index", res)
+	if err == nil || !strings.Contains(err.Error(), "(truncated)") {
+		t.Fatalf("responseError() = %v, want truncated marker", err)
+	}
+	if len(err.Error()) > maxErrorBytes+128 {
+		t.Fatalf("responseError() length = %d, want bounded diagnostic", len(err.Error()))
 	}
 }


### PR DESCRIPTION
## Summary

- cap successful Elasticsearch/OpenSearch JSON responses at 16 MiB
- cap error diagnostics at 4 KiB and mark truncated messages
- preserve response read errors and existing streaming decode behavior

## Why

HTTP timeouts limit elapsed time but not bytes. A malfunctioning or misrouted
backend could otherwise force unbounded allocations while a response is decoded
or copied into an error.

Closes #701

## Testing

- `go test ./internal/storage/elasticsearch`
- `goimports` on changed Go files
- tests cover normal JSON, streamed overflow, and bounded error diagnostics