### PR TITLE
fix(storage): surface localfile directory stat errors

### DIFF
--- a/internal/storage/localfile/localfile.go
+++ b/internal/storage/localfile/localfile.go
@@ -146,7 +146,10 @@ func (b *Storage) writerByName(name string) (io.Writer, error) {
 		return fileWriter, nil
 	}
 
-	if _, err := os.Stat(b.path); os.IsNotExist(err) {
+	if _, err := os.Stat(b.path); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
 		if mkdirErr := os.MkdirAll(b.path, 0o755); mkdirErr != nil {
 			return nil, mkdirErr
 		}

--- a/internal/storage/localfile/localfile_test.go
+++ b/internal/storage/localfile/localfile_test.go
@@ -146,3 +146,22 @@ func TestBackendUnsupportedOperations(t *testing.T) {
 		t.Errorf("Backend.Terms() error = %v, want ErrUnsupported", err)
 	}
 }
+
+// TestWriterByNameReturnsStatError verifies that writerByName surfaces
+// non-ENOENT os.Stat errors instead of silently proceeding to create a lazy
+// file writer.
+func TestWriterByNameReturnsStatError(t *testing.T) {
+	invalidPath := string([]byte{'b', 'a', 'd', 0, 'p', 'a', 't', 'h'})
+	if _, statErr := os.Stat(invalidPath); statErr == nil || os.IsNotExist(statErr) {
+		t.Skip("path does not produce a non-ENOENT stat error on this platform")
+	}
+
+	backend := NewBackend(invalidPath, 1024, 3)
+	writer, err := backend.writerByName("tracer")
+	if err == nil {
+		t.Fatalf("writerByName() error=nil, want non-ENOENT stat error")
+	}
+	if writer != nil {
+		t.Fatalf("writerByName() writer=%v, want nil on stat error", writer)
+	}
+}


### PR DESCRIPTION
## Summary
Return non-ENOENT `os.Stat` errors from `localfile.Storage.writerByName`
instead of silently continuing to create a lazy file writer. The deferred
failure made permission-denied and invalid directory paths hard to diagnose.

## Evidence
`writerByName` only handled `os.IsNotExist`. Any other directory stat error
was discarded, so the method returned `(writer, nil)`.

## Regression test
Added `TestWriterByNameReturnsStatError`, which uses a path producing a
non-ENOENT stat error and asserts `writerByName` returns an error and no
writer. Verified failing before the fix and passing after.

## Testing
- `gofmt -w internal/storage/localfile/localfile.go internal/storage/localfile/localfile_test.go`
- `git diff --check`
- `go test -mod=vendor ./internal/storage/localfile -run TestWriterByNameReturnsStatError -count=1`

Fixes #802
