### PR TITLE
fix(ci): pin mockery to Go-1.24-compatible version

### DIFF
--- a/.github/workflows/scripts/qemu-2-run-in-vm.sh
+++ b/.github/workflows/scripts/qemu-2-run-in-vm.sh
@@ -132,9 +132,12 @@ function prapre_test_env() {
 		;;
 	esac
 
-	which mockery || go install github.com/vektra/mockery/v2@latest
+	# These pins must stay compatible with GOLANG_VERSION above and move
+	# together with it: newer releases (shfmt v3.13.1+, mockery v2.53.7+)
+	# raise their minimum Go past 1.24.0, which would fail the install.
+	which mockery || go install github.com/vektra/mockery/v2@v2.53.6
 	which capnpc-go || go install capnproto.org/go/capnp/v3/capnpc-go@v3.1.0-alpha.2
-	which shfmt || go install mvdan.cc/sh/v3/cmd/shfmt@latest
+	which shfmt || go install mvdan.cc/sh/v3/cmd/shfmt@v3.12.0
 
 	git config --global --add safe.directory /mnt/host
 }

--- a/.github/workflows/scripts/qemu-2-run-in-vm.sh
+++ b/.github/workflows/scripts/qemu-2-run-in-vm.sh
@@ -132,12 +132,9 @@ function prapre_test_env() {
 		;;
 	esac
 
-	# These pins must stay compatible with GOLANG_VERSION above and move
-	# together with it: newer releases (shfmt v3.13.1+, mockery v2.53.7+)
-	# raise their minimum Go past 1.24.0, which would fail the install.
 	which mockery || go install github.com/vektra/mockery/v2@v2.53.6
 	which capnpc-go || go install capnproto.org/go/capnp/v3/capnpc-go@v3.1.0-alpha.2
-	which shfmt || go install mvdan.cc/sh/v3/cmd/shfmt@v3.12.0
+	which shfmt || go install mvdan.cc/sh/v3/cmd/shfmt@latest
 
 	git config --global --add safe.directory /mnt/host
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN set -x; \
     apt-get update && apt-get install -y --no-install-recommends \
     make clang libbpf-dev bpftool curl git binutils-gold musl-tools capnproto &&\
-    go install github.com/vektra/mockery/v2@latest &&\
+    go install github.com/vektra/mockery/v2@v2.53.6 &&\
     go install capnproto.org/go/capnp/v3/capnpc-go@latest
 
 RUN set -x; \


### PR DESCRIPTION
## Problem / Evidence

The VM setup pins `GOLANG_VERSION="1.24.0"`, while its fallback mockery
install used `@latest`. The release Dockerfile has the same mismatch because
it builds from `golang:1.24` and also installed mockery at `@latest`.

`mockery@v2.53.7` requires Go 1.25 or later, so either install path fails when
the tool is not already present. The repository's development Dockerfile and
compiling documentation already use `v2.53.6`, which is compatible with Go
1.24.

Closes #721.

## Fix

Pin mockery to `v2.53.6` in both Go 1.24 environments:

- `.github/workflows/scripts/qemu-2-run-in-vm.sh`
- `Dockerfile`

Per maintainer review, shfmt remains at `@latest`; this PR no longer changes
it. The final diff is limited to the two mockery install lines.

## Verification

- `bash -n .github/workflows/scripts/qemu-2-run-in-vm.sh`: pass.
- Go 1.24 container install and `mockery --version`: pass, reports `v2.53.6`.
- `make check` in the repository development toolchain image: pass (mock
  generation, formatting, and golangci-lint).
- `docker build --network=host --target build -f Dockerfile .`: pass, including
  mock generation and all project binaries.
- GitHub CI: all required checks pass, including Build/Lint/Vendor and the
  Ubuntu 20.04, 22.04, 24.04, and 26.04 QEMU jobs. The Ubuntu 22.04 job passed
  on rerun after an unrelated physical-memory sampling mismatch in its first
  run.

## Risk

Low. The change only replaces two unbounded mockery installs with the same
version already used elsewhere in the repository. No Go source or generated
file changes.
