### PR TITLE
feat(metrics): export file descriptor usage

### DIFF
--- a/core/metrics/system_filefd.go
+++ b/core/metrics/system_filefd.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+)
+
+type fileFDCollector struct{}
+
+func init() {
+	tracing.RegisterEventTracing("filefd", newFileFDCollector)
+}
+
+func newFileFDCollector() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &fileFDCollector{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+func parseFileFD(raw string) (allocated, maximum uint64, err error) {
+	fields := strings.Fields(raw)
+	if len(fields) != 3 {
+		return 0, 0, fmt.Errorf("file-nr has %d fields, want 3", len(fields))
+	}
+	allocated, err = strconv.ParseUint(fields[0], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse allocated file handles: %w", err)
+	}
+	maximum, err = strconv.ParseUint(fields[2], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse maximum file handles: %w", err)
+	}
+	return allocated, maximum, nil
+}
+
+func (c *fileFDCollector) Update() ([]*metric.Data, error) {
+	raw, err := os.ReadFile(procfs.Path("sys/fs/file-nr"))
+	if err != nil {
+		return nil, err
+	}
+	allocated, maximum, err := parseFileFD(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	usagePercent := float64(0)
+	if maximum > 0 {
+		usagePercent = float64(allocated) / float64(maximum) * 100
+	}
+	return []*metric.Data{
+		metric.NewGaugeData("allocated", float64(allocated),
+			"Allocated file handles.", nil),
+		metric.NewGaugeData("maximum", float64(maximum),
+			"Maximum file handles.", nil),
+		metric.NewGaugeData("usage_percent", usagePercent,
+			"Allocated file handles as a percentage of the maximum.", nil),
+	}, nil
+}

--- a/core/metrics/system_filefd_test.go
+++ b/core/metrics/system_filefd_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+)
+
+func TestParseFileFD(t *testing.T) {
+	allocated, maximum, err := parseFileFD("128\t0\t4096\n")
+	if err != nil {
+		t.Fatalf("parseFileFD() error = %v", err)
+	}
+	if allocated != 128 || maximum != 4096 {
+		t.Fatalf("parseFileFD() = (%d, %d), want (128, 4096)", allocated, maximum)
+	}
+}
+
+func TestParseFileFDRejectsMalformedInput(t *testing.T) {
+	for _, raw := range []string{"", "1 2", "bad 0 100", "1 0 bad"} {
+		if _, _, err := parseFileFD(raw); err == nil {
+			t.Errorf("parseFileFD(%q) error = nil", raw)
+		}
+	}
+}
+
+func TestFileFDCollectorUpdate(t *testing.T) {
+	root := t.TempDir()
+	originalRoot := filepath.Dir(procfs.DefaultPath())
+	procfs.RootPrefix(root)
+	t.Cleanup(func() { procfs.RootPrefix(originalRoot) })
+
+	dir := filepath.Join(root, "proc/sys/fs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create proc fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file-nr"), []byte("128 0 4096\n"), 0o600); err != nil {
+		t.Fatalf("write file-nr fixture: %v", err)
+	}
+
+	metrics, err := (&fileFDCollector{}).Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	want := []float64{128, 4096, 3.125}
+	for i := range want {
+		if metrics[i].Value != want[i] {
+			t.Errorf("metric %d value = %v, want %v", i, metrics[i].Value, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add a `filefd` collector for allocated and maximum file handles
- expose host-wide file handle utilization as a percentage
- validate malformed `/proc/sys/fs/file-nr` input

## Testing

- `make check`
- `make unit`

Closes #747