### PR TITLE
fix(events): degrade oom cgroup snapshot when manager init fails

### DIFF
--- a/core/events/oom_snapshot.go
+++ b/core/events/oom_snapshot.go
@@ -69,6 +69,12 @@ func hostMemorySnapshot() (*OOMMemorySnapshot, error) {
 }
 
 func cgroupMemorySnapshot(cgroup cgroups.Cgroup, container *pod.Container) (*OOMCgroupMemorySnapshot, error) {
+	if cgroup == nil {
+		// NewManager can fail (e.g. cgroupfs unavailable or unsupported
+		// mode); the collector then degrades to snapshot-less OOM events.
+		return nil, fmt.Errorf("cgroup manager is unavailable")
+	}
+
 	snapshot := &OOMCgroupMemorySnapshot{
 		Path: container.CgroupPath,
 	}

--- a/core/events/oom_snapshot_test.go
+++ b/core/events/oom_snapshot_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/bpf/abi"
+	"huatuo-bamai/internal/pod"
+)
+
+// Regression: when cgroups.NewManager() fails (e.g. cgroupfs unavailable,
+// cgroup mode unsupported), the oom collector keeps running with a nil
+// manager, and the first container OOM panicked in cgroupMemorySnapshot
+// instead of degrading to a snapshot-less event.
+func TestCgroupMemorySnapshotNilManagerReturnsError(t *testing.T) {
+	snapshot, err := cgroupMemorySnapshot(nil, &pod.Container{CgroupPath: "/kubepods/podabc/containerdef"})
+	if err == nil {
+		t.Fatalf("cgroupMemorySnapshot() err=nil, want error for nil cgroup manager")
+	}
+	if snapshot != nil {
+		t.Errorf("cgroupMemorySnapshot() snapshot=%+v, want nil", snapshot)
+	}
+}
+
+func TestBuildTracingDataWithoutCgroupManagerDegrades(t *testing.T) {
+	containers := map[string]*pod.Container{
+		"containerabc": {
+			ID:         "containerabc",
+			CgroupPath: "/kubepods/podabc/containerabc",
+			CgroupCss:  map[string]uint64{"memory": 0x1234},
+		},
+	}
+
+	data := buildTracingData(abi.OOMEvent{
+		TriggerMemcgCSS: 0x1234,
+		VictimMemcgCSS:  0x1234,
+	}, containers, nil)
+
+	if data == nil {
+		t.Fatalf("buildTracingData()=nil, want an event without cgroup snapshots")
+	}
+	if data.Trigger.Cgroup != nil || data.Victim.Cgroup != nil {
+		t.Errorf("buildTracingData() trigger/victim cgroup snapshots = %+v/%+v, want nil",
+			data.Trigger.Cgroup, data.Victim.Cgroup)
+	}
+	if data.Victim.ContainerID != "containerabc" {
+		t.Errorf("buildTracingData() victim container = %q, want %q",
+			data.Victim.ContainerID, "containerabc")
+	}
+}


### PR DESCRIPTION
## Problem / Evidence

`cgroups.NewManager()` can fail with `(nil, err)`, and the oom collector swallows
that error but keeps running with a nil manager. The first container OOM then
dereferences the nil interface and **panics, killing the whole daemon**.

Call path (all on current main, ae0badc0):

1. `newOOMCollector` — core/events/oom.go:72-85: `cgroups.NewManager()` error is
   logged (`log.Warnf`) and dropped; `oomCollector.cgroup` stays a nil interface.
2. `cgroups.NewManager` — internal/cgroups/cgroups.go:94-103: only the
   `default:` branch fails, returning `nil, fmt.Errorf("not supported")`.
   `extcgroups.Mode()` returns `Unavailable` when `statfs("/sys/fs/cgroup")`
   fails (vendor/github.com/containerd/cgroups/v3/utils.go:55-61), i.e. cgroupfs
   not mounted — sandboxed/restricted deployments.
   Note `v1.New()` / `v2.New()` never fail (internal/cgroups/v1/cgroups.go:43-47,
   internal/cgroups/v2/cgroups.go:44-48), so **nil is the exact failure
   signature** — a nil guard cannot false-positive.
3. First container OOM: `Start` → `buildTracingData` (core/events/oom.go:148)
   → container match → `cgroupMemorySnapshot(cgroup, container)`
   (core/events/oom.go:195 and oom.go:204) → `cgroup.MemoryUsage(...)`
   (core/events/oom_snapshot.go:76) on a nil interface → panic. A panic in any
   goroutine terminates the process.

Verbatim pre-fix regression output (`go test ./core/events/ -run
'TestCgroupMemorySnapshotNilManagerReturnsError|TestBuildTracingDataWithoutCgroupManagerDegrades' -v`):

```
=== RUN   TestCgroupMemorySnapshotNilManagerReturnsError
--- FAIL: TestCgroupMemorySnapshotNilManagerReturnsError (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1abb2bc]

goroutine 36 [running]:
...
huatuo-bamai/core/events.cgroupMemorySnapshot({0x0, 0x0}, 0xc000088690)
	/home/xiaoyang/huatuo/core/events/oom_snapshot.go:76 +0x5c
huatuo-bamai/core/events.TestCgroupMemorySnapshotNilManagerReturnsError(0xc000456380)
	/home/xiaoyang/huatuo/core/events/oom_snapshot_test.go:29 +0x66
FAIL	huatuo-bamai/core/events	0.013s
```

Upstream precedent: issue #209 reported the identical bug class for
`core/autotracing/cpuidle.go` and #210 (merged) fixed exactly one file there —
`gh pr view 210 --json files` → `core/autotracing/cpuidle.go` only. The oom
path with the same swallowed-error pattern was left unfixed. Duplication check
against open PRs/issues found no existing fix for core/events/oom.go.

## Root cause / Fix

Root cause: the error from `cgroups.NewManager()` is swallowed, and the nil
manager is dereferenced at event time instead of degrading.

Fix (one guard, core/events/oom_snapshot.go):

```diff
 func cgroupMemorySnapshot(cgroup cgroups.Cgroup, container *pod.Container) (*OOMCgroupMemorySnapshot, error) {
+	if cgroup == nil {
+		// NewManager can fail (e.g. cgroupfs unavailable or unsupported
+		// mode); the collector then degrades to snapshot-less OOM events.
+		return nil, fmt.Errorf("cgroup manager is unavailable")
+	}
+
 	snapshot := &OOMCgroupMemorySnapshot{
```

The guard sits at the only dereference point. The existing callers already
implement per-actor degradation (oom.go:195-199, 204-209: log + omit snapshot),
so a nil manager now yields an OOM event without `cgroup` snapshots — counting
and tracing still work — instead of a dead daemon.

Alternatives considered and rejected:
- Returning the error from `newOOMCollector` would fail the entire tracing
  registration (pkg/tracing/register_event.go:79-88 sets `errRegistration` for
  any non-`ErrNotSupported` factory error), taking the daemon down on
  cgroup-less hosts.
- Returning `types.ErrNotSupported` would disable oom tracing entirely, although
  its BPF counting path needs no cgroups.

## Priority & confidence

- Impact 30/40 — nil-interface panic terminates the whole agent at the first
  container OOM, exactly when OOM observability is needed.
- Scope 12/20 — single dereference point in the oom collector; only on hosts
  where cgroupfs is unavailable/unsupported.
- Reproducibility 16/20 — deterministic unit repro (panic at
  oom_snapshot.go:76); trigger environment uncommon but real.
- Maintainability 14/20 — maintainer already accepted fixing this exact class
  (#209/#210); the swallowed error defeats the intended degradation.
- **PRIORITY 72/100, FIX_CONFIDENCE 92/100** (nil is precisely the failure
  signature; guard-only change, no interface or behavior change on the healthy
  path).

## Tests

Commands and verbatim results (local: root container, go1.24.6,
`perf_event_paranoid=2`; VM-only sampling-dependent tests are skipped here as
in CI, where `perf_event_paranoid=4` and asprof/java are absent):

1. Regression, before fix — both new tests fail: `panic: runtime error:
   invalid memory address or nil pointer dereference` at
   core/events/oom_snapshot.go:76 (full trace above).
2. Regression, after fix — both pass:

```
=== RUN   TestCgroupMemorySnapshotNilManagerReturnsError
--- PASS: TestCgroupMemorySnapshotNilManagerReturnsError (0.00s)
=== RUN   TestBuildTracingDataWithoutCgroupManagerDegrades
time="..." level="warning" msg="trigger cgroup snapshot: cgroup manager is unavailable" file="oom.go:196"
time="..." level="warning" msg="victim cgroup snapshot: cgroup manager is unavailable" file="oom.go:205"
--- PASS: TestBuildTracingDataWithoutCgroupManagerDegrades (0.00s)
PASS
ok  	huatuo-bamai/core/events	0.011s
```

   (The warnings demonstrate the intended degradation: event produced, snapshot
   omitted.)
3. Full suite — re-run on this branch just now:

```
$ go build ./... && go test ./...
ok  	huatuo-bamai/apis/v1	(cached)
ok  	huatuo-bamai/cmd/dropwatch	(cached)
[... 79 more "ok huatuo-bamai/..." lines, 0 FAIL ...]
ok  	huatuo-bamai/pkg/profiling	(cached)
ok  	huatuo-bamai/pkg/tracing	(cached)
ok  	huatuo-bamai/pkg/types	(cached)
$ echo $?
0
```

   83 packages ok, 0 FAIL, exit 0.

## CI

- pr_name_lint: **pass**.
- Build / Lint / Vendor: **pass** (6m18s).
- Test in VM (ubuntu26.04): **fail 5m33s — infrastructure, unrelated to this
  change.** The job died in the VM bootstrap step `qemu-0-host-init.sh amd64
  ubuntu26.04` (exit code 1) before building the repo; the log shows the
  in-VM k8s cluster failing to provision pods: `RunPodSandbox from runtime
  service failed ... plugin type="flannel" failed (add): loadFlannelSubnetEnv
  failed: open /run/flannel/subnet.env: no such file or directory`. No
  `go test` phase was reached.
- Test in VM (ubuntu22.04 / 24.04): **fail with the identical infrastructure
  signature** — both die in VM bootstrap/ssh wait with 9 occurrences of
  `loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or
  directory` in each log, before any repo build or test step. A maintainer
  rerun is needed (outside contributors cannot rerun runs on this repo).
- Context / timeline: the same VM pipeline was fully green for #716 and for
  fix/folded-negative-counts on 2026-09-04 ~22:44 UTC. A first outage
  (shfmt@latest toolchain breakage, `go >= 1.26.0` vs VM go 1.24.0) broke VM
  env setup for all new pushes starting 2026-09-04 23:41 UTC (see #718). This
  flannel breakage is a second, distinct outage starting with the 2026-09-05
  01:16+ runs. Nothing in this diff touches VM provisioning, k8s, or flannel.
- Test in VM (ubuntu20.04): **fail with the same infrastructure signature**
  (9 `loadFlannelSubnetEnv` occurrences, exit 1 in bootstrap/ssh wait, no
  `go test` phase reached). All four VM jobs of this PR failed on the same
  environment outage; no test executed against this diff in CI yet.
- Expected VM skips unchanged (SKIPPED vs PASSed under `make test` = unit +
  integration + e2e): the 3 java profiler integration tests skip (no
  java/javac/asprof/libasyncProfiler.so in the VM), the python test skips (no
  py-spy), native CPU sampling tests skip (`perf_event_paranoid=4 > 2`), the
  hardware PMU test skips (VM); BPF-based integration tests (metrics, events,
  memory-profiler) run - `test_profiler_native_mem_physical_usage.sh` passed
  on #718's first-commit run. This change is unit-covered (core/events tests
  above) and touches no sampling path.

## Risk

- Low: the guard only changes the previously-panicking nil-manager path; the
  healthy path is untouched. On affected hosts OOM events now serialize without
  the `cgroup` field (both structs use `omitempty`) instead of crashing.
- No generated, vendored or third-party code touched; no API changes.
