### PR TITLE
fix(autotracing): honor dload sampling interval

### DIFF
--- a/core/autotracing/dload.go
+++ b/core/autotracing/dload.go
@@ -49,7 +49,7 @@ func newDload() (*tracing.EventTracingAttr, error) {
 
 	return &tracing.EventTracingAttr{
 		TracingData: tracer,
-		Interval:    30,
+		Interval:    int(tracer.interval / time.Second),
 		Flag:        tracing.FlagTracing,
 	}, nil
 }

--- a/core/autotracing/dload_test.go
+++ b/core/autotracing/dload_test.go
@@ -224,3 +224,17 @@ func TestUpdateLoad(t *testing.T) {
 		t.Fatalf("loadAvg = %v, want %v", info.loadAvg, expectedLoadAvg)
 	}
 }
+
+func TestNewDloadUsesConfiguredSamplingInterval(t *testing.T) {
+	config := &Config{}
+	config.Dload.Interval = 7
+	config.Dload.IntervalTracing = 30
+	Set(config)
+	attr, err := newDload()
+	if err != nil {
+		t.Fatalf("newDload() error = %v", err)
+	}
+	if attr.Interval != 7 {
+		t.Fatalf("newDload() interval = %d, want 7", attr.Interval)
+	}
+}


### PR DESCRIPTION
## Summary

Make dload event tracing use its configured sampling interval.

## Problem

`newDload` validated and stored `Config.Dload.Interval` in the tracer, but returned an `EventTracingAttr` with a hard-coded 30-second interval. As a result, changing the documented sampling interval had no effect on scheduler cadence.

## Changes

- Derive the registered event interval from the validated tracer interval.
- Add a regression test configuring 7 seconds and asserting the event attribute reports 7.

## Verification

- Base SHA: `$(git rev-parse main)`; current main inspected before change.
- `git diff --check` passed.
- Go tests could not be executed because the workspace environment does not provide `go`/`gofmt`; please let CI validate the Go test.

## Risk

Low; this restores the configured behavior and leaves default configuration unchanged.

AI-assisted contribution; implementation and verification performed against current main.