### PR TITLE
fix(pod): fall back for missing host namespace label

### DIFF
--- a/internal/pod/container.go
+++ b/internal/pod/container.go
@@ -68,7 +68,11 @@ func (c *Container) LifeResources(key string) any {
 
 // LabelHostNamespace returns namespace label
 func (c *Container) LabelHostNamespace() string {
-	return c.Labels[labelHostNamespace].(string)
+	if value, ok := c.Labels[labelHostNamespace].(string); ok {
+		return value
+	}
+
+	return ""
 }
 
 func (c *Container) InitPidOrInitnsPid() int {

--- a/internal/pod/container_json_test.go
+++ b/internal/pod/container_json_test.go
@@ -145,3 +145,25 @@ func TestContainerJSONUnknownValues(t *testing.T) {
 		t.Errorf("container qos = %v, want unknown", qos)
 	}
 }
+
+func TestContainerLabelHostNamespaceFallback(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]any
+		want   string
+	}{
+		{name: "nil labels", labels: nil, want: ""},
+		{name: "missing label", labels: map[string]any{}, want: ""},
+		{name: "wrong label type", labels: map[string]any{labelHostNamespace: 42}, want: ""},
+		{name: "string label", labels: map[string]any{labelHostNamespace: "kube-system"}, want: "kube-system"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := &Container{Labels: tt.labels}
+			if got := container.LabelHostNamespace(); got != tt.want {
+				t.Fatalf("LabelHostNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Make `Container.LabelHostNamespace` return an empty string instead of panicking when the namespace label is nil, missing, or not a string.

## Root cause

The accessor used a bare type assertion:

```go
return c.Labels[labelHostNamespace].(string)
```

A nil label map, absent `HostNamespace` key, or a value with another type causes a runtime panic while metrics or tracing documents serialize the container.

## Fix

Use a comma-ok assertion and return `""` when the label cannot be read as a string.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/pod` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added `TestContainerLabelHostNamespaceFallback` for nil, missing, wrong-type, and valid labels.

Fixes #757