### PR TITLE
fix(server): guard pprof server against nil context

### DIFF
--- a/internal/server/pprof/server.go
+++ b/internal/server/pprof/server.go
@@ -54,6 +54,9 @@ func Start(ctx context.Context, listener net.Listener) (*Server, error) {
 		return nil, fmt.Errorf("start pprof server: listener is nil")
 	}
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	httpServer := &http.Server{
 		Handler:           Handler(),
 		ReadHeaderTimeout: readHeaderTimeout,

--- a/internal/server/pprof/server_test.go
+++ b/internal/server/pprof/server_test.go
@@ -86,3 +86,21 @@ func TestStartRejectsNilListener(t *testing.T) {
 		t.Fatalf("Start() error=%v, want nil listener error", err)
 	}
 }
+
+func TestStartAcceptsNilContext(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for pprof server: %v", err)
+	}
+	server, err := Start(nil, listener) //nolint:staticcheck // intentional nil-context regression test
+	if err != nil {
+		t.Fatalf("Start(nil, listener) error=%v", err)
+	}
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("close pprof server: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`pprof.Start(nil, listener)` started a watcher goroutine that called
`ctx.Done()` on a nil context, causing a startup panic instead of a
conventional error.

## Fix

Fall back to `context.Background()` before starting the watcher when
callers pass a nil context.

## Test plan

- `go test -mod=vendor ./internal/server/pprof`
- `go vet -mod=vendor ./internal/server/pprof`

Fixes #803

