### PR TITLE
fix(server): disable zero-valued rate limit config

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -63,7 +63,7 @@ func buildMiddlewareChain(cfg *Config) []httpGin.HandlerFunc {
 			wrapHandler(NewAuthMiddleware(authService, publicPaths, adminPaths)),
 		)
 	}
-	if cfg.RateLimit != nil {
+	if cfg.RateLimit != nil && cfg.RateLimit.RequestsPerSecond > 0 && cfg.RateLimit.Burst > 0 {
 		chain = append(chain, newRateLimitMiddleware(
 			rate.Limit(cfg.RateLimit.RequestsPerSecond),
 			cfg.RateLimit.Burst,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -355,6 +355,11 @@ func TestNewServerRateLimit(t *testing.T) {
 			expectedSecondStatus: http.StatusNoContent,
 		},
 		{
+			name:                 "zero config disables rate limiting",
+			rateLimit:            &RateLimitConfig{},
+			expectedSecondStatus: http.StatusNoContent,
+		},
+		{
 			name: "enabled when configured",
 			rateLimit: &RateLimitConfig{
 				RequestsPerSecond: 1,


### PR DESCRIPTION
## Summary

Ignore a zero-valued or non-positive `RateLimitConfig` instead of adding a rate limiter that rejects every request.

## Root cause

`buildMiddlewareChain` only checked `cfg.RateLimit != nil`. `rate.NewLimiter(0, 0)` then caused the first request to consume the only available burst token, and every subsequent request received HTTP 429.

## Validation

- `gofmt -w internal/server/middleware.go internal/server/server_test.go`
- `git diff --check`
- `go test -mod=vendor ./internal/server`
- `go test -mod=vendor ./internal/server -run '^TestNewServerRateLimit$' -count=1 -v`

Fixes #795
