### PR TITLE
fix(profiler): preserve samples collected during periodic export

### DIFF
--- a/cmd/profiler/provider/native_aggregator_test.go
+++ b/cmd/profiler/provider/native_aggregator_test.go
@@ -15,6 +15,8 @@
 package provider
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"runtime"
 	"slices"
@@ -22,6 +24,7 @@ import (
 	"testing"
 
 	"huatuo-bamai/internal/profiler"
+	"huatuo-bamai/internal/profiler/aggregator"
 	pcontext "huatuo-bamai/internal/profiler/context"
 	"huatuo-bamai/internal/profiler/output"
 	"huatuo-bamai/pkg/profiling"
@@ -226,6 +229,126 @@ func TestNativeAggregatorPhysicalMemoryFiltersAfterAggregation(t *testing.T) {
 	}
 }
 
+func TestNativeAggregatorSnapshotSurvivesResetAndNewSamples(t *testing.T) {
+	tests := []struct {
+		name        string
+		typ         profiling.Type
+		cpuMode     profiling.CPUMode
+		memoryMode  profiling.MemoryMode
+		profileType string
+		scale       int64
+	}{
+		{
+			name:        "on-CPU samples become nanoseconds",
+			typ:         profiling.TypeCPU,
+			cpuMode:     profiling.CPUModeOnCPU,
+			profileType: profiler.ProfileTypeCpuSample,
+			scale:       10_000_000,
+		},
+		{
+			name:        "off-CPU nanoseconds stay unchanged",
+			typ:         profiling.TypeCPU,
+			cpuMode:     profiling.CPUModeOffCPU,
+			profileType: profiler.ProfileTypeOffCpuSample,
+			scale:       1,
+		},
+		{
+			name:        "virtual allocation bytes stay unchanged",
+			typ:         profiling.TypeMemory,
+			memoryMode:  profiling.MemoryModeVirtualAlloc,
+			profileType: profiler.ProfileTypeMemSample,
+			scale:       1,
+		},
+		{
+			name:        "physical allocation bytes stay unchanged",
+			typ:         profiling.TypeMemory,
+			memoryMode:  profiling.MemoryModePhysicalAlloc,
+			profileType: profiler.ProfileTypeMemSample,
+			scale:       1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pctx := &pcontext.ProfilerContext{
+				Type:         tt.typ,
+				CPUMode:      tt.cpuMode,
+				MemoryMode:   tt.memoryMode,
+				Freq:         100,
+				OutputFormat: output.FormatRemote,
+			}
+			aggr, err := newNativeAggregator(pctx)
+			if err != nil {
+				t.Fatalf("newNativeAggregator() error = %v", err)
+			}
+			takeSnapshot := func() *profiler.ProfileData {
+				t.Helper()
+				snapshot, err := aggr.Snapshot(pctx)
+				if err != nil {
+					t.Fatalf("Snapshot() error = %v", err)
+				}
+				data, ok := snapshot.(*profiler.ProfileData)
+				if !ok {
+					t.Fatalf("Snapshot() type = %T, want *profiler.ProfileData", snapshot)
+				}
+				if data.ProfileType != tt.profileType {
+					t.Fatalf("ProfileType = %q, want %q", data.ProfileType, tt.profileType)
+				}
+				return data
+			}
+			sample := stackSample{
+				Process:    processKey{PID: 12, Comm: "app"},
+				StackTrace: symbolizedStackTrace{UserFrames: []string{"main", "original"}},
+				Value:      3,
+			}
+			aggr.Aggregate(&sample)
+			pending := takeSnapshot()
+			if len(pending.Profile.Sample) != 1 ||
+				!slices.Equal(pending.Profile.Sample[0].Value, []int64{3 * tt.scale}) {
+				t.Fatalf("pending samples = %v, want one sample with value %d", pending.Profile.Sample, 3*tt.scale)
+			}
+			before, err := pending.Profile.MarshalVT()
+			if err != nil {
+				t.Fatalf("marshal pending profile: %v", err)
+			}
+
+			aggr.Reset()
+			// A pending profile must stay independent even when the interner reuses IDs.
+			aggr.Aggregate(&stackSample{
+				Process:    sample.Process,
+				StackTrace: symbolizedStackTrace{UserFrames: []string{"main", "new"}},
+				Value:      7,
+			})
+			sample.Value = 5
+			aggr.Aggregate(&sample)
+			next := takeSnapshot()
+			var values []int64
+			for _, sample := range next.Profile.Sample {
+				if len(sample.Value) != 1 {
+					t.Fatalf("next sample values = %v, want one value", sample.Value)
+				}
+				values = append(values, sample.Value[0])
+			}
+			slices.Sort(values)
+			if want := []int64{5 * tt.scale, 7 * tt.scale}; !slices.Equal(values, want) {
+				t.Fatalf("next sample values = %v, want %v", values, want)
+			}
+			for _, frame := range []string{"original", "new"} {
+				if !slices.Contains(next.Profile.StringTable, frame) {
+					t.Errorf("next profile is missing frame %q", frame)
+				}
+			}
+			after, err := pending.Profile.MarshalVT()
+			if err != nil {
+				t.Fatalf("marshal pending profile after reset: %v", err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("pending profile changed after resetting and aggregating the next window")
+			}
+		})
+	}
+}
+
 func TestSymbolizedStackTraceAppendToPreservesFrameNames(t *testing.T) {
 	trace := symbolizedStackTrace{
 		UserFrames:   []string{"generic::<[u8; 7]>", "main"},
@@ -400,6 +523,84 @@ func BenchmarkNativeAggregatorAggregate(b *testing.B) {
 			runtime.KeepAlive(aggregator)
 		}
 	})
+}
+
+const nativePipelineBenchmarkBatchSize = 1024
+
+type nativePipelineBenchmarkAggregator struct {
+	*nativeAggregator
+	batchDone chan struct{}
+	records   int
+}
+
+func (a *nativePipelineBenchmarkAggregator) Aggregate(rec any) {
+	a.nativeAggregator.Aggregate(rec)
+	a.records++
+	if a.records%nativePipelineBenchmarkBatchSize == 0 {
+		a.batchDone <- struct{}{}
+	}
+}
+
+func (*nativePipelineBenchmarkAggregator) Snapshot(*pcontext.ProfilerContext) (any, error) {
+	// Export would measure serialization and storage instead of the queue hot path.
+	return nil, nil
+}
+
+func BenchmarkNativeAggregatorPipeline(b *testing.B) {
+	for _, depth := range []int{5, 32, 64} {
+		b.Run(fmt.Sprintf("repeated/user=%d/batch=%d", depth, nativePipelineBenchmarkBatchSize), func(b *testing.B) {
+			pctx := &pcontext.ProfilerContext{
+				Ctx:          context.Background(),
+				Type:         profiling.TypeCPU,
+				CPUMode:      profiling.CPUModeOnCPU,
+				Freq:         99,
+				TracerID:     "native-pipeline-benchmark",
+				OutputFormat: output.FormatRemote,
+				IsOneShotAgg: true,
+			}
+			native, err := newNativeAggregator(pctx)
+			if err != nil {
+				b.Fatalf("newNativeAggregator() error = %v", err)
+			}
+			aggr := &nativePipelineBenchmarkAggregator{
+				nativeAggregator: native,
+				batchDone:        make(chan struct{}, 1),
+			}
+			pipe := aggregator.NewPipeline(pctx, aggr)
+			pipe.Start()
+			b.Cleanup(pipe.Stop)
+			sample := &stackSample{
+				Process: processKey{PID: 123, Comm: "worker"},
+				StackTrace: symbolizedStackTrace{
+					UserFrames: benchmarkStackFrames("user", depth),
+				},
+				Value: 1,
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				for range nativePipelineBenchmarkBatchSize {
+					pipe.Enqueue(sample)
+				}
+				// Bound outstanding records below queue capacity and time their consumption.
+				<-aggr.batchDone
+			}
+			pipe.Stop()
+			want := b.N * nativePipelineBenchmarkBatchSize
+			if aggr.records != want {
+				b.Fatalf("consumed records = %d, want %d", aggr.records, want)
+			}
+			if len(native.stackSamples) != 1 {
+				b.Fatalf("stack records = %d, want 1", len(native.stackSamples))
+			}
+			for _, value := range native.stackSamples {
+				if value != int64(want) {
+					b.Fatalf("aggregated value = %d, want %d", value, want)
+				}
+			}
+			b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(want), "ns/record")
+		})
+	}
 }
 
 func benchmarkStackFrames(prefix string, depth int) []string {

--- a/internal/profiler/aggregator/aggregator.go
+++ b/internal/profiler/aggregator/aggregator.go
@@ -30,6 +30,8 @@ type Aggregator interface {
 	Aggregate(rec any)
 
 	// Snapshot returns the pprof profile data for upload backends.
+	// The result must remain valid after subsequent Aggregate and Reset calls:
+	// the pipeline retains it for retries while collecting the next window.
 	// For raw/flamegraph/svg output, returns nil — the pipeline reads
 	// the output formatter directly via OutputFormatter.
 	Snapshot(pctx *pcontext.ProfilerContext) (any, error)

--- a/internal/profiler/aggregator/pipeline.go
+++ b/internal/profiler/aggregator/pipeline.go
@@ -49,6 +49,12 @@ type Pipeline struct {
 
 	pctx *profctx.ProfilerContext
 	aggr Aggregator
+	// Snapshot and Reset must exclude Aggregate as one operation. Uploads
+	// happen outside this lock so a slow receiver cannot block consumption.
+	aggregationMu sync.Mutex
+	// Only the export worker owns pending. Keep one failed window instead of
+	// taking more snapshots while the receiver is unavailable.
+	pending any
 	// A channel blocks idle consumers; RingBuffer.Poll spins on timeout checks
 	// and spends CPU in runtime.nanotime and scheduler operations. The mutex
 	// makes stopping atomic with respect to accepting a record.
@@ -150,18 +156,24 @@ func (p *Pipeline) runDequeueAndAggregate() {
 	for {
 		select {
 		case rec := <-p.queue:
-			p.aggr.Aggregate(rec)
+			p.aggregate(rec)
 		case <-p.stopCh:
 			for {
 				select {
 				case rec := <-p.queue:
-					p.aggr.Aggregate(rec)
+					p.aggregate(rec)
 				default:
 					return
 				}
 			}
 		}
 	}
+}
+
+func (p *Pipeline) aggregate(rec any) {
+	p.aggregationMu.Lock()
+	defer p.aggregationMu.Unlock()
+	p.aggr.Aggregate(rec)
 }
 
 // Stop signals the pipeline to terminate and waits for all goroutines to exit.
@@ -206,21 +218,7 @@ func (p *Pipeline) logAggregateExportError(err error) {
 
 func (p *Pipeline) aggregateAndSnapshot(ctx context.Context, final bool) error {
 	if p.pctx.OutputFormat.IsUpload() {
-		data, err := p.aggr.Snapshot(p.pctx)
-		if err != nil {
-			return fmt.Errorf("aggregate snapshot: %w", err)
-		}
-
-		if data == nil {
-			return nil
-		}
-
-		if err := p.saveProfilingDocument(ctx, data); err != nil {
-			return fmt.Errorf("upload profiling document: %w", err)
-		}
-
-		p.aggr.Reset()
-		return nil
+		return p.uploadSnapshot(ctx, final, p.saveProfilingDocument)
 	}
 
 	if !final {
@@ -249,5 +247,42 @@ func (p *Pipeline) aggregateAndSnapshot(ctx context.Context, final bool) error {
 
 	p.aggr.Reset()
 
+	return nil
+}
+
+func (p *Pipeline) uploadSnapshot(ctx context.Context, final bool, send func(context.Context, any) error) error {
+	if p.pending != nil {
+		if err := p.sendPending(ctx, send); err != nil {
+			return err
+		}
+		if !final {
+			return nil
+		}
+		// Stop has drained the queue. After retrying the previous window, also
+		// export the samples accepted while that window was pending.
+	}
+
+	p.aggregationMu.Lock()
+	data, err := p.aggr.Snapshot(p.pctx)
+	if err == nil && data != nil {
+		p.aggr.Reset()
+		p.pending = data
+	}
+	p.aggregationMu.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("aggregate snapshot: %w", err)
+	}
+	if p.pending == nil {
+		return nil
+	}
+	return p.sendPending(ctx, send)
+}
+
+func (p *Pipeline) sendPending(ctx context.Context, send func(context.Context, any) error) error {
+	if err := send(ctx, p.pending); err != nil {
+		return fmt.Errorf("upload profiling document: %w", err)
+	}
+	p.pending = nil
 	return nil
 }

--- a/internal/profiler/aggregator/pipeline_toolstream_test.go
+++ b/internal/profiler/aggregator/pipeline_toolstream_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"huatuo-bamai/internal/profiler"
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/profiler/output"
+	"huatuo-bamai/internal/toolstream"
+	"huatuo-bamai/internal/toolstream/transport"
+
+	capnp "capnproto.org/go/capnp/v3"
+	ptree "github.com/grafana/pyroscope/pkg/og/storage/tree"
+)
+
+type toolstreamUploadAggregator struct {
+	*uploadTestAggregator
+	snapshotReady chan struct{}
+}
+
+func (a *toolstreamUploadAggregator) Snapshot(pctx *profctx.ProfilerContext) (any, error) {
+	snapshot, err := a.uploadTestAggregator.Snapshot(pctx)
+	if err != nil || snapshot == nil {
+		return nil, err
+	}
+	samples := snapshot.(map[string]int64)
+	items := make([]*profiler.TreeItem, 0, len(samples))
+	for stack, value := range samples {
+		items = append(items, &profiler.TreeItem{
+			Stack: [][]byte{[]byte(stack)},
+			Value: uint64(value),
+		})
+	}
+	data, err := profiler.ParseTree(time.Unix(1, 0), profiler.ProfileTypeCpuSample, items, nil)
+	if err != nil {
+		return nil, err
+	}
+	// A large comment forces the real socket write to wait for the receiver.
+	data.Profile.Comment = append(data.Profile.Comment, int64(len(data.Profile.StringTable)))
+	data.Profile.StringTable = append(data.Profile.StringTable, strings.Repeat("x", 8<<20))
+	a.snapshotReady <- struct{}{}
+	return data, nil
+}
+
+type toolstreamProfileResult struct {
+	data *profiler.ProfileData
+	err  error
+}
+
+func TestPipelineToolstreamUploadPreservesConcurrentSamples(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "profile.sock")
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	if err := listener.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	client, err := toolstream.NewClient(toolstream.ClientOptions{
+		SockPath: path, ToolName: "profiler", Version: "test", TaskID: "upload-test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	conn, err := listener.AcceptUnix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := readToolstreamUploadHandshake(capnp.NewDecoder(conn)); err != nil {
+		t.Fatalf("read handshake: %v", err)
+	}
+
+	a := &toolstreamUploadAggregator{
+		uploadTestAggregator: newUploadTestAggregator(),
+		snapshotReady:        make(chan struct{}, 2),
+	}
+	p := startUploadConsumer(t, a)
+	p.pctx.OutputFormat = output.FormatRemote
+	p.pctx.ToolstreamClient = client
+	p.Enqueue(uploadSample{stack: "existing", value: 3})
+	waitUploadSignal(t, a.aggregated)
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReceiver := func() { releaseOnce.Do(func() { close(release) }) }
+	sending := make(chan struct{})
+	received := make(chan toolstreamProfileResult, 2)
+	receiverDone := make(chan struct{})
+	uploadDone := make(chan struct{})
+	uploadErr := make(chan error, 1)
+	var secondUploadDone chan struct{}
+	// Unblock socket I/O before startUploadConsumer's Stop cleanup can wait.
+	t.Cleanup(func() {
+		releaseReceiver()
+		_ = conn.Close()
+		_ = client.Close()
+		for _, done := range []<-chan struct{}{receiverDone, uploadDone, secondUploadDone} {
+			if done == nil {
+				continue
+			}
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Error("toolstream upload goroutine did not exit after closing the socket")
+			}
+		}
+	})
+	go func() {
+		defer close(receiverDone)
+		defer conn.Close()
+		var prefix [1]byte
+		if _, err := io.ReadFull(conn, prefix[:]); err != nil {
+			received <- toolstreamProfileResult{err: err}
+			return
+		}
+		// Seeing the frame prefix proves Send has started, not just Snapshot.
+		close(sending)
+		<-release
+		decoder := capnp.NewDecoder(io.MultiReader(bytes.NewReader(prefix[:]), conn))
+		for range 2 {
+			data, err := readToolstreamUploadProfile(decoder)
+			received <- toolstreamProfileResult{data: data, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	go func() {
+		defer close(uploadDone)
+		uploadErr <- p.aggregateAndSnapshot(t.Context(), false)
+	}()
+	waitUploadSignal(t, a.snapshotReady)
+	waitUploadSignal(t, sending)
+	for _, sample := range []uploadSample{{stack: "existing", value: 5}, {stack: "new", value: 7}} {
+		p.Enqueue(sample)
+		waitUploadSignal(t, a.aggregated)
+	}
+	select {
+	case <-uploadDone:
+		t.Fatalf("upload finished before the paused receiver resumed: %v", <-uploadErr)
+	default:
+	}
+	releaseReceiver()
+	waitUploadSignal(t, uploadDone)
+	if err := <-uploadErr; err != nil {
+		t.Fatalf("first toolstream upload: %v", err)
+	}
+	assertToolstreamUploadProfile(t, received, map[string]int64{"existing": 3})
+
+	secondUploadDone = make(chan struct{})
+	go func() {
+		defer close(secondUploadDone)
+		uploadErr <- p.aggregateAndSnapshot(t.Context(), false)
+	}()
+	waitUploadSignal(t, secondUploadDone)
+	if err := <-uploadErr; err != nil {
+		t.Fatalf("second toolstream upload: %v", err)
+	}
+	assertToolstreamUploadProfile(t, received, map[string]int64{"existing": 5, "new": 7})
+	waitUploadSignal(t, receiverDone)
+	if got := p.overflowCount.Load(); got != 0 {
+		t.Fatalf("queue overflow = %d, want 0", got)
+	}
+}
+
+func readToolstreamUploadHandshake(decoder *capnp.Decoder) error {
+	message, err := decoder.Decode()
+	if err != nil {
+		return err
+	}
+	defer message.Release()
+	root, err := transport.ReadRootMessage(message)
+	if err != nil {
+		return err
+	}
+	if root.Which() != transport.Message_Which_connect {
+		return fmt.Errorf("first toolstream frame is not a handshake")
+	}
+	return nil
+}
+
+func readToolstreamUploadProfile(decoder *capnp.Decoder) (*profiler.ProfileData, error) {
+	message, err := decoder.Decode()
+	if err != nil {
+		return nil, err
+	}
+	defer message.Release()
+	root, err := transport.ReadRootMessage(message)
+	if err != nil {
+		return nil, err
+	}
+	if root.Which() != transport.Message_Which_chunk {
+		return nil, fmt.Errorf("profile toolstream frame is not a chunk")
+	}
+	chunk, err := root.Chunk()
+	if err != nil {
+		return nil, err
+	}
+	payload, err := chunk.Data()
+	if err != nil {
+		return nil, err
+	}
+	var event struct {
+		TracerData profctx.TracerData `json:"tracer_data"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return nil, err
+	}
+	if event.TracerData.FlameData == nil {
+		return nil, fmt.Errorf("toolstream event has no profile")
+	}
+	return event.TracerData.FlameData, nil
+}
+
+func assertToolstreamUploadProfile(t *testing.T, received <-chan toolstreamProfileResult, want map[string]int64) {
+	t.Helper()
+	var result toolstreamProfileResult
+	select {
+	case result = <-received:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out receiving toolstream profile")
+	}
+	if result.err != nil {
+		t.Fatalf("receive toolstream profile: %v", result.err)
+	}
+	got := make(map[string]int64)
+	for _, sample := range result.data.Profile.Sample {
+		if len(sample.LocationId) != 1 || len(sample.Value) != 1 {
+			t.Fatalf("unexpected profile sample shape: %v", sample)
+		}
+		name, ok := ptree.FindFunctionName(&result.data.Profile, sample.LocationId[0])
+		if !ok {
+			t.Fatalf("profile location %d has no function", sample.LocationId[0])
+		}
+		got[name] += sample.Value[0]
+	}
+	if !maps.Equal(got, want) {
+		t.Fatalf("toolstream profile = %v, want %v", got, want)
+	}
+}

--- a/internal/profiler/aggregator/pipeline_upload_test.go
+++ b/internal/profiler/aggregator/pipeline_upload_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregator
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"sync"
+	"testing"
+	"time"
+
+	profctx "huatuo-bamai/internal/profiler/context"
+	"huatuo-bamai/internal/profiler/output"
+)
+
+type uploadSample struct {
+	stack string
+	value int64
+}
+
+// Model the providers' independently locked Aggregate, Snapshot and Reset.
+type uploadTestAggregator struct {
+	mu         sync.Mutex
+	samples    map[string]int64
+	aggregated chan struct{}
+	snapshots  int
+	resets     int
+}
+
+func newUploadTestAggregator() *uploadTestAggregator {
+	return &uploadTestAggregator{
+		samples:    make(map[string]int64),
+		aggregated: make(chan struct{}, 16),
+	}
+}
+
+func (a *uploadTestAggregator) Aggregate(rec any) {
+	sample := rec.(uploadSample)
+	a.mu.Lock()
+	a.samples[sample.stack] += sample.value
+	a.mu.Unlock()
+	if a.aggregated != nil {
+		a.aggregated <- struct{}{}
+	}
+}
+
+func (a *uploadTestAggregator) Snapshot(*profctx.ProfilerContext) (any, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.snapshots++
+	if len(a.samples) == 0 {
+		return nil, nil
+	}
+	return maps.Clone(a.samples), nil
+}
+
+func (a *uploadTestAggregator) Reset() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.resets++
+	clear(a.samples)
+}
+
+func (*uploadTestAggregator) OutputFormatter() output.Formatter { return nil }
+
+func startUploadConsumer(t *testing.T, a Aggregator) *Pipeline {
+	t.Helper()
+	p := NewPipeline(&profctx.ProfilerContext{Ctx: t.Context()}, a)
+	// Drive export explicitly so the test does not depend on ticker timing.
+	p.wg.Add(1)
+	go p.runDequeueAndAggregate()
+	t.Cleanup(p.Stop)
+	return p
+}
+
+func waitUploadSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for profile aggregation during upload")
+	}
+}
+
+func TestPipelineUploadPreservesConcurrentSamples(t *testing.T) {
+	a := newUploadTestAggregator()
+	p := startUploadConsumer(t, a)
+	p.Enqueue(uploadSample{stack: "existing", value: 3})
+	waitUploadSignal(t, a.aggregated)
+
+	uploading := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseUpload := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseUpload)
+	finished := make(chan error, 1)
+	var first map[string]int64
+	go func() {
+		finished <- p.uploadSnapshot(t.Context(), false, func(_ context.Context, data any) error {
+			first = data.(map[string]int64)
+			close(uploading)
+			<-release
+			return nil
+		})
+	}()
+	waitUploadSignal(t, uploading)
+
+	for _, sample := range []uploadSample{{stack: "existing", value: 5}, {stack: "new", value: 7}} {
+		p.Enqueue(sample)
+		waitUploadSignal(t, a.aggregated)
+	}
+	releaseUpload()
+	if err := <-finished; err != nil {
+		t.Fatalf("first upload: %v", err)
+	}
+	if !maps.Equal(first, map[string]int64{"existing": 3}) {
+		t.Fatalf("first window = %v, want existing=3", first)
+	}
+
+	var second map[string]int64
+	if err := p.uploadSnapshot(t.Context(), false, func(_ context.Context, data any) error {
+		second = data.(map[string]int64)
+		return nil
+	}); err != nil {
+		t.Fatalf("second upload: %v", err)
+	}
+	if !maps.Equal(second, map[string]int64{"existing": 5, "new": 7}) {
+		t.Fatalf("second window = %v, want existing=5 and new=7", second)
+	}
+	if got := p.overflowCount.Load(); got != 0 {
+		t.Fatalf("queue overflow = %d, want 0", got)
+	}
+}
+
+type snapshotBoundaryAggregator struct {
+	*uploadTestAggregator
+	checkExclusion func()
+	afterSnapshot  func()
+}
+
+func (a *snapshotBoundaryAggregator) Aggregate(rec any) {
+	a.checkExclusion()
+	a.uploadTestAggregator.Aggregate(rec)
+}
+
+func (a *snapshotBoundaryAggregator) Snapshot(pctx *profctx.ProfilerContext) (any, error) {
+	data, err := a.uploadTestAggregator.Snapshot(pctx)
+	a.checkExclusion()
+	// The provider has released its own lock, exposing the Snapshot/Reset gap.
+	a.afterSnapshot()
+	return data, err
+}
+
+func (a *snapshotBoundaryAggregator) Reset() {
+	a.checkExclusion()
+	a.uploadTestAggregator.Reset()
+}
+
+func TestPipelineUploadSnapshotAndResetExcludeAggregation(t *testing.T) {
+	a := &snapshotBoundaryAggregator{uploadTestAggregator: newUploadTestAggregator()}
+	p := NewPipeline(&profctx.ProfilerContext{Ctx: t.Context()}, a)
+	// A completed send proves the consumer has received the concurrent record.
+	p.queue = make(chan any)
+	a.checkExclusion = func() {
+		// Detect a missing boundary lock without relying on goroutine scheduling.
+		if p.aggregationMu.TryLock() {
+			p.aggregationMu.Unlock()
+			t.Error("Aggregate, Snapshot and Reset must share pipeline exclusion")
+		}
+	}
+	snapshotReady := make(chan struct{})
+	release := make(chan struct{})
+	var pauseOnce, releaseOnce sync.Once
+	releaseSnapshot := func() { releaseOnce.Do(func() { close(release) }) }
+	a.afterSnapshot = func() {
+		pauseOnce.Do(func() {
+			close(snapshotReady)
+			<-release
+		})
+	}
+	p.wg.Add(1)
+	go p.runDequeueAndAggregate()
+	t.Cleanup(p.Stop)
+	t.Cleanup(releaseSnapshot)
+	enqueue := func(sample uploadSample) {
+		t.Helper()
+		select {
+		case p.queue <- sample:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out delivering sample to aggregation consumer")
+		}
+	}
+	enqueue(uploadSample{stack: "existing", value: 3})
+	waitUploadSignal(t, a.aggregated)
+
+	finished := make(chan error, 1)
+	uploadDone := make(chan struct{})
+	var first map[string]int64
+	go func() {
+		defer close(uploadDone)
+		finished <- p.uploadSnapshot(t.Context(), false, func(_ context.Context, data any) error {
+			first = data.(map[string]int64)
+			return nil
+		})
+	}()
+	t.Cleanup(func() {
+		releaseSnapshot()
+		waitUploadSignal(t, uploadDone)
+	})
+	waitUploadSignal(t, snapshotReady)
+	enqueue(uploadSample{stack: "existing", value: 5})
+	releaseSnapshot()
+	if err := <-finished; err != nil {
+		t.Fatalf("first upload: %v", err)
+	}
+	waitUploadSignal(t, a.aggregated)
+	enqueue(uploadSample{stack: "new", value: 7})
+	waitUploadSignal(t, a.aggregated)
+
+	var second map[string]int64
+	if err := p.uploadSnapshot(t.Context(), false, func(_ context.Context, data any) error {
+		second = data.(map[string]int64)
+		return nil
+	}); err != nil {
+		t.Fatalf("second upload: %v", err)
+	}
+	if !maps.Equal(first, map[string]int64{"existing": 3}) ||
+		!maps.Equal(second, map[string]int64{"existing": 5, "new": 7}) {
+		t.Fatalf("windows = %v, %v; want existing=3 followed by existing=5 and new=7", first, second)
+	}
+}
+
+func TestPipelineUploadRetriesFrozenWindow(t *testing.T) {
+	a := newUploadTestAggregator()
+	p := startUploadConsumer(t, a)
+	p.Enqueue(uploadSample{stack: "existing", value: 3})
+	waitUploadSignal(t, a.aggregated)
+	uploadErr := errors.New("receiver unavailable")
+	fail := func(_ context.Context, data any) error {
+		if got := data.(map[string]int64); !maps.Equal(got, map[string]int64{"existing": 3}) {
+			t.Errorf("retry window = %v, want only existing=3", got)
+		}
+		return uploadErr
+	}
+	if err := p.uploadSnapshot(t.Context(), false, fail); !errors.Is(err, uploadErr) {
+		t.Fatalf("initial upload error = %v, want %v", err, uploadErr)
+	}
+	p.Enqueue(uploadSample{stack: "existing", value: 5})
+	p.Enqueue(uploadSample{stack: "new", value: 7})
+	waitUploadSignal(t, a.aggregated)
+	waitUploadSignal(t, a.aggregated)
+	for range 3 {
+		if err := p.uploadSnapshot(t.Context(), false, fail); !errors.Is(err, uploadErr) {
+			t.Fatalf("retry error = %v, want %v", err, uploadErr)
+		}
+	}
+
+	var windows []map[string]int64
+	send := func(_ context.Context, data any) error {
+		windows = append(windows, data.(map[string]int64))
+		return nil
+	}
+	if err := p.uploadSnapshot(t.Context(), false, send); err != nil {
+		t.Fatalf("retry after recovery: %v", err)
+	}
+	if len(windows) != 1 || !maps.Equal(windows[0], map[string]int64{"existing": 3}) {
+		t.Fatalf("recovered windows = %v, want one frozen window", windows)
+	}
+	if err := p.uploadSnapshot(t.Context(), false, send); err != nil {
+		t.Fatalf("upload active window: %v", err)
+	}
+	if len(windows) != 2 || !maps.Equal(windows[1], map[string]int64{"existing": 5, "new": 7}) {
+		t.Fatalf("windows = %v, want original and concurrent values separately", windows)
+	}
+	if a.snapshots != 2 || a.resets != 2 {
+		t.Fatalf("snapshots/resets = %d/%d, want 2/2", a.snapshots, a.resets)
+	}
+}
+
+func TestPipelineFinalUploadDrainsPendingAndActive(t *testing.T) {
+	for _, failRetry := range []bool{false, true} {
+		name := "recovered"
+		if failRetry {
+			name = "still unavailable"
+		}
+		t.Run(name, func(t *testing.T) {
+			a := newUploadTestAggregator()
+			p := startUploadConsumer(t, a)
+			p.Enqueue(uploadSample{stack: "first", value: 3})
+			waitUploadSignal(t, a.aggregated)
+			uploadErr := errors.New("receiver unavailable")
+			if err := p.uploadSnapshot(t.Context(), false, func(context.Context, any) error {
+				return uploadErr
+			}); !errors.Is(err, uploadErr) {
+				t.Fatalf("initial upload error = %v", err)
+			}
+			p.Enqueue(uploadSample{stack: "last", value: 5})
+			p.Stop()
+
+			var windows []map[string]int64
+			err := p.uploadSnapshot(t.Context(), true, func(_ context.Context, data any) error {
+				windows = append(windows, data.(map[string]int64))
+				if failRetry {
+					return uploadErr
+				}
+				return nil
+			})
+			if len(windows) == 0 || !maps.Equal(windows[0], map[string]int64{"first": 3}) {
+				t.Fatalf("final windows = %v, want frozen first window", windows)
+			}
+			if failRetry {
+				if !errors.Is(err, uploadErr) || len(windows) != 1 || a.resets != 1 {
+					t.Fatalf("failed final upload: error=%v windows=%v resets=%d", err, windows, a.resets)
+				}
+				if !maps.Equal(a.samples, map[string]int64{"last": 5}) {
+					t.Fatalf("active samples = %v, want last=5", a.samples)
+				}
+				return
+			}
+			if err != nil || len(windows) != 2 || !maps.Equal(windows[1], map[string]int64{"last": 5}) {
+				t.Fatalf("final upload: error=%v windows=%v, want both windows", err, windows)
+			}
+		})
+	}
+}
+
+func TestPipelineUploadSnapshotFailureDoesNotReset(t *testing.T) {
+	for _, snapshotErr := range []error{nil, errors.New("snapshot failed")} {
+		name := "empty"
+		if snapshotErr != nil {
+			name = "error"
+		}
+		t.Run(name, func(t *testing.T) {
+			a := NewMockAggregator(t)
+			pctx := &profctx.ProfilerContext{}
+			a.On("Snapshot", pctx).Return(nil, snapshotErr).Once()
+			p := NewPipeline(pctx, a)
+			err := p.uploadSnapshot(t.Context(), false, func(context.Context, any) error {
+				t.Error("upload called without a snapshot")
+				return nil
+			})
+			if !errors.Is(err, snapshotErr) {
+				t.Fatalf("upload error = %v, want %v", err, snapshotErr)
+			}
+			a.AssertNotCalled(t, "Reset")
+		})
+	}
+}
+
+func BenchmarkPipelineAggregation(b *testing.B) {
+	a := newUploadTestAggregator()
+	a.aggregated = nil
+	p := NewPipeline(&profctx.ProfilerContext{TracerID: "benchmark"}, a)
+	p.wg.Add(1)
+	go p.runDequeueAndAggregate()
+	sample := uploadSample{stack: "same stack", value: 1}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		p.queue <- sample
+	}
+	p.Stop()
+}


### PR DESCRIPTION
## Problem

The periodic upload path snapshots the aggregator, sends the profile over
Toolstream, and only then calls Reset. The consumer keeps aggregating during
Send. A successful slow upload therefore clears samples that were never in
the uploaded snapshot, with no queue overflow recorded.

The providers lock Aggregate, Snapshot and Reset individually, so simply moving
Reset before Send still leaves a Snapshot-to-Reset race.

Reproduction uses an initial value of 3, then adds 5 to the same stack and 7 to a
new stack while sending is blocked:

- Original ordering: first window contains 3; the next window is empty.
- This patch: first window contains 3; the next contains 5 and 7.
- Queue overflow remains 0.

## Fix

- Serialize Aggregate with Snapshot + Reset as one pipeline operation.
- Reset only after a successful, non-empty snapshot, then send outside the lock.
  Collection can continue while the receiver is slow.
- Retain one frozen pending snapshot when Send fails. Periodic retries resend
  that window without resnapshotting or resetting the active window.
- After a successful periodic retry, export the active window on the next tick.
  During final export, retry pending first and, if successful, also export the
  active samples after the queue has drained.
- Document snapshot independence from subsequent Aggregate/Reset calls; the
  Aggregator API and provider production code remain unchanged.

Scope is the upload window ownership bug. Local-file output behavior, wire
format, units and queue overflow policy are unchanged. One pending window bounds
the number of frozen retry snapshots, not total memory: the active unique-stack
map can still grow during a prolonged outage. This is not a durable retry queue
or an exactly-once delivery guarantee. Toolstream Send success is not a storage
acknowledgment. Existing shutdown error propagation/cancellation work in #654 is
not included; a failed final upload retains state but does not make Stop return
an error.

## Regression coverage

- Deterministic blocked-send test: same-stack and new-stack increments survive.
- Snapshot/Reset boundary test: an unbuffered queue places the consumer at the
  boundary; exclusion assertions detect removal of either side of the lock.
- Repeated send failures preserve the exact frozen window and take no new
  snapshots; recovery sends pending and active separately.
- Final export covers successful and failed pending retries after draining.
- Empty/failed snapshots do not Reset or Send.
- Real Unix socket + Toolstream/Cap'n Proto + profile JSON round trip. A paused
  receiver and a large valid profile force backpressure, proving Send is
  underway while samples are consumed; both decoded windows are checked.
- Native snapshot ownership across Reset and interner ID reuse, including on-CPU
  scaling, off-CPU nanoseconds and allocation bytes.

The original ordering was exposed through the same send callback for a
baseline-only regression harness, without changing its Snapshot/Send/Reset
behavior. It fails the blocked-send and retry tests; its real Toolstream test
cannot receive a second profile. A separate no-lock mutation fails the
Snapshot/Reset boundary test immediately.

## Validation

Linux/arm64 container, Go 1.24.6, clang 14, libbpf 1.1.2, Cap'n Proto 0.9.2.
Generated files were produced with make gen-build and are not part of the diff.

Passed:

```sh
make gen-build
go build -p 2 ./...
make check
go test -p 2 -race -count=1 ./internal/profiler/... ./cmd/profiler/provider ./internal/toolstream/...
go test -p 2 -race -count=20 -run 'TestPipeline(Upload|FinalUpload|Toolstream)' ./internal/profiler/aggregator
```

Commands used GOMAXPROCS=2. make check used golangci-lint v1.64.8 built with
Go 1.24.6, rather than the older v1.62.2 pin in Dockerfile.devel.

Also attempted go test -p 2 -count=1 ./...: it does **not** pass in this
unprivileged container. Failures are confined to internal/bpf and
internal/pcapfilter (BPF/perf permissions), and internal/cgroups (no
/run/systemd/private). Other packages pass. Privileged VM integration/e2e
has not been run locally.

## Hot-path cost

Sequential baseline/fix runs in the same container, GOMAXPROCS=2, 1s x 5;
the table shows medians, not a production CPU-cost claim.

| Benchmark | Before ns/record | After ns/record | Allocation behavior |
| --- | ---: | ---: | --- |
| Minimal pipeline aggregation | 140.0 | 143.5 | unchanged: 24 B, 1 alloc/record |
| Native repeated stack, 5 user frames | 117.0 | 120.3 | 0 B, 0 allocs |
| Native repeated stack, 32 user frames | 337.2 | 337.4 | 0 B, 0 allocs |
| Native repeated stack, 64 user frames | 590.4 | 585.7 | 0 B, 0 allocs |

Native runs use the real native aggregator and Enqueue/consumer path, with
1024-record batches acknowledged before the next batch. The final aggregate
count is checked, so queue overflow cannot make the benchmark appear faster.
The standard ns/op unit is a batch; ns/record is reported separately. Export is
excluded. Small differences, including the apparent 64-frame improvement,
should be treated as benchmark noise, not a speedup.

```sh
go test -p 2 -run '^$' \
  -bench '^(BenchmarkPipelineAggregation|BenchmarkNativeAggregatorPipeline)$' \
  -benchtime=1s -count=5 \
  ./internal/profiler/aggregator ./cmd/profiler/provider
```
