### PR TITLE
fix(tracing): keep documents when the container vanishes before save

### DIFF
--- a/pkg/tracing/document_writer.go
+++ b/pkg/tracing/document_writer.go
@@ -98,6 +98,10 @@ func (s *documentWriter) saveDocument(document *Document) error {
 	return errors.Join(errs...)
 }
 
+// containerByID resolves a container for document attribution; overridable
+// in tests.
+var containerByID = pod.ContainerByID
+
 func newBaseDocument(options DocumentOptions, req *WriteRequest) (*Document, error) {
 	formattedTime := req.TracerTime.Format(tracingDocumentTimeLayout)
 	document := Document{
@@ -119,12 +123,14 @@ func newBaseDocument(options DocumentOptions, req *WriteRequest) (*Document, err
 		return &document, nil
 	}
 
-	container, err := pod.ContainerByID(req.ContainerID)
-	if err != nil {
-		return nil, fmt.Errorf("get container %s: %w", req.ContainerID, err)
-	}
-	if container == nil {
-		return nil, fmt.Errorf("container %s not found", req.ContainerID)
+	// The container can vanish between the event and this save - an OOM
+	// victim dies from the very OOM being reported, or a profiled container
+	// exits mid-run. Keep the document with host-level attribution instead
+	// of dropping it, matching how collectors treat unresolvable containers
+	// (e.g. oom.go counts them as host events).
+	container, err := containerByID(req.ContainerID)
+	if err != nil || container == nil {
+		return &document, nil
 	}
 
 	document.ContainerID = container.ID

--- a/pkg/tracing/document_writer_test.go
+++ b/pkg/tracing/document_writer_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracing
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/pod"
+)
+
+func testWriteRequest(containerID string) *WriteRequest {
+	return &WriteRequest{
+		TracerName:  "test-tracer",
+		TracerTime:  time.Now(),
+		TracerData:  map[string]any{"payload": "keep"},
+		ContainerID: containerID,
+	}
+}
+
+func TestNewBaseDocumentAttributesContainer(t *testing.T) {
+	orig := containerByID
+	defer func() { containerByID = orig }()
+	containerByID = func(id string) (*pod.Container, error) {
+		return &pod.Container{ID: id, Hostname: "pod-1", Labels: map[string]any{"HostNamespace": "ns-1"}}, nil
+	}
+
+	document, err := newBaseDocument(DocumentOptions{Hostname: "host-1"}, testWriteRequest("container-1"))
+	if err != nil {
+		t.Fatalf("newBaseDocument() error = %v", err)
+	}
+	if document.ContainerID != "container-1" {
+		t.Errorf("ContainerID = %q, want container-1", document.ContainerID)
+	}
+	if document.ContainerHostname != "pod-1" {
+		t.Errorf("ContainerHostname = %q, want pod-1", document.ContainerHostname)
+	}
+	if document.Hostname != "host-1" {
+		t.Errorf("Hostname = %q, want host-1", document.Hostname)
+	}
+}
+
+// A container can vanish between the event and the save (an OOM victim dies
+// from the very OOM being reported). The document must be kept with
+// host-level attribution, matching how collectors treat unresolvable
+// containers, instead of being dropped.
+func TestNewBaseDocumentKeepsDocumentWhenContainerVanished(t *testing.T) {
+	orig := containerByID
+	defer func() { containerByID = orig }()
+	containerByID = func(string) (*pod.Container, error) {
+		return nil, nil
+	}
+
+	document, err := newBaseDocument(DocumentOptions{Hostname: "host-1"}, testWriteRequest("gone-container"))
+	if err != nil {
+		t.Fatalf("newBaseDocument() dropped the document: %v", err)
+	}
+	if document.ContainerID != "" {
+		t.Errorf("ContainerID = %q, want empty host-level attribution", document.ContainerID)
+	}
+	if document.TracerName != "test-tracer" {
+		t.Errorf("TracerName = %q, want test-tracer", document.TracerName)
+	}
+}
+
+func TestNewBaseDocumentKeepsDocumentWhenContainerLookupFails(t *testing.T) {
+	orig := containerByID
+	defer func() { containerByID = orig }()
+	containerByID = func(string) (*pod.Container, error) {
+		return nil, errors.New("kubelet sync failed")
+	}
+
+	document, err := newBaseDocument(DocumentOptions{Hostname: "host-1"}, testWriteRequest("some-container"))
+	if err != nil {
+		t.Fatalf("newBaseDocument() dropped the document: %v", err)
+	}
+	if document.ContainerID != "" {
+		t.Errorf("ContainerID = %q, want empty host-level attribution", document.ContainerID)
+	}
+}
+
+func TestNewBaseDocumentHostLevelWithoutContainerID(t *testing.T) {
+	orig := containerByID
+	defer func() { containerByID = orig }()
+	containerByID = func(string) (*pod.Container, error) {
+		t.Fatal("containerByID must not be called without a container ID")
+		return nil, nil
+	}
+
+	document, err := newBaseDocument(DocumentOptions{Hostname: "host-1"}, testWriteRequest(""))
+	if err != nil {
+		t.Fatalf("newBaseDocument() error = %v", err)
+	}
+	if document.ContainerID != "" {
+		t.Errorf("ContainerID = %q, want empty", document.ContainerID)
+	}
+}


### PR DESCRIPTION
## Problem / Evidence

`newBaseDocument` (pkg/tracing/document_writer.go:118-128) hard-drops the
whole document whenever a write request carries a container ID that
`pod.ContainerByID` can no longer resolve:

```go
container, err := pod.ContainerByID(req.ContainerID)
if err != nil {
    return nil, fmt.Errorf("get container %s: %w", req.ContainerID, err)
}
if container == nil {
    return nil, fmt.Errorf("container %s not found", req.ContainerID)
}
```

That state is exactly when the daemon's most valuable events fire:

- **OOM victims** (core/events/oom.go:160-167 passes
  `oomData.Victim.ContainerID`): the victim's container dies from the very
  OOM being reported and disappears from the runtime container listing
  before the event document is saved. The document - PID, comm, cgroup
  snapshot, trigger/victim actors - is dropped; the caller only logs
  `failed to save tracing data: ... container not found`.
- **Autotracing profiles** (cpuidle/memburst/dload via
  profiler_ingest.go:44): a container exiting mid-profile loses the entire
  flamegraph document at save time.
- tcp_retransmit / dropwatch / net_rx_latency event docs hit the same race
  whenever the container exits between event resolution and save.

Meanwhile the codebase already defines what should happen with an
unresolvable container:

- `net_rx_latency.go:254-258` returns an empty container ID on lookup
  failure and saves the document host-level.
- `oom.go:152-156` counts a victim whose container is no longer resolvable
  as a **host** event (`outOfMemoryCounterHost++`) - and then still drops
  its document at save time.
- The document model treats `ContainerID == ""` as a first-class
  host-level document (document_writer.go:118-120).

Reproduced deterministically with unit tests (container lookup stubbed;
no container runtime needed):

```
$ go test ./pkg/tracing/ -run 'TestNewBaseDocument' -count=1 -v     # pre-fix
--- PASS: TestNewBaseDocumentAttributesContainer
    document_writer_test.go:69: newBaseDocument() dropped the document: container gone-container not found
--- FAIL: TestNewBaseDocumentKeepsDocumentWhenContainerVanished
    document_writer_test.go:88: newBaseDocument() dropped the document: get container some-container: kubelet sync failed
--- FAIL: TestNewBaseDocumentKeepsDocumentWhenContainerLookupFails
--- PASS: TestNewBaseDocumentHostLevelWithoutContainerID
```

## Root cause / Fix

`Save` is the single choke point all event/task documents flow through,
and it treats "container no longer resolvable" as a hard failure even
though the rest of the codebase treats it as a host-level event. Fix:
keep the document with host-level attribution on a failed or missing
container lookup:

```go
container, err := containerByID(req.ContainerID)
if err != nil || container == nil {
    return &document, nil
}
```

The resolution itself is behind a package-level `containerByID` seam
(default `pod.ContainerByID`) for tests. Considered alternative: keep
`document.ContainerID` set with blank metadata fields - rejected because
no other code path produces that hybrid state, while host-level
documents are the established convention; callers that need the ID embed
it in the tracer payload anyway (the oom tracer's victim actor keeps
`ContainerID` inside `TracerData`).

## Priority / scoring

PRIORITY 77 = impact 32 (silent, permanent loss of the highest-value
diagnostic documents precisely when containers die - OOM victims, profiles
of exited containers) + blast radius 12 (single choke point covering all
event and task documents) + reproducibility 18 (deterministic unit tests,
no runtime needed) + maintenance value 15 (aligns Save with the
documented host-level degradation used everywhere else).
FIX_CONFIDENCE 85: four unit tests pin all three paths (attributed /
vanished / lookup error / no container ID), no schema or metric changes,
behavior change only on the previously data-losing path.

## Tests

```
$ go test ./pkg/tracing/ -run 'TestNewBaseDocument' -count=1 -v        # post-fix
--- PASS: TestNewBaseDocumentAttributesContainer (0.00s)
--- PASS: TestNewBaseDocumentKeepsDocumentWhenContainerVanished (0.00s)
--- PASS: TestNewBaseDocumentKeepsDocumentWhenContainerLookupFails (0.00s)
--- PASS: TestNewBaseDocumentHostLevelWithoutContainerID (0.00s)

$ go test ./pkg/tracing/ ./core/events/ -count=1
ok  	huatuo-bamai/pkg/tracing	1.052s
ok  	huatuo-bamai/core/events	0.013s

$ go build ./...    # OK
```

Coverage: attributed saves (fields populated), vanished container (kept,
host-level), lookup error (kept, host-level), and empty container ID
(unchanged host-level path; also asserts the resolver is not consulted).

## Risk

Low. The only behavior change is on the previously data-losing path.
Edge case: a transient kubelet sync failure now yields a host-level
document instead of no document; the tracer payload retains the
attribution data for callers that embed it, and host-level documents are
the established state for unresolvable containers in this codebase.

## CI (final, 2026-09-05)

- `pr_name_lint`: **pass**.
- `Build, Lint and Vendor`: **pass**.
- `Test in VM` (20.04/22.04/24.04/26.04): **fail — infrastructure, not this
  change**. All four jobs die in pod sandbox setup with the recurring flannel
  CNI outage before any repo build/test runs. Verified verbatim in the run
  logs (35 occurrences in ubuntu-22.04 for #730, 31 for #731, 34 for #732's
  sibling runs):
  `plugin type="flannel" failed (add): loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory`
  The same VM pipeline was green earlier for #724. Rerunning failed jobs
  requires admin rights (403 for outside contributors) — a maintainer rerun
  would exercise the integration suite; the unit tests here are deterministic
  and need no privileges or kernel features.
- Local: full `go test ./...` = 83 packages ok / 0 FAIL / exit 0 on this
  branch.

## Evidence-chain audit (2026-09-05)

### Full call path with file:line (pre-fix)

1. Event side, oom tracer (the sharpest case): BPF OOM event →
   `pod.Containers()` snapshot (core/events/oom.go:143) → victim resolved
   from the memcg CSS map (oom.go:172-191) → counter path treats an
   unresolvable victim as a **host** event (oom.go:152-156,
   `outOfMemoryCounterHost++`) → `tracing.Save` with
   `ContainerID: oomData.Victim.ContainerID` (oom.go:160-167).
2. Save side: `Save` → `saveRaw` (pkg/tracing/store.go:66-76) →
   `documentWriter.saveRaw` (document_writer.go:76-83) →
   `newBaseDocument` (document_writer.go:101-136) → `pod.ContainerByID`
   (internal/pod/container.go:133-143; returns `nil, nil` when the id is
   absent from the runtime container view) → pre-fix returned
   `error("container %s not found")` → the whole document was dropped; the
   caller logs `failed to save tracing data: ...` (oom.go:166) and the
   event is gone.
3. Same drop path for autotracing profiles (cpuidle/memburst/dload via
   core/autotracing/profiler_ingest.go:44) and retransmit/dropwatch/net_rx_latency
   docs whenever the container exits between event resolution and save.

### Correction to the original description

The sibling-convention cite for net_rx_latency is
core/events/net_rx_latency.go:254-261 (not 254-258): on lookup failure it
returns `("", true)` — an empty container ID that downstream becomes a
host-level document. Semantics unchanged from what was claimed; verified
by reading the code during this audit.

### Why this is the established convention, not a policy choice

- `Document.ContainerID == ""` is a first-class host-level state with its
  own early-return branch (document_writer.go:118-120).
- oom.go's own counter logic classifies an unresolvable victim as a host
  event — the document save then contradicted the counter for the same
  event.
- net_rx_latency degrades to an empty container ID at resolution time;
  hungtask/dropwatch/tcp_retransmit save host-level documents for events
  they cannot attribute.
- Pre-fix, the one place that could not degrade was the choke point every
  one of them flows through — so the most attribution-critical events
  (OOM victims) were the most likely to be lost entirely.

### Fix diff (core hunk, on top of main)

```diff
--- a/pkg/tracing/document_writer.go
+++ b/pkg/tracing/document_writer.go
+// containerByID resolves a container for document attribution; overridable
+// in tests.
+var containerByID = pod.ContainerByID
+
 func newBaseDocument(options DocumentOptions, req *WriteRequest) (*Document, error) {
 	...
 	if req.ContainerID == "" {
 		return &document, nil
 	}
 
-	container, err := pod.ContainerByID(req.ContainerID)
-	if err != nil {
-		return nil, fmt.Errorf("get container %s: %w", req.ContainerID, err)
-	}
-	if container == nil {
-		return nil, fmt.Errorf("container %s not found", req.ContainerID)
-	}
+	// The container can vanish between the event and this save - an OOM
+	// victim dies from the very OOM being reported, or a profiled container
+	// exits mid-run. Keep the document with host-level attribution instead
+	// of dropping it, matching how collectors treat unresolvable containers
+	// (e.g. oom.go counts them as host events).
+	container, err := containerByID(req.ContainerID)
+	if err != nil || container == nil {
+		return &document, nil
+	}
```

### Integration coverage enumeration

- No dedicated integration script exists for the document save path; it is
  exercised broadly by the VM suite (e.g. `test_basic_startup_log.sh`,
  `test_metrics.sh`) wherever tracer documents are produced.
- This run's VM jobs never reached the test phase (flannel infra outage
  documented above), so nothing was skipped or passed in the VM.
- Local coverage: 4 unit tests pinning all paths (attributed fields
  populated / vanished container kept host-level / lookup error kept
  host-level / empty container ID never consults the resolver), plus full
  `go test ./...` = 83 packages ok / 0 FAIL / exit 0 on this branch.
Fixes #736
