### PR TITLE
feat(metrics): export thermal zone temperatures

### DIFF
--- a/core/metrics/system_thermal.go
+++ b/core/metrics/system_thermal.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"huatuo-bamai/internal/procfs"
+	"huatuo-bamai/pkg/metric"
+	"huatuo-bamai/pkg/tracing"
+	"huatuo-bamai/pkg/types"
+)
+
+type thermalCollector struct{}
+
+func init() {
+	tracing.RegisterEventTracing("thermal", newThermalCollector)
+}
+
+func thermalZonePaths() ([]string, error) {
+	return filepath.Glob(filepath.Join(
+		procfs.DefaultPathByType("sys"), "class/thermal/thermal_zone*"))
+}
+
+func newThermalCollector() (*tracing.EventTracingAttr, error) {
+	paths, err := thermalZonePaths()
+	if err != nil {
+		return nil, fmt.Errorf("find thermal zones: %w", err)
+	}
+	if len(paths) == 0 {
+		return nil, types.ErrNotSupported
+	}
+	return &tracing.EventTracingAttr{
+		TracingData: &thermalCollector{},
+		Flag:        tracing.FlagMetric,
+	}, nil
+}
+
+func parseThermalTemperature(raw []byte) (float64, error) {
+	milliCelsius, err := strconv.ParseInt(strings.TrimSpace(string(raw)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse thermal temperature: %w", err)
+	}
+	return float64(milliCelsius) / 1000, nil
+}
+
+func readThermalZone(path string) (*metric.Data, error) {
+	typeRaw, err := os.ReadFile(filepath.Join(path, "type"))
+	if err != nil {
+		return nil, err
+	}
+	tempRaw, err := os.ReadFile(filepath.Join(path, "temp"))
+	if err != nil {
+		return nil, err
+	}
+	temperature, err := parseThermalTemperature(tempRaw)
+	if err != nil {
+		return nil, err
+	}
+	return metric.NewGaugeData("temperature_celsius", temperature,
+		"Thermal zone temperature in degrees Celsius.", map[string]string{
+			"zone": filepath.Base(path),
+			"type": strings.TrimSpace(string(typeRaw)),
+		}), nil
+}
+
+func (c *thermalCollector) Update() ([]*metric.Data, error) {
+	paths, err := thermalZonePaths()
+	if err != nil {
+		return nil, err
+	}
+	metrics := make([]*metric.Data, 0, len(paths))
+	for _, path := range paths {
+		data, err := readThermalZone(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		metrics = append(metrics, data)
+	}
+	return metrics, nil
+}

--- a/core/metrics/system_thermal_test.go
+++ b/core/metrics/system_thermal_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"huatuo-bamai/internal/procfs"
+)
+
+func TestParseThermalTemperature(t *testing.T) {
+	got, err := parseThermalTemperature([]byte("42500\n"))
+	if err != nil {
+		t.Fatalf("parseThermalTemperature() error = %v", err)
+	}
+	if got != 42.5 {
+		t.Fatalf("parseThermalTemperature() = %v, want 42.5", got)
+	}
+}
+
+func TestParseThermalTemperatureRejectsMalformedInput(t *testing.T) {
+	if _, err := parseThermalTemperature([]byte("unknown")); err == nil {
+		t.Fatal("parseThermalTemperature() error = nil")
+	}
+}
+
+func TestThermalCollectorUpdate(t *testing.T) {
+	root := t.TempDir()
+	originalRoot := filepath.Dir(procfs.DefaultPath())
+	procfs.RootPrefix(root)
+	t.Cleanup(func() { procfs.RootPrefix(originalRoot) })
+
+	zone := filepath.Join(root, "sys/class/thermal/thermal_zone7")
+	if err := os.MkdirAll(zone, 0o755); err != nil {
+		t.Fatalf("create thermal fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(zone, "type"), []byte("x86_pkg_temp\n"), 0o600); err != nil {
+		t.Fatalf("write type fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(zone, "temp"), []byte("42500\n"), 0o600); err != nil {
+		t.Fatalf("write temperature fixture: %v", err)
+	}
+
+	metrics, err := (&thermalCollector{}).Update()
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if len(metrics) != 1 || metrics[0].Value != 42.5 {
+		t.Fatalf("Update() metrics = %v, want one metric with value 42.5", metrics)
+	}
+	labels := metrics[0].Labels()
+	if labels["zone"] != "thermal_zone7" || labels["type"] != "x86_pkg_temp" {
+		t.Fatalf("Update() labels = %v", labels)
+	}
+}


### PR DESCRIPTION
## Summary

- add a `thermal` collector for Linux thermal zones
- export Celsius values with zone and type labels
- disable unsupported hosts and tolerate disappearing zones

## Testing

- `make check`
- `make unit`

Closes #750