### PR TITLE
fix(autotracing): honor cpuidle sampling interval

### DIFF
--- a/core/autotracing/cpuidle.go
+++ b/core/autotracing/cpuidle.go
@@ -52,7 +52,7 @@ func newCPUIdle() (*tracing.EventTracingAttr, error) {
 
 	return &tracing.EventTracingAttr{
 		TracingData: tracer,
-		Interval:    20,
+		Interval:    int(tracer.interval / time.Second),
 		Flag:        tracing.FlagTracing,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Make cpuidle event tracing use its configured sampling interval.

## Problem

`newCPUIdle` builds a tracer with `Config.CPUIdle.Interval`, but registers a hard-coded 20-second event interval. Configuration changes therefore do not affect scheduler cadence.

## Changes

- Derive `EventTracingAttr.Interval` from the validated tracer interval.

## Verification

- Base SHA: `$(git rev-parse main)`.
- Confirmed current main stores the configured interval in `cpuIdleTracing.interval` while returning `Interval: 20`.
- `git diff --check` passed.
- Go tests unavailable in this environment because `go` and `gofmt` are not installed; CI should run the project test suite.

## Risk

Low; default cadence remains unchanged when the default configuration is used.

AI-assisted contribution; implementation and verification performed against current main.