### PR TITLE
fix(metrics): report tcp memory usage percent on the 0-100 scale

### DIFF
--- a/core/metrics/net_tcp_memory.go
+++ b/core/metrics/net_tcp_memory.go
@@ -25,7 +25,9 @@ import (
 	"huatuo-bamai/pkg/types"
 )
 
-type tcpMemory struct{}
+type tcpMemory struct {
+	parseStats func() (*tcpMemoryStat, error)
+}
 
 func init() {
 	tracing.RegisterEventTracing("tcp_memory", newTcpMemory)
@@ -41,8 +43,10 @@ func newTcpMemory() (*tracing.EventTracingAttr, error) {
 	}
 
 	return &tracing.EventTracingAttr{
-		TracingData: &tcpMemory{},
-		Flag:        tracing.FlagMetric,
+		TracingData: &tcpMemory{
+			parseStats: parseTcpMemory,
+		},
+		Flag: tracing.FlagMetric,
 	}, nil
 }
 
@@ -88,14 +92,14 @@ func parseTcpMemory() (*tcpMemoryStat, error) {
 }
 
 func (c *tcpMemory) Update() ([]*metric.Data, error) {
-	stats, err := parseTcpMemory()
+	stats, err := c.parseStats()
 	if err != nil {
 		return nil, err
 	}
 
 	usagePercent := float64(0)
 	if stats.memoryLimit > 0 {
-		usagePercent = stats.memoryPages / stats.memoryLimit
+		usagePercent = stats.memoryPages / stats.memoryLimit * 100
 	}
 
 	return []*metric.Data{

--- a/core/metrics/net_tcp_memory_test.go
+++ b/core/metrics/net_tcp_memory_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"io/fs"
+	"testing"
+
+	"huatuo-bamai/pkg/metric"
+)
+
+func TestTcpMemoryUpdateReportsUsagePercent(t *testing.T) {
+	testcases := []struct {
+		name        string
+		stats       tcpMemoryStat
+		wantPercent float64
+	}{
+		{
+			name:        "quarter of the limit",
+			stats:       tcpMemoryStat{memoryPages: 500, memoryLimit: 2000},
+			wantPercent: 25,
+		},
+		{
+			name:        "limit reached",
+			stats:       tcpMemoryStat{memoryPages: 2000, memoryLimit: 2000},
+			wantPercent: 100,
+		},
+		{
+			name:        "no limit reported",
+			stats:       tcpMemoryStat{memoryPages: 500, memoryLimit: 0},
+			wantPercent: 0,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &tcpMemory{parseStats: func() (*tcpMemoryStat, error) {
+				stats := tc.stats
+				return &stats, nil
+			}}
+
+			metrics, err := c.Update()
+			if err != nil {
+				t.Fatalf("update tcp memory metrics: %v", err)
+			}
+
+			var percent *metric.Data
+			present := make(map[string]bool, len(metrics))
+			for _, m := range metrics {
+				present[m.Name()] = true
+				if m.Name() == "usage_percent" {
+					percent = m
+				}
+			}
+
+			for _, want := range []string{"usage_pages", "usage_bytes", "limit_pages", "usage_percent"} {
+				if !present[want] {
+					t.Errorf("metric %q missing from the update result", want)
+				}
+			}
+
+			if percent == nil {
+				t.Fatal("usage_percent metric missing from the update result")
+			}
+			if percent.Value != tc.wantPercent {
+				t.Errorf("usage_percent = %v, want %v", percent.Value, tc.wantPercent)
+			}
+		})
+	}
+}
+
+func TestTcpMemoryUpdatePropagatesParseFailure(t *testing.T) {
+	c := &tcpMemory{parseStats: func() (*tcpMemoryStat, error) {
+		return nil, fs.ErrNotExist
+	}}
+
+	if _, err := c.Update(); err == nil {
+		t.Fatal("update succeeded, want the parse error to propagate")
+	}
+}


### PR DESCRIPTION
## Problem

The `tcp_memory` collector exports `usage_percent` as

```go
usagePercent = stats.memoryPages / stats.memoryLimit
```

which is a **0-1 ratio**, while both the metric name and its help text ("tcp memory usage percent") promise a percent. Every other percent metric in this package is on the 0-100 scale:

- `cpu_stat` `wait_sum_percent`: `deltaWait * 100 / (deltaWait + deltaCPU)` (`core/metrics/cpu_stat.go`)
- `disk_io` `disk_iowait_percent`: `deltaIOWait / deltaTotal * 100` (`core/metrics/disk_io.go`)
- `metax_gpu` `utilization_percent`: "GPU utilization, ranging from 0 to 100."

As a result, an alerting rule such as `tcp_memory_usage_percent > 90` can never fire, and dashboards showing the raw value read `1.0` as 1% instead of 100%.

This is distinct from the already fixed/ongoing tcp_memory issues: #421 (NaN when the limit is zero — the zero guard is kept) and #551 (parseTcpMemory index guard); neither touches the percent computation.

## Fix

Multiply the ratio by 100 so the value matches the documented 0-100 scale.

To make the computation observable in tests, `tcpMemory` gains a `parseStats` seam defaulting to `parseTcpMemory` — the same pattern already used by the qdisc collector's `readStats` (`core/metrics/netdev_qdisc.go`).

## Tests

`TestTcpMemoryUpdateReportsUsagePercent` — table-driven over quarter/limit-reached/zero-limit stats, asserting the 0-100 value and that all four documented series are emitted. Fails before the fix (`0.25` vs `25`, `1` vs `100`), passes after.

`TestTcpMemoryUpdatePropagatesParseFailure` — a `parseStats` error surfaces from `Update`.

## Verification

- `go test ./core/metrics/ -count=1` — full package green
- `gofmt -l core/metrics/` — clean; `go vet ./core/metrics/` — clean
- Regression verified fail-before/pass-after in a Linux container (golang:1.24)
- Checked open PRs for overlap: none touch `net_tcp_memory.go`

Signed-off-by: zjncs <18910855655@163.com>