### PR TITLE
fix(autotracing): honor cpusys sampling interval

### DIFF
--- a/core/autotracing/cpusys.go
+++ b/core/autotracing/cpusys.go
@@ -67,7 +67,7 @@ func newCPUSys() (*tracing.EventTracingAttr, error) {
 			perfDuration:     time.Duration(perfDurationSeconds) * time.Second,
 			threshold:        threshold,
 		},
-		Interval: 20,
+		Interval: int(intervalSeconds),
 		Flag:     tracing.FlagTracing,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Make CPU system event tracing honor its configured sampling interval.

## Problem

`newCPUSys` validates and stores `Config.CPUSys.Interval` but registers a hard-coded 20-second scheduler interval, so configuration changes have no effect on sampling cadence.

## Changes

- Return the configured interval in `EventTracingAttr.Interval`.

## Verification

- Base SHA: `$(git rev-parse main)`.
- Current main inspection confirmed `intervalSeconds` is used for tracer state while `Interval` was fixed at 20.
- `git diff --check` passed.
- Go tests unavailable because this environment has no `go` or `gofmt`; CI should run the project suite.

## Risk

Low; default behavior remains unchanged when the default interval is used.

AI-assisted contribution; implementation and verification performed against current main.