### PR TITLE
fix(metrics): align netlink netdev counter names with the proc backend

### DIFF
--- a/core/metrics/netdev_stats.go
+++ b/core/metrics/netdev_stats.go
@@ -172,40 +172,70 @@ func (c *netdevCollector) netlinkStats(container *pod.Container, f *matcher.Valu
 		}
 
 		// https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_link.h#L42-L246
-		metrics[name] = map[string]uint64{
-			"receive_packets":  stats.RXPackets,
-			"transmit_packets": stats.TXPackets,
-			"receive_bytes":    stats.RXBytes,
-			"transmit_bytes":   stats.TXBytes,
-			"receive_errors":   stats.RXErrors,
-			"transmit_errors":  stats.TXErrors,
-			"receive_dropped":  stats.RXDropped,
-			"transmit_dropped": stats.TXDropped,
-			"multicast":        stats.Multicast,
-			"collisions":       stats.Collisions,
-
-			// detailed rx_errors
-			"receive_length_errors": stats.RXLengthErrors,
-			"receive_over_errors":   stats.RXOverErrors,
-			"receive_crc_errors":    stats.RXCRCErrors,
-			"receive_frame_errors":  stats.RXFrameErrors,
-			"receive_fifo_errors":   stats.RXFIFOErrors,
-			"receive_missed_errors": stats.RXMissedErrors,
-
-			// detailed tx_errors
-			"transmit_aborted_errors":   stats.TXAbortedErrors,
-			"transmit_carrier_errors":   stats.TXCarrierErrors,
-			"transmit_fifo_errors":      stats.TXFIFOErrors,
-			"transmit_heartbeat_errors": stats.TXHeartbeatErrors,
-			"transmit_window_errors":    stats.TXWindowErrors,
-
-			// for cslip etc
-			"receive_compressed":  stats.RXCompressed,
-			"transmit_compressed": stats.TXCompressed,
-			"receive_nohandler":   stats.RXNoHandler,
-		}
+		metrics[name] = netlinkDeviceStats(stats)
 	}
 	return metrics, nil
+}
+
+// netlinkDeviceStats maps rtnetlink link statistics to metric names.
+func netlinkDeviceStats(stats *rtnetlink.LinkStats64) map[string]uint64 {
+	return map[string]uint64{
+		"receive_packets":  stats.RXPackets,
+		"transmit_packets": stats.TXPackets,
+		"receive_bytes":    stats.RXBytes,
+		"transmit_bytes":   stats.TXBytes,
+		"receive_errors":   stats.RXErrors,
+		"transmit_errors":  stats.TXErrors,
+		"receive_dropped":  stats.RXDropped,
+		"transmit_dropped": stats.TXDropped,
+
+		// Names shared with the proc backend, which follows the
+		// node_exporter conventions.
+		"receive_multicast": stats.Multicast,
+		"transmit_colls":    stats.Collisions,
+		"receive_frame":     stats.RXFrameErrors,
+		"receive_fifo":      stats.RXFIFOErrors,
+		"transmit_carrier":  stats.TXCarrierErrors,
+		"transmit_fifo":     stats.TXFIFOErrors,
+
+		// detailed rx_errors
+		"receive_length_errors": stats.RXLengthErrors,
+		"receive_over_errors":   stats.RXOverErrors,
+		"receive_crc_errors":    stats.RXCRCErrors,
+		"receive_missed_errors": stats.RXMissedErrors,
+
+		// detailed tx_errors
+		"transmit_aborted_errors":   stats.TXAbortedErrors,
+		"transmit_heartbeat_errors": stats.TXHeartbeatErrors,
+		"transmit_window_errors":    stats.TXWindowErrors,
+
+		// for cslip etc
+		"receive_compressed":  stats.RXCompressed,
+		"transmit_compressed": stats.TXCompressed,
+		"receive_nohandler":   stats.RXNoHandler,
+	}
+}
+
+// procDeviceStats maps /proc/net/dev statistics to metric names.
+func procDeviceStats(stats *procfs.NetDevLine) map[string]uint64 {
+	return map[string]uint64{
+		"receive_bytes":       stats.RxBytes,
+		"receive_packets":     stats.RxPackets,
+		"receive_errors":      stats.RxErrors,
+		"receive_dropped":     stats.RxDropped,
+		"receive_fifo":        stats.RxFIFO,
+		"receive_frame":       stats.RxFrame,
+		"receive_compressed":  stats.RxCompressed,
+		"receive_multicast":   stats.RxMulticast,
+		"transmit_bytes":      stats.TxBytes,
+		"transmit_packets":    stats.TxPackets,
+		"transmit_errors":     stats.TxErrors,
+		"transmit_dropped":    stats.TxDropped,
+		"transmit_fifo":       stats.TxFIFO,
+		"transmit_colls":      stats.TxCollisions,
+		"transmit_carrier":    stats.TxCarrier,
+		"transmit_compressed": stats.TxCompressed,
+	}
 }
 
 func (c *netdevCollector) procStats(container *pod.Container, f *matcher.ValueMatcher) (netdevStats, error) {
@@ -229,24 +259,7 @@ func (c *netdevCollector) procStats(container *pod.Container, f *matcher.ValueMa
 			continue
 		}
 
-		metrics[name] = map[string]uint64{
-			"receive_bytes":       stats.RxBytes,
-			"receive_packets":     stats.RxPackets,
-			"receive_errors":      stats.RxErrors,
-			"receive_dropped":     stats.RxDropped,
-			"receive_fifo":        stats.RxFIFO,
-			"receive_frame":       stats.RxFrame,
-			"receive_compressed":  stats.RxCompressed,
-			"receive_multicast":   stats.RxMulticast,
-			"transmit_bytes":      stats.TxBytes,
-			"transmit_packets":    stats.TxPackets,
-			"transmit_errors":     stats.TxErrors,
-			"transmit_dropped":    stats.TxDropped,
-			"transmit_fifo":       stats.TxFIFO,
-			"transmit_colls":      stats.TxCollisions,
-			"transmit_carrier":    stats.TxCarrier,
-			"transmit_compressed": stats.TxCompressed,
-		}
+		metrics[name] = procDeviceStats(&stats)
 	}
 
 	return metrics, nil

--- a/core/metrics/netdev_stats_test.go
+++ b/core/metrics/netdev_stats_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+
+	"github.com/jsimonetti/rtnetlink"
+)
+
+func TestNetdevBackendsExportSharedCountersUnderIdenticalNames(t *testing.T) {
+	linkStats := &rtnetlink.LinkStats64{
+		RXPackets:       10,
+		TXPackets:       11,
+		RXBytes:         12,
+		TXBytes:         13,
+		RXErrors:        14,
+		TXErrors:        15,
+		RXDropped:       16,
+		TXDropped:       17,
+		Multicast:       18,
+		Collisions:      19,
+		RXFrameErrors:   20,
+		RXFIFOErrors:    21,
+		TXCarrierErrors: 22,
+		TXFIFOErrors:    23,
+		RXCompressed:    24,
+		TXCompressed:    25,
+	}
+
+	procLine := &procfs.NetDevLine{
+		RxPackets:    10,
+		TxPackets:    11,
+		RxBytes:      12,
+		TxBytes:      13,
+		RxErrors:     14,
+		TxErrors:     15,
+		RxDropped:    16,
+		TxDropped:    17,
+		RxMulticast:  18,
+		TxCollisions: 19,
+		RxFrame:      20,
+		RxFIFO:       21,
+		TxCarrier:    22,
+		TxFIFO:       23,
+		RxCompressed: 24,
+		TxCompressed: 25,
+	}
+
+	netlink := netlinkDeviceStats(linkStats)
+	proc := procDeviceStats(procLine)
+
+	// Both backends feed the same emitter, which appends "_total". Every
+	// counter exported by the default proc backend must keep its name when
+	// netlink is enabled, otherwise toggling EnableNetlink silently renames
+	// the series and breaks dashboards and rate() expressions.
+	for name, want := range proc {
+		got, ok := netlink[name]
+		if !ok {
+			t.Errorf("counter %q exported by the proc backend is missing from the netlink backend", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("counter %q: netlink value = %d, proc value = %d", name, got, want)
+		}
+	}
+}

--- a/internal/procfs/proc.go
+++ b/internal/procfs/proc.go
@@ -18,6 +18,9 @@ import "github.com/prometheus/procfs"
 
 type Proc = procfs.Proc
 
+// NetDevLine is one line of /proc/[pid]/net/dev for a single interface.
+type NetDevLine = procfs.NetDevLine
+
 func Self() (procfs.Proc, error) {
 	fs, err := NewFS(defaultProcMountPoint)
 	if err != nil {


### PR DESCRIPTION
## Problem

The netdev collector has two backends selected by `EnableNetlink` (`core/metrics/netdev_stats.go`), and they label six shared counters differently:

| counter | netlink name | proc name |
|---|---|---|
| Multicast | `multicast` | `receive_multicast` |
| Collisions | `collisions` | `transmit_colls` |
| RXFrameErrors | `receive_frame_errors` | `receive_frame` |
| RXFIFOErrors | `receive_fifo_errors` | `receive_fifo` |
| TXCarrierErrors | `transmit_carrier_errors` | `transmit_carrier` |
| TXFIFOErrors | `transmit_fifo_errors` | `transmit_fifo` |

Both backends feed the same emitter, which appends `_total`, so the exported series name depends on the config flag: toggling `EnableNetlink` (or running nodes with differing config) silently renames e.g. `netdev_receive_fifo_errors_total` to `netdev_receive_fifo_total`, breaking dashboards, `rate()` expressions and recording rules.

The proc names follow the node_exporter conventions referenced in the file header and match the documented examples (`docs/key-feature/kernel-wide-insight_zh.md` shows `netdev_container_receive_fifo_total`, `netdev_container_receive_multicast_total`), so the netlink side is the outlier.

## Fix

Rename the six netlink keys to the proc names. Netlink-only counters without a proc counterpart (`receive_crc_errors`, `transmit_window_errors`, ...) keep their descriptive names. `EnableNetlink` defaults to `false`, so only opt-in deployments are affected — and their series now match the default backend instead of diverging.

To make the naming contract assertable, the per-device map literals move into `netlinkDeviceStats`/`procDeviceStats`. `internal/procfs` gains a `NetDevLine` alias next to the existing `Proc` alias.

This PR does not touch `Update()`/`getStats()` and is complementary to #678 (per-container failure isolation in the same file; no overlapping hunks).

## Tests

`TestNetdevBackendsExportSharedCountersUnderIdenticalNames` — builds one `LinkStats64` and one `NetDevLine` with identical values and asserts every counter exported by the proc backend exists under the same name and value in the netlink backend. Fails before the rename (all six keys reported missing), passes after.

## Verification

- `go test ./core/metrics/ ./internal/procfs/ -count=1` — both packages green
- `gofmt -l` — clean; `go vet` — clean
- Regression verified fail-before/pass-after in a Linux container (golang:1.24)
- Checked open PRs: none rename netdev counter names (#238 regex device matching, #385/#677 netdev_hw, #678 error isolation)

Signed-off-by: zjncs <18910855655@163.com>