### PR TITLE
fix(job): reject malformed lone dash sort field

### DIFF
--- a/internal/job/storage_store.go
+++ b/internal/job/storage_store.go
@@ -169,6 +169,9 @@ func validateJobQuery(query *JobQuery) error {
 	field := query.Sort
 	if field != "" && field[0] == '-' {
 		field = field[1:]
+		if field == "" {
+			return fmt.Errorf("%w: unsupported sort field %q", ErrInvalidQuery, query.Sort)
+		}
 	}
 	switch field {
 	case "", "id", "created_at", "finished_at", "hostname", "container_id", "status", "type":

--- a/internal/job/storage_store_test.go
+++ b/internal/job/storage_store_test.go
@@ -239,3 +239,10 @@ func TestToStorageQueryUsesJobFieldNames(t *testing.T) {
 		t.Errorf("default sorts=%v, want descending created_at", query.Sorts)
 	}
 }
+
+func TestValidateJobQueryRejectsLoneDescendingSort(t *testing.T) {
+	err := validateJobQuery(&JobQuery{Sort: "-"})
+	if !errors.Is(err, ErrInvalidQuery) {
+		t.Fatalf("validateJobQuery(Sort: %q) error = %v, want ErrInvalidQuery", "-", err)
+	}
+}


### PR DESCRIPTION
## Summary

Reject the lone descending sort value `"-"` while validating job queries. Previously `validateJobQuery` stripped the leading dash, accepted the resulting empty field, and the error surfaced later from the SQLite backend.

## Root cause

`validateJobQuery` only checked that the field was non-empty before stripping a leading `-`; it never verified that a field remained after stripping.

## Validation

- `gofmt -w internal/job/storage_store.go internal/job/storage_store_test.go`
- `git diff --check`
- `go test ./internal/job -run '^TestValidateJobQueryRejectsLoneDescendingSort$' -count=1`
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/job`

Fixes #771
