### PR TITLE
fix(config): reject trailing JSON in config.Set values

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -135,6 +136,12 @@ func Set(cfg any, key string, val any) error {
 		decoder := json.NewDecoder(bytes.NewReader(raw))
 		decoder.DisallowUnknownFields()
 		if err := decoder.Decode(decoded.Interface()); err != nil {
+			return fmt.Errorf("decoding config field %q as %s: %w", key, c.Type(), err)
+		}
+		if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) {
+			if err == nil {
+				err = errors.New("multiple JSON values")
+			}
 			return fmt.Errorf("decoding config field %q as %s: %w", key, c.Type(), err)
 		}
 		c.Set(decoded.Elem())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -203,6 +203,8 @@ func TestSetRejectsInvalidAssignments(t *testing.T) {
 		{name: "fractional integer", dst: cfg, key: "Count", val: json.RawMessage("1.5")},
 		{name: "integer overflow", dst: cfg, key: "Count", val: json.RawMessage("18446744073709551616")},
 		{name: "null", dst: cfg, key: "Name", val: json.RawMessage("null")},
+		{name: "trailing scalar garbage", dst: cfg, key: "Count", val: json.RawMessage("8 true")},
+		{name: "trailing object garbage", dst: cfg, key: "Count", val: json.RawMessage(`8 {"Unknown":"value"}`)},
 		{
 			name: "unknown nested field",
 			dst:  cfg,


### PR DESCRIPTION
## Summary

Reject `json.RawMessage` values passed to `config.Set` when they contain trailing JSON data after the first value.

## Root cause

`Set` performed one `decoder.Decode` call and never checked for end-of-input, so inputs such as `"8 true"` or `8 {"Unknown":"value"}` were silently accepted and the field was mutated.

## Validation

- `gofmt -w internal/config/config.go internal/config/config_test.go`
- `git diff --check`
- `go vet ./internal/config`
- `go test -mod=vendor ./internal/config`
- `go test -mod=vendor ./internal/config -run '^TestSetRejectsInvalidAssignments$' -count=1 -v`

Fixes #799
