### PR TITLE
feat(metrics): export entropy pool status

### DIFF
--- a/core/metrics/system_entropy.go
+++ b/core/metrics/system_entropy.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+)
+
+type entropyCollector struct{}
+
+func init() {
+	tracing.RegisterEventTracing("entropy", newEntropyCollector)
+}
+
+func newEntropyCollector() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &entropyCollector{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+func parseEntropyValue(name string, raw []byte) (uint64, error) {
+	value, err := strconv.ParseUint(strings.TrimSpace(string(raw)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", name, err)
+	}
+	return value, nil
+}
+
+func readEntropyValue(name string) (uint64, error) {
+	raw, err := os.ReadFile(procfs.Path("sys/kernel/random", name))
+	if err != nil {
+		return 0, err
+	}
+	return parseEntropyValue(name, raw)
+}
+
+func (c *entropyCollector) Update() ([]*metric.Data, error) {
+	available, err := readEntropyValue("entropy_avail")
+	if err != nil {
+		return nil, err
+	}
+	poolSize, err := readEntropyValue("poolsize")
+	if err != nil {
+		return nil, err
+	}
+	availablePercent := float64(0)
+	if poolSize > 0 {
+		availablePercent = float64(available) / float64(poolSize) * 100
+	}
+	return []*metric.Data{
+		metric.NewGaugeData("available_bits", float64(available),
+			"Bits of entropy available to the kernel random-number generator.", nil),
+		metric.NewGaugeData("pool_size_bits", float64(poolSize),
+			"Kernel random-number generator entropy pool size in bits.", nil),
+		metric.NewGaugeData("available_percent", availablePercent,
+			"Available entropy as a percentage of the pool size.", nil),
+	}, nil
+}

--- a/core/metrics/system_entropy_test.go
+++ b/core/metrics/system_entropy_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+)
+
+func TestParseEntropyValue(t *testing.T) {
+	got, err := parseEntropyValue("entropy_avail", []byte("256\n"))
+	if err != nil {
+		t.Fatalf("parseEntropyValue() error = %v", err)
+	}
+	if got != 256 {
+		t.Fatalf("parseEntropyValue() = %d, want 256", got)
+	}
+}
+
+func TestParseEntropyValueRejectsMalformedInput(t *testing.T) {
+	for _, raw := range [][]byte{nil, []byte("-1"), []byte("unknown")} {
+		if _, err := parseEntropyValue("entropy_avail", raw); err == nil {
+			t.Errorf("parseEntropyValue(%q) error = nil", raw)
+		}
+	}
+}
+
+func TestEntropyCollectorUpdate(t *testing.T) {
+	root := t.TempDir()
+	originalRoot := filepath.Dir(procfs.DefaultPath())
+	procfs.RootPrefix(root)
+	t.Cleanup(func() { procfs.RootPrefix(originalRoot) })
+
+	dir := filepath.Join(root, "proc/sys/kernel/random")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create proc fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "entropy_avail"), []byte("128\n"), 0o600); err != nil {
+		t.Fatalf("write entropy fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "poolsize"), []byte("256\n"), 0o600); err != nil {
+		t.Fatalf("write poolsize fixture: %v", err)
+	}
+
+	metrics, err := (&entropyCollector{}).Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	want := []float64{128, 256, 50}
+	for i := range want {
+		if metrics[i].Value != want[i] {
+			t.Errorf("metric %d value = %v, want %v", i, metrics[i].Value, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add an `entropy` collector for available bits and pool capacity
- expose available entropy as a percentage without zero division
- validate malformed kernel interface values

## Testing

- `make check`
- `make unit`

Closes #748