### PR TITLE
fix(events): prune oom container counters of deleted containers

### DIFF
--- a/core/events/oom.go
+++ b/core/events/oom.go
@@ -56,7 +56,8 @@ type oomMetric struct {
 }
 
 type oomCollector struct {
-	cgroup cgroups.Cgroup
+	cgroup           cgroups.Cgroup
+	normalContainers func() (map[string]*pod.Container, error)
 }
 
 var (
@@ -77,7 +78,8 @@ func newOOMCollector() (*tracing.EventTracingAttr, error) {
 
 	return &tracing.EventTracingAttr{
 		TracingData: &oomCollector{
-			cgroup: cgroup,
+			cgroup:           cgroup,
+			normalContainers: pod.NormalContainers,
 		},
 		Interval: 10,
 		Flag:     tracing.FlagTracing | tracing.FlagMetric,
@@ -85,7 +87,7 @@ func newOOMCollector() (*tracing.EventTracingAttr, error) {
 }
 
 func (c *oomCollector) Update() ([]*metric.Data, error) {
-	containers, err := pod.NormalContainers()
+	containers, err := c.normalContainers()
 	if err != nil {
 		return nil, fmt.Errorf("get normal container: %w", err)
 	}
@@ -93,6 +95,15 @@ func (c *oomCollector) Update() ([]*metric.Data, error) {
 	var metrics []*metric.Data
 
 	mutex.Lock()
+	defer mutex.Unlock()
+
+	// Drop counters of containers that no longer exist, otherwise the map
+	// grows without bound on nodes with container churn.
+	for id := range outOfMemoryCounterContainer {
+		if _, ok := containers[id]; !ok {
+			delete(outOfMemoryCounterContainer, id)
+		}
+	}
 
 	metrics = append(metrics, metric.NewCounterData("host_total", outOfMemoryCounterHost, "host oom counter", nil))
 	for _, container := range containers {
@@ -104,7 +115,6 @@ func (c *oomCollector) Update() ([]*metric.Data, error) {
 		}
 	}
 
-	mutex.Unlock()
 	return metrics, nil
 }
 

--- a/core/events/oom_test.go
+++ b/core/events/oom_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"errors"
+	"testing"
+
+	"huatuo-bamai/internal/pod"
+)
+
+func TestOOMCollectorUpdatePrunesStaleContainerCounters(t *testing.T) {
+	savedCounters := outOfMemoryCounterContainer
+	savedHost := outOfMemoryCounterHost
+	t.Cleanup(func() {
+		outOfMemoryCounterContainer = savedCounters
+		outOfMemoryCounterHost = savedHost
+	})
+	outOfMemoryCounterContainer = make(map[string]*oomMetric)
+	outOfMemoryCounterHost = 0
+
+	live := &pod.Container{
+		ID:       "aaaaaaaaaaaa",
+		Name:     "live",
+		Hostname: "live",
+		Type:     pod.ContainerTypeNormal,
+		Labels:   map[string]any{"HostNamespace": "default"},
+	}
+	collector := &oomCollector{
+		normalContainers: func() (map[string]*pod.Container, error) {
+			return map[string]*pod.Container{live.ID: live}, nil
+		},
+	}
+
+	containerCounterUpdate(live.ID, "java")
+	containerCounterUpdate("bbbbbbbbbbbb", "python") // its container is already gone
+
+	metrics, err := collector.Update()
+	if err != nil {
+		t.Fatalf("update oom metrics: %v", err)
+	}
+
+	mutex.Lock()
+	_, staleExists := outOfMemoryCounterContainer["bbbbbbbbbbbb"]
+	liveEntry, liveExists := outOfMemoryCounterContainer[live.ID]
+	counterSize := len(outOfMemoryCounterContainer)
+	mutex.Unlock()
+
+	if staleExists {
+		t.Error("counter of the deleted container was not pruned")
+	}
+	if !liveExists {
+		t.Fatal("counter of the live container was pruned")
+	}
+	if counterSize != 1 {
+		t.Errorf("container counter map size = %d, want 1", counterSize)
+	}
+	if liveEntry.count != 1 || liveEntry.latestVictimComm != "java" {
+		t.Errorf("live counter = (%d, %q), want (1, %q)", liveEntry.count, liveEntry.latestVictimComm, "java")
+	}
+
+	// Counters of surviving containers keep accumulating across scrapes.
+	containerCounterUpdate(live.ID, "go")
+	mutex.Lock()
+	count := outOfMemoryCounterContainer[live.ID].count
+	mutex.Unlock()
+	if count != 2 {
+		t.Errorf("live counter after one more OOM = %d, want 2", count)
+	}
+
+	var totals, hostTotals int
+	var totalValue float64
+	var totalComm string
+	for _, m := range metrics {
+		switch m.Name() {
+		case "container_total":
+			totals++
+			totalValue = m.Value
+			totalComm = m.Labels()["latest_victim_comm"]
+		case "host_total":
+			hostTotals++
+		}
+	}
+	if totals != 1 {
+		t.Fatalf("container total metrics = %d, want 1", totals)
+	}
+	if totalValue != 1 {
+		t.Errorf("container total = %v, want 1", totalValue)
+	}
+	if totalComm != "java" {
+		t.Errorf("latest_victim_comm label = %q, want %q", totalComm, "java")
+	}
+	if hostTotals != 1 {
+		t.Errorf("host_total metrics = %d, want 1", hostTotals)
+	}
+}
+
+func TestOOMCollectorUpdatePropagatesContainerListFailure(t *testing.T) {
+	collector := &oomCollector{
+		normalContainers: func() (map[string]*pod.Container, error) {
+			return nil, errors.New("kubelet unreachable")
+		},
+	}
+
+	if _, err := collector.Update(); err == nil {
+		t.Fatal("update succeeded, want the container list error to propagate")
+	}
+}


### PR DESCRIPTION
## Problem

`outOfMemoryCounterContainer` (`core/events/oom.go`) gains an entry for every container that OOMs, but nothing ever removes one:

- `containerCounterUpdate` (called from the BPF event loop) only inserts/increments;
- `Update()` only reads entries whose container ID is still present in `pod.NormalContainers()`.

So on a long-running node with pod churn, every container that ever OOM-ed keeps a permanent map entry — the classic stale-entries-never-removed leak. The counters are also invisible forever once their container is gone, so keeping them has no value.

Related open PRs touch different parts of the oom tracer and do not overlap: #719 (`oom_snapshot.go` cgroup manager init), #731 (hungtask/softlockup counters), #732 (tracing document save).

## Fix

During `Update()`, under the same `mutex` that already guards the report loop, delete entries whose container ID is no longer present. Surviving containers' counters keep accumulating; stale ones are dropped.

To make `Update()` testable without a live pod store, `oomCollector` gains a `normalContainers` seam defaulting to `pod.NormalContainers` — the same pattern as the qdisc collector's `readStats` (`core/metrics/netdev_qdisc.go`). The explicit `mutex.Unlock()` becomes a `defer` since the critical section now has an early shape.

## Tests

`TestOOMCollectorUpdatePrunesStaleContainerCounters` — seeds one live and one already-deleted container counter, runs `Update()`, and asserts: the stale entry is pruned, the live entry survives with its count and `latest_victim_comm`, the live counter still accumulates afterwards, and exactly one `container_total` + one `host_total` metric is emitted. Fails before the prune is added (`counter of the deleted container was not pruned`, `map size = 2, want 1`), passes after.

`TestOOMCollectorUpdatePropagatesContainerListFailure` — a `normalContainers` error surfaces from `Update()`.

## Verification

- `go test ./core/events/ -count=1` — full package green
- `gofmt -l core/events/` — clean; `go vet ./core/events/` — clean
- Regression verified fail-before/pass-after in a Linux container (golang:1.24)
- Checked open PRs for overlap: none touch `core/events/oom.go`

Signed-off-by: zjncs <18910855655@163.com>