### PR TITLE
fix(metrics): skip qdisc entries with unresolved device

### DIFF
--- a/core/metrics/netdev_qdisc.go
+++ b/core/metrics/netdev_qdisc.go
@@ -67,7 +67,7 @@ func (c *qdiscCollector) Update() ([]*metric.Data, error) {
 	labels := map[string]string{"device": "", "kind": ""}
 	for i := range stats {
 		stat := &stats[i]
-		if !c.deviceMatcher.Match(stat.Netdev) || stat.Kind == "noqueue" || !stat.IsRoot() {
+		if stat.Netdev == "" || !c.deviceMatcher.Match(stat.Netdev) || stat.Kind == "noqueue" || !stat.IsRoot() {
 			continue
 		}
 

--- a/core/metrics/netdev_qdisc_test.go
+++ b/core/metrics/netdev_qdisc_test.go
@@ -81,6 +81,36 @@ func TestQdiscCollectorUpdate(t *testing.T) {
 	}
 }
 
+func TestQdiscCollectorSkipsUnresolvedDevice(t *testing.T) {
+	originalConfig := configSnapshot()
+	t.Cleanup(func() { Set(originalConfig) })
+	Set(&Config{})
+
+	attr, err := newQdiscCollector()
+	if err != nil {
+		t.Fatalf("create qdisc collector: %v", err)
+	}
+	collector, ok := attr.TracingData.(*qdiscCollector)
+	if !ok {
+		t.Fatalf("tracing data type = %T, want *qdiscCollector", attr.TracingData)
+	}
+	collector.readStats = func() ([]qdisc.Stats, error) {
+		return []qdisc.Stats{{
+			Netdev: "",
+			Parent: math.MaxUint32,
+			Kind:   "fq_codel",
+		}}, nil
+	}
+
+	metrics, err := collector.Update()
+	if err != nil {
+		t.Fatalf("update qdisc metrics: %v", err)
+	}
+	if len(metrics) != 0 {
+		t.Fatalf("metric count = %d, want 0", len(metrics))
+	}
+}
+
 func TestQdiscCollectorUpdateReadError(t *testing.T) {
 	wantErr := errors.New("netlink unavailable")
 	collector := &qdiscCollector{


### PR DESCRIPTION
## Summary

Skip qdisc records whose device name could not be resolved instead of emitting qdisc metrics with `device=""`.

## Root cause

`qdisc.Read` resolves interface indexes against a snapshot of network interfaces; an interface that disappears after the snapshot produces a qdisc entry with an empty `Netdev` name, which `Update` previously emitted.

## Validation

- `gofmt -w core/metrics/netdev_qdisc.go core/metrics/netdev_qdisc_test.go`
- `git diff --check`
- `go test ./core/metrics -run '^TestQdiscCollectorSkipsUnresolvedDevice$' -count=1` cannot run in this Windows checkout due pre-existing vendored build constraints (`internal/bpf/abi` and `prometheus/procfs/sysfs`); the new regression test is intended to run on Linux CI.
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./core/metrics` is blocked by the same pre-existing `internal/bpf/abi` vendored-path error.

Fixes #777
