### PR TITLE
fix(perf): validate duration before startup

### DIFF
--- a/cmd/perf/perf.go
+++ b/cmd/perf/perf.go
@@ -48,6 +48,10 @@ func mainAction(ctx *cli.Context) error {
 	bpfPath := ctx.String("bpf-path")
 	optPid := ctx.Uint64("pid")
 	optDuration := ctx.Int("duration")
+	duration, err := validatePerfDuration(optDuration)
+	if err != nil {
+		return err
+	}
 
 	var targetCssAddr uint64
 	if containerID := ctx.String("container-id"); containerID != "" {
@@ -90,7 +94,7 @@ func mainAction(ctx *cli.Context) error {
 	signal.Notify(signalWait, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGINT, syscall.SIGTERM)
 
 	select {
-	case <-time.After(time.Duration(optDuration) * time.Second):
+	case <-time.After(duration):
 	case <-ctx.Done():
 		return fmt.Errorf("caller requests stop")
 	case sig := <-signalWait:
@@ -109,6 +113,17 @@ func mainAction(ctx *cli.Context) error {
 	}
 
 	return nil
+}
+
+func validatePerfDuration(seconds int) (time.Duration, error) {
+	const maxSeconds = int64(time.Duration(1<<63-1) / time.Second)
+	if seconds <= 0 {
+		return 0, fmt.Errorf("duration must be greater than zero seconds")
+	}
+	if int64(seconds) > maxSeconds {
+		return 0, fmt.Errorf("duration exceeds maximum of %d seconds", maxSeconds)
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 func main() {

--- a/cmd/perf/perf_test.go
+++ b/cmd/perf/perf_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidatePerfDuration(t *testing.T) {
+	const maxSeconds = int64(time.Duration(1<<63-1) / time.Second)
+	tests := []struct {
+		name      string
+		seconds   int
+		want      time.Duration
+		wantError string
+	}{
+		{name: "zero", seconds: 0, wantError: "greater than zero"},
+		{name: "negative", seconds: -1, wantError: "greater than zero"},
+		{name: "valid", seconds: 5, want: 5 * time.Second},
+		{
+			name:      "overflow",
+			seconds:   int(maxSeconds + 1),
+			wantError: "exceeds maximum",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validatePerfDuration(tt.seconds)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("validatePerfDuration() error = %v, want %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validatePerfDuration() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("validatePerfDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- reject zero and negative `--duration` values
- reject seconds that overflow `time.Duration`
- validate before container lookup or BPF initialization

## Why

Invalid values currently create immediate or overflowed timers and are also
forwarded to BPF keepalive setup, producing unintended collection behavior.

Closes #703

## Testing

- `goimports` on changed Go files
- table-driven tests cover zero, negative, valid, and overflow values
- full Linux checks deferred to CI because generated BPF ABI packages are not
  available in the Windows checkout