### PR TITLE
fix(metrics): keep memory_reclaim zero series per container

### DIFF
--- a/core/metrics/memory_reclaim.go
+++ b/core/metrics/memory_reclaim.go
@@ -68,10 +68,17 @@ func (c *memoryCgroupReclaim) Update() ([]*metric.Data, error) {
 		return nil, err
 	}
 
+	return buildReclaimMetrics(items, containersCssMem)
+}
+
+// buildReclaimMetrics turns dumped BPF map items keyed by memory-cgroup css
+// address into per-container directstall metrics.
+func buildReclaimMetrics(items []bpf.MapItem, containersCssMem map[uint64]*pod.Container) ([]*metric.Data, error) {
 	var (
 		reclaimVal memoryBpfStruct
 		cssAddr    uint64
 		data       []*metric.Data
+		reported   = make(map[uint64]struct{}, len(items))
 	)
 	for _, v := range items {
 		keyBuf := bytes.NewReader(v.Key)
@@ -85,14 +92,16 @@ func (c *memoryCgroupReclaim) Update() ([]*metric.Data, error) {
 		}
 
 		if container, exist := containersCssMem[cssAddr]; exist {
+			reported[cssAddr] = struct{}{}
 			data = append(data, metric.NewContainerGaugeData(container, "directstall",
 				float64(reclaimVal.DirectstallCount), "counter of cgroup reclaim when try_charge", nil))
 		}
 	}
 
-	// if events haven't happened, upload zero for all containers.
-	if len(items) == 0 {
-		for _, container := range containersCssMem {
+	// Upload zero for the containers whose events haven't happened, so their
+	// series stay present once any other container starts reclaiming.
+	for css, container := range containersCssMem {
+		if _, ok := reported[css]; !ok {
 			data = append(data, metric.NewContainerGaugeData(container, "directstall",
 				float64(0), "counter of cgroup reclaim when try_charge", nil))
 		}

--- a/core/metrics/memory_reclaim_test.go
+++ b/core/metrics/memory_reclaim_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"huatuo-bamai/internal/bpf"
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/pkg/metric"
+)
+
+func reclaimMapItem(t *testing.T, cssAddr, stalls uint64) bpf.MapItem {
+	t.Helper()
+
+	key := make([]byte, 8)
+	binary.LittleEndian.PutUint64(key, cssAddr)
+
+	value := make([]byte, 8)
+	binary.LittleEndian.PutUint64(value, stalls)
+
+	return bpf.MapItem{Key: key, Value: value}
+}
+
+func reclaimTestContainers() map[uint64]*pod.Container {
+	newContainer := func(id, name string) *pod.Container {
+		return &pod.Container{
+			ID:       id,
+			Name:     name,
+			Hostname: name,
+			Type:     pod.ContainerTypeNormal,
+			Labels:   map[string]any{"HostNamespace": "default"},
+		}
+	}
+
+	return map[uint64]*pod.Container{
+		0x1000: newContainer("aaaaaaaaaaaa", "reclaimer"),
+		0x2000: newContainer("bbbbbbbbbbbb", "quiet"),
+	}
+}
+
+func summarizeReclaimMetrics(t *testing.T, metrics []*metric.Data) map[string]float64 {
+	t.Helper()
+
+	byContainer := make(map[string]float64, len(metrics))
+	for _, m := range metrics {
+		if m.Name() != "container_directstall" {
+			t.Fatalf("unexpected metric %q in the update result", m.Name())
+		}
+		byContainer[m.Labels()["container_name"]] = m.Value
+	}
+	return byContainer
+}
+
+func TestMemoryReclaimReportsZeroForContainersWithoutEvents(t *testing.T) {
+	// Only the reclaimer has stall events; the quiet container must keep its
+	// zero series instead of disappearing from the scrape.
+	items := []bpf.MapItem{reclaimMapItem(t, 0x1000, 7)}
+
+	metrics, err := buildReclaimMetrics(items, reclaimTestContainers())
+	if err != nil {
+		t.Fatalf("build reclaim metrics: %v", err)
+	}
+
+	got := summarizeReclaimMetrics(t, metrics)
+	want := map[string]float64{"reclaimer": 7, "quiet": 0}
+	for name, wantValue := range want {
+		if got[name] != wantValue {
+			t.Errorf("container %q directstall = %v, want %v", name, got[name], wantValue)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("reported containers = %v, want %v", got, want)
+	}
+}
+
+func TestMemoryReclaimReportsZeroForAllContainersWhenMapEmpty(t *testing.T) {
+	metrics, err := buildReclaimMetrics(nil, reclaimTestContainers())
+	if err != nil {
+		t.Fatalf("build reclaim metrics: %v", err)
+	}
+
+	got := summarizeReclaimMetrics(t, metrics)
+	want := map[string]float64{"reclaimer": 0, "quiet": 0}
+	for name, wantValue := range want {
+		if got[name] != wantValue {
+			t.Errorf("container %q directstall = %v, want %v", name, got[name], wantValue)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("reported containers = %v, want %v", got, want)
+	}
+}
+
+func TestMemoryReclaimIgnoresEntriesWithoutContainer(t *testing.T) {
+	// 0x3000 belongs to a cgroup that is no longer tracked as a container.
+	items := []bpf.MapItem{
+		reclaimMapItem(t, 0x3000, 3),
+		reclaimMapItem(t, 0x1000, 5),
+	}
+
+	metrics, err := buildReclaimMetrics(items, reclaimTestContainers())
+	if err != nil {
+		t.Fatalf("build reclaim metrics: %v", err)
+	}
+
+	got := summarizeReclaimMetrics(t, metrics)
+	want := map[string]float64{"reclaimer": 5, "quiet": 0}
+	for name, wantValue := range want {
+		if got[name] != wantValue {
+			t.Errorf("container %q directstall = %v, want %v", name, got[name], wantValue)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("reported containers = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

`memory_reclaim` (`core/metrics/memory_reclaim.go`) uploads zero for containers without reclaim events only when the BPF map is **completely empty**:

```go
// if events haven't happened, upload zero for all containers.
if len(items) == 0 { ... }
```

As soon as a single container stalls, the condition is false and every other container's `container_memory_reclaim_directstall` series disappears from the scrape until it also stalls. On a node where one container reclaims occasionally, all the other containers' series flap present/absent on every event, which breaks `absent()`-style alerts and any consumer expecting a stable label set per container.

## Fix

Emit the zero fallback per container instead of only in the empty-map case: track the css addresses reported from the dumped map, then emit zero for the remaining tracked containers. The documented all-zero behaviour when no events happened anywhere is preserved.

The per-item aggregation moves into `buildReclaimMetrics(items, containersCssMem)` so the semantics can be tested without a BPF object or a live pod store; `Update()` keeps its flow unchanged.

## Tests

- `TestMemoryReclaimReportsZeroForContainersWithoutEvents` — one container with events, one without: both series present, sibling at 0. Fails before the fix (`quiet` missing), passes after.
- `TestMemoryReclaimReportsZeroForAllContainersWhenMapEmpty` — empty map: all containers at 0 (existing behaviour preserved).
- `TestMemoryReclaimIgnoresEntriesWithoutContainer` — a stale cgroup entry with no tracked container produces no metric.

## Verification

- `go test ./core/metrics/ -count=1` — full package green
- `gofmt -l` — clean; `go vet` — clean
- Regression verified fail-before/pass-after in a Linux container (golang:1.24)
- Checked open PRs: none touch `core/metrics/memory_reclaim.go`

Signed-off-by: zjncs <18910855655@163.com>