### PR TITLE
fix(pod): skip missing kubelet container statuses without panicking

### DIFF
--- a/internal/pod/container_kubelet_sync.go
+++ b/internal/pod/container_kubelet_sync.go
@@ -264,7 +264,12 @@ func kubeletSyncContainers() error {
 		}
 
 		for _, c := range m {
-			containerStatus := c[1].(*corev1.ContainerStatus)
+			container := c[0].(*corev1.Container)
+			containerStatus, ok := c[1].(*corev1.ContainerStatus)
+			if !ok || containerStatus == nil {
+				log.Warnf("pod %s has no running status for container %s, skipping", pod.Name, container.Name)
+				continue
+			}
 			containerID, err := parseContainerIDInPodStatus(containerStatus.ContainerID)
 			if err != nil {
 				log.Warnf("failed to parse container id %s in pod %s status: %v", containerStatus.ContainerID, pod.Name, err)
@@ -272,7 +277,7 @@ func kubeletSyncContainers() error {
 			}
 
 			newContainers[containerID] = &containerInfo{
-				container:       c[0].(*corev1.Container),
+				container:       container,
 				containerStatus: containerStatus,
 				pod:             pod,
 			}
@@ -564,6 +569,10 @@ func isRuningPod(pod *corev1.Pod) bool {
 	// At least one container is still running, or is in the process of starting or
 	// restarting.
 	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	if len(pod.Status.ContainerStatuses) != len(pod.Spec.Containers) {
 		return false
 	}
 

--- a/internal/pod/container_kubelet_sync_test.go
+++ b/internal/pod/container_kubelet_sync_test.go
@@ -498,3 +498,62 @@ func (t bodyReadErrorTransport) RoundTrip(_ *http.Request) (*http.Response, erro
 		)),
 	}, nil
 }
+
+func TestIsRuningPodRequiresRunningContainerStatuses(t *testing.T) {
+	runningPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "app",
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "missing status for spec container",
+			pod: func() *corev1.Pod {
+				pod := runningPod()
+				pod.Status.ContainerStatuses = nil
+				return pod
+			}(),
+			want: false,
+		},
+		{
+			name: "container is not running",
+			pod: func() *corev1.Pod {
+				pod := runningPod()
+				pod.Status.ContainerStatuses[0].State.Running = nil
+				return pod
+			}(),
+			want: false,
+		},
+		{
+			name: "all containers running",
+			pod:  runningPod(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRuningPod(tt.pod); got != tt.want {
+				t.Fatalf("isRuningPod() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Guard the kubelet container-sync path against missing container statuses and make `isRuningPod` require one running status per spec container.

## Root cause

`kubeletSyncContainers` builds a `map[string][2]any` entry with a nil second slot for every spec container, then fills that slot only when `pod.Status.ContainerStatuses` contains a matching name. The consumer performs a bare type assertion:

```go
containerStatus := c[1].(*corev1.ContainerStatus)
```

A container whose status is absent remains nil, so the assertion panics. The same pod would also be considered running by `isRuningPod` because it only checked the statuses that happened to exist, not whether every spec container had one.

## Fix

- Use a comma-ok assertion and skip containers with a nil/missing status.
- In `isRuningPod`, reject pods whose `ContainerStatuses` count does not match `Spec.Containers`.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/pod` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added `TestIsRuningPodRequiresRunningContainerStatuses` covering missing, non-running, and running statuses.

Fixes #416