### PR TITLE
fix(metrics): track only iolatency containers with blkio CSS

### DIFF
--- a/core/metrics/iolatency_tracing.go
+++ b/core/metrics/iolatency_tracing.go
@@ -220,6 +220,16 @@ func (c *iolatencyTracing) updateContainerBlkDisk(b bpf.BPF) error {
 		}
 	}
 
-	c.latestContainers = containers
+	c.latestContainers = trackContainersWithBlkioCSS(containers)
 	return nil
+}
+
+func trackContainersWithBlkioCSS(containers map[string]*pod.Container) map[string]*pod.Container {
+	tracked := make(map[string]*pod.Container, len(containers))
+	for id, container := range containers {
+		if _, ok := container.CgroupCss[subsystem.SubsystemBlkIO]; ok {
+			tracked[id] = container
+		}
+	}
+	return tracked
 }

--- a/core/metrics/iolatency_tracing_test.go
+++ b/core/metrics/iolatency_tracing_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/ccfos/huatuo/internal/cgroups/subsystem"
+	"github.com/ccfos/huatuo/internal/pod"
+)
+
+func TestTrackContainersWithBlkioCSS(t *testing.T) {
+	containers := map[string]*pod.Container{
+		"with-blkio": {
+			CgroupCss: map[string]uint64{subsystem.SubsystemBlkIO: 10},
+		},
+		"without-blkio": {},
+	}
+
+	tracked := trackContainersWithBlkioCSS(containers)
+	if _, ok := tracked["with-blkio"]; !ok {
+		t.Fatal("container with blkio CSS was not tracked")
+	}
+	if _, ok := tracked["without-blkio"]; ok {
+		t.Fatal("container without blkio CSS was tracked")
+	}
+}


### PR DESCRIPTION
## Summary

Remember only containers that currently have a `SubsystemBlkIO` cgroup CSS as already tracked. Containers whose blkio cgroup appears after first discovery are now added on a later refresh instead of being skipped forever.

## Root cause

`updateContainerBlkDisk` assigned `latestContainers = containers` (all containers), so a container without `SubsystemBlkIO` at first discovery was considered already tracked and never re-evaluated for BPF map insertion.

## Validation

- `gofmt -w core/metrics/iolatency_tracing.go core/metrics/iolatency_tracing_test.go`
- `git diff --check`
- `go test ./core/metrics -run '^TestTrackContainersWithBlkioCSS$' -count=1` cannot run in this Windows checkout due pre-existing vendored build constraints (`internal/bpf/abi` and `prometheus/procfs/sysfs`); the regression test is intended to run on Linux CI.
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./core/metrics` is blocked by the same pre-existing `internal/bpf/abi` vendored-path error.

Fixes #779
