### PR TITLE
fix(profiler): split java collapsed stacks into per-frame samples

### DIFF
--- a/cmd/profiler/provider/java_aggregator.go
+++ b/cmd/profiler/provider/java_aggregator.go
@@ -78,7 +78,10 @@ func (a *javaAggregator) Aggregate(rec any) {
 			continue
 		}
 
-		frames := []string{fmt.Sprintf("process %d", so.PID), stack}
+		// Frames must be one element per frame: the raw formatter rewrites
+		// ';' inside a frame to ':', which would weld the whole collapsed
+		// stack into a single frame.
+		frames := append([]string{fmt.Sprintf("process %d", so.PID)}, strings.Split(stack, ";")...)
 		if err := a.formatter.Add(&output.Sample{Frames: frames, Count: count}); err != nil {
 			log.Warnf("formatter add sample: %v", err)
 		}

--- a/cmd/profiler/provider/java_aggregator_test.go
+++ b/cmd/profiler/provider/java_aggregator_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"bytes"
+	"testing"
+
+	"huatuo-bamai/internal/profiler"
+	pcontext "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/profiler/output"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJavaAggregatorSplitsCollapsedFrames(t *testing.T) {
+	pctx := &pcontext.ProfilerContext{Freq: 99, OutputFormat: output.FormatCollapsed}
+	aggr, err := newJavaAggregator(pctx)
+	require.NoError(t, err)
+
+	aggr.Aggregate(profiler.SampleOutput{
+		PID:    1234,
+		Output: "HotCode.main;HotCode.hotMethod;java/util/UUID.randomUUID 42\n",
+	})
+	aggr.Aggregate(profiler.SampleOutput{
+		PID:    1234,
+		Output: "HotCode.main;HotCode.hotMethod;java/util/UUID.randomUUID 8\n",
+	})
+
+	var folded bytes.Buffer
+	require.NoError(t, aggr.OutputFormatter().Write(&folded))
+	require.Equal(
+		t,
+		"process 1234;HotCode.main;HotCode.hotMethod;java/util/UUID.randomUUID 50\n",
+		folded.String(),
+	)
+}


### PR DESCRIPTION
Fixes #722.

## Problem / Evidence

`javaAggregator.Aggregate` (cmd/profiler/provider/java_aggregator.go) built each sample as

```go
frames := []string{fmt.Sprintf("process %d", so.PID), stack}
```

where `stack` is the whole semicolon-joined collapsed line emitted by async-profiler. The `output.Sample.Frames` contract is **one element per frame**, and the raw formatter (`internal/profiler/output/raw/raw.go`, `writeFoldedFrame`) rewrites every `;` inside a frame to `:`. The asprof input format is the one documented in this repo (`internal/profiler/profiler.go`, `ParseCollapsedData`):

```
HotCode.main;HotCode.hotmethod3;java/util/UUID.randomUUID;... 1
```

So every local-file output (collapsed is the CLI default, plus flamegraph/svg) welded the **entire Java call tree into a single bogus frame**. Verbatim regression-test output, before the fix (line produced by the new test):

```
process 1234;HotCode.main:HotCode.hotMethod:java/util/UUID.randomUUID 50
```

after the fix:

```
process 1234;HotCode.main;HotCode.hotMethod;java/util/UUID.randomUUID 50
```

The java upload/pprof path is unaffected: `ParseCollapsedData` splits collapsed stacks itself; only the local formatter path was missed. The python aggregator already does the correct split (`strings.Split(stack, ";")` in python_aggregator.go), and the native aggregator appends one frame per element.

## Root cause / Fix

Split the collapsed stack on `;` before handing it to the formatter, mirroring the python aggregator:

```go
// Frames must be one element per frame: the raw formatter rewrites
// ';' inside a frame to ':', which would weld the whole collapsed
// stack into a single frame.
frames := append([]string{fmt.Sprintf("process %d", so.PID)}, strings.Split(stack, ";")...)
```

## Priority

PRIORITY 80/100: impact 30 (default collapsed/flamegraph output for Java profiling - a flagship use case - renders a useless two-level graph), scope 15 (all local formatter outputs for java profiles), reproducibility 20 (deterministic, pure in-process), maintenance 15 (restores the Frames contract and python-path parity). FIX_CONFIDENCE 90.

## Tests

Regression test `TestJavaAggregatorSplitsCollapsedFrames` (cmd/profiler/provider/java_aggregator_test.go): feeds two asprof-style collapsed lines, asserts the folded output frame-by-frame including count accumulation (42 + 8 = 50).

```
$ go test ./cmd/profiler/provider/ -run TestJavaAggregatorSplitsCollapsedFrames -v
--- FAIL before fix:
    --- Expected: "process 1234;HotCode.main;HotCode.hotMethod;java/util/UUID.randomUUID 50"
    +++ Actual:   "process 1234;HotCode.main:HotCode.hotMethod:java/util/UUID.randomUUID 50"
--- PASS after fix
$ go test ./cmd/profiler/provider/
ok  	huatuo-bamai/cmd/profiler/provider	0.017s
$ go test ./... -timeout=6m      # full suite on this branch: exit 0
```

`gofmt -l` and `go vet` clean.

## CI

All green on this branch: `Build, Lint and Vendor` pass; `Test in VM` pass on ubuntu 20.04 / 22.04 / 24.04 / 26.04; `pr_name_lint` pass.
Note that the VM environment skips the sampling-dependent java profiler integration tests (`perf_event_paranoid=4`, asprof absent), so the folded-output fix above is covered by the unit regression test, not exercised by CI.

## Risk

Low. Only the java local collapsed/flamegraph/svg output changes; aggregation counts, upload path, and other languages are untouched.
