### PR TITLE
fix(profiler): drop net-negative stacks from folded output

### DIFF
--- a/internal/profiler/output/raw/raw.go
+++ b/internal/profiler/output/raw/raw.go
@@ -48,12 +48,9 @@ func (f *Formatter) Add(s *output.Sample) error {
 	}
 	key := foldedStackKey(s.Frames)
 	f.counts[key] += s.Count
-	if f.counts[key] <= 0 {
-		// Zero and net-negative stacks have no visual weight in folded
-		// output and would render as zero/negative-width frames; negative
-		// counts only occur as physical_usage free events, which the pprof
-		// path also skips when a stack nets negative. Do not remove this
-		// deletion unless such stacks become part of the output contract.
+	if f.counts[key] == 0 {
+		// Zero-count stacks have no visual weight and make empty profiles appear non-empty.
+		// Do not remove this deletion unless zero-count stacks become part of the output contract.
 		delete(f.counts, key)
 	}
 	return nil
@@ -103,7 +100,15 @@ func writeFoldedFrame(key *strings.Builder, frame string) {
 func (f *Formatter) Write(w io.Writer) error {
 	keys := make([]string, 0, len(f.counts))
 
-	for k := range f.counts {
+	for k, count := range f.counts {
+		// Net-negative and zero-count stacks have no visual weight in
+		// folded output; negative counts come from physical_usage free
+		// events, which the pprof path also drops when a stack nets
+		// negative. Filtering here (not in Add) keeps every running sum
+		// exact, so a stack that nets positive still shows its full net.
+		if count <= 0 {
+			continue
+		}
 		keys = append(keys, k)
 	}
 
@@ -122,13 +127,27 @@ func (f *Formatter) Reset() {
 	f.counts = make(map[string]int64)
 }
 
-// IsEmpty reports whether the formatter contains no samples.
+// IsEmpty reports whether the formatter contains no visible samples.
+// Stacks with a non-positive net count are dropped from output, so they do
+// not count as samples here either.
 func (f *Formatter) IsEmpty() bool {
-	return len(f.counts) == 0
+	for _, count := range f.counts {
+		if count > 0 {
+			return false
+		}
+	}
+	return true
 }
 
-// Counts returns the accumulated stack-to-count map. The returned map
-// must not be modified; callers should treat it as read-only.
+// Counts returns a copy of the accumulated stack-to-count map, keeping only
+// stacks with a positive net count; see Write for why non-positive stacks
+// are excluded.
 func (f *Formatter) Counts() map[string]int64 {
-	return f.counts
+	counts := make(map[string]int64, len(f.counts))
+	for stack, count := range f.counts {
+		if count > 0 {
+			counts[stack] = count
+		}
+	}
+	return counts
 }

--- a/internal/profiler/output/raw/raw.go
+++ b/internal/profiler/output/raw/raw.go
@@ -48,9 +48,12 @@ func (f *Formatter) Add(s *output.Sample) error {
 	}
 	key := foldedStackKey(s.Frames)
 	f.counts[key] += s.Count
-	if f.counts[key] == 0 {
-		// Zero-count stacks have no visual weight and make empty profiles appear non-empty.
-		// Do not remove this deletion unless zero-count stacks become part of the output contract.
+	if f.counts[key] <= 0 {
+		// Zero and net-negative stacks have no visual weight in folded
+		// output and would render as zero/negative-width frames; negative
+		// counts only occur as physical_usage free events, which the pprof
+		// path also skips when a stack nets negative. Do not remove this
+		// deletion unless such stacks become part of the output contract.
 		delete(f.counts, key)
 	}
 	return nil

--- a/internal/profiler/output/raw/raw_test.go
+++ b/internal/profiler/output/raw/raw_test.go
@@ -47,8 +47,9 @@ func TestFormatterAdd_RemovesBalancedStack(t *testing.T) {
 
 func TestFormatterAdd_DropsNetNegativeStack(t *testing.T) {
 	// physical_usage free events report negative page counts
-	// (bpf/native_physical_usage.c); a stack that nets negative must not
-	// surface in folded output, matching the pprof path's net-negative skip.
+	// (bpf/native_physical_usage.c); stacks must net exactly, and a stack
+	// that nets non-positive must not surface in folded output, matching
+	// the pprof path's net-negative skip.
 	formatter := New()
 	freeFrames := []string{"process 123:worker", "folio_remove_rmap_ptes"}
 
@@ -73,6 +74,25 @@ func TestFormatterAdd_DropsNetNegativeStack(t *testing.T) {
 	const want = "process 123:worker;page_alloc 70\n"
 	if got.String() != want {
 		t.Fatalf("output = %q, want %q", got.String(), want)
+	}
+
+	// A stack whose running sum dips negative mid-window must keep its
+	// full net (+100 -150 +200 = 150), not just the part allocated after
+	// the dip.
+	formatter = New()
+	for _, count := range []int64{100, -150, 200} {
+		if err := formatter.Add(&output.Sample{Frames: allocFrames, Count: count}); err != nil {
+			t.Fatalf("add sample: %v", err)
+		}
+	}
+
+	got.Reset()
+	if err := formatter.Write(&got); err != nil {
+		t.Fatalf("write formatter: %v", err)
+	}
+	const wantNet = "process 123:worker;page_alloc 150\n"
+	if got.String() != wantNet {
+		t.Fatalf("output = %q, want %q", got.String(), wantNet)
 	}
 }
 

--- a/internal/profiler/output/raw/raw_test.go
+++ b/internal/profiler/output/raw/raw_test.go
@@ -45,6 +45,37 @@ func TestFormatterAdd_RemovesBalancedStack(t *testing.T) {
 	}
 }
 
+func TestFormatterAdd_DropsNetNegativeStack(t *testing.T) {
+	// physical_usage free events report negative page counts
+	// (bpf/native_physical_usage.c); a stack that nets negative must not
+	// surface in folded output, matching the pprof path's net-negative skip.
+	formatter := New()
+	freeFrames := []string{"process 123:worker", "folio_remove_rmap_ptes"}
+
+	if err := formatter.Add(&output.Sample{Frames: freeFrames, Count: -256}); err != nil {
+		t.Fatalf("add free sample: %v", err)
+	}
+	if !formatter.IsEmpty() {
+		t.Fatalf("net-negative stack retained in formatter: %v", formatter.Counts())
+	}
+
+	allocFrames := []string{"process 123:worker", "page_alloc"}
+	for _, count := range []int64{100, -30} {
+		if err := formatter.Add(&output.Sample{Frames: allocFrames, Count: count}); err != nil {
+			t.Fatalf("add sample: %v", err)
+		}
+	}
+
+	var got bytes.Buffer
+	if err := formatter.Write(&got); err != nil {
+		t.Fatalf("write formatter: %v", err)
+	}
+	const want = "process 123:worker;page_alloc 70\n"
+	if got.String() != want {
+		t.Fatalf("output = %q, want %q", got.String(), want)
+	}
+}
+
 func TestFormatterAddNormalizesFoldedFrames(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Fixes #723.

## Problem / Evidence

In `physical_usage` memory mode the BPF free path emits negative page counts (`bpf/native_physical_usage.c`: `event->value = -nr_pages;` on folio unmap / free), and `nativeAggregator.Aggregate` (cmd/profiler/provider/native_aggregator.go:106) forwards every event to the output formatter, while the pprof upload path deliberately skips net-negative stacks (`snapshotCpuMemProfile`, `skipNegForPprof`, #673). The file-output path had no equivalent handling, so the default `collapsed` output (and flamegraph/svg, which share `raw.Formatter` via embedding) could contain:

```
process 1234;...;page_remove_rmap -256
```

Negative counts are not representable in folded-stack format, and the flamegraph renderer computes frame width from `SamplePercent`, producing negative-width frames.

**History of this draft (kept for review transparency):** the first cut fixed this by deleting stacks from the formatter as soon as the running sum turned non-positive. That was wrong in the other direction - it loses the earlier allocation phase when frees temporarily exceed allocs mid-window: `+100,-150,+200` folded to `200` instead of the true net `150`. The reviewer caught it; this rewrite filters at the **output** boundaries instead, so running sums stay exact.

## Root cause / Fix

`Add` now behaves exactly as before this PR (accumulate everything; delete only exact-zero sums, per f8dda795). Non-positive stacks are excluded where output is produced:

- `Write` (folded file) skips counts `<= 0`;
- `Counts()` returns a filtered copy, so the flamegraph/SVG renderer (its only caller, `toStacks`) never sees negative samples;
- `IsEmpty()` reports whether any positive-count stack remains, so the pipeline (internal/profiler/aggregator/pipeline.go:236) still skips writing a file for a free-only profile.

Every running sum is kept intact, so a stack's folded count equals its true net - the same value the pprof path would show.

## Priority

PRIORITY 80/100: impact 30 (default local output of physical_usage memory profiles must not contain negative counts, and nets must match the pprof path), scope 14 (folded file output; pprof path already correct), reproducibility 20 (deterministic in-process), maintenance 16 (aligns file output with the pprof contract and the f8dda795 zero-count precedent). FIX_CONFIDENCE 90.

## Tests

`TestFormatterAdd_DropsNetNegativeStack` (internal/profiler/output/raw/raw_test.go) now covers three behaviors, each verified against the states it guards:

| scenario | original main | 1st cut (Add-time delete) | this rewrite |
|---|---|---|---|
| free-only stack (`-256`) | FAIL: `-256` retained, written to output | pass | pass |
| `+100,-30` -> net `70` | pass | pass | pass |
| `+100,-150,+200` -> net `150` | pass | **FAIL: folded `200`** | pass |

Verbatim failures that pinned the two bugs:

```
# original main:
raw_test.go:60: net-negative stack retained in formatter: map[process 123:worker;folio_remove_rmap_ptes:-256]
# 1st cut:
raw_test.go:95: output = "process 123:worker;page_alloc 200\n", want "process 123:worker;page_alloc 150\n"

# this rewrite:
$ go test ./internal/profiler/output/raw/ -run TestFormatterAdd_DropsNetNegativeStack -v
--- PASS: TestFormatterAdd_DropsNetNegativeStack (0.00s)
$ go test ./internal/profiler/output/... ./cmd/profiler/provider/
ok  huatuo-bamai/internal/profiler/output/flamegraph ... ok raw ... ok provider
```

`TestFormatterAdd_RemovesBalancedStack` (+4096/-4096) still passes. Full suite on the branch: `go test ./... -timeout=6m` exit 0 (re-run after the rewrite). `gofmt -l` and `go vet` clean.

## CI

First commit: all green (`Build, Lint and Vendor`, 4x `Test in VM` incl. `test_profiler_native_mem_physical_usage.sh` which genuinely ran and passed, `pr_name_lint`). The rewrite commit triggers a fresh run; note the VM workflow is currently broken repo-wide for any new push (`qemu-2-run-in-vm.sh:137` installs `shfmt@latest`, whose newly released v3.14.0 requires go >= 1.26.0 vs the VM's go 1.24.0 - same failure documented on #717), so if the fresh run fails during environment setup that is the cause, not this change.

## Risk

Low. `Write`/`Counts`/`IsEmpty` now consistently exclude non-positive nets; `Counts()` returns a filtered copy (its only production caller is read-only). Stacks that net positive keep their exact net; free-only and net-negative stacks disappear from folded/flamegraph output exactly as from the pprof path.
