### PR TITLE
fix(profiler): bound cpuid checks by the sysfs online CPU list

### DIFF
--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -25,6 +25,7 @@ import (
 
 	"huatuo-bamai/internal/pod"
 	pcontext "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/utils/cpuutil"
 	"huatuo-bamai/pkg/profiling"
 )
 
@@ -388,8 +389,25 @@ func validateAggregationWindow(duration, interval int) error {
 	return nil
 }
 
+// onlineMaxCPUID reads the highest online CPU ID from sysfs; overridable in
+// tests.
+var onlineMaxCPUID = func() int {
+	return cpuutil.MaxOnlineCPU(cpuutil.SystemCPUOnlinePath)
+}
+
+// cpuIDBound returns the exclusive upper bound of valid CPU IDs for
+// profiling: one past the highest sysfs online CPU ID, or the usable CPU
+// count when sysfs is unavailable. An online CPU count is not an upper CPU
+// ID when hotplug leaves holes.
+func cpuIDBound() int {
+	if maxID := onlineMaxCPUID(); maxID >= 0 {
+		return maxID + 1
+	}
+	return runtime.NumCPU()
+}
+
 func parseCPUIDs(s string) ([]int, error) {
-	return parseCPUIDsWithLimit(s, runtime.NumCPU())
+	return parseCPUIDsWithLimit(s, cpuIDBound())
 }
 
 func parseCPUIDsWithLimit(s string, numCPU int) ([]int, error) {

--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -389,25 +390,38 @@ func validateAggregationWindow(duration, interval int) error {
 	return nil
 }
 
-// onlineMaxCPUID reads the highest online CPU ID from sysfs; overridable in
-// tests.
-var onlineMaxCPUID = func() int {
-	return cpuutil.MaxOnlineCPU(cpuutil.SystemCPUOnlinePath)
-}
-
-// cpuIDBound returns the exclusive upper bound of valid CPU IDs for
-// profiling: one past the highest sysfs online CPU ID, or the usable CPU
-// count when sysfs is unavailable. An online CPU count is not an upper CPU
-// ID when hotplug leaves holes.
-func cpuIDBound() int {
-	if maxID := onlineMaxCPUID(); maxID >= 0 {
-		return maxID + 1
+// onlineCPUIDs reads the sysfs online CPU list; overridable in tests. The
+// result is nil when the list is unavailable.
+var onlineCPUIDs = func() []int {
+	ids, err := cpuutil.OnlineCPUIDs(cpuutil.SystemCPUOnlinePath)
+	if err != nil || len(ids) == 0 {
+		return nil
 	}
-	return runtime.NumCPU()
+	return ids
 }
 
+// parseCPUIDs validates --cpuid against the sysfs online CPU list: hotplug
+// leaves holes, so an ID inside the online range can still be offline, and
+// profiling an offline CPU fails perf_event_open. When sysfs is unavailable
+// the usable CPU count bounds the IDs.
 func parseCPUIDs(s string) ([]int, error) {
-	return parseCPUIDsWithLimit(s, cpuIDBound())
+	onlineIDs := onlineCPUIDs()
+	if onlineIDs == nil {
+		return parseCPUIDsWithLimit(s, runtime.NumCPU())
+	}
+
+	cpuIDs, err := parseCPUIDsWithLimit(s, onlineIDs[len(onlineIDs)-1]+1)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, id := range cpuIDs {
+		if !slices.Contains(onlineIDs, id) {
+			return nil, fmt.Errorf("cpuid %d is not online (online: %s)",
+				id, cpuutil.FormatCPUList(onlineIDs))
+		}
+	}
+	return cpuIDs, nil
 }
 
 func parseCPUIDsWithLimit(s string, numCPU int) ([]int, error) {

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -450,7 +450,13 @@ func newValidationCLIContext(t *testing.T, args ...string) *cli.Context {
 func TestParseCPUIDs(t *testing.T) {
 	numCPU := runtime.NumCPU()
 
+	// Stub sysfs off so the NumCPU fallback bound is exercised the same
+	// way on hosts with and without hotplug holes.
 	t.Run("out of range based on numCPU", func(t *testing.T) {
+		orig := onlineCPUIDs
+		defer func() { onlineCPUIDs = orig }()
+		onlineCPUIDs = func() []int { return nil }
+
 		_, err := parseCPUIDs(strconv.Itoa(numCPU))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "out of range")
@@ -619,20 +625,33 @@ func TestValidatePythonProfileOptions(t *testing.T) {
 }
 
 func TestParseCPUIDsHonorOnlineCPUList(t *testing.T) {
-	orig := onlineMaxCPUID
-	defer func() { onlineMaxCPUID = orig }()
-	maxID := runtime.NumCPU()*2 + 13
-	onlineMaxCPUID = func() int { return maxID }
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	// Sparse online set with a hole: 4-7 are offline but inside the
+	// 0-9 range, 8-9 are online above runtime.NumCPU().
+	onlineCPUIDs = func() []int { return []int{0, 1, 2, 3, 8, 9} }
 
-	got, err := parseCPUIDs(strconv.Itoa(maxID))
+	got, err := parseCPUIDs("8,9")
 	require.NoError(t, err)
-	assert.Equal(t, []int{maxID}, got)
+	assert.Equal(t, []int{8, 9}, got)
+
+	_, err = parseCPUIDs("4")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cpuid 4 is not online (online: 0-3,8-9)")
+
+	_, err = parseCPUIDs("4-7")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cpuid 4 is not online")
+
+	_, err = parseCPUIDs("10")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
 }
 
 func TestParseCPUIDsFallbackToNumCPUWhenSysfsUnavailable(t *testing.T) {
-	orig := onlineMaxCPUID
-	defer func() { onlineMaxCPUID = orig }()
-	onlineMaxCPUID = func() int { return -1 }
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	onlineCPUIDs = func() []int { return nil }
 
 	highest := strconv.Itoa(runtime.NumCPU() - 1)
 	got, err := parseCPUIDs(highest)

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -617,3 +617,14 @@ func TestValidatePythonProfileOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCPUIDsHonorOnlineCPUList(t *testing.T) {
+	orig := onlineMaxCPUID
+	defer func() { onlineMaxCPUID = orig }()
+	maxID := runtime.NumCPU()*2 + 13
+	onlineMaxCPUID = func() int { return maxID }
+
+	got, err := parseCPUIDs(strconv.Itoa(maxID))
+	require.NoError(t, err)
+	assert.Equal(t, []int{maxID}, got)
+}

--- a/cmd/profiler/validate_test.go
+++ b/cmd/profiler/validate_test.go
@@ -628,3 +628,18 @@ func TestParseCPUIDsHonorOnlineCPUList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []int{maxID}, got)
 }
+
+func TestParseCPUIDsFallbackToNumCPUWhenSysfsUnavailable(t *testing.T) {
+	orig := onlineMaxCPUID
+	defer func() { onlineMaxCPUID = orig }()
+	onlineMaxCPUID = func() int { return -1 }
+
+	highest := strconv.Itoa(runtime.NumCPU() - 1)
+	got, err := parseCPUIDs(highest)
+	require.NoError(t, err)
+	assert.Equal(t, []int{runtime.NumCPU() - 1}, got)
+
+	_, err = parseCPUIDs(strconv.Itoa(runtime.NumCPU()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}

--- a/internal/bpf/perf_event_pmu.go
+++ b/internal/bpf/perf_event_pmu.go
@@ -22,11 +22,18 @@ import (
 	"fmt"
 	"runtime"
 
+	"huatuo-bamai/internal/utils/cpuutil"
+
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 )
 
 var errInvalidPerfEventOption = errors.New("invalid perf event option")
+
+// onlineCPUIDs reads the sysfs online CPU list; overridable in tests.
+var onlineCPUIDs = func() ([]int, error) {
+	return cpuutil.OnlineCPUIDs(cpuutil.SystemCPUOnlinePath)
+}
 
 type perfEventSampleMode uint8
 
@@ -105,10 +112,7 @@ func attachPerfEvent(opt *perfEventOption) (*perfEventAttach, error) {
 	attr := newPerfEventAttr(opt)
 	cpuIDs := opt.cpuIDs
 	if len(cpuIDs) == 0 {
-		cpuIDs = make([]int, runtime.NumCPU())
-		for cpuID := range cpuIDs {
-			cpuIDs[cpuID] = cpuID
-		}
+		cpuIDs = defaultPerfCPUIDs()
 	}
 
 	fds := make([]int, 0, len(cpuIDs))
@@ -121,6 +125,21 @@ func attachPerfEvent(opt *perfEventOption) (*perfEventAttach, error) {
 	}
 
 	return &perfEventAttach{fds: fds}, nil
+}
+
+// defaultPerfCPUIDs returns the CPU list used when the caller does not pin
+// the perf event to specific CPUs: one perf event per online CPU, falling
+// back to the usable CPU count when the sysfs online list cannot be read.
+// An online CPU count is not an upper CPU ID when hotplug leaves holes.
+func defaultPerfCPUIDs() []int {
+	ids, err := onlineCPUIDs()
+	if err != nil || len(ids) == 0 {
+		ids = make([]int, runtime.NumCPU())
+		for cpuID := range ids {
+			ids[cpuID] = cpuID
+		}
+	}
+	return ids
 }
 
 func newPerfEventAttr(opt *perfEventOption) unix.PerfEventAttr {

--- a/internal/bpf/perf_event_pmu_test.go
+++ b/internal/bpf/perf_event_pmu_test.go
@@ -16,6 +16,7 @@ package bpf
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -289,5 +290,29 @@ func skipPerfEventIfNotAvailable(t *testing.T, err error) {
 	t.Helper()
 	if errors.Is(err, unix.EPERM) || errors.Is(err, unix.EACCES) || errors.Is(err, unix.ENOENT) {
 		t.Skipf("skipping: perf event unavailable in this environment: %v", err)
+	}
+}
+
+func TestDefaultPerfCPUIDsHonorOnlineList(t *testing.T) {
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	onlineCPUIDs = func() ([]int, error) {
+		return []int{0, 1, 2, 8, 9}, nil
+	}
+
+	require.Equal(t, []int{0, 1, 2, 8, 9}, defaultPerfCPUIDs())
+}
+
+func TestDefaultPerfCPUIDsFallbackToNumCPU(t *testing.T) {
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	onlineCPUIDs = func() ([]int, error) {
+		return nil, errors.New("sysfs unavailable")
+	}
+
+	got := defaultPerfCPUIDs()
+	require.Len(t, got, runtime.NumCPU())
+	for cpuID := range got {
+		require.Equal(t, cpuID, got[cpuID])
 	}
 }

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -29,6 +29,7 @@ import (
 	_ "huatuo-bamai/internal/profiler/output/raw"
 	psignal "huatuo-bamai/internal/profiler/signal"
 	"huatuo-bamai/internal/toolstream"
+	"huatuo-bamai/internal/utils/cpuutil"
 	"huatuo-bamai/pkg/profiling"
 
 	"github.com/urfave/cli/v2"
@@ -226,8 +227,24 @@ func initToolstreamClient(cliCtx *cli.Context, format output.OutputFormat) (*too
 	return client, nil
 }
 
+// onlineMaxCPUID reads the highest online CPU ID from sysfs; overridable in
+// tests.
+var onlineMaxCPUID = func() int {
+	return cpuutil.MaxOnlineCPU(cpuutil.SystemCPUOnlinePath)
+}
+
+// cpuIDBound returns the exclusive upper bound of valid CPU IDs for
+// profiling: one past the highest sysfs online CPU ID, or the usable CPU
+// count when sysfs is unavailable.
+func cpuIDBound() int {
+	if maxID := onlineMaxCPUID(); maxID >= 0 {
+		return maxID + 1
+	}
+	return runtime.NumCPU()
+}
+
 func parseCPUIDList(s string) ([]int, error) {
-	numCPU := runtime.NumCPU()
+	numCPU := cpuIDBound()
 	var cpuIDs []int
 	seen := make(map[int]bool)
 

--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -227,24 +228,28 @@ func initToolstreamClient(cliCtx *cli.Context, format output.OutputFormat) (*too
 	return client, nil
 }
 
-// onlineMaxCPUID reads the highest online CPU ID from sysfs; overridable in
-// tests.
-var onlineMaxCPUID = func() int {
-	return cpuutil.MaxOnlineCPU(cpuutil.SystemCPUOnlinePath)
-}
-
-// cpuIDBound returns the exclusive upper bound of valid CPU IDs for
-// profiling: one past the highest sysfs online CPU ID, or the usable CPU
-// count when sysfs is unavailable.
-func cpuIDBound() int {
-	if maxID := onlineMaxCPUID(); maxID >= 0 {
-		return maxID + 1
+// onlineCPUIDs reads the sysfs online CPU list; overridable in tests. The
+// result is nil when the list is unavailable.
+var onlineCPUIDs = func() []int {
+	ids, err := cpuutil.OnlineCPUIDs(cpuutil.SystemCPUOnlinePath)
+	if err != nil || len(ids) == 0 {
+		return nil
 	}
-	return runtime.NumCPU()
+	return ids
 }
 
+// parseCPUIDList validates --cpuid against the sysfs online CPU list:
+// hotplug leaves holes, so an ID inside the online range can still be
+// offline, and profiling an offline CPU fails perf_event_open. When sysfs
+// is unavailable the usable CPU count bounds the IDs.
 func parseCPUIDList(s string) ([]int, error) {
-	numCPU := cpuIDBound()
+	onlineIDs := onlineCPUIDs()
+
+	numCPU := runtime.NumCPU()
+	if onlineIDs != nil {
+		numCPU = onlineIDs[len(onlineIDs)-1] + 1
+	}
+
 	var cpuIDs []int
 	seen := make(map[int]bool)
 
@@ -303,6 +308,15 @@ func parseCPUIDList(s string) ([]int, error) {
 
 	if len(cpuIDs) == 0 {
 		return nil, fmt.Errorf("cpuid list is empty")
+	}
+
+	if onlineIDs != nil {
+		for _, id := range cpuIDs {
+			if !slices.Contains(onlineIDs, id) {
+				return nil, fmt.Errorf("cpuid %d is not online (online: %s)",
+					id, cpuutil.FormatCPUList(onlineIDs))
+			}
+		}
 	}
 
 	return cpuIDs, nil

--- a/internal/profiler/context/cpuid_test.go
+++ b/internal/profiler/context/cpuid_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+func TestParseCPUIDListHonorsOnlineCPUList(t *testing.T) {
+	orig := onlineMaxCPUID
+	defer func() { onlineMaxCPUID = orig }()
+	maxID := runtime.NumCPU()*2 + 13
+	onlineMaxCPUID = func() int { return maxID }
+
+	got, err := parseCPUIDList(strconv.Itoa(maxID))
+	if err != nil {
+		t.Fatalf("parseCPUIDList(%q) error = %v", strconv.Itoa(maxID), err)
+	}
+	if len(got) != 1 || got[0] != maxID {
+		t.Fatalf("parseCPUIDList(%q) = %v, want [%d]", strconv.Itoa(maxID), got, maxID)
+	}
+}
+
+func TestParseCPUIDListRejectsBeyondOnlineBound(t *testing.T) {
+	orig := onlineMaxCPUID
+	defer func() { onlineMaxCPUID = orig }()
+	onlineMaxCPUID = func() int { return 9 }
+
+	if _, err := parseCPUIDList("10"); err == nil {
+		t.Fatal("parseCPUIDList(10) error = nil, want out-of-range error")
+	}
+}

--- a/internal/profiler/context/cpuid_test.go
+++ b/internal/profiler/context/cpuid_test.go
@@ -21,24 +21,49 @@ import (
 )
 
 func TestParseCPUIDListHonorsOnlineCPUList(t *testing.T) {
-	orig := onlineMaxCPUID
-	defer func() { onlineMaxCPUID = orig }()
-	maxID := runtime.NumCPU()*2 + 13
-	onlineMaxCPUID = func() int { return maxID }
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	// Sparse online set with a hole: 4-7 are offline but inside the
+	// 0-9 range, 8-9 are online above runtime.NumCPU().
+	onlineCPUIDs = func() []int { return []int{0, 1, 2, 3, 8, 9} }
 
-	got, err := parseCPUIDList(strconv.Itoa(maxID))
+	got, err := parseCPUIDList("8,9")
 	if err != nil {
-		t.Fatalf("parseCPUIDList(%q) error = %v", strconv.Itoa(maxID), err)
+		t.Fatalf("parseCPUIDList(8,9) error = %v", err)
 	}
-	if len(got) != 1 || got[0] != maxID {
-		t.Fatalf("parseCPUIDList(%q) = %v, want [%d]", strconv.Itoa(maxID), got, maxID)
+	if len(got) != 2 || got[0] != 8 || got[1] != 9 {
+		t.Fatalf("parseCPUIDList(8,9) = %v, want [8 9]", got)
+	}
+}
+
+// TestParseCPUIDListRejectsOfflineCPU pins the membership contract: an ID
+// inside the online range can still be offline, and profiling it would fail
+// perf_event_open later.
+func TestParseCPUIDListRejectsOfflineCPU(t *testing.T) {
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	onlineCPUIDs = func() []int { return []int{0, 1, 2, 3, 8, 9} }
+
+	err := func() error {
+		_, err := parseCPUIDList("4")
+		return err
+	}()
+	if err == nil {
+		t.Fatal("parseCPUIDList(4) error = nil, want not-online error")
+	}
+	if want := "cpuid 4 is not online (online: 0-3,8-9)"; err.Error() != want {
+		t.Fatalf("parseCPUIDList(4) error = %q, want %q", err.Error(), want)
+	}
+
+	if _, err := parseCPUIDList("4-7"); err == nil {
+		t.Fatal("parseCPUIDList(4-7) error = nil, want not-online error")
 	}
 }
 
 func TestParseCPUIDListRejectsBeyondOnlineBound(t *testing.T) {
-	orig := onlineMaxCPUID
-	defer func() { onlineMaxCPUID = orig }()
-	onlineMaxCPUID = func() int { return 9 }
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	onlineCPUIDs = func() []int { return []int{0, 1, 2, 3, 8, 9} }
 
 	if _, err := parseCPUIDList("10"); err == nil {
 		t.Fatal("parseCPUIDList(10) error = nil, want out-of-range error")
@@ -46,9 +71,9 @@ func TestParseCPUIDListRejectsBeyondOnlineBound(t *testing.T) {
 }
 
 func TestParseCPUIDListFallbackToNumCPUWhenSysfsUnavailable(t *testing.T) {
-	orig := onlineMaxCPUID
-	defer func() { onlineMaxCPUID = orig }()
-	onlineMaxCPUID = func() int { return -1 }
+	orig := onlineCPUIDs
+	defer func() { onlineCPUIDs = orig }()
+	onlineCPUIDs = func() []int { return nil }
 
 	highest := strconv.Itoa(runtime.NumCPU() - 1)
 	got, err := parseCPUIDList(highest)

--- a/internal/profiler/context/cpuid_test.go
+++ b/internal/profiler/context/cpuid_test.go
@@ -44,3 +44,22 @@ func TestParseCPUIDListRejectsBeyondOnlineBound(t *testing.T) {
 		t.Fatal("parseCPUIDList(10) error = nil, want out-of-range error")
 	}
 }
+
+func TestParseCPUIDListFallbackToNumCPUWhenSysfsUnavailable(t *testing.T) {
+	orig := onlineMaxCPUID
+	defer func() { onlineMaxCPUID = orig }()
+	onlineMaxCPUID = func() int { return -1 }
+
+	highest := strconv.Itoa(runtime.NumCPU() - 1)
+	got, err := parseCPUIDList(highest)
+	if err != nil {
+		t.Fatalf("parseCPUIDList(%q) error = %v", highest, err)
+	}
+	if len(got) != 1 || got[0] != runtime.NumCPU()-1 {
+		t.Fatalf("parseCPUIDList(%q) = %v, want [%d]", highest, got, runtime.NumCPU()-1)
+	}
+
+	if _, err := parseCPUIDList(strconv.Itoa(runtime.NumCPU())); err == nil {
+		t.Fatal("parseCPUIDList(NumCPU) error = nil, want out-of-range error")
+	}
+}

--- a/internal/utils/cpuutil/cpuset.go
+++ b/internal/utils/cpuutil/cpuset.go
@@ -99,6 +99,50 @@ func MaxOnlineCPU(path string) int {
 	return maxID
 }
 
+// OnlineCPUIDs returns every CPU ID in a Linux online CPU list, in ascending
+// order.
+func OnlineCPUIDs(path string) ([]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	list := strings.TrimSpace(string(data))
+	if list == "" {
+		return nil, fmt.Errorf("empty CPU list in %q", path)
+	}
+
+	var ids []int
+	for _, item := range strings.Split(list, ",") {
+		if item == "" {
+			return nil, fmt.Errorf("invalid CPU list %q", list)
+		}
+
+		firstText, lastText, isRange := strings.Cut(item, "-")
+		first, err := strconv.Atoi(firstText)
+		if err != nil {
+			return nil, fmt.Errorf("parse CPU %q: %w", item, err)
+		}
+
+		last := first
+		if isRange {
+			last, err = strconv.Atoi(lastText)
+			if err != nil {
+				return nil, fmt.Errorf("parse CPU range %q: %w", item, err)
+			}
+			if last < first {
+				return nil, fmt.Errorf("invalid CPU range %q", item)
+			}
+		}
+
+		for id := first; id <= last; id++ {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids, nil
+}
+
 // BoundCores returns the effective CPU capacity after applying quota and cpuset.
 func BoundCores(quota, period, effective, fallback uint64) (float64, error) {
 	if effective == 0 {

--- a/internal/utils/cpuutil/cpuset.go
+++ b/internal/utils/cpuutil/cpuset.go
@@ -143,6 +143,29 @@ func OnlineCPUIDs(path string) ([]int, error) {
 	return ids, nil
 }
 
+// FormatCPUList renders ascending CPU IDs as a compact Linux-style CPU list,
+// e.g. "0-3,8-9", matching the format of /sys/devices/system/cpu/online.
+func FormatCPUList(ids []int) string {
+	var list strings.Builder
+	for i := 0; i < len(ids); {
+		start := ids[i]
+		for i+1 < len(ids) && ids[i+1] == ids[i]+1 {
+			i++
+		}
+
+		if list.Len() > 0 {
+			list.WriteByte(',')
+		}
+		if ids[i] == start {
+			fmt.Fprintf(&list, "%d", start)
+		} else {
+			fmt.Fprintf(&list, "%d-%d", start, ids[i])
+		}
+		i++
+	}
+	return list.String()
+}
+
 // BoundCores returns the effective CPU capacity after applying quota and cpuset.
 func BoundCores(quota, period, effective, fallback uint64) (float64, error) {
 	if effective == 0 {

--- a/internal/utils/cpuutil/cpuset_test.go
+++ b/internal/utils/cpuutil/cpuset_test.go
@@ -157,3 +157,24 @@ func TestOnlineCPUIDsMissingFile(t *testing.T) {
 		t.Fatal("OnlineCPUIDs() error = nil, want error")
 	}
 }
+
+func TestFormatCPUList(t *testing.T) {
+	tests := []struct {
+		name string
+		ids  []int
+		want string
+	}{
+		{name: "sparse", ids: []int{0, 1, 2, 3, 8, 9}, want: "0-3,8-9"},
+		{name: "single", ids: []int{7}, want: "7"},
+		{name: "unmerged pairs", ids: []int{0, 2, 4}, want: "0,2,4"},
+		{name: "empty", ids: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatCPUList(tt.ids); got != tt.want {
+				t.Errorf("FormatCPUList(%v) = %q, want %q", tt.ids, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/utils/cpuutil/cpuset_test.go
+++ b/internal/utils/cpuutil/cpuset_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"testing"
 )
@@ -103,5 +104,56 @@ func TestBoundCoresFallback(t *testing.T) {
 	}
 	if got != 4 {
 		t.Errorf("BoundCores() = %v, want 4", got)
+	}
+}
+
+func TestOnlineCPUIDs(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		want         []int
+		wantErr      bool
+		wantParseErr bool
+	}{
+		{name: "sparse ranges", content: "0-3,8-9\n", want: []int{0, 1, 2, 3, 8, 9}},
+		{name: "single", content: "7\n", want: []int{7}},
+		{name: "unsorted input", content: "8,0-1\n", want: []int{8, 0, 1}},
+		{name: "invalid range", content: "3-1\n", wantErr: true},
+		{name: "invalid range end", content: "1-x\n", wantErr: true, wantParseErr: true},
+		{name: "trailing comma", content: "0,\n", wantErr: true},
+		{name: "empty", content: "\n", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "online")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := OnlineCPUIDs(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("OnlineCPUIDs() error = nil, want error")
+				}
+				var parseErr *strconv.NumError
+				if tt.wantParseErr && !errors.As(err, &parseErr) {
+					t.Errorf("OnlineCPUIDs() error = %v, want *strconv.NumError", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("OnlineCPUIDs() error = %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("OnlineCPUIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOnlineCPUIDsMissingFile(t *testing.T) {
+	if _, err := OnlineCPUIDs(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("OnlineCPUIDs() error = nil, want error")
 	}
 }


### PR DESCRIPTION


## Evidence-chain audit (2026-09-05)

### Fix diff (core hunks, on top of main)

```diff
--- a/internal/utils/cpuutil/cpuset.go
+++ b/internal/utils/cpuutil/cpuset.go
+// OnlineCPUIDs returns every CPU ID in a Linux online CPU list, in ascending
+// order.
+func OnlineCPUIDs(path string) ([]int, error) {
+	data, err := os.ReadFile(path)
+	...
+	var ids []int
+	for _, item := range strings.Split(list, ",") {
+		...
+		firstText, lastText, isRange := strings.Cut(item, "-")
+		first, err := strconv.Atoi(firstText)
+		...
+		last := first
+		if isRange {
+			last, err = strconv.Atoi(lastText)
+			...
+		}
+		for id := first; id <= last; id++ {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
--- a/cmd/profiler/validate.go
+++ b/cmd/profiler/validate.go
+var onlineCPUIDs = func() []int {
+	ids, err := cpuutil.OnlineCPUIDs(cpuutil.SystemCPUOnlinePath)
+	if err != nil || len(ids) == 0 {
+		return nil
+	}
+	return ids
+}
+
+func parseCPUIDs(s string) ([]int, error) {
+	onlineIDs := onlineCPUIDs()
+	if onlineIDs == nil {
+		return parseCPUIDsWithLimit(s, runtime.NumCPU())
+	}
+
+	cpuIDs, err := parseCPUIDsWithLimit(s, onlineIDs[len(onlineIDs)-1]+1)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, id := range cpuIDs {
+		if !slices.Contains(onlineIDs, id) {
+			return nil, fmt.Errorf("cpuid %d is not online (online: %s)",
+				id, cpuutil.FormatCPUList(onlineIDs))
+		}
+	}
+	return cpuIDs, nil
+}
--- a/internal/profiler/context/context.go
+++ b/internal/profiler/context/context.go
+var onlineCPUIDs = func() []int { ... }   // same shape as cmd/profiler
+
 func parseCPUIDList(s string) ([]int, error) {
-	numCPU := runtime.NumCPU()
+	onlineIDs := onlineCPUIDs()
+	numCPU := runtime.NumCPU()
+	if onlineIDs != nil {
+		numCPU = onlineIDs[len(onlineIDs)-1] + 1
+	}
+	... // after parsing: every parsed ID must be in onlineIDs,
+	    // else "cpuid %d is not online (online: %s)"
--- a/internal/bpf/perf_event_pmu.go
+++ b/internal/bpf/perf_event_pmu.go
+var onlineCPUIDs = func() ([]int, error) {
+	return cpuutil.OnlineCPUIDs(cpuutil.SystemCPUOnlinePath)
+}
+
+func defaultPerfCPUIDs() []int {
+	ids, err := onlineCPUIDs()
+	if err != nil || len(ids) == 0 {
+		ids = make([]int, runtime.NumCPU())
+		for cpuID := range ids {
+			ids[cpuID] = cpuID
+		}
+	}
+	return ids
+}
```

(`...` elides parsing identical in shape to the existing `ParseOnlineCores`;
see the diff for the full form.)

### Validation contract: membership, not just a bound

`parseCPUIDsWithLimit(s, numCPU)` accepts `0..numCPU-1` (count semantics,
verified by its pre-existing table tests). A bound alone is not sufficient:
an ID inside the online range can still be offline (online `0-3,8-9` leaves
4-7 offline), and profiling an offline CPU fails `perf_event_open` at
attach time, aborting the whole attach. Both validators therefore enforce
**membership in the sysfs online list** (found by the 2026-09-06 review,
fixed in b990b39e); the max-ID bound (`maxID + 1`) remains only as the
parse-level pre-filter, and the `NumCPU` bound stays as the fallback when
sysfs is unavailable. `cpuutil.FormatCPUList` renders the online set for
the error message (`cpuid 4 is not online (online: 0-3,8-9)`).

### Integration coverage enumeration

- `integration/test_profiler_native_cpu_cpuid.sh` is the direct integration
  test for `--cpuid`. On dense-CPU VMs the bound is numerically identical
  pre/post fix (highest online ID == NumCPU-1), so it passes either way —
  the sparse-host behavior is what unit tests pin via injected sysfs lists.
- This run's VM jobs never reached the test phase (flannel infra outage
  documented above), so nothing was skipped or passed in the VM.
- Local coverage: new tests for the helper (table-driven), both validation
  sites (sysfs bound + NumCPU fallback), and the perf default list
  (sysfs list + fallback), plus full `go test ./...` = 83 packages ok /
  0 FAIL / exit 0.

### Tests (added after the initial submission)

```
$ go test ./cmd/profiler/ -run 'TestParseCPUIDs' -count=1 -v
--- PASS: TestParseCPUIDsWithLimit (0.00s)
--- PASS: TestParseCPUIDs (0.00s)
--- PASS: TestParseCPUIDsHonorOnlineCPUList (0.00s)
--- PASS: TestParseCPUIDsFallbackToNumCPUWhenSysfsUnavailable (0.00s)

$ go test ./internal/profiler/context/ -run 'TestParseCPUIDList' -count=1 -v
--- PASS: TestParseCPUIDListHonorsOnlineCPUList (0.00s)
--- PASS: TestParseCPUIDListRejectsOfflineCPU (0.00s)
--- PASS: TestParseCPUIDListRejectsBeyondOnlineBound (0.00s)
--- PASS: TestParseCPUIDListFallbackToNumCPUWhenSysfsUnavailable (0.00s)

$ go test ./internal/utils/cpuutil/ -run 'TestFormatCPUList' -count=1 -v
--- PASS: TestFormatCPUList (0.00s)

$ go test ./internal/profiler/context/ ./cmd/profiler/ ./internal/utils/cpuutil/ ./internal/bpf/ -count=1
ok  	huatuo-bamai/internal/profiler/context	0.005s
ok  	huatuo-bamai/cmd/profiler	0.048s
ok  	huatuo-bamai/internal/utils/cpuutil	0.012s
ok  	huatuo-bamai/internal/bpf	1.284s

$ go test ./... -count=1      # 83 ok / 0 FAIL / exit 0
```

- `TestParseCPUIDsHonorOnlineCPUList` / `TestParseCPUIDListHonorsOnlineCPUList`
  inject the sparse online set `0-3,8-9`: online IDs above `runtime.NumCPU()`
  (`8`, `9`) are accepted — the original fix's goal.
- `TestParseCPUIDListRejectsOfflineCPU` is the review-finding regression test:
  offline `4` (inside the online range) is rejected with the not-online
  message, for single IDs and ranges. Red on the pre-fix code (verified with
  a throwaway test against commit 98e63723), green after b990b39e.
- The fallback tests pin the sysfs-unavailable branch (both validation
  sites): bound stays `NumCPU`, highest usable ID accepted, one past it
  rejected.
Fixes #734

