### PR TITLE
fix(tracing): bound task command output

### DIFF
--- a/pkg/tracing/task.go
+++ b/pkg/tracing/task.go
@@ -101,15 +101,26 @@ var (
 )
 
 type boundedBuffer struct {
-	buffer   bytes.Buffer
-	limit    int
-	exceeded bool
+	mu         sync.Mutex
+	buffer     bytes.Buffer
+	limit      int
+	exceeded   bool
+	onExceeded func()
 }
 
 func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.exceeded {
+		return 0, ErrTaskOutputLimitExceeded
+	}
 	remaining := b.limit - b.buffer.Len()
 	if remaining <= 0 {
 		b.exceeded = true
+		if b.onExceeded != nil {
+			b.onExceeded()
+		}
 		return 0, ErrTaskOutputLimitExceeded
 	}
 	if len(p) <= remaining {
@@ -117,14 +128,21 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 	}
 	n, _ := b.buffer.Write(p[:remaining])
 	b.exceeded = true
+	if b.onExceeded != nil {
+		b.onExceeded()
+	}
 	return n, ErrTaskOutputLimitExceeded
 }
 
 func (b *boundedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.buffer.Bytes()
 }
 
 func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.buffer.String()
 }
 
@@ -298,8 +316,11 @@ func runTask(ctx context.Context, task *task) {
 }
 
 func runTaskCommand(ctx context.Context, binary string, args []string, limit int) ([]byte, error) {
-	output := &boundedBuffer{limit: limit}
-	cmd := exec.CommandContext(ctx, binary, args...)
+	outputCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	output := &boundedBuffer{limit: limit, onExceeded: cancel}
+	cmd := exec.CommandContext(outputCtx, binary, args...)
 	cmd.Stdout = output
 	cmd.Stderr = output
 	err := cmd.Run()

--- a/pkg/tracing/task.go
+++ b/pkg/tracing/task.go
@@ -15,6 +15,7 @@
 package tracing
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"errors"
@@ -44,6 +45,8 @@ const (
 )
 
 var TaskBinDir = "bin"
+
+const maxTaskOutputBytes = 64 * 1024 * 1024
 
 type TaskStorageType int
 
@@ -93,7 +96,37 @@ var (
 	ErrTaskCanceled = errors.New("task canceled")
 	// ErrTaskLimitExceeded is returned when a new task would exceed the active limit.
 	ErrTaskLimitExceeded = errors.New("too many running tasks")
+	// ErrTaskOutputLimitExceeded is returned when a task produces too much output.
+	ErrTaskOutputLimitExceeded = errors.New("task output limit exceeded")
 )
+
+type boundedBuffer struct {
+	buffer   bytes.Buffer
+	limit    int
+	exceeded bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buffer.Len()
+	if remaining <= 0 {
+		b.exceeded = true
+		return 0, ErrTaskOutputLimitExceeded
+	}
+	if len(p) <= remaining {
+		return b.buffer.Write(p)
+	}
+	n, _ := b.buffer.Write(p[:remaining])
+	b.exceeded = true
+	return n, ErrTaskOutputLimitExceeded
+}
+
+func (b *boundedBuffer) Bytes() []byte {
+	return b.buffer.Bytes()
+}
+
+func (b *boundedBuffer) String() string {
+	return b.buffer.String()
+}
 
 func init() {
 	go tasksGarbageCollect()
@@ -229,8 +262,12 @@ func runTask(ctx context.Context, task *task) {
 	task.status = StatusRunning
 	task.mu.Unlock()
 
-	cmd := exec.CommandContext(ctx, path.Join(TaskBinDir, task.execBinary), task.execArgs...)
-	output, err := cmd.CombinedOutput()
+	output, err := runTaskCommand(
+		ctx,
+		path.Join(TaskBinDir, task.execBinary),
+		task.execArgs,
+		maxTaskOutputBytes,
+	)
 	if err != nil {
 		contextErr := ctx.Err()
 		var taskErr error
@@ -238,6 +275,8 @@ func runTask(ctx context.Context, task *task) {
 			taskErr = ErrTaskTimeout
 		} else if errors.Is(contextErr, context.Canceled) {
 			taskErr = ErrTaskCanceled
+		} else if errors.Is(err, ErrTaskOutputLimitExceeded) {
+			taskErr = ErrTaskOutputLimitExceeded
 		} else {
 			taskErr = fmt.Errorf("task error: %s| cmd error: %s", err.Error(), string(output))
 		}
@@ -256,6 +295,18 @@ func runTask(ctx context.Context, task *task) {
 	task.status = StatusCompleted
 	task.deadlineTime = time.Now().Add(10 * time.Minute)
 	task.mu.Unlock()
+}
+
+func runTaskCommand(ctx context.Context, binary string, args []string, limit int) ([]byte, error) {
+	output := &boundedBuffer{limit: limit}
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
+	if output.exceeded {
+		err = ErrTaskOutputLimitExceeded
+	}
+	return output.Bytes(), err
 }
 
 func saveTaskOutputByType(task *task, startAt time.Time, output []byte) {

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -16,6 +16,7 @@ package tracing
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,6 +72,38 @@ func TestAllocTaskID(t *testing.T) {
 			t.Errorf("AllocTaskID contains invalid char %q", ch)
 			return
 		}
+	}
+}
+
+func TestBoundedBuffer(t *testing.T) {
+	buffer := &boundedBuffer{limit: 5}
+	n, err := io.WriteString(buffer, "1234567")
+	if !errors.Is(err, ErrTaskOutputLimitExceeded) {
+		t.Fatalf("Write() error = %v, want ErrTaskOutputLimitExceeded", err)
+	}
+	if n != 5 {
+		t.Fatalf("Write() bytes = %d, want 5", n)
+	}
+	if got := buffer.String(); got != "12345" {
+		t.Fatalf("buffer = %q, want %q", got, "12345")
+	}
+
+	n, err = io.WriteString(buffer, "8")
+	if n != 0 || !errors.Is(err, ErrTaskOutputLimitExceeded) {
+		t.Fatalf("second Write() = (%d, %v), want (0, ErrTaskOutputLimitExceeded)", n, err)
+	}
+}
+
+func TestRunTaskCommandLimitsCombinedOutput(t *testing.T) {
+	tmp := t.TempDir()
+	script := createExecutableScript(t, tmp, "noisy.sh", "#!/bin/sh\nprintf 1234567\n")
+
+	output, err := runTaskCommand(t.Context(), script, nil, 5)
+	if !errors.Is(err, ErrTaskOutputLimitExceeded) {
+		t.Fatalf("runTaskCommand() error = %v, want ErrTaskOutputLimitExceeded", err)
+	}
+	if got := string(output); got != "12345" {
+		t.Fatalf("runTaskCommand() output = %q, want %q", got, "12345")
 	}
 }
 

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -118,6 +118,8 @@ func TestRunTaskCommandKillsOutputLimitedProcess(t *testing.T) {
 	}
 	resultCh := make(chan result, 1)
 	go func() {
+		// The helper writes before sleeping, but this test only needs to
+		// observe that reaching the output limit wins promptly.
 		_, err := runTaskCommand(t.Context(), exe, []string{
 			"-test.run=^TestNoisySleepHelperProcess$",
 			"--",

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -107,6 +107,47 @@ func TestRunTaskCommandLimitsCombinedOutput(t *testing.T) {
 	}
 }
 
+func TestRunTaskCommandKillsOutputLimitedProcess(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable() error = %v", err)
+	}
+
+	type result struct {
+		output []byte
+		err    error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		output, err := runTaskCommand(t.Context(), exe, []string{
+			"-test.run=^TestNoisySleepHelperProcess$",
+			"--",
+			"noisy-sleep-helper",
+		}, 1024)
+		resultCh <- result{output: output, err: err}
+	}()
+
+	select {
+	case res := <-resultCh:
+		if !errors.Is(res.err, ErrTaskOutputLimitExceeded) {
+			t.Fatalf("runTaskCommand() error = %v, want ErrTaskOutputLimitExceeded", res.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runTaskCommand() did not kill the output-limited process promptly")
+	}
+}
+
+func TestNoisySleepHelperProcess(t *testing.T) {
+	for _, arg := range os.Args {
+		if arg == "noisy-sleep-helper" {
+			_, _ = os.Stdout.WriteString(strings.Repeat("x", 8192))
+			time.Sleep(time.Hour)
+			return
+		}
+	}
+	t.Skip("helper process only")
+}
+
 func TestNewTaskWithIDIsIdempotent(t *testing.T) {
 	clearTaskCache()
 	t.Cleanup(clearTaskCache)

--- a/pkg/tracing/task_test.go
+++ b/pkg/tracing/task_test.go
@@ -114,17 +114,16 @@ func TestRunTaskCommandKillsOutputLimitedProcess(t *testing.T) {
 	}
 
 	type result struct {
-		output []byte
-		err    error
+		err error
 	}
 	resultCh := make(chan result, 1)
 	go func() {
-		output, err := runTaskCommand(t.Context(), exe, []string{
+		_, err := runTaskCommand(t.Context(), exe, []string{
 			"-test.run=^TestNoisySleepHelperProcess$",
 			"--",
 			"noisy-sleep-helper",
 		}, 1024)
-		resultCh <- result{output: output, err: err}
+		resultCh <- result{err: err}
 	}()
 
 	select {


### PR DESCRIPTION
## Summary

- capture task stdout and stderr through a shared 64 MiB bounded buffer
- surface a dedicated task error when combined output reaches the limit
- retain existing timeout, cancellation, and successful-output behavior

## Why

`exec.Cmd.CombinedOutput` grows without a byte limit. A noisy or malfunctioning
tracing tool could exhaust the agent before its result is stored or returned.

Closes #702

## Testing

- `goimports` on changed Go files
- focused tests cover partial writes, repeated writes after the limit, and
  combined command output
- full Linux checks deferred to CI because generated BPF ABI packages are not
  available in the Windows checkout