### PR TITLE
feat(metrics): add host kernel counters from /proc/stat

### DIFF
--- a/core/metrics/system_stat.go
+++ b/core/metrics/system_stat.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+// ref: https://github.com/flashcatcloud/categraf/blob/main/inputs/kernel/kernel.go
+// ref: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kernel/kernel.go
+
+import (
+	"fmt"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+)
+
+type systemStat struct {
+	procFS procfs.FS
+}
+
+func init() {
+	tracing.RegisterEventTracing("system_stat", newSystemStat)
+}
+
+func newSystemStat() (*tracing.EventTracingAttr, error) {
+	procFS, err := procfs.NewDefaultFS()
+	if err != nil {
+		return nil, fmt.Errorf("system_stat: init procfs: %w", err)
+	}
+
+	return &tracing.EventTracingAttr{
+		TracingData: &systemStat{procFS: procFS},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+func (c *systemStat) Update() ([]*metric.Data, error) {
+	stat, err := c.procFS.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return []*metric.Data{
+		metric.NewCounterData("context_switches_total", float64(stat.ContextSwitches),
+			"Total number of context switches (from /proc/stat ctxt).", nil),
+		metric.NewCounterData("interrupts_total", float64(stat.IRQTotal),
+			"Total number of interrupts handled (from /proc/stat intr).", nil),
+		metric.NewCounterData("processes_forked_total", float64(stat.ProcessCreated),
+			"Total number of processes created by fork since boot (from /proc/stat processes).", nil),
+		metric.NewGaugeData("procs_running", float64(stat.ProcessesRunning),
+			"Processes currently in runnable state (from /proc/stat procs_running).", nil),
+		metric.NewGaugeData("procs_blocked", float64(stat.ProcessesBlocked),
+			"Processes currently blocked waiting for I/O (from /proc/stat procs_blocked).", nil),
+		metric.NewGaugeData("boot_time_seconds", float64(stat.BootTime),
+			"Boot time in seconds since the Epoch (from /proc/stat btime).", nil),
+	}, nil
+}

--- a/core/metrics/system_stat_test.go
+++ b/core/metrics/system_stat_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+	metricpkg "huatuo-bamai/pkg/metric"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSystemStatTestCollector(t testing.TB, stat string) *systemStat {
+	t.Helper()
+
+	tmpRoot := t.TempDir()
+	procDir := filepath.Join(tmpRoot, "proc")
+	require.NoError(t, os.MkdirAll(procDir, 0o755))
+	if stat != "" {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(procDir, "stat"), []byte(stat), 0o600))
+	}
+
+	originalPrefix := filepath.Dir(procfs.DefaultPath())
+	t.Cleanup(func() { procfs.RootPrefix(originalPrefix) })
+	procfs.RootPrefix(tmpRoot)
+
+	procFS, err := procfs.NewDefaultFS()
+	require.NoError(t, err)
+
+	return &systemStat{procFS: procFS}
+}
+
+func TestSystemStatUpdate(t *testing.T) {
+	// testStat is the /proc/stat fixture shared with disk_io_test.go.
+	collector := newSystemStatTestCollector(t, testStat)
+
+	metrics, err := collector.Update()
+	require.NoError(t, err)
+	require.Len(t, metrics, 6)
+
+	expected := []struct {
+		name       string
+		value      float64
+		metricType int
+	}{
+		{name: "context_switches_total", value: 200000, metricType: metricpkg.MetricTypeCounter},
+		{name: "interrupts_total", value: 100000, metricType: metricpkg.MetricTypeCounter},
+		{name: "processes_forked_total", value: 5000, metricType: metricpkg.MetricTypeCounter},
+		{name: "procs_running", value: 3, metricType: metricpkg.MetricTypeGauge},
+		{name: "procs_blocked", value: 1, metricType: metricpkg.MetricTypeGauge},
+		{name: "boot_time_seconds", value: 1700000000, metricType: metricpkg.MetricTypeGauge},
+	}
+	for i, exp := range expected {
+		assert.Equal(t, exp.name, metrics[i].Name())
+		assert.Equal(t, exp.value, metrics[i].Value)
+		assert.Equal(t, exp.metricType, metrics[i].Type())
+	}
+}
+
+func TestSystemStatErrorWithoutProcStat(t *testing.T) {
+	collector := newSystemStatTestCollector(t, "")
+
+	_, err := collector.Update()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Source

Stable capability in two mature agents of the same class:

1. **flashcatcloud/categraf** (sister agent in the same ecosystem, ships a `huatuo` input) — `inputs/kernel/kernel.go`: exports `interrupts`, `context_switches`, `processes_forked`, `boot_time`, `processes_running`, `processes_blocked` from `/proc/stat`. https://github.com/flashcatcloud/categraf/blob/main/inputs/kernel/kernel.go
2. **influxdata/telegraf** — `plugins/inputs/kernel/kernel.go`: exports `context_switches`, `interrupts`, `processes_created`, `boot_time`, `processes_running`, `processes_blocked`, `disk_pages` from `/proc/stat`. https://github.com/influxdata/telegraf/blob/master/plugins/inputs/kernel/kernel.go

No corresponding huatuo Issue, roadmap entry or doc exists (see Current gap); the feature source is the two external implementations above, not maintainer feedback.

## Current gap

huatuo exposes host load averages (`system_loadavg` → load1/5/15) but none of the instantaneous kernel counters from `/proc/stat` that the load figures are computed from:

- `grep -rn "procs_running\|procs_blocked\|ctxt\|context_switches" --include="*.go"` over core/, pkg/ matches only test fixtures (disk_io_test.go).
- `/proc/stat` is read today in exactly one place — the `diskio` collector's `collectIOWait()` uses only the cpu-line iowait delta.
- `cpu_stat`/`cpu_util` are cgroup-scoped per-container collectors, not host-level /proc/stat counters.
- No issue/PR tracks this (searched open+closed issues and PRs, 2026-09-06). No existing implementation and no sign of intentional omission — the missing fields are on the same file the diskio collector already parses.

Without these, a load spike cannot be classified at collection time as CPU-runnable vs D-state (I/O-blocked), and fork-rate bursts (fork bombs, job churn, sandbox respawns) are invisible until load averages catch up.

## Project fit

- **Positioning**: the runnable/blocked process counts and context-switch/interrupt/fork rates are the standard saturation and churn signals of the USE method for the CPU subsystem — the same kernel-wide, zero-instrumentation insight README promises. Pure `/proc/stat` reads, no BPF.
- **Architecture**: joins the existing collector mechanism only (`tracing.RegisterEventTracing("system_stat", ...)` + `FlagMetric` → `metric.Data` → `pkg/metric` Prometheus pipeline); no other wiring.
- **Complements, not duplicates**: `system_loadavg` documents the 1/5/15-minute averages; this adds their instantaneous sources. `cpu_stat`/`cpu_util` are per-cgroup; this is the host view. `diskio` derives iowait% from the same file — these are the saturation counters from it.
- **Code reuse**: parsing is delegated to the already-vendored prometheus/procfs `FS.Stat()` (fields ContextSwitches/IRQTotal/ProcessCreated/ProcessesRunning/ProcessesBlocked/BootTime) — the same library call diskio already makes; the `procFS` field seam mirrors diskio's struct.
- Naming follows the `system_` file prefix convention (`system_loadavg`, `system_softirq`).

## Scope

**Implemented** (one new file pair, no changes to existing files):
- Metric collector `system_stat` (`core/metrics/system_stat.go`) reading `/proc/stat` via vendored procfs.

**User-observable behavior** (namespace `huatuo_bamai`, per `pkg/metric.DefaultNamespace`):
- `huatuo_bamai_system_stat_context_switches_total` (counter, from `ctxt`)
- `huatuo_bamai_system_stat_interrupts_total` (counter, from `intr`)
- `huatuo_bamai_system_stat_processes_forked_total` (counter, from `processes`)
- `huatuo_bamai_system_stat_procs_running` (gauge, from `procs_running`)
- `huatuo_bamai_system_stat_procs_blocked` (gauge, from `procs_blocked`)
- `huatuo_bamai_system_stat_boot_time_seconds` (gauge, from `btime`)

**Not included**:
- Per-IRQ breakdown (`intr` sub-fields).
- `disk_pages` (paging counters — already covered by `memory_vmstat`, pswpin/pswpout included).
- CPU time lines (covered by `cpu_util`/`cpu_stat` at container scope and `diskio` at host scope).
- Config knobs.

## Implementation

- `core/metrics/system_stat.go` (new): holds a `procfs.FS` (same seam as `diskio`), `newSystemStat()` fails only if /proc is not mounted; `Update()` emits three counters + three gauges from one `Stat()` call.
- `core/metrics/system_stat_test.go` (new): fixture-based behavior tests; reuses the `/proc/stat` fixture already present in `disk_io_test.go` (same package).

## Priority & Confidence

- `FEATURE_PRIORITY = 80` = 项目需求 30 + 外部实现成熟度 25 (categraf kernel + telegraf kernel, both long-stable) + 项目契合度 16 + 可测试性 9.
- `IMPLEMENTATION_CONFIDENCE = 92`: single new file, parsing already provided by the vendored procfs library, fixture tests, no privileges needed.

## Tests

All executed on this branch (Go 1.24, WSL2 kernel 6.6); VM-based integration tests are not executable in this environment and are covered by CI (see CI section):

```
$ go test ./core/metrics/ -run "TestSystemStat" -v -count=1
=== RUN   TestSystemStatUpdate
--- PASS: TestSystemStatUpdate (0.00s)
=== RUN   TestSystemStatErrorWithoutProcStat
--- PASS: TestSystemStatErrorWithoutProcStat (0.00s)
PASS
ok  	huatuo-bamai/core/metrics	0.013s
$ go build ./...   # exit 0
```

- `TestSystemStatUpdate` pins all six metric names, gauge/counter types and values against the shared `/proc/stat` fixture.
- `TestSystemStatErrorWithoutProcStat` pins the error path when `/proc/stat` is unreadable.
- Full suite: `go test ./...` → exit 0, 83 packages ok, 0 FAIL (run on this branch at commit time).

## Compatibility & Risk

- **Kernel compatibility**: all six fields have existed in `/proc/stat` since long before 4.18; the vendored parser tolerates any subset (missing optional fields parse as 0).
- **Regression risk**: none to existing behavior — no existing file is touched; the collector adds one more `Stat()` read per scrape (the file is world-readable and cheap).
- **API/dependency**: no public API change, no new dependencies (vendored prometheus/procfs v0.19.2 already in use by diskio/tcp_memory).
- **License**: repo is Apache-2.0. No code copied from any reference project; categraf and telegraf are MIT — compatible; nothing is taken from GPL-licensed projects.
- **Metric volume**: 6 new host-level series per scrape.

## Issue

No corresponding upstream Issue exists (searched open+closed issues and PRs, 2026-09-06 — see Current gap). There is no Issue to link with `Closes`/`Fixes`/`Resolves`; this PR is the first tracker record for the feature.

## CI

- `pr_name_lint`: **pass**.
- `Build, Lint and Vendor`: **pass** (job 101428517450, https://github.com/ccfos/huatuo/actions/runs/34011689658).
- `Test in VM` (amd64 ubuntu 20.04/22.04/24.04/26.04): **fail — infrastructure outage, not this change.** All four VM jobs abort during K8s pod sandbox creation, before any repository build/test runs, with the recurring signature (job log 101428517599, 5 occurrences):
  ```
  plugin type="flannel" failed (add): loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory
  ```
  Run: https://github.com/ccfos/huatuo/actions/runs/34011689652. Local verification stands in: full `go test ./...` exit 0 (83 packages ok / 0 FAIL). Outside contributors cannot rerun VM jobs (403 admin required) — a maintainer rerun after the flannel recovery would be appreciated.
