### PR TITLE
test(config): cover transactional UpdateAndSync rollback

### DIFF
--- a/cmd/huatuo-bamai/config/config_test.go
+++ b/cmd/huatuo-bamai/config/config_test.go
@@ -528,3 +528,19 @@ func TestUpdatePublishesConsistentSnapshots(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUpdateAndSyncRollsBackInvalidBatch(t *testing.T) {
+	loadConfigDefaults(t)
+	before := Get()
+
+	err := UpdateAndSync(map[string]any{
+		"BlackList": []string{"dropwatch"},
+		"NotExist":  1,
+	})
+	if !errors.Is(err, ErrInvalidUpdate) {
+		t.Fatalf("UpdateAndSync() error = %v, want ErrInvalidUpdate", err)
+	}
+	if Get() != before {
+		t.Fatal("UpdateAndSync() published a partial config")
+	}
+}


### PR DESCRIPTION
## Summary

Add regression coverage that `UpdateAndSync` rejects an invalid batch atomically and does not publish a partial configuration.

## Root cause

The issue described partial application of config updates. Current main already stages updates on a cloned config, validates the whole clone, and publishes only after success; the existing test covered `Update` but not the persisted `UpdateAndSync` path.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./cmd/huatuo-bamai/config` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added `TestUpdateAndSyncRollsBackInvalidBatch`.

Fixes #531