### PR TITLE
fix(server): tolerate duplicate Prometheus registry registration

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"strconv"
@@ -113,7 +114,8 @@ func newHTTPMetricsMiddleware(reg prometheus.Registerer) httpGin.HandlerFunc {
 		Help:      "API request duration by route and method.",
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"route", "method"})
-	reg.MustRegister(requests, duration)
+	requests = registerOrReuseCounterVec(reg, requests)
+	duration = registerOrReuseHistogramVec(reg, duration)
 
 	return func(ctx *httpGin.Context) {
 		startedAt := time.Now()
@@ -126,6 +128,36 @@ func newHTTPMetricsMiddleware(reg prometheus.Registerer) httpGin.HandlerFunc {
 		requests.WithLabelValues(route, ctx.Request.Method, status).Inc()
 		duration.WithLabelValues(route, ctx.Request.Method).Observe(time.Since(startedAt).Seconds())
 	}
+}
+
+func registerOrReuseCounterVec(reg prometheus.Registerer, vec *prometheus.CounterVec) *prometheus.CounterVec {
+	if err := reg.Register(vec); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if !errors.As(err, &alreadyRegistered) {
+			panic(err)
+		}
+		existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.CounterVec)
+		if !ok {
+			panic(err)
+		}
+		return existing
+	}
+	return vec
+}
+
+func registerOrReuseHistogramVec(reg prometheus.Registerer, vec *prometheus.HistogramVec) *prometheus.HistogramVec {
+	if err := reg.Register(vec); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if !errors.As(err, &alreadyRegistered) {
+			panic(err)
+		}
+		existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.HistogramVec)
+		if !ok {
+			panic(err)
+		}
+		return existing
+	}
+	return vec
 }
 
 // a middleware for global rate limiting.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -47,6 +47,33 @@ func TestNewServerRegistersMetricsRouteWithoutRegistry(t *testing.T) {
 	}
 }
 
+func TestNewServerReusesPrometheusRegistry(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	first := NewServer(&Config{PromReg: reg})
+	second := NewServer(&Config{PromReg: reg})
+
+	for name, s := range map[string]*Server{"first": first, "second": second} {
+		t.Run(name, func(t *testing.T) {
+			s.MustRegisterRoutes("", []Route{{
+				Method: http.MethodGet,
+				Path:   "/ping",
+				Handler: func(ctx *Context) error {
+					ctx.Status(http.StatusNoContent)
+					return nil
+				},
+			}})
+
+			request := httptest.NewRequest(http.MethodGet, "/ping", http.NoBody)
+			recorder := httptest.NewRecorder()
+			s.engine.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusNoContent {
+				t.Fatalf("response status = %d, want %d", recorder.Code, http.StatusNoContent)
+			}
+		})
+	}
+}
+
 func TestNewServerUsesHTTPGuardDefaults(t *testing.T) {
 	s := NewServer(nil)
 


### PR DESCRIPTION
## Summary

Make HTTP metric registration idempotent so multiple `Server` instances can share one `*prometheus.Registry` without panicking.

## Root cause

`newHTTPMetricsMiddleware` called `reg.MustRegister` on every `NewServer`. The second server with the same registry attempted to register identical `huatuo_http_server_requests_total` and `huatuo_http_server_request_duration_seconds` collectors, causing a `duplicate metrics collector registration attempted` panic.

## Validation

- `gofmt -w internal/server/middleware.go internal/server/server_test.go`
- `git diff --check`
- `go vet ./internal/server`
- `go test -mod=vendor ./internal/server`
- `go test -mod=vendor ./internal/server -run '^TestNewServerReusesPrometheusRegistry$' -count=1 -v`

Fixes #797
