### PR TITLE
fix(pidfile): preserve owner PID on competing lock

### DIFF
--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"syscall"
@@ -45,7 +46,7 @@ type Handle struct {
 func Lock(name string) (*Handle, error) {
 	p := path(name)
 
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +61,21 @@ func Lock(name string) (*Handle, error) {
 
 			return nil, fmt.Errorf("already running: %s pid=%s", p, bytes.TrimSpace(pid))
 		}
+
+		return nil, err
+	}
+
+	if err := f.Truncate(0); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		_ = os.Remove(p)
+
+		return nil, err
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		_ = os.Remove(p)
 
 		return nil, err
 	}

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -79,6 +79,10 @@ func TestLock_AlreadyLocked(t *testing.T) {
 	_, err = Lock(name)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already running")
+
+	data, err := os.ReadFile(path(name))
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(os.Getpid()), string(data))
 }
 
 func TestUnlock_RemovesFile(t *testing.T) {


### PR DESCRIPTION
## Summary

- Acquire the pidfile flock before truncating its contents.
- Preserve the running process PID when a competing lock attempt fails.
- Add a regression assertion for the preserved PID file.

## Testing

- `go test ./internal/pidfile -count=1` (Linux)
- `go vet ./internal/pidfile` (Linux)
- `git diff --check`

The repository `make check` target could not run in the available Linux
environment because `make`, `gofumpt`, and `goimports` are not installed.

Fixes #583
