### PR TITLE
feat(metrics): add conntrack usage collector

### DIFF
--- a/core/metrics/net_conntrack.go
+++ b/core/metrics/net_conntrack.go
@@ -86,14 +86,17 @@ func (c *netConntrack) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
+	// Sibling *_percent metrics (cpu_stat wait_sum_percent, disk_io
+	// disk_iowait_percent) report 0-100, so alert thresholds such as >90
+	// fire as expected.
 	usagePercent := float64(0)
 	if stats.limit > 0 {
-		usagePercent = stats.entries / stats.limit
+		usagePercent = stats.entries / stats.limit * 100
 	}
 
 	return []*metric.Data{
 		metric.NewGaugeData("entries", stats.entries, "currently tracked connections in the kernel conntrack table", nil),
 		metric.NewGaugeData("entries_limit", stats.limit, "conntrack table capacity", nil),
-		metric.NewGaugeData("usage_percent", usagePercent, "conntrack table usage as a fraction of its limit", nil),
+		metric.NewGaugeData("usage_percent", usagePercent, "conntrack table usage as a percentage of its limit (0-100)", nil),
 	}, nil
 }

--- a/core/metrics/net_conntrack.go
+++ b/core/metrics/net_conntrack.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+// ref: https://github.com/prometheus/node_exporter/blob/master/collector/conntrack_linux.go
+// ref: https://github.com/flashcatcloud/categraf/blob/main/inputs/conntrack/conntrack.go
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+type netConntrack struct{}
+
+func init() {
+	tracing.RegisterEventTracing("conntrack", newNetConntrack)
+}
+
+func newNetConntrack() (*tracing.EventTracingAttr, error) {
+	if err := procfs.RequireFile("sys/net/netfilter/nf_conntrack_count"); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, types.ErrNotSupported
+		}
+
+		return nil, fmt.Errorf("check conntrack statistics support: %w", err)
+	}
+
+	return &tracing.EventTracingAttr{
+		TracingData: &netConntrack{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+type conntrackStat struct {
+	entries float64
+	limit   float64
+}
+
+func parseConntrack() (*conntrackStat, error) {
+	fs, err := procfs.NewDefaultFS()
+	if err != nil {
+		return nil, err
+	}
+
+	count, err := fs.SysctlInts("net.netfilter.nf_conntrack_count")
+	if err != nil {
+		return nil, fmt.Errorf("read conntrack count: %w", err)
+	}
+
+	limit, err := fs.SysctlInts("net.netfilter.nf_conntrack_max")
+	if err != nil {
+		return nil, fmt.Errorf("read conntrack limit: %w", err)
+	}
+
+	if len(count) != 1 || len(limit) != 1 {
+		return nil, fmt.Errorf("unexpected conntrack sysctl format: count=%v limit=%v", count, limit)
+	}
+
+	return &conntrackStat{
+		entries: float64(count[0]),
+		limit:   float64(limit[0]),
+	}, nil
+}
+
+func (c *netConntrack) Update() ([]*metric.Data, error) {
+	stats, err := parseConntrack()
+	if err != nil {
+		return nil, err
+	}
+
+	usagePercent := float64(0)
+	if stats.limit > 0 {
+		usagePercent = stats.entries / stats.limit
+	}
+
+	return []*metric.Data{
+		metric.NewGaugeData("entries", stats.entries, "currently tracked connections in the kernel conntrack table", nil),
+		metric.NewGaugeData("entries_limit", stats.limit, "conntrack table capacity", nil),
+		metric.NewGaugeData("usage_percent", usagePercent, "conntrack table usage as a fraction of its limit", nil),
+	}, nil
+}

--- a/core/metrics/net_conntrack_test.go
+++ b/core/metrics/net_conntrack_test.go
@@ -77,13 +77,35 @@ func TestNetConntrackUpdate(t *testing.T) {
 	}{
 		{name: "entries", value: 1234, metricType: metricpkg.MetricTypeGauge},
 		{name: "entries_limit", value: 262144, metricType: metricpkg.MetricTypeGauge},
-		{name: "usage_percent", value: 1234.0 / 262144.0, metricType: metricpkg.MetricTypeGauge},
+		{name: "usage_percent", value: 1234.0 / 262144.0 * 100, metricType: metricpkg.MetricTypeGauge},
 	}
 	for i, exp := range expected {
 		assert.Equal(t, exp.name, metrics[i].Name())
 		assert.Equal(t, exp.value, metrics[i].Value)
 		assert.Equal(t, exp.metricType, metrics[i].Type())
 	}
+}
+
+// TestNetConntrackUsagePercentScale pins usage_percent to the repo-wide 0-100
+// scale of the sibling *_percent metrics: a percentage alert threshold such
+// as >90 must fire once the table is 91% full, which a 0-1 ratio (0.91)
+// would never do.
+func TestNetConntrackUsagePercentScale(t *testing.T) {
+	conntrackDir := newConntrackTestRoot(t, true)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(conntrackDir, "nf_conntrack_count"), []byte("91\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(conntrackDir, "nf_conntrack_max"), []byte("100\n"), 0o600))
+
+	collector := &netConntrack{}
+	metrics, err := collector.Update()
+	require.NoError(t, err)
+	require.Len(t, metrics, 3)
+
+	usage := metrics[2]
+	assert.Equal(t, "usage_percent", usage.Name())
+	assert.Equal(t, float64(91), usage.Value,
+		"usage_percent must be 0-100 so percentage thresholds fire")
 }
 
 func TestNetConntrackNotSupported(t *testing.T) {

--- a/core/metrics/net_conntrack_test.go
+++ b/core/metrics/net_conntrack_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+	metricpkg "huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testConntrackCount = "1234\n"
+	testConntrackLimit = "262144\n"
+)
+
+// newConntrackTestRoot writes the conntrack sysctl fixture under a temp
+// procfs root. When withConntrack is false the netfilter directory is left
+// empty, mirroring a host without the conntrack module loaded.
+func newConntrackTestRoot(t testing.TB, withConntrack bool) string {
+	t.Helper()
+
+	tmpRoot := t.TempDir()
+	procDir := filepath.Join(tmpRoot, "proc")
+	conntrackDir := filepath.Join(procDir, "sys", "net", "netfilter")
+	require.NoError(t, os.MkdirAll(conntrackDir, 0o755))
+	if withConntrack {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(conntrackDir, "nf_conntrack_count"), []byte(testConntrackCount), 0o600))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(conntrackDir, "nf_conntrack_max"), []byte(testConntrackLimit), 0o600))
+	}
+
+	originalPrefix := filepath.Dir(procfs.DefaultPath())
+	t.Cleanup(func() { procfs.RootPrefix(originalPrefix) })
+	procfs.RootPrefix(tmpRoot)
+
+	return conntrackDir
+}
+
+func TestNetConntrackUpdate(t *testing.T) {
+	newConntrackTestRoot(t, true)
+
+	attr, err := newNetConntrack()
+	require.NoError(t, err)
+	require.Equal(t, tracing.FlagMetric, attr.Flag)
+	collector, ok := attr.TracingData.(*netConntrack)
+	require.True(t, ok)
+
+	metrics, err := collector.Update()
+	require.NoError(t, err)
+	require.Len(t, metrics, 3)
+
+	expected := []struct {
+		name       string
+		value      float64
+		metricType int
+	}{
+		{name: "entries", value: 1234, metricType: metricpkg.MetricTypeGauge},
+		{name: "entries_limit", value: 262144, metricType: metricpkg.MetricTypeGauge},
+		{name: "usage_percent", value: 1234.0 / 262144.0, metricType: metricpkg.MetricTypeGauge},
+	}
+	for i, exp := range expected {
+		assert.Equal(t, exp.name, metrics[i].Name())
+		assert.Equal(t, exp.value, metrics[i].Value)
+		assert.Equal(t, exp.metricType, metrics[i].Type())
+	}
+}
+
+func TestNetConntrackNotSupported(t *testing.T) {
+	newConntrackTestRoot(t, false)
+
+	_, err := newNetConntrack()
+	require.ErrorIs(t, err, types.ErrNotSupported)
+}
+
+func TestNetConntrackMalformedSysctl(t *testing.T) {
+	conntrackDir := newConntrackTestRoot(t, true)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(conntrackDir, "nf_conntrack_count"), []byte("1 2\n"), 0o600))
+
+	collector := &netConntrack{}
+	_, err := collector.Update()
+	require.ErrorContains(t, err, "unexpected conntrack sysctl format")
+}


### PR DESCRIPTION
## Source

Stable capability in two mature agents of the same class:

1. **prometheus/node_exporter** — `collector/conntrack_linux.go` (shipped for years): exports `node_nf_conntrack_entries` from `/proc/sys/net/netfilter/nf_conntrack_count` and `node_nf_conntrack_entries_limit` from `/proc/sys/net/netfilter/nf_conntrack_max`. https://github.com/prometheus/node_exporter/blob/master/collector/conntrack_linux.go
2. **flashcatcloud/categraf** (sister agent in the same ecosystem, ships a `huatuo` input) — `inputs/conntrack/conntrack.go`: reads the same two sysctl files (`nf_conntrack_count`/`nf_conntrack_max`, legacy `ip_` variants). https://github.com/flashcatcloud/categraf/blob/main/inputs/conntrack/conntrack.go

No corresponding huatuo Issue, roadmap entry or doc exists (see Current gap); the feature source is the two external implementations above, not maintainer feedback.

## Current gap

huatuo covers the network stack deeply (sockstat, tcp_memory, netdev qdisc/dcb/hw, arp, BPF retransmit tracing, dropwatch), but the kernel **conntrack table** is not observable anywhere in the codebase:

- `grep -rn conntrack --include="*.go"` over core/, internal/, pkg/ matches only `internal/symbol/symbols_test.go` (BPF symbol list, unrelated to metrics).
- No collector reads `/proc/sys/net/netfilter/nf_conntrack_*`.
- Searched open+closed issues and PRs for "conntrack" (none; open PR list reviewed 2026-09-06). No existing implementation and no sign of intentional omission — the sibling collectors in the same file (`tcp_memory` etc.) follow a "expose what /proc exposes" pattern this feature simply extends.

On NAT-heavy hosts (kube-proxy iptables mode, host gateway services), once `nf_conntrack_count` reaches `nf_conntrack_max` the kernel **drops new connections with no application-visible error** until entries expire. Today huatuo users can only see the downstream symptom (retransmits), not the cause.

## Project fit

- **Positioning**: README scopes huatuo to "kernel-wide insight" into kernel subsystems including networking, at <1% overhead. Conntrack saturation is a kernel resource-exhaustion failure exactly of that class — and the counters are pure sysctl reads, no BPF, no overhead concern.
- **Architecture**: joins the existing collector mechanism only — `tracing.RegisterEventTracing("conntrack", ...)` in `init()` with `FlagMetric`, data flows through the same `metric.Data` → `pkg/metric` Prometheus pipeline as every other host-level collector. No other wiring.
- **Existing code reuse**: same surface and degradation contract as the in-repo `tcp_memory` collector (`procfs.RequireFile` + vendored prometheus/procfs `SysctlInts` + `types.ErrNotSupported` when the kernel surface is absent).
- It completes a hole inside the documented network pillar rather than adding a new domain: sockstat/tcp_memory/qdisc/dcb/arp exist, connection-state table pressure does not.

## Scope

**Implemented** (one new file pair, no changes to existing files):
- Metric collector `conntrack` (`core/metrics/net_conntrack.go`) reading `/proc/sys/net/netfilter/nf_conntrack_count` and `nf_conntrack_max`.

**User-observable behavior** (namespace `huatuo_bamai`, per `pkg/metric.DefaultNamespace`):
- `huatuo_bamai_conntrack_entries` (gauge) — currently tracked connections.
- `huatuo_bamai_conntrack_entries_limit` (gauge) — table capacity.
- `huatuo_bamai_conntrack_usage_percent` (gauge) — entries/limit as a percentage 0–100, matching the scale of the sibling `*_percent` metrics (`wait_sum_percent`, `disk_iowait_percent`, GPU utilization).
- Hosts without the module: collector not registered (`ErrNotSupported`), zero new series, no errors.

**Not included**:
- Legacy `ip_conntrack_*` sysctls (pre-2.6.20 kernels; huatuo's floor is 4.18).
- Per-CPU `/proc/net/stat/nf_conntrack` stat columns (`insert_failed`, `drop`, `early_drop`, `search_restart` — node_exporter has these, categraf does not). Deliberately deferred to keep the change minimal; a natural follow-up if wanted.
- Per-container netns views and config include/exclude knobs.

## Implementation

- `core/metrics/net_conntrack.go` (new): `newNetConntrack()` gates on `RequireFile` (missing file → `types.ErrNotSupported`, the tcp_memory pattern); `parseConntrack()` reads the two sysctls via vendored prometheus/procfs `SysctlInts` (rejecting unexpected multi-value format); `Update()` emits the three gauges.
- `core/metrics/net_conntrack_test.go` (new): fixture-based behavior tests using the repo's `procfs.RootPrefix` seam (same pattern as `disk_io_test.go`).

## Priority & Confidence

- `FEATURE_PRIORITY = 84` = 项目需求 32 + 外部实现成熟度 26 (node_exporter ~10y stable + categraf) + 项目契合度 17 + 可测试性 9.
- `IMPLEMENTATION_CONFIDENCE = 90`: single new file, existing `RequireFile`/`ErrNotSupported`/`SysctlInts` machinery, no new dependencies, no BPF.

## Tests

All executed on this branch (Go 1.24, WSL2 kernel 6.6); VM-based integration tests are not executable in this environment and are covered by CI (see CI section):

```
$ go test ./core/metrics/ -run "TestNetConntrack" -v
=== RUN   TestNetConntrackUpdate
--- PASS: TestNetConntrackUpdate (0.00s)
=== RUN   TestNetConntrackUsagePercentScale
--- PASS: TestNetConntrackUsagePercentScale (0.00s)
=== RUN   TestNetConntrackNotSupported
--- PASS: TestNetConntrackNotSupported (0.00s)
=== RUN   TestNetConntrackMalformedSysctl
--- PASS: TestNetConntrackMalformedSysctl (0.00s)
PASS
ok  	huatuo-bamai/core/metrics	(cached)
$ go build ./...   # exit 0
```

- `TestNetConntrackUpdate` pins the exported names, gauge types and values (incl. `usage_percent = entries/limit*100`) against a fixture `/proc/sys/net/netfilter`.
- `TestNetConntrackUsagePercentScale` pins the 0–100 scale: with count=91, limit=100 the exported value is 91, so a percentage alert threshold such as `>90` fires (a 0–1 ratio of 0.91 would never do). Regression test for the review finding CR-001.
- `TestNetConntrackNotSupported` pins the degradation contract (no netfilter dir → `types.ErrNotSupported`, collector disabled instead of failing registration).
- `TestNetConntrackMalformedSysctl` pins the malformed-sysctl error path.
- Full suite: `go test ./...` → exit 0, 83 packages ok, 0 FAIL (run on this branch at commit time).

## Compatibility & Risk

- **Kernel compatibility**: both sysctl files exist on every kernel ≥ 2.6.20 with conntrack loaded; huatuo's floor is 4.18, so no version branching needed. Module absent → graceful skip via `ErrNotSupported` (same as `tcp_memory`).
- **Regression risk**: none to existing behavior — no existing file is touched; the only change is a new collector registration.
- **API/dependency**: no public API change, no new module dependencies (vendored prometheus/procfs v0.19.2 already in use).
- **License**: repo is Apache-2.0. No code copied from any reference project; only the design (which counters, which files) is referenced. node_exporter is Apache-2.0, categraf is MIT — both compatible; nothing is taken from GPL-licensed projects.
- **Metric volume**: 3 new host-level series per scrape.

## Issue

No corresponding upstream Issue exists (searched open+closed issues and PRs, 2026-09-06 — see Current gap). There is no Issue to link with `Closes`/`Fixes`/`Resolves`; this PR is the first tracker record for the feature.

## Review fix (2026-09-07)

Review finding CR-001 (blocking): `usage_percent` exported a 0–1 ratio while sibling percentage metrics report 0–100, so thresholds such as `>90` could never fire. Fixed in c9650e6c: the value is now `entries/limit*100` (the majority repo convention), the help text states the scale, and `TestNetConntrackUsagePercentScale` reproduces the finding (red on the pre-fix code, green after).

## CI

- `pr_name_lint`: **pass**.
- `Build, Lint and Vendor`: **pass** (job 101415210556, https://github.com/ccfos/huatuo/actions/runs/34006736668).
- `Test in VM` (amd64 ubuntu 20.04/22.04/24.04/26.04): **fail — infrastructure outage, not this change.** All four VM jobs abort during K8s pod sandbox creation, before any repository build/test runs, with the recurring signature (job log 101415210752, 9 occurrences):
  ```
  plugin type="flannel" failed (add): loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory
  ```
  Run: https://github.com/ccfos/huatuo/actions/runs/34006736665. Local verification stands in: full `go test ./...` exit 0 (83 packages ok / 0 FAIL). Outside contributors cannot rerun VM jobs (403 admin required) — a maintainer rerun after the flannel recovery would be appreciated.

