### PR TITLE
fix(container): bound API response bodies

### DIFF
--- a/internal/command/container/container.go
+++ b/internal/command/container/container.go
@@ -17,16 +17,27 @@ package container
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
+	"huatuo-bamai/internal/httputil"
 	"huatuo-bamai/internal/pod"
 )
 
 func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
+	return getContainersWithLimits(
+		serverAddr,
+		containerID,
+		httputil.DefaultResponseBodyLimit,
+		httputil.DefaultErrorBodyLimit,
+	)
+}
+
+func getContainersWithLimits(
+	serverAddr, containerID string,
+	responseLimit, errorLimit int64,
+) ([]*pod.Container, error) {
 	client := &http.Client{
 		Timeout: 3 * time.Second,
 	}
@@ -47,11 +58,31 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		body, _, err := httputil.ReadLimitedBody(resp.Body, errorLimit)
 		if err != nil {
 			return nil, fmt.Errorf("get container failed, status code: %d, read body: %w", resp.StatusCode, err)
 		}
-		return nil, fmt.Errorf("get container failed, status code: %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf(
+			"get container failed, status code: %d, body: %s",
+			resp.StatusCode,
+			httputil.ErrorPreview(body, errorLimit),
+		)
+	}
+
+	if resp.ContentLength > responseLimit {
+		return nil, fmt.Errorf(
+			"get container failed: response body declares %d bytes, limit is %d bytes",
+			resp.ContentLength,
+			responseLimit,
+		)
+	}
+
+	body, truncated, err := httputil.ReadLimitedBody(resp.Body, responseLimit)
+	if err != nil {
+		return nil, fmt.Errorf("get container failed: read response body: %w", err)
+	}
+	if truncated {
+		return nil, fmt.Errorf("get container failed: response body exceeds %d bytes", responseLimit)
 	}
 
 	type containersResp struct {
@@ -61,7 +92,7 @@ func getContainers(serverAddr, containerID string) ([]*pod.Container, error) {
 	}
 
 	var ctResp containersResp
-	if err := json.NewDecoder(resp.Body).Decode(&ctResp); err != nil {
+	if err := json.Unmarshal(body, &ctResp); err != nil {
 		return nil, fmt.Errorf("containersResp decode failed: %w", err)
 	}
 

--- a/internal/command/container/container.go
+++ b/internal/command/container/container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package container
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -92,7 +93,7 @@ func getContainersWithLimits(
 	}
 
 	var ctResp containersResp
-	if err := json.Unmarshal(body, &ctResp); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&ctResp); err != nil {
 		return nil, fmt.Errorf("containersResp decode failed: %w", err)
 	}
 

--- a/internal/command/container/container_test.go
+++ b/internal/command/container/container_test.go
@@ -40,6 +40,59 @@ func TestGetContainersIncludesErrorBody(t *testing.T) {
 	}
 }
 
+func TestGetContainersBoundsResponseBodies(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        int
+		body          string
+		contentLength string
+		streamed      bool
+		want          string
+	}{
+		{
+			name:          "declared success response",
+			status:        http.StatusOK,
+			contentLength: "65",
+			want:          "declares 65 bytes, limit is 64 bytes",
+		},
+		{
+			name:     "streamed success response",
+			status:   http.StatusOK,
+			body:     strings.Repeat("x", 65),
+			streamed: true,
+			want:     "response body exceeds 64 bytes",
+		},
+		{
+			name:   "error preview",
+			status: http.StatusServiceUnavailable,
+			body:   "backend unavailable",
+			want:   "back... [truncated after 4 bytes]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.contentLength != "" {
+					w.Header().Set("Content-Length", tt.contentLength)
+				}
+				w.WriteHeader(tt.status)
+				if tt.streamed {
+					w.(http.Flusher).Flush()
+				}
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			serverAddr := strings.TrimPrefix(server.URL, "http://")
+			_, err := getContainersWithLimits(serverAddr, "", 64, 4)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("getContainersWithLimits() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetContainersCompatibility(t *testing.T) {
 	var requestedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/command/container/container_test.go
+++ b/internal/command/container/container_test.go
@@ -141,6 +141,22 @@ func TestGetContainersCompatibility(t *testing.T) {
 	}
 }
 
+func TestGetContainersPreservesFirstJSONValue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{"code":0,"message":"success","data":[]}trailing`)
+	}))
+	defer server.Close()
+
+	serverAddr := strings.TrimPrefix(server.URL, "http://")
+	containers, err := getContainers(serverAddr, "")
+	if err != nil {
+		t.Fatalf("getContainers() error = %v", err)
+	}
+	if len(containers) != 0 {
+		t.Fatalf("len(containers) = %d, want 0", len(containers))
+	}
+}
+
 // TestGetContainersURLEscaped verifies that containerID containing URL-special
 // characters (e.g. +, &) is properly URL-escaped in the query string.
 func TestGetContainersURLEscaped(t *testing.T) {

--- a/internal/httputil/body.go
+++ b/internal/httputil/body.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httputil contains bounded HTTP response helpers shared by clients.
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strings"
+)
+
+const (
+	// DefaultResponseBodyLimit covers dense kubelet responses while bounding
+	// memory used by local HTTP clients.
+	DefaultResponseBodyLimit = 128 << 20
+	// DefaultErrorBodyLimit keeps diagnostic text useful without echoing an
+	// arbitrarily large response into an error.
+	DefaultErrorBodyLimit = 8 << 10
+)
+
+// ReadLimitedBody reads at most limit+1 bytes so callers can distinguish an
+// exact-limit response from a truncated one.
+func ReadLimitedBody(body io.Reader, limit int64) ([]byte, bool, error) {
+	if limit <= 0 || limit == math.MaxInt64 {
+		return nil, false, fmt.Errorf("invalid response byte limit %d", limit)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	return data, int64(len(data)) > limit, nil
+}
+
+// ErrorPreview formats bounded response text and marks truncated diagnostics.
+func ErrorPreview(body []byte, limit int64) string {
+	truncated := int64(len(body)) > limit
+	if truncated {
+		body = body[:limit]
+	}
+
+	message := strings.TrimSpace(string(body))
+	if truncated {
+		message += fmt.Sprintf("... [truncated after %d bytes]", limit)
+	}
+	return message
+}

--- a/internal/httputil/body_test.go
+++ b/internal/httputil/body_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputil
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingReader struct {
+	err error
+}
+
+func (r failingReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestReadLimitedBody(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		limit         int64
+		wantBody      string
+		wantTruncated bool
+		wantErr       bool
+	}{
+		{name: "below limit", body: "abc", limit: 4, wantBody: "abc"},
+		{name: "exact limit", body: "abcd", limit: 4, wantBody: "abcd"},
+		{name: "over limit", body: "abcdef", limit: 4, wantBody: "abcde", wantTruncated: true},
+		{name: "zero limit", body: "a", limit: 0, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, truncated, err := ReadLimitedBody(strings.NewReader(tt.body), tt.limit)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ReadLimitedBody() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if string(got) != tt.wantBody {
+				t.Errorf("ReadLimitedBody() body = %q, want %q", got, tt.wantBody)
+			}
+			if truncated != tt.wantTruncated {
+				t.Errorf("ReadLimitedBody() truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+		})
+	}
+}
+
+func TestReadLimitedBodyPropagatesReadError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	if _, _, err := ReadLimitedBody(failingReader{err: wantErr}, 8); !errors.Is(err, wantErr) {
+		t.Fatalf("ReadLimitedBody() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestErrorPreview(t *testing.T) {
+	if got := ErrorPreview([]byte("  failure  \n"), 32); got != "failure" {
+		t.Errorf("ErrorPreview() = %q, want %q", got, "failure")
+	}
+	want := "fail... [truncated after 4 bytes]"
+	if got := ErrorPreview([]byte("failure"), 4); got != want {
+		t.Errorf("ErrorPreview() = %q, want %q", got, want)
+	}
+}

--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -21,13 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"strings"
 	"syscall"
 	"time"
 
+	"huatuo-bamai/internal/httputil"
 	"huatuo-bamai/internal/log"
 	"huatuo-bamai/internal/utils/netutil"
 
@@ -39,8 +39,8 @@ import (
 const (
 	kubeletReqTimeout                       = 5 * time.Second
 	kubeletOversizedResponseWarningInterval = 30 * time.Minute
-	maxKubeletResponseBodyBytes             = 128 << 20
-	maxKubeletErrorBodyBytes                = 8 << 10
+	maxKubeletResponseBodyBytes             = httputil.DefaultResponseBodyLimit
+	maxKubeletErrorBodyBytes                = httputil.DefaultErrorBodyLimit
 )
 
 var (
@@ -424,31 +424,11 @@ func httpDoRequest(client *http.Client, url string) ([]byte, error) {
 }
 
 func requestLimitedBody(body io.Reader, limit int64) ([]byte, bool, error) {
-	if limit <= 0 || limit == math.MaxInt64 {
-		return nil, false, fmt.Errorf("invalid response byte limit %d", limit)
-	}
-	data, err := io.ReadAll(io.LimitReader(body, limit+1))
-	if err != nil {
-		return nil, false, err
-	}
-	if int64(len(data)) <= limit {
-		return data, false, nil
-	}
-	// Preserve the probe byte so error formatting can identify truncation without
-	// carrying separate state.
-	return data, true, nil
+	return httputil.ReadLimitedBody(body, limit)
 }
 
 func requestErrorBody(body []byte) string {
-	truncated := len(body) > maxKubeletErrorBodyBytes
-	if len(body) > maxKubeletErrorBodyBytes {
-		body = body[:maxKubeletErrorBodyBytes]
-	}
-	message := strings.TrimSpace(string(body))
-	if truncated {
-		message += fmt.Sprintf("... [truncated after %d bytes]", maxKubeletErrorBodyBytes)
-	}
-	return message
+	return httputil.ErrorPreview(body, maxKubeletErrorBodyBytes)
 }
 
 // func updateKubeletContainer(containerID string, container *corev1.Container, containerStatus *corev1.ContainerStatus, pod *corev1.Pod, css map[string]uint64) error {


### PR DESCRIPTION
## Summary
- extract shared helpers for bounded HTTP response reads and error previews
- reuse them in the kubelet and container API clients
- reject oversized declared and streamed success bodies while bounding error diagnostics

This follows the common-helper direction discussed in #692 after #662.

## Testing
- make check
- make unit

Fixes #692