### PR TITLE
feat(metrics): add UDP datagram and error counters

### DIFF
--- a/core/metrics/net_udp.go
+++ b/core/metrics/net_udp.go
@@ -49,20 +49,34 @@ var udpFields = []struct {
 	name string
 	help string
 }{
-	{"InDatagrams", "datagrams_received_total",
-		"Total number of UDP datagrams delivered to userspace."},
-	{"OutDatagrams", "datagrams_sent_total",
-		"Total number of UDP datagrams sent."},
-	{"InErrors", "in_errors_total",
-		"Total number of UDP datagrams dropped for reasons other than a full receive buffer, e.g. invalid checksum."},
-	{"NoPorts", "no_ports_total",
-		"Total number of UDP datagrams received with no application listening on the destination port."},
-	{"RcvbufErrors", "rcvbuf_errors_total",
-		"Total number of UDP datagrams dropped because the receiving socket buffer was full."},
-	{"SndbufErrors", "sndbuf_errors_total",
-		"Total number of UDP datagrams dropped because the sending socket buffer was full."},
-	{"InCsumErrors", "in_csum_errors_total",
-		"Total number of UDP datagrams dropped because of an invalid checksum."},
+	{
+		"InDatagrams", "datagrams_received_total",
+		"Total number of UDP datagrams delivered to userspace.",
+	},
+	{
+		"OutDatagrams", "datagrams_sent_total",
+		"Total number of UDP datagrams sent.",
+	},
+	{
+		"InErrors", "in_errors_total",
+		"Total number of UDP datagrams dropped for reasons other than a full receive buffer, e.g. invalid checksum.",
+	},
+	{
+		"NoPorts", "no_ports_total",
+		"Total number of UDP datagrams received with no application listening on the destination port.",
+	},
+	{
+		"RcvbufErrors", "rcvbuf_errors_total",
+		"Total number of UDP datagrams dropped because the receiving socket buffer was full.",
+	},
+	{
+		"SndbufErrors", "sndbuf_errors_total",
+		"Total number of UDP datagrams dropped because the sending socket buffer was full.",
+	},
+	{
+		"InCsumErrors", "in_csum_errors_total",
+		"Total number of UDP datagrams dropped because of an invalid checksum.",
+	},
 }
 
 // parseUdpSnmp parses the "Udp:" header/value line pair from

--- a/core/metrics/net_udp.go
+++ b/core/metrics/net_udp.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+// ref: https://github.com/prometheus/node_exporter/blob/master/collector/netstat_linux.go
+// ref: https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nstat/nstat.go
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+)
+
+type netUdp struct{}
+
+func init() {
+	tracing.RegisterEventTracing("udp", newNetUdp)
+}
+
+func newNetUdp() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &netUdp{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+// udpFields maps the /proc/net/snmp Udp section fields to exported metrics.
+// Fields absent on the running kernel are skipped at export time.
+var udpFields = []struct {
+	key  string
+	name string
+	help string
+}{
+	{"InDatagrams", "datagrams_received_total",
+		"Total number of UDP datagrams delivered to userspace."},
+	{"OutDatagrams", "datagrams_sent_total",
+		"Total number of UDP datagrams sent."},
+	{"InErrors", "in_errors_total",
+		"Total number of UDP datagrams dropped for reasons other than a full receive buffer, e.g. invalid checksum."},
+	{"NoPorts", "no_ports_total",
+		"Total number of UDP datagrams received with no application listening on the destination port."},
+	{"RcvbufErrors", "rcvbuf_errors_total",
+		"Total number of UDP datagrams dropped because the receiving socket buffer was full."},
+	{"SndbufErrors", "sndbuf_errors_total",
+		"Total number of UDP datagrams dropped because the sending socket buffer was full."},
+	{"InCsumErrors", "in_csum_errors_total",
+		"Total number of UDP datagrams dropped because of an invalid checksum."},
+}
+
+// parseUdpSnmp parses the "Udp:" header/value line pair from
+// /proc/net/snmp. Other protocol sections are skipped without consuming
+// their value lines, so a truncated or empty section cannot desync the
+// parser.
+func parseUdpSnmp(fileName string) (map[string]uint64, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var (
+		stats   = map[string]uint64{}
+		scanner = bufio.NewScanner(file)
+	)
+
+	for scanner.Scan() {
+		nameParts := strings.Fields(scanner.Text())
+		if len(nameParts) < 2 || nameParts[0] != "Udp:" {
+			continue
+		}
+
+		if !scanner.Scan() {
+			break
+		}
+
+		valueParts := strings.Fields(scanner.Text())
+		if len(valueParts) < 2 || valueParts[0] != "Udp:" {
+			return nil, fmt.Errorf("udp: malformed value line in %s", fileName)
+		}
+
+		if len(nameParts) != len(valueParts) {
+			return nil, fmt.Errorf("udp: field mismatch in %s", fileName)
+		}
+
+		for i := 1; i < len(nameParts); i++ {
+			value, err := strconv.ParseUint(valueParts[i], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("udp: parse %s in %s: %w", nameParts[i], fileName, err)
+			}
+
+			stats[nameParts[i]] = value
+		}
+	}
+
+	return stats, scanner.Err()
+}
+
+func (c *netUdp) Update() ([]*metric.Data, error) {
+	stats, err := parseUdpSnmp(procfs.Path("net", "snmp"))
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := make([]*metric.Data, 0, len(udpFields))
+	for _, field := range udpFields {
+		value, ok := stats[field.key]
+		if !ok {
+			continue
+		}
+
+		metrics = append(metrics, metric.NewCounterData(field.name, float64(value), field.help, nil))
+	}
+
+	if len(metrics) == 0 {
+		return nil, metric.ErrNoData
+	}
+
+	return metrics, nil
+}

--- a/core/metrics/net_udp_test.go
+++ b/core/metrics/net_udp_test.go
@@ -87,7 +87,12 @@ func TestNetUdpUpdate(t *testing.T) {
 }
 
 func TestNetUdpNoDataWithoutUdpSection(t *testing.T) {
-	collector := newUdpTestCollector(t, testUdpSnmp[:strings.Index(testUdpSnmp, "Udp: InDatagrams")])
+	// Drop the Udp section (and everything after it) from the fixture,
+	// keeping only the Ip/Icmp/IcmpMsg/Tcp sections.
+	noUdp := strings.SplitN(testUdpSnmp, "\nUdp:", 2)[0]
+	require.NotContains(t, noUdp, "Udp:")
+
+	collector := newUdpTestCollector(t, noUdp)
 
 	_, err := collector.Update()
 	require.ErrorIs(t, err, metricpkg.ErrNoData)

--- a/core/metrics/net_udp_test.go
+++ b/core/metrics/net_udp_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+	metricpkg "huatuo-bamai/pkg/metric"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testUdpSnmp = `Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates
+Ip: 1 64 100 0 0 0 0 0 100 200 0 0 0 0 0 0 0 0 0
+Icmp: InMsgs InErrors InCsumErrors InDestUnreachs InTimeExcds InParmProbs InSrcQuenchs InRedirects InEchors InEchoReps InTimestamps InTimestampReps InAddrMasks InAddrMaskReps OutMsgs OutErrors OutDestUnreachs OutTimeExcds OutParmProbs OutSrcQuenchs OutRedirects OutEchors OutEchoReps OutTimestamps OutTimestampReps OutAddrMasks OutAddrMaskReps
+Icmp: 5 0 0 5 0 0 0 0 0 0 0 0 0 0 5 0 5 0 0 0 0 0 0 0 0 0 0
+IcmpMsg: InType3 OutType3
+IcmpMsg: 5 5
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 10 5 1 2 3 1000 2000 4 0 5 0
+Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
+Udp: 1000 2 3 1500 4 5 6 7
+UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors
+UdpLite: 0 0 0 0 0 0 0
+`
+
+func newUdpTestCollector(t testing.TB, snmp string) *netUdp {
+	t.Helper()
+
+	tmpRoot := t.TempDir()
+	netDir := filepath.Join(tmpRoot, "proc", "net")
+	require.NoError(t, os.MkdirAll(netDir, 0o755))
+	if snmp != "" {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(netDir, "snmp"), []byte(snmp), 0o600))
+	}
+
+	originalPrefix := filepath.Dir(procfs.DefaultPath())
+	t.Cleanup(func() { procfs.RootPrefix(originalPrefix) })
+	procfs.RootPrefix(tmpRoot)
+
+	return &netUdp{}
+}
+
+func TestNetUdpUpdate(t *testing.T) {
+	collector := newUdpTestCollector(t, testUdpSnmp)
+
+	metrics, err := collector.Update()
+	require.NoError(t, err)
+	require.Len(t, metrics, 7)
+
+	expected := []struct {
+		name       string
+		value      float64
+		metricType int
+	}{
+		{name: "datagrams_received_total", value: 1000, metricType: metricpkg.MetricTypeCounter},
+		{name: "datagrams_sent_total", value: 1500, metricType: metricpkg.MetricTypeCounter},
+		{name: "in_errors_total", value: 3, metricType: metricpkg.MetricTypeCounter},
+		{name: "no_ports_total", value: 2, metricType: metricpkg.MetricTypeCounter},
+		{name: "rcvbuf_errors_total", value: 4, metricType: metricpkg.MetricTypeCounter},
+		{name: "sndbuf_errors_total", value: 5, metricType: metricpkg.MetricTypeCounter},
+		{name: "in_csum_errors_total", value: 6, metricType: metricpkg.MetricTypeCounter},
+	}
+	for i, exp := range expected {
+		assert.Equal(t, exp.name, metrics[i].Name())
+		assert.Equal(t, exp.value, metrics[i].Value)
+		assert.Equal(t, exp.metricType, metrics[i].Type())
+	}
+}
+
+func TestNetUdpNoDataWithoutUdpSection(t *testing.T) {
+	collector := newUdpTestCollector(t, testUdpSnmp[:strings.Index(testUdpSnmp, "Udp: InDatagrams")])
+
+	_, err := collector.Update()
+	require.ErrorIs(t, err, metricpkg.ErrNoData)
+}
+
+func TestNetUdpRejectsMalformedValueLine(t *testing.T) {
+	collector := newUdpTestCollector(t, `Udp: InDatagrams NoPorts
+Udp:
+`)
+
+	_, err := collector.Update()
+	require.ErrorContains(t, err, "malformed value line")
+}
+
+func TestNetUdpRejectsFieldMismatch(t *testing.T) {
+	collector := newUdpTestCollector(t, `Udp: InDatagrams NoPorts InErrors
+Udp: 1 2
+`)
+
+	_, err := collector.Update()
+	require.ErrorContains(t, err, "field mismatch")
+}
+
+func TestNetUdpErrorWithoutSnmpFile(t *testing.T) {
+	collector := newUdpTestCollector(t, "")
+
+	_, err := collector.Update()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Source

Stable capability in two mature projects of the same class:

1. **prometheus/node_exporter** — `collector/netstat_linux.go`: exports `node_netstat_Udp_InDatagrams`, `Udp_OutDatagrams`, `Udp_InErrors`, `Udp_NoPorts`, `Udp_RcvbufErrors`, `Udp_SndbufErrors`, `Udp_InCsumErrors` (and `UdpLite`) from `/proc/net/snmp`. https://github.com/prometheus/node_exporter/blob/master/collector/netstat_linux.go
2. **influxdata/telegraf** — `plugins/inputs/nstat/nstat.go`: dumps `/proc/net/snmp`+`/proc/net/netstat` counters including the `udp_*` family. https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nstat

No corresponding huatuo Issue, roadmap entry or doc exists (see Current gap); the feature source is the two external implementations above, not maintainer feedback.

## Current gap

UDP is the transport of DNS, QUIC and high-fanout traffic, and its failure modes are kernel-side buffer and accounting events — but huatuo exports **no UDP counter** today:

- `core/metrics/net_netstat.go:147` hard-filters `/proc/net/snmp` to `Tcp`/`TcpExt` sections only (`if protocol != "Tcp" && protocol != "TcpExt" { continue }`) — the Udp section is present in the file it already reads but deliberately out of that collector's parsed surface. Extending that collector instead would change the default export surface of an existing collector (its include/exclude config only filters within the parsed protocols), so a separate curated collector is the smaller change.
- `core/metrics/net_sockstat.go` (from `/proc/net/sockstat`) exports socket counts/memory only — that file carries no error counters.
- No issue/PR tracks this (searched open+closed issues and PRs, 2026-09-06). No existing implementation and no sign of intentional omission — sockstat/tcp_memory demonstrate the file family is in scope; only the Udp section is unreached.

The missing signals are exactly the ones seen in production incidents: `RcvbufErrors` (application cannot drain its socket fast enough / buffer too small), `SndbufErrors`, `InErrors`/`InCsumErrors` (corrupt datagrams) and `NoPorts` (traffic to a closed port — service-down or scan signal).

## Project fit

- **Positioning**: UDP buffer-overflow and parse-error counters are kernel-level transport-health signals of exactly the class README scopes huatuo to. Pure `/proc/net/snmp` reads, no BPF, no overhead concern.
- **Architecture**: joins the existing collector mechanism only (`tracing.RegisterEventTracing("udp", ...)` + `FlagMetric` → `metric.Data` → `pkg/metric` Prometheus pipeline); no other wiring.
- **Complements, not duplicates**: `net_sockstat` covers socket counts/memory, `netstat` covers Tcp/TcpExt — the Udp section of the same snmp file is the remaining hole in the transport-layer pillar.
- **Code style**: a small dedicated two-line parser follows the repo's hand-rolled net_* parser style (net_netstat, net_arpcache) and is written defensively where the generic `parseNetStat` is not: sections are skipped without consuming their value lines (issue #598 documents that parser's empty-line desync panic), so a truncated foreign section cannot corrupt the Udp read.

## Scope

**Implemented** (one new file pair, no changes to existing files):
- Metric collector `udp` (`core/metrics/net_udp.go`) parsing the `Udp:` section of `/proc/net/snmp` (host-level; the file is the netns view of the reading process, same as the netstat collector's host case).

**User-observable behavior** (namespace `huatuo_bamai`, per `pkg/metric.DefaultNamespace`; all counters):
- `huatuo_bamai_udp_datagrams_received_total` (InDatagrams)
- `huatuo_bamai_udp_datagrams_sent_total` (OutDatagrams)
- `huatuo_bamai_udp_in_errors_total` (InErrors)
- `huatuo_bamai_udp_no_ports_total` (NoPorts)
- `huatuo_bamai_udp_rcvbuf_errors_total` (RcvbufErrors)
- `huatuo_bamai_udp_sndbuf_errors_total` (SndbufErrors)
- `huatuo_bamai_udp_in_csum_errors_total` (InCsumErrors)
- A kernel without a listed field (none known ≥ 4.18) skips that series; a file without a `Udp:` section yields `metric.ErrNoData` (the repo-wide no-data contract), not an error.

**Not included**:
- `UdpLite` counters (near-zero value on general-purpose hosts).
- `IgnoredMulti` (kernel ≥ 5.13; parsed but not exported — addable later without format changes).
- IPv6 (`/proc/net/snmp6` has a different flat format; node_exporter's netstat does not read it either).
- Config knobs.

## Implementation

- `core/metrics/net_udp.go` (new): `parseUdpSnmp()` parses only the `Udp:` header/value pair (rejecting malformed value lines and header/value field-count mismatches); `Update()` emits the seven counters, skipping fields absent on the running kernel.
- `core/metrics/net_udp_test.go` (new): fixture-based behavior tests over a realistic `/proc/net/snmp` body (Ip/Icmp/IcmpMsg/Tcp/Udp/UdpLite sections present, proving foreign sections are skipped).
- The existing `netstat` collector is deliberately untouched.

## Priority & Confidence

- `FEATURE_PRIORITY = 77` = 项目需求 28 + 外部实现成熟度 24 (node_exporter netstat + telegraf nstat) + 项目契合度 16 + 可测试性 9.
- `IMPLEMENTATION_CONFIDENCE = 85`: single new file, defensive parser with pinned error paths, no dependencies.

## Tests

All executed on this branch (Go 1.24, WSL2 kernel 6.6); VM-based integration tests are not executable in this environment and are covered by CI (see CI section):

```
$ go test ./core/metrics/ -run "TestNetUdp" -v -count=1
=== RUN   TestNetUdpUpdate
--- PASS: TestNetUdpUpdate (0.00s)
=== RUN   TestNetUdpNoDataWithoutUdpSection
--- PASS: TestNetUdpNoDataWithoutUdpSection (0.00s)
=== RUN   TestNetUdpRejectsMalformedValueLine
--- PASS: TestNetUdpRejectsMalformedValueLine (0.00s)
=== RUN   TestNetUdpRejectsFieldMismatch
--- PASS: TestNetUdpRejectsFieldMismatch (0.00s)
=== RUN   TestNetUdpErrorWithoutSnmpFile
--- PASS: TestNetUdpErrorWithoutSnmpFile (0.00s)
PASS
ok  	huatuo-bamai/core/metrics	0.015s
$ go build ./...   # exit 0
```

- `TestNetUdpUpdate` pins names, counter types and values against the full realistic fixture.
- The remaining tests pin the error contracts: no `Udp:` section → `metric.ErrNoData`; truncated value line; header/value mismatch; missing file.
- Full suite: `go test ./...` → exit 0, 83 packages ok, 0 FAIL (run on this branch at commit time).

## Compatibility & Risk

- **Kernel compatibility**: the `Udp:` section of `/proc/net/snmp` has existed since 2.6 with all seven fields present on 4.18+; extra future fields are stored generically and ignored unless mapped.
- **Regression risk**: none to existing behavior — the `netstat` collector and its parser are not modified; the only change is a new collector registration.
- **API/dependency**: no public API change, no new dependencies.
- **License**: repo is Apache-2.0. No code copied from any reference project; node_exporter is Apache-2.0, telegraf is MIT — both compatible; nothing is taken from GPL-licensed projects.
- **Metric volume**: 7 new host-level series per scrape, constant.

## Issue

No corresponding upstream Issue exists (searched open+closed issues and PRs, 2026-09-06 — see Current gap). There is no Issue to link with `Closes`/`Fixes`/`Resolves`; this PR is the first tracker record for the feature.

## CI

- `pr_name_lint`: **pass**.
- `Build, Lint and Vendor`: first run failed on two style findings in the new files only (gocritic `offBy1` on the test's `strings.Index` fixture slice; gofumpt `-extra` composite-literal braces) — fixed in e3364961; rerun **pass** (job 101430446454, https://github.com/ccfos/huatuo/actions/runs/34012437933).
- `Test in VM` (amd64 ubuntu 20.04/22.04/24.04/26.04): **fail — infrastructure outage, not this change.** All four VM jobs abort during K8s pod sandbox creation, before any repository build/test runs, with the recurring signature (job log 101430446768, 9 occurrences):
  ```
  plugin type="flannel" failed (add): loadFlannelSubnetEnv failed: open /run/flannel/subnet.env: no such file or directory
  ```
  Run: https://github.com/ccfos/huatuo/actions/runs/34012437970. Local verification stands in: full `go test ./...` exit 0 (83 packages ok / 0 FAIL). Outside contributors cannot rerun VM jobs (403 admin required) — a maintainer rerun after the flannel recovery would be appreciated.
