### PR TITLE
test(storage): cover query building and the index snapshot

### DIFF
--- a/internal/job/storage_store_test.go
+++ b/internal/job/storage_store_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ccfos/huatuo/internal/storage/driver"
 	"github.com/ccfos/huatuo/pkg/observation"
 	"github.com/ccfos/huatuo/pkg/profiling"
 )
@@ -233,4 +234,34 @@ func jobIDs(jobs []*Job) []string {
 		ids[i] = job.ID
 	}
 	return ids
+}
+
+func TestValidateQuerySortRejectsLoneDescendingField(t *testing.T) {
+	err := validateQuerySort(&Query{Sort: "-"})
+	if !errors.Is(err, ErrInvalidQuery) {
+		t.Fatalf("validateQuerySort() error = %v, want ErrInvalidQuery", err)
+	}
+}
+
+func TestBuildStorageQueryFiltersByID(t *testing.T) {
+	query, err := buildStorageQuery(&Query{ID: "job-store-alpha"})
+	if err != nil {
+		t.Fatalf("buildStorageQuery() error = %v", err)
+	}
+	var found bool
+	for _, filter := range query.Filters {
+		if filter.Field != "id" {
+			continue
+		}
+		found = true
+		if filter.Op != driver.OpEq {
+			t.Fatalf("id filter op = %v, want %v", filter.Op, driver.OpEq)
+		}
+		if filter.Value != "job-store-alpha" {
+			t.Fatalf("id filter value = %v, want %q", filter.Value, "job-store-alpha")
+		}
+	}
+	if !found {
+		t.Fatalf("buildStorageQuery() filters = %v, want an id filter", query.Filters)
+	}
 }

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1044,3 +1044,22 @@ func TestStoreTerms(t *testing.T) {
 		})
 	}
 }
+
+func TestNewStoreUsesSingleIndexSnapshot(t *testing.T) {
+	mapper := newTestMapper()
+	backend := &testBackend{}
+
+	store, err := NewStore(t.Context(), "jobs", backend, "jobs", mapper)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if store == nil {
+		t.Fatal("NewStore() returned nil store")
+	}
+	if mapper.indexesCalls != 1 {
+		t.Fatalf("mapper.Indexes() calls = %d, want 1", mapper.indexesCalls)
+	}
+	if !reflect.DeepEqual(backend.indexes, mapper.indexes) {
+		t.Fatalf("backend indexes = %v, want %v", backend.indexes, mapper.indexes)
+	}
+}


### PR DESCRIPTION
## Summary

Add the regression coverage for three behaviours that `main` already implements but does not assert:

- `NewStore` must take one `mapper.Indexes()` snapshot and hand that same slice to `backend.Init`.
- `validateQuerySort` must reject a lone `-`, which names no field.
- `buildStorageQuery` must turn `Query.ID` into an `id` equality filter.

## Why this is now tests only

This PR originally also changed `internal/storage/store.go` to stop calling `mapper.Indexes()` twice. That production change has since landed on `main` through the storage refactor (`1b270fc9`), so after rebasing onto `852d724d` the code change is a no-op and only the regression test remains. I have retitled it accordingly rather than leaving a `fix(...)` title on a change that no longer fixes anything.

The two `internal/job` cases come from PRs #781 and #782, which are superseded in the same way: probing `main` shows

```
validateQuerySort(&Query{Sort: "-"})      = invalid job query: unsupported sort field ""
buildStorageQuery(&Query{ID: "job-store-alpha"}).Filters = [{Field:id Op:eq Value:job-store-alpha}]
```

so both behaviours already hold and only the assertions were missing. I folded them in here and closed those PRs, so the coverage lives in one place instead of three.

## Testing

On Ubuntu 22.04 with go1.24.13, on top of `852d724d`:

```
$ gofmt -l internal/storage/store_test.go internal/job/storage_store_test.go   # no output
$ go vet  ./internal/storage/ ./internal/job/                                   # clean
$ go test -count=1 ./internal/storage/ ./internal/job/
ok  	github.com/ccfos/huatuo/internal/storage
ok  	github.com/ccfos/huatuo/internal/job
$ go test -count=1 ./internal/storage/ ./internal/job/ \
    -run 'TestNewStoreUsesSingleIndexSnapshot|TestValidateQuerySortRejectsLoneDescendingField|TestBuildStorageQueryFiltersByID' -v
--- PASS: TestNewStoreUsesSingleIndexSnapshot (0.00s)
--- PASS: TestValidateQuerySortRejectsLoneDescendingField (0.00s)
--- PASS: TestBuildStorageQueryFiltersByID (0.00s)
$ go build ./...                                                                # exit 0
```

Assisted-by: OpenAI:Codex (GPT-5)
Percentage of AI-generated code: 100%