### PR TITLE
fix(metrics): skip zero disk iolatency buckets

### DIFF
--- a/core/metrics/iolatency_collector.go
+++ b/core/metrics/iolatency_collector.go
@@ -105,21 +105,8 @@ func (c *iolatencyTracing) fetchBlkDiskIOlatency(object bpf.BPF) ([]*metric.Data
 	for _, disk := range blkIOdata {
 		diskDev := fmt.Sprintf("%d:%d", disk.Major, disk.Minor)
 
-		for zone, cnt := range disk.Q2CZone {
-			metrics = append(metrics, metric.NewCounterData(
-				"blkdisk_q2c", float64(cnt),
-				"the disk q2c latency",
-				map[string]string{"disk": diskDev, "zone": strconv.Itoa(zone)},
-			))
-		}
-
-		for zone, cnt := range disk.D2CZone {
-			metrics = append(metrics, metric.NewCounterData(
-				"blkdisk_d2c", float64(cnt),
-				"the disk d2c latency",
-				map[string]string{"disk": diskDev, "zone": strconv.Itoa(zone)},
-			))
-		}
+		metrics = appendBlkdiskZoneMetrics(metrics, diskDev, disk.Q2CZone, "blkdisk_q2c", "the disk q2c latency")
+		metrics = appendBlkdiskZoneMetrics(metrics, diskDev, disk.D2CZone, "blkdisk_d2c", "the disk d2c latency")
 
 		metrics = append(metrics, metric.NewCounterData(
 			"blkdisk_freeze", float64(disk.FreezeNr),
@@ -129,4 +116,22 @@ func (c *iolatencyTracing) fetchBlkDiskIOlatency(object bpf.BPF) ([]*metric.Data
 	}
 
 	return metrics, nil
+}
+
+func appendBlkdiskZoneMetrics(
+	metrics []*metric.Data,
+	diskDev string,
+	zones [blkLatencyZone]uint64,
+	name, help string,
+) []*metric.Data {
+	for zone, cnt := range zones {
+		if cnt == 0 {
+			continue
+		}
+		metrics = append(metrics, metric.NewCounterData(
+			name, float64(cnt), help,
+			map[string]string{"disk": diskDev, "zone": strconv.Itoa(zone)},
+		))
+	}
+	return metrics
 }

--- a/core/metrics/iolatency_collector_test.go
+++ b/core/metrics/iolatency_collector_test.go
@@ -60,3 +60,23 @@ func TestIOLatencyUpdateReturnsContainerCollectionError(t *testing.T) {
 		t.Fatalf("Update() returned %d metrics, want 0", len(metrics))
 	}
 }
+
+func TestAppendBlkdiskZoneMetricsSkipsZeroBuckets(t *testing.T) {
+	var zones [blkLatencyZone]uint64
+	zones[0] = 10
+	zones[2] = 5
+
+	metrics := appendBlkdiskZoneMetrics(nil, "8:0", zones, "blkdisk_q2c", "the disk q2c latency")
+	if len(metrics) != 2 {
+		t.Fatalf("metric count = %d, want 2", len(metrics))
+	}
+	if got := metrics[0].Labels()["zone"]; got != "0" {
+		t.Fatalf("first zone = %q, want 0", got)
+	}
+	if got := metrics[1].Labels()["zone"]; got != "2" {
+		t.Fatalf("second zone = %q, want 2", got)
+	}
+	if got := metrics[0].Labels()["disk"]; got != "8:0" {
+		t.Fatalf("disk label = %q, want 8:0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Skip zero-count disk iolatency histogram buckets. The disk path now matches the container path, which already skips zero buckets, and both share one helper.

## Root cause

`fetchBlkDiskIOlatency` emitted `blkdisk_q2c` and `blkdisk_d2c` samples for every zone, including zones with a zero count, while `fetchContainerIOlatency` already skipped them. The two disk zone loops were copies of each other, so the skip is added once in `appendBlkdiskZoneMetrics`, which takes the formatted device instead of the whole 120-byte entry (the caller already builds that device for `blkdisk_freeze`).

## Validation

Ubuntu 22.04, kernel 6.8, as root, `-mod=vendor`, tree = current `main` + this patch:

```
--- PASS: TestIOLatencyUpdateReturnsContainerCollectionError (0.00s)
--- PASS: TestAppendBlkdiskZoneMetricsSkipsZeroBuckets (0.00s)
ok  github.com/ccfos/huatuo/core/metrics  0.016s

make build      → 0
sudo make unit  → 0
make check      → 0   (gofumpt + golangci-lint, 0 issues, no generated or formatting drift)
```

The regression test drives the helper with `zones[0] = 10` and `zones[2] = 5` and asserts that exactly two samples are produced, labelled `zone="0"` and `zone="2"`, so a zero-count zone no longer exports `blkdisk_q2c`/`blkdisk_d2c`.

The diff against `main` only adds that helper and its test; the existing `TestIOLatencyUpdateReturnsContainerCollectionError` coverage is preserved.

Fixes #778

Signed-off-by: yyqdbngt <btlqql@gmail.com>