### PR TITLE
fix(metrics): report missing memory_others cgroup key

### DIFF
--- a/core/metrics/memory_others.go
+++ b/core/metrics/memory_others.go
@@ -95,7 +95,12 @@ func parseValueWithKey(cgroupPath, cgroupFile, key string) (uint64, error) {
 		return 0, err
 	}
 
-	return raw[key], nil
+	value, ok := raw[key]
+	if !ok {
+		return 0, fmt.Errorf("key %q not found in %s", key, filePath)
+	}
+
+	return value, nil
 }
 
 func (c *memOthersCollector) Update() ([]*metric.Data, error) {

--- a/core/metrics/memory_others_test.go
+++ b/core/metrics/memory_others_test.go
@@ -70,3 +70,41 @@ func TestNewMemOthersCollectorSupported(t *testing.T) {
 		t.Fatalf("newMemOthersCollector() attr = %+v, want metric collector", attr)
 	}
 }
+
+func TestParseValueWithKeyReportsMissingKey(t *testing.T) {
+	memDir := setCgroupRootfs(t)
+	podDir := filepath.Join(memDir, "pod-1")
+	if err := os.MkdirAll(podDir, 0o755); err != nil {
+		t.Fatalf("create pod cgroup dir: %v", err)
+	}
+
+	file := "memory.directstall_stat"
+	if err := os.WriteFile(filepath.Join(podDir, file), []byte("other_key 42\n"), 0o600); err != nil {
+		t.Fatalf("create %s: %v", file, err)
+	}
+
+	if _, err := parseValueWithKey("pod-1", file, "directstall_time"); err == nil {
+		t.Fatal("parseValueWithKey() error = nil, want missing-key error")
+	}
+}
+
+func TestParseValueWithKeyReturnsPresentValue(t *testing.T) {
+	memDir := setCgroupRootfs(t)
+	podDir := filepath.Join(memDir, "pod-1")
+	if err := os.MkdirAll(podDir, 0o755); err != nil {
+		t.Fatalf("create pod cgroup dir: %v", err)
+	}
+
+	file := "memory.directstall_stat"
+	if err := os.WriteFile(filepath.Join(podDir, file), []byte("directstall_time 123\n"), 0o600); err != nil {
+		t.Fatalf("create %s: %v", file, err)
+	}
+
+	value, err := parseValueWithKey("pod-1", file, "directstall_time")
+	if err != nil {
+		t.Fatalf("parseValueWithKey() error = %v, want nil", err)
+	}
+	if value != 123 {
+		t.Fatalf("parseValueWithKey() = %d, want 123", value)
+	}
+}


### PR DESCRIPTION
## Summary

Return an error when `memory_others` requests a key that is absent from a successfully parsed cgroup stat file.

## Root cause

`parseValueWithKey` returned `raw[key]` without a presence check. A missing key is the zero value in Go maps, so the collector exported a valid-looking zero metric instead of treating the interface as unavailable.

## Fix

Use a comma-ok lookup and return `key %q not found in %s` when the requested key is missing.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./core/metrics` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added tests for both missing and present keys using a temporary cgroup rootfs.

Fixes #759