### PR TITLE
fix(config): reject out-of-range Elasticsearch ports

### DIFF
--- a/internal/config/elasticsearch.go
+++ b/internal/config/elasticsearch.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -62,6 +63,12 @@ func (c ElasticsearchConfig) Validate() error {
 		if err != nil || parsed.Host == "" ||
 			(parsed.Scheme != "http" && parsed.Scheme != "https") {
 			return fmt.Errorf("invalid address %q", address)
+		}
+		if port := parsed.Port(); port != "" {
+			portNumber, err := strconv.Atoi(port)
+			if err != nil || portNumber < 1 || portNumber > 65535 {
+				return fmt.Errorf("invalid address %q", address)
+			}
 		}
 	}
 	return nil

--- a/internal/config/elasticsearch_test.go
+++ b/internal/config/elasticsearch_test.go
@@ -75,6 +75,38 @@ func TestElasticsearchConfigValidate(t *testing.T) {
 			wantEnabled: true,
 			wantError:   `invalid address "127.0.0.1:9200"`,
 		},
+		{
+			name: "out of range port",
+			config: ElasticsearchConfig{
+				Address:  "http://127.0.0.1:99999",
+				Index:    "huatuo_bamai",
+				Username: "elastic",
+				Password: "secret",
+			},
+			wantEnabled: true,
+			wantError:   `invalid address "http://127.0.0.1:99999"`,
+		},
+		{
+			name: "non-numeric port",
+			config: ElasticsearchConfig{
+				Address:  "http://127.0.0.1:es",
+				Index:    "huatuo_bamai",
+				Username: "elastic",
+				Password: "secret",
+			},
+			wantEnabled: true,
+			wantError:   `invalid address "http://127.0.0.1:es"`,
+		},
+		{
+			name: "ipv6 without explicit port",
+			config: ElasticsearchConfig{
+				Address:  "http://[::1]",
+				Index:    "huatuo_bamai",
+				Username: "elastic",
+				Password: "secret",
+			},
+			wantEnabled: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`ElasticsearchConfig.Validate` previously accepted numeric ports outside the valid TCP range because `url.Parse` does not range-check them. Validate explicit ports with `strconv.Atoi` and reject values outside 1-65535. IPv6 hosts without an explicit port remain accepted.

Fixes #801

Signed-off-by: yyqdbngt <btlqql@gmail.com>
