### PR TITLE
fix(metrics): label RDMA link metrics by port

### DIFF
--- a/core/metrics/netdev_rdma_link.go
+++ b/core/metrics/netdev_rdma_link.go
@@ -61,12 +61,22 @@ func (r *rdmaLink) Update() ([]*metric.Data, error) {
 		}
 
 		for _, s := range stats.RdmaPortStatistics {
+			portTags := rdmaPortTags(tags, s.PortIndex)
 			for lable, val := range s.Statistics {
 				data = append(data, metric.NewCounterData(lable, float64(val),
-					fmt.Sprintf("rdma device statistic %s.", lable), tags))
+					fmt.Sprintf("rdma device statistic %s.", lable), portTags))
 			}
 		}
 	}
 
 	return data, nil
+}
+
+func rdmaPortTags(base map[string]string, portIndex uint32) map[string]string {
+	tags := make(map[string]string, len(base)+1)
+	for key, value := range base {
+		tags[key] = value
+	}
+	tags["port"] = strconv.FormatUint(uint64(portIndex), 10)
+	return tags
 }

--- a/core/metrics/netdev_rdma_link_test.go
+++ b/core/metrics/netdev_rdma_link_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import "testing"
+
+func TestRdmaPortTagsIncludesPortLabel(t *testing.T) {
+	base := map[string]string{
+		"device":    "mlx5_0",
+		"nodeguid":  "0000:0000:0000:0000",
+		"index":     "0",
+		"num_ports": "2",
+	}
+
+	tags := rdmaPortTags(base, 1)
+	if tags["port"] != "1" {
+		t.Fatalf("port label = %q, want 1", tags["port"])
+	}
+	if tags["device"] != "mlx5_0" {
+		t.Fatalf("device label = %q, want mlx5_0", tags["device"])
+	}
+	if base["port"] != "" {
+		t.Fatalf("base labels were mutated: port=%q", base["port"])
+	}
+}


### PR DESCRIPTION
## Summary

Add a `port` label to each RDMA port statistic so multi-port devices no longer emit duplicate series with identical labels. The per-port labels are built by a small helper and the base device label map is no longer reused/mutated.

## Root cause

`netdev_rdma_link.Update` emitted every `RdmaPortStatistics` entry with the same device-level label set, ignoring `RdmaPortStatistic.PortIndex`.

## Validation

- `gofmt -w core/metrics/netdev_rdma_link.go core/metrics/netdev_rdma_link_test.go`
- `git diff --check`
- `go test ./core/metrics -run '^TestRdmaPortTagsIncludesPortLabel$' -count=1` could not run in this Windows environment: the package setup fails on pre-existing vendored build constraints (`internal/bpf/abi` and `prometheus/procfs/sysfs`). The added test targets the pure helper and is kept for Linux CI.
- Linux `go test -c -mod=vendor ./core/metrics` is blocked by the same pre-existing `internal/bpf/abi` vendored-path error in this checkout.

Fixes #776
