### PR TITLE
test(metrics): cover cpu_stat cpu_total reset underflow

### DIFF
--- a/core/metrics/cpu_stat_test.go
+++ b/core/metrics/cpu_stat_test.go
@@ -185,3 +185,16 @@ func TestNewCPUStatSample(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateWaitPercentCPUTotalUnderflow(t *testing.T) {
+	previous := cpuStat{waitSum: math.MaxUint64 - 100, cpuTotal: math.MaxUint64}
+	current := cpuStat{waitSum: 10, cpuTotal: 0}
+
+	value, valid := calculateWaitPercent(&current, &previous)
+	if valid {
+		t.Fatalf("calculateWaitPercent() = (%v, true), want invalid when cpu_total resets", value)
+	}
+	if value != 0 {
+		t.Fatalf("calculateWaitPercent() value = %v, want 0", value)
+	}
+}


### PR DESCRIPTION
## Summary

Add a regression test that pins `calculateWaitPercent` behavior when `cpu_total` resets across samples.

## Root cause

The issue describes a uint64 underflow in the old `deltaWaitRunSum` calculation. Current main no longer contains that code path: `calculateWaitPercent` rejects samples where `current.cpuTotal < previous.cpuTotal`. This change adds explicit overflow-level coverage (`previous.cpuTotal = math.MaxUint64`, `current.cpuTotal = 0`) so the underflow cannot regress without a failing test.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./core/metrics` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.

Fixes #536