### PR TITLE
fix(pod): fall back to unknown for invalid container types

### DIFF
--- a/internal/pod/container_json_test.go
+++ b/internal/pod/container_json_test.go
@@ -145,3 +145,11 @@ func TestContainerJSONUnknownValues(t *testing.T) {
 		t.Errorf("container qos = %v, want unknown", qos)
 	}
 }
+
+func TestContainerTypeStringUnknownFallback(t *testing.T) {
+	for _, typ := range []ContainerType{0, ContainerTypeUnknown + 1, ContainerType(1 << 20)} {
+		if got, want := typ.String(), "unknown"; got != want {
+			t.Fatalf("ContainerType(%d).String() = %q, want %q", typ, got, want)
+		}
+	}
+}

--- a/internal/pod/container_type.go
+++ b/internal/pod/container_type.go
@@ -43,7 +43,11 @@ var containerType2String = map[ContainerType]string{
 }
 
 func (t ContainerType) String() string {
-	return containerType2String[t]
+	if value, ok := containerType2String[t]; ok {
+		return value
+	}
+
+	return containerType2String[ContainerTypeUnknown]
 }
 
 // MarshalJSON marshal container type to json.


### PR DESCRIPTION
## Summary

Make `ContainerType.String` fall back to `unknown` for zero, invalid, or unregistered type values.

## Root cause

`String` returned `containerType2String[t]` directly. Missing map keys yield the empty string, so invalid container types become an empty `container_type` metric label and JSON `type` field instead of the established `unknown` value used by `ContainerQos`.

## Fix

Use a comma-ok lookup and return `containerType2String[ContainerTypeUnknown]` when the value is not registered.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/pod` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added `TestContainerTypeStringUnknownFallback` for zero, invalid, and oversized type values.

Fixes #756