### PR TITLE
feat(metrics): export system uptime

### DIFF
--- a/core/metrics/system_uptime.go
+++ b/core/metrics/system_uptime.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+)
+
+type uptimeCollector struct{}
+
+func init() {
+	tracing.RegisterEventTracing("uptime", newUptimeCollector)
+}
+
+func newUptimeCollector() (*tracing.EventTracingAttr, error) {
+	return &tracing.EventTracingAttr{
+		TracingData: &uptimeCollector{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+func parseUptime(raw string) (float64, error) {
+	fields := strings.Fields(raw)
+	if len(fields) != 2 {
+		return 0, fmt.Errorf("uptime has %d fields, want 2", len(fields))
+	}
+	uptime, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse uptime: %w", err)
+	}
+	if _, err := strconv.ParseFloat(fields[1], 64); err != nil {
+		return 0, fmt.Errorf("parse idle time: %w", err)
+	}
+	if uptime < 0 {
+		return 0, fmt.Errorf("uptime must not be negative")
+	}
+	return uptime, nil
+}
+
+func (c *uptimeCollector) Update() ([]*metric.Data, error) {
+	raw, err := os.ReadFile(procfs.Path("uptime"))
+	if err != nil {
+		return nil, err
+	}
+	uptime, err := parseUptime(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	return []*metric.Data{
+		metric.NewGaugeData("seconds", uptime,
+			"Seconds since the system booted.", nil),
+	}, nil
+}

--- a/core/metrics/system_uptime_test.go
+++ b/core/metrics/system_uptime_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+)
+
+func TestParseUptime(t *testing.T) {
+	got, err := parseUptime("1234.56 789.01\n")
+	if err != nil {
+		t.Fatalf("parseUptime() error = %v", err)
+	}
+	if got != 1234.56 {
+		t.Fatalf("parseUptime() = %v, want 1234.56", got)
+	}
+}
+
+func TestParseUptimeRejectsMalformedInput(t *testing.T) {
+	for _, raw := range []string{"", "12", "-1 2", "invalid 2", "1 invalid", "1 2 3"} {
+		if _, err := parseUptime(raw); err == nil {
+			t.Errorf("parseUptime(%q) error = nil", raw)
+		}
+	}
+}
+
+func TestUptimeCollectorUpdate(t *testing.T) {
+	root := t.TempDir()
+	originalRoot := filepath.Dir(procfs.DefaultPath())
+	procfs.RootPrefix(root)
+	t.Cleanup(func() { procfs.RootPrefix(originalRoot) })
+
+	dir := filepath.Join(root, "proc")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create proc fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "uptime"), []byte("1234.5 678.9\n"), 0o600); err != nil {
+		t.Fatalf("write uptime fixture: %v", err)
+	}
+
+	metrics, err := (&uptimeCollector{}).Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if len(metrics) != 1 || metrics[0].Value != 1234.5 {
+		t.Fatalf("Update() metrics = %v, want one metric with value 1234.5", metrics)
+	}
+}


### PR DESCRIPTION
## Summary

- add an `uptime` collector backed by `/proc/uptime`
- export host uptime in seconds
- validate malformed, incomplete, and negative values

## Testing

- `make check`
- `make unit`

Closes #749