### PR TITLE
fix(pod): guard nil container string formatting

### DIFF
--- a/internal/pod/container.go
+++ b/internal/pod/container.go
@@ -58,6 +58,10 @@ type Container struct {
 }
 
 func (c *Container) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+
 	return fmt.Sprintf("%s:%s/%s/%s:%s/%s", c.ID, c.Hostname, c.Name, c.Type, c.Qos, c.IPAddress)
 }
 

--- a/internal/pod/container_json_test.go
+++ b/internal/pod/container_json_test.go
@@ -145,3 +145,15 @@ func TestContainerJSONUnknownValues(t *testing.T) {
 		t.Errorf("container qos = %v, want unknown", qos)
 	}
 }
+
+func TestContainerStringNilReceiver(t *testing.T) {
+	var container *Container
+	if got := container.String(); got != "<nil>" {
+		t.Fatalf("nil Container.String() = %q, want <nil>", got)
+	}
+
+	container = &Container{ID: "abc", Name: "app", Type: ContainerTypeNormal}
+	if got, want := container.String(), "abc:/app/normal:unknown/"; got != want {
+		t.Fatalf("Container.String() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Make `Container.String` safe to call on a nil receiver.

## Root cause

`String` formatted `c.ID`, `c.Hostname`, and other fields without checking `c`. A nil `*Container` is used as the host-fallback sentinel in collectors, so formatting or logging such a sentinel panics.

## Fix

Return the stable `<nil>` representation when the receiver is nil.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/pod` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added `TestContainerStringNilReceiver` for nil and non-nil receivers.

Fixes #758