### PR TITLE
fix(qdisc): decode hardware-only basic statistics

### DIFF
--- a/internal/qdisc/qdisc.go
+++ b/internal/qdisc/qdisc.go
@@ -186,6 +186,7 @@ func decodeStats2(attributes []byte) (counters, error) {
 	var basicPackets uint32
 	var packets64 uint64
 	var hasPackets64 bool
+	var hasSoftwareBasic bool
 	var previousType uint16
 	for len(attributes) > 0 {
 		attributeType, payload, remaining, err := nextAttribute(attributes)
@@ -199,6 +200,19 @@ func decodeStats2(attributes []byte) (counters, error) {
 			if len(payload) < 12 {
 				return counters{}, fmt.Errorf(
 					"qdisc basic statistics length is %d bytes, want at least 12",
+					len(payload),
+				)
+			}
+			decoded.bytes = nlenc.Uint64(payload[0:8])
+			basicPackets = nlenc.Uint32(payload[8:12])
+			hasSoftwareBasic = true
+		case tcaStatsBasicHardware:
+			if hasSoftwareBasic {
+				break
+			}
+			if len(payload) < 12 {
+				return counters{}, fmt.Errorf(
+					"qdisc hardware basic statistics length is %d bytes, want at least 12",
 					len(payload),
 				)
 			}
@@ -224,6 +238,9 @@ func decodeStats2(attributes []byte) (counters, error) {
 				)
 			}
 			if previousType == tcaStatsBasic {
+				packets64 = nlenc.Uint64(payload[0:8])
+				hasPackets64 = true
+			} else if previousType == tcaStatsBasicHardware && !hasSoftwareBasic {
 				packets64 = nlenc.Uint64(payload[0:8])
 				hasPackets64 = true
 			}

--- a/internal/qdisc/qdisc_test.go
+++ b/internal/qdisc/qdisc_test.go
@@ -68,6 +68,38 @@ func TestDecodeNetlinkMessageStats2(t *testing.T) {
 	}
 }
 
+func TestDecodeNetlinkMessageUsesHardwareBasicStats(t *testing.T) {
+	stats2 := marshalAttributes(t, []netlink.Attribute{
+		{Type: tcaStatsBasicHardware, Data: basicStats(777, 888)},
+		{Type: tcaStatsPacket64, Data: uint64Stats(999)},
+		{Type: tcaStatsQueue, Data: queueStats(1, 2, 3, 4, 5)},
+	})
+	message := qdiscMessage(t, 1, math.MaxUint32, []netlink.Attribute{
+		{Type: unix.TCA_KIND, Data: []byte("mq\x00")},
+		{Type: unix.TCA_STATS2, Data: stats2},
+	})
+
+	got, err := decodeMessage(message, map[int]string{1: "eth0"})
+	if err != nil {
+		t.Fatalf("decode qdisc message: %v", err)
+	}
+	want := Stats{
+		Netdev:       "eth0",
+		Parent:       math.MaxUint32,
+		Kind:         "mq",
+		Bytes:        777,
+		Packets:      999,
+		Drops:        3,
+		Requeues:     4,
+		Overlimits:   5,
+		QueueLength:  1,
+		BacklogBytes: 2,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("qdisc statistics mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestDecodeNetlinkMessageFallsBackToBasicPackets(t *testing.T) {
 	stats2 := marshalAttributes(t, []netlink.Attribute{
 		{Type: tcaStatsBasic, Data: basicStats(100, 200)},


### PR DESCRIPTION
## Summary

Decode `TCA_STATS_BASIC_HW` in qdisc statistics. Hardware-only qdisc counters now report bytes and packets instead of zero. Software `TCA_STATS_BASIC` still takes precedence when both software and hardware basic stats are present.

## Root cause

`decodeStats2` handled `TCA_STATS_BASIC` and `TCA_STATS_QUEUE` but ignored `TCA_STATS_BASIC_HW`.

## Validation

- `gofmt -w internal/qdisc/qdisc.go internal/qdisc/qdisc_test.go`
- `git diff --check`
- Windows `go test ./internal/qdisc` cannot build this package (Linux-only `unix.TCA_*` constants are not defined on Windows).
- `GOOS=linux GOARCH=amd64 go test -c -mod=vendor ./internal/qdisc` compiles successfully.
- Added regression test `TestDecodeNetlinkMessageUsesHardwareBasicStats`; it runs on Linux CI where qdisc netlink constants are available.

Fixes #790
