### PR TITLE
fix(cgroups): treat v1 unlimited memory limit as unlimited

### DIFF
--- a/internal/cgroups/v1/cgroups.go
+++ b/internal/cgroups/v1/cgroups.go
@@ -175,11 +175,17 @@ func (c *CgroupV1) MemoryUsage(path string) (*stats.MemoryUsage, error) {
 		return nil, err
 	}
 
-	maxLimited, err := parseutil.ReadUint(paths.Path(subsystem.SubsystemMemory,
+	// cgroup v1 reports an unlimited memcg as -1, which ReadUint cannot
+	// parse; return the same MaxUint64 sentinel the unlimited CPU quota
+	// uses in CpuQuotaAndPeriod and that the v2 "max" read produces.
+	maxLimited, err := parseutil.ReadInt(paths.Path(subsystem.SubsystemMemory,
 		path, "memory.limit_in_bytes"))
 	if err != nil {
 		return nil, err
 	}
+	if maxLimited == -1 {
+		return &stats.MemoryUsage{Usage: usage, MaxLimited: math.MaxUint64}, nil
+	}
 
-	return &stats.MemoryUsage{Usage: usage, MaxLimited: maxLimited}, nil
+	return &stats.MemoryUsage{Usage: usage, MaxLimited: uint64(maxLimited)}, nil
 }

--- a/internal/cgroups/v1/cgroups_test.go
+++ b/internal/cgroups/v1/cgroups_test.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -87,19 +88,33 @@ func TestMemoryUsageHandlesUnlimitedLimit(t *testing.T) {
 	paths.RootfsDefaultPath = root
 	t.Cleanup(func() { paths.RootfsDefaultPath = oldRoot })
 
-	path := filepath.Join("test", "memusage")
-	writeCgroupFile(t, paths.Path(subsystem.SubsystemMemory, path, "memory.usage_in_bytes"), "4096\n")
-	writeCgroupFile(t, paths.Path(subsystem.SubsystemMemory, path, "memory.limit_in_bytes"), "-1\n")
-
-	usage, err := (&CgroupV1{}).MemoryUsage(path)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		limit    string
+		wantMax  uint64
+		wantUsed uint64
+	}{
+		// cgroup v1 reports an unlimited memcg as -1; the unlimited CPU
+		// quota path already maps the same sentinel to MaxUint64.
+		{name: "unlimited", limit: "-1\n", wantMax: math.MaxUint64, wantUsed: 4096},
+		{name: "decimalLimit", limit: "1073741824\n", wantMax: 1073741824, wantUsed: 2048},
 	}
 
-	// cgroup v1 reports an unlimited memcg as -1; the unlimited CPU quota
-	// path already maps the same sentinel to MaxUint64.
-	if usage.Usage != 4096 || usage.MaxLimited != math.MaxUint64 {
-		t.Errorf("MemoryUsage() = %+v, want Usage=4096 MaxLimited=MaxUint64", usage)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join("test", tt.name)
+			writeCgroupFile(t, paths.Path(subsystem.SubsystemMemory, path, "memory.usage_in_bytes"), fmt.Sprintf("%d\n", tt.wantUsed))
+			writeCgroupFile(t, paths.Path(subsystem.SubsystemMemory, path, "memory.limit_in_bytes"), tt.limit)
+
+			usage, err := (&CgroupV1{}).MemoryUsage(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if usage.Usage != tt.wantUsed || usage.MaxLimited != tt.wantMax {
+				t.Errorf("MemoryUsage() = %+v, want Usage=%d MaxLimited=%d", usage, tt.wantUsed, tt.wantMax)
+			}
+		})
 	}
 }
 

--- a/internal/cgroups/v1/cgroups_test.go
+++ b/internal/cgroups/v1/cgroups_test.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,6 +78,28 @@ func TestCpuQuotaAndPeriodEffectiveCPUCount(t *testing.T) {
 				t.Errorf("EffectiveCPUCount = %d, want %d", quota.EffectiveCPUCount, tt.want)
 			}
 		})
+	}
+}
+
+func TestMemoryUsageHandlesUnlimitedLimit(t *testing.T) {
+	root := t.TempDir()
+	oldRoot := paths.RootfsDefaultPath
+	paths.RootfsDefaultPath = root
+	t.Cleanup(func() { paths.RootfsDefaultPath = oldRoot })
+
+	path := filepath.Join("test", "memusage")
+	writeCgroupFile(t, paths.Path(subsystem.SubsystemMemory, path, "memory.usage_in_bytes"), "4096\n")
+	writeCgroupFile(t, paths.Path(subsystem.SubsystemMemory, path, "memory.limit_in_bytes"), "-1\n")
+
+	usage, err := (&CgroupV1{}).MemoryUsage(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// cgroup v1 reports an unlimited memcg as -1; the unlimited CPU quota
+	// path already maps the same sentinel to MaxUint64.
+	if usage.Usage != 4096 || usage.MaxLimited != math.MaxUint64 {
+		t.Errorf("MemoryUsage() = %+v, want Usage=4096 MaxLimited=MaxUint64", usage)
 	}
 }
 


### PR DESCRIPTION
## Problem / Evidence

`CgroupV1.MemoryUsage` (internal/cgroups/v1/cgroups.go) reads `memory.limit_in_bytes` with `parseutil.ReadUint`. On cgroup v1 an **unlimited** memcg holds the literal `-1` in that file - the kernel documents that writing `-1` resets the limit to unlimited (Documentation/admin-guide/cgroup-v1/memory.rst, "We can write '-1' to reset the `*.limit_in_bytes` (unlimited)"), and reading it back yields `-1`. `ReadUint` only knows the cgroup v2 `max` sentinel, so it fails:

```
$ go test ./internal/cgroups/v1/ -run TestMemoryUsageHandlesUnlimitedLimit -v   # before the fix
    cgroups_test.go:96: strconv.ParseUint: parsing "-1": invalid syntax
--- FAIL: TestMemoryUsageHandlesUnlimitedLimit
```

**Call path and consequence** (both verified in-tree): BPF OOM event -> `oomEventLoop` -> `buildTracingData` -> `cgroupMemorySnapshot` (core/events/oom_snapshot.go:76) -> `cgroup.MemoryUsage(container.CgroupPath)`. The returned error aborts the whole cgroup snapshot, so the OOM tracing record loses `current`, `max`, `memory.stat` and `memory.events` - the forensic fields that matter most. On cgroup v1 hosts (Legacy/Hybrid, both supported by `internal/cgroups/cgroups.go`), every container without a memory limit hits this; unlimited memcgs are the default for pods without memory limits.

The v1 CPU path already handles the identical sentinel explicitly (`quota == -1` -> `math.MaxUint64` in `CpuQuotaAndPeriod`), which shows the intended pattern; the memory path was missed. (Related open issue #637 discusses the v2 `max` sentinel; current v2 code already maps it via `ReadUint`, so this PR deliberately touches the v1 `-1` case only.)

## Root cause / Fix

Read the limit with `parseutil.ReadInt` and map `-1` to `math.MaxUint64`, matching the unlimited CPU quota representation and the v2 `max` read:

```go
maxLimited, err := parseutil.ReadInt(paths.Path(subsystem.SubsystemMemory,
	path, "memory.limit_in_bytes"))
if err != nil {
	return nil, err
}
if maxLimited == -1 {
	return &stats.MemoryUsage{Usage: usage, MaxLimited: math.MaxUint64}, nil
}
```

## Priority

PRIORITY 78/100: impact 30 (OOM forensics silently lost on cgroup v1 hosts for the common unlimited-container case), scope 14 (OOM snapshot path; single consumer), reproducibility 18 (deterministic fixture repro), maintenance 16 (sibling `-1` handling already exists in the CPU path). FIX_CONFIDENCE 90.

## Tests

Fixture-backed tests via `paths.RootfsDefaultPath` override (internal/cgroups/v1/cgroups_test.go, `TestMemoryUsageHandlesUnlimitedLimit`, table-driven):

- `unlimited`: `memory.limit_in_bytes = -1` -> `MaxLimited = MaxUint64`, `Usage` passed through. **Fails before the fix** (output above), passes after.
- `decimalLimit`: `memory.limit_in_bytes = 1073741824` -> unchanged passthrough (guards the `ReadUint` -> `ReadInt` switch).

```
$ go test ./internal/cgroups/v1/ -run TestMemoryUsageHandlesUnlimitedLimit -v
--- PASS: TestMemoryUsageHandlesUnlimitedLimit (0.00s)
    --- PASS: TestMemoryUsageHandlesUnlimitedLimit/unlimited (0.00s)
    --- PASS: TestMemoryUsageHandlesUnlimitedLimit/decimalLimit (0.00s)
$ go test ./internal/cgroups/... ./core/events/ ./pkg/tracing/   # consumers
ok  huatuo-bamai/internal/cgroups/v1 ... ok huatuo-bamai/core/events ... ok huatuo-bamai/pkg/tracing
$ go test ./... -timeout=6m      # full suite on this branch: exit 0
```

`gofmt -l` and `go vet` clean.

## CI

First commit: `Build, Lint and Vendor` pass, `pr_name_lint` pass; VM integration pass on ubuntu 20.04 / 24.04 / 26.04. On ubuntu 22.04, `test_tcp_retransmit_fast.sh` failed ("tcpshark produced no retransmit events"), which is unrelated to this change: the commit only touches `internal/cgroups/v1` (no BPF/tcpshark/retransmit code), the same commit passed the identical test on the other three distros, and the same 22.04 suite passed for sibling PRs #716/#718 raised in the same window. Recorded as environment flake. A fresh CI run for the test-only second commit failed in all four VMs during environment setup, before the repository was built: `.github/workflows/scripts/qemu-2-run-in-vm.sh:137` runs `go install mvdan.cc/sh/v3/cmd/shfmt@latest`, and the newly released shfmt v3.14.0 requires go >= 1.26.0 while the VM images ship go 1.24.0 (the toolchain auto-download then also failed on the proxy). This breaks the VM workflow for every branch right now and is unrelated to the code here. The relevant CI signal remains the first commit's run described above; the test-only commit itself passes locally (`go test ./internal/cgroups/v1/`, see Tests).

## Risk

Low. Only the v1 unlimited-limit reading changes (`error` -> `MaxUint64`); decimal limits, usage reading, and the v2 path are untouched (covered by the new `decimalLimit` case).
