### PR TITLE
fix(job): apply ID filter in job storage queries

### DIFF
--- a/internal/job/storage_store.go
+++ b/internal/job/storage_store.go
@@ -255,6 +255,9 @@ func toStorageQuery(q *JobQuery) driver.Query {
 		q = &JobQuery{}
 	}
 	filters := make([]driver.Filter, 0, 6)
+	if q.ID != "" {
+		filters = append(filters, driver.Filter{Field: "id", Op: driver.OpEq, Value: q.ID})
+	}
 	if q.UserID != "" && !q.IsAdmin {
 		filters = append(filters, driver.Filter{Field: "user_id", Op: driver.OpEq, Value: q.UserID})
 	}

--- a/internal/job/storage_store_test.go
+++ b/internal/job/storage_store_test.go
@@ -239,3 +239,13 @@ func TestToStorageQueryUsesJobFieldNames(t *testing.T) {
 		t.Errorf("default sorts=%v, want descending created_at", query.Sorts)
 	}
 }
+
+func TestToStorageQueryIncludesIDFilter(t *testing.T) {
+	query := toStorageQuery(&JobQuery{ID: "job-store-alpha"})
+	if len(query.Filters) != 1 {
+		t.Fatalf("filter count=%d, want 1", len(query.Filters))
+	}
+	if query.Filters[0].Field != "id" || query.Filters[0].Op != driver.OpEq {
+		t.Fatalf("filter=%+v, want id equality filter", query.Filters[0])
+	}
+}


### PR DESCRIPTION
## Summary

Apply `JobQuery.ID` when translating a job query to the generic storage query. A non-empty ID now becomes an `id = ?` filter instead of being silently ignored.

## Root cause

`toStorageQuery` built filters for user, container, host, status, and type, but never read `JobQuery.ID`.

## Validation

- `gofmt -w internal/job/storage_store.go internal/job/storage_store_test.go`
- `git diff --check`
- `go test ./internal/job -run '^TestToStorageQueryIncludesIDFilter$' -count=1`
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/job`

Fixes #772
