### PR TITLE
test(cgroups): cover unlimited memory limit

### DIFF
--- a/internal/cgroups/v2/cgroups_test.go
+++ b/internal/cgroups/v2/cgroups_test.go
@@ -15,6 +15,7 @@
 package v2
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -339,6 +340,71 @@ func TestCpuQuotaAndPeriodEffectiveCPUCount(t *testing.T) {
 			}
 			if quota.EffectiveCPUCount != tt.want {
 				t.Errorf("EffectiveCPUCount = %d, want %d", quota.EffectiveCPUCount, tt.want)
+			}
+		})
+	}
+}
+
+func TestMemoryUsage(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := paths.RootfsDefaultPath
+	paths.RootfsDefaultPath = root
+	t.Cleanup(func() { paths.RootfsDefaultPath = oldRoot })
+
+	tests := []struct {
+		name      string
+		current   string
+		maximum   string
+		wantUsage uint64
+		wantMax   uint64
+		wantErr   bool
+	}{
+		{
+			name:      "limited",
+			current:   "1024\n",
+			maximum:   "2048\n",
+			wantUsage: 1024,
+			wantMax:   2048,
+		},
+		{
+			name:      "unlimited",
+			current:   "1024\n",
+			maximum:   "max\n",
+			wantUsage: 1024,
+			wantMax:   math.MaxUint64,
+		},
+		{
+			name:    "invalid current",
+			current: "invalid\n",
+			maximum: "2048\n",
+			wantErr: true,
+		},
+		{
+			name:    "invalid max",
+			current: "1024\n",
+			maximum: "invalid\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join("memory", tt.name)
+			writeCgroupFile(t, paths.Path(path, "memory.current"), tt.current)
+			writeCgroupFile(t, paths.Path(path, "memory.max"), tt.maximum)
+
+			got, err := (&CgroupV2{}).MemoryUsage(path)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MemoryUsage() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.Usage != tt.wantUsage {
+				t.Errorf("MemoryUsage().Usage = %d, want %d", got.Usage, tt.wantUsage)
+			}
+			if got.MaxLimited != tt.wantMax {
+				t.Errorf("MemoryUsage().MaxLimited = %d, want %d", got.MaxLimited, tt.wantMax)
 			}
 		})
 	}

--- a/internal/utils/parseutil/parseutils_test.go
+++ b/internal/utils/parseutil/parseutils_test.go
@@ -51,7 +51,8 @@ func TestReadUint(t *testing.T) {
 		want    uint64
 		wantErr bool
 	}{
-		{"max", strconv.FormatUint(math.MaxUint64, 10) + "\n", math.MaxUint64, false},
+		{"max keyword", "max\n", math.MaxUint64, false},
+		{"max uint64", strconv.FormatUint(math.MaxUint64, 10) + "\n", math.MaxUint64, false},
 		{"trimmed", " 2026 ", 2026, false},
 		{"invalid", "huatuo", 0, true},
 		{"empty", "", 0, true},


### PR DESCRIPTION
## Description

Adds unit-test coverage for `CgroupV2.MemoryUsage`, including the unlimited-memory case (`memory.max` containing the `max` keyword), and fixes a misleading `parseutil.ReadUint` test case.

## Problem

- `CgroupV2.MemoryUsage` had no unit test at all.
- The existing `parseutil` table case labeled `"max"` actually fed the numeric string `strconv.FormatUint(math.MaxUint64, 10)` instead of the literal `max` keyword, so the keyword branch of `ReadUint` was untested.

## Changes

- `internal/cgroups/v2/cgroups_test.go`: add a table-driven `TestMemoryUsage` covering limited, unlimited (`max`), and invalid inputs.
- `internal/utils/parseutil/parseutils_test.go`: split the `"max"` case into `"max keyword"` (literal `max\n`) and `"max uint64"` (numeric string) so both branches are exercised.

No production code is changed.

## Verification

- Base SHA: `ae0badc0` (tip of `main` at the time of the branch; branch is rebased on it).
- `go test ./internal/utils/parseutil/...` — ok (macOS, Go 1.24.7).
- `go test ./internal/cgroups/v2/...` — ok (linux/arm64 Docker container, `golang:1.24`, `-mod=vendor`).

## Risk

None: test-only change.

## AI assistance disclosure

This patch was prepared by an autonomous AI coding agent at the direction of the account owner, following the repository's CONTRIBUTING guide (fork, branch, conventional commit, DCO sign-off).