### PR TITLE
test(autotracing): cover cpuidle zero-capacity divide guard

### DIFF
--- a/core/autotracing/cpuidle_test.go
+++ b/core/autotracing/cpuidle_test.go
@@ -601,3 +601,20 @@ func TestSaveCPUIdleTraceRejectsInvalidPerfOutput(t *testing.T) {
 		t.Fatalf("saveCPUIdleTrace() error = %v, want decode error", err)
 	}
 }
+
+func TestContainerCPUStateUpdateZeroCapacityDoesNotDivide(t *testing.T) {
+	t.Parallel()
+
+	start := time.Unix(100, 0)
+	state := containerCPUState{hasPercent: true}
+	if state.update(cpuUsageBreakdown[uint64]{}, 0, start) {
+		t.Fatal("first update = true, want false")
+	}
+
+	if state.update(cpuUsageBreakdown[uint64]{user: 10, total: 10}, 0, start.Add(time.Second)) {
+		t.Fatal("zero-capacity update = true, want false")
+	}
+	if state.hasUsage || state.hasPercent {
+		t.Fatalf("state after zero-capacity update = %+v, want no usage/percent", state)
+	}
+}


### PR DESCRIPTION
## Summary

Add regression coverage for the cpuidle divide-by-zero guard when the CPU capacity is zero.

## Root cause

The issue described a divide-by-zero in cpuidle when elapsed time or CPU capacity was zero. Current main already rejects samples with `elapsedMicroseconds <= 0 || cpuCapacity <= 0`; existing tests covered zero and sub-microsecond elapsed time but not zero CPU capacity.

## Validation

- `gofmt` on changed Go files
- `git diff --check` clean
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./core/autotracing` was attempted but could not compile in this Windows checkout because generated `internal/bpf/abi` is absent. Linux CI should run the package tests.
- Added `TestContainerCPUStateUpdateZeroCapacityDoesNotDivide`.

Fixes #418