### PR TITLE
fix(server): force-close server after shutdown deadline

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -172,10 +172,17 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Unlock()
 
 	shutdownErr := execution.shutdown(ctx)
-	serveResult := execution.wait(ctx)
 	if shutdownErr != nil && ctx.Err() != nil {
+		// The graceful drain ran out of time. Force the remaining connections
+		// closed and wait for the serving goroutine without a deadline, so the
+		// server cannot stay in the stopping state with a live execution.
+		shutdownErr = errors.Join(shutdownErr, execution.httpServer.Close())
+		serveResult := execution.wait(context.Background())
+
+		s.finishExecution(execution)
 		return errors.Join(shutdownErr, serveResult)
 	}
+	serveResult := execution.wait(ctx)
 
 	s.finishExecution(execution)
 	return errors.Join(shutdownErr, serveResult)

--- a/internal/server/server_lifecycle_test.go
+++ b/internal/server/server_lifecycle_test.go
@@ -167,6 +167,78 @@ func TestServerRejectsOperationsWhileStopping(t *testing.T) {
 	}
 }
 
+func TestServerShutdownForceClosesActiveConnectionsOnDeadline(t *testing.T) {
+	srv := NewServer(nil)
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerDone := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseHandler:
+		default:
+			close(releaseHandler)
+		}
+	})
+
+	srv.MustRegisterRoutes("", []Route{{
+		Method: http.MethodGet,
+		Path:   "/block",
+		Handler: func(ctx *Context) error {
+			close(handlerStarted)
+			select {
+			case <-releaseHandler:
+			case <-ctx.Request().Context().Done():
+			}
+			close(handlerDone)
+			ctx.Status(http.StatusNoContent)
+			return nil
+		},
+	}})
+
+	if err := srv.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	addr := testServerAddr(t, srv)
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, err := http.Get("http://" + addr + "/block")
+		if err != nil {
+			requestDone <- err
+			return
+		}
+		requestDone <- response.Body.Close()
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request handler did not start")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := srv.Shutdown(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Shutdown() error = %v, want context.Canceled", err)
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("active connection was not force-closed after Shutdown deadline")
+	}
+
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("request goroutine did not exit after force-close")
+	}
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown() error = %v, want nil", err)
+	}
+}
+
 func testServerAddr(t *testing.T, srv *Server) string {
 	t.Helper()
 	srv.mu.Lock()


### PR DESCRIPTION
## Summary

Force-close the HTTP server when graceful shutdown exceeds the caller deadline, then wait for the serving goroutine to exit before marking the server stopped.

## Root cause

`Server.Shutdown(ctx)` used the same context for `http.Server.Shutdown` and `serveExecution.wait`. On deadline or cancellation, both returned the context error and the method cleared `activeExecution` and set `serverStateStopped` while active connections and the serving goroutine were still alive.

## Validation

- `gofmt -w internal/server/server.go internal/server/server_lifecycle_test.go`
- `git diff --check`
- `go test -mod=vendor ./internal/server`
- `go test -mod=vendor ./internal/server -run '^TestServerShutdownForceClosesActiveConnectionsOnDeadline$' -count=1 -v`
- `go test -race` was not available on this Windows host because race requires cgo.

Fixes #793
