### PR TITLE
fix(iolatency): preserve full-width elapsed time in latency buckets

### DIFF
--- a/bpf/iolatency_tracing.c
+++ b/bpf/iolatency_tracing.c
@@ -115,8 +115,8 @@ static __always_inline int q2c_latency_index(struct bio *bio, u64 now)
 	u64 bi_issue, val;
 
 	/*
-	 * pre-7.0: bio::bi_issue (struct bio_issue, low bits packed timestamp)
-	 * 7.0+:    bio::issue_time_ns (plain u64 nanosecond timestamp)
+	 * bio::bi_issue packs the timestamp into the low bits of struct bio_issue;
+	 * newer kernels use bio::issue_time_ns, a plain u64 nanosecond timestamp.
 	 */
 	if (bpf_core_field_exists(bio->bi_issue)) {
 		if (bpf_probe_read(&val, sizeof(val), &bio->bi_issue))
@@ -130,7 +130,8 @@ static __always_inline int q2c_latency_index(struct bio *bio, u64 now)
 
 	bi_issue = val & TIMESTAMP_MASK;
 
-	int q2c = now - bi_issue;
+	/* Keep nanoseconds full-width and handle the 51-bit clock wrapping. */
+	u64 q2c = (now - bi_issue) & TIMESTAMP_MASK;
 	return zone_index(q2c);
 }
 
@@ -146,8 +147,8 @@ static __always_inline int d2c_latency_index(struct bio *bio, u64 now)
 	bi_start = *start_time;
 	bpf_map_delete_elem(&bio_start_time, &bio_addr);
 
-	// That d2c may be negative, it is safe.
-	int d2c = now - bi_start;
+	/* Both timestamps use the same wrapping 51-bit clock. */
+	u64 d2c = (now - bi_start) & TIMESTAMP_MASK;
 	return zone_index(d2c);
 }
 

--- a/integration/test_iolatency_delta.sh
+++ b/integration/test_iolatency_delta.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+
+WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/iolatency-delta.XXXXXX")
+FIXTURE="${ROOT_DIR}/integration/testdata/iolatency_delta.c"
+
+# The native fixture executes the production functions with controlled helper
+# responses. Separately compiling the real BPF target is not a verifier test.
+command -v clang > /dev/null || fatal "clang not found in PATH"
+clang -O2 -Wall -Wextra -Werror -Wno-unknown-attributes \
+	-I "${ROOT_DIR}/bpf/include" "${FIXTURE}" -o "${WORK_DIR}/iolatency_delta" \
+	2> "${WORK_DIR}/native.compile.log" \
+	|| fatal "clang failed compiling ${FIXTURE}:"$'\n'"$(< "${WORK_DIR}/native.compile.log")"
+"${WORK_DIR}/iolatency_delta"
+if (($# > 0)); then
+	"${WORK_DIR}/iolatency_delta" "$@"
+fi
+compile_bpf_fixture "${ROOT_DIR}/bpf/iolatency_tracing.c" "${WORK_DIR}/iolatency_tracing.o"
+log_info "I/O latency production-function regression and BPF target compilation passed"

--- a/integration/testdata/iolatency_delta.c
+++ b/integration/testdata/iolatency_delta.c
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The HuaTuo Authors.
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+/* Replace only the kernel/helper boundary, not the production arithmetic. */
+#define __BPF_HELPERS__
+#define __BPF_CORE_READ_H__
+#define __BPF_TRACING_H__
+
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint8_t u8;
+
+#ifndef __always_inline
+#define __always_inline inline __attribute__((always_inline))
+#endif
+
+#define SEC(name)
+#define __uint(name, value) int (*name)[value]
+#define __type(name, value) value *name
+#define BPF_MAP_TYPE_HASH 1
+#define PT_REGS_PARM1(ctx) ((ctx)->arg1)
+#define PT_REGS_PARM2(ctx) ((ctx)->arg2)
+#define READ_ONE(src, field) ((src)->field)
+#define READ_TWO(src, field, next) ((src)->field->next)
+#define READ_SELECT(_1, _2, NAME, ...) NAME
+#define BPF_CORE_READ(src, ...) \
+	READ_SELECT(__VA_ARGS__, READ_TWO, READ_ONE)(src, __VA_ARGS__)
+#define BPF_CORE_READ_INTO(dst, src, ...) \
+	(*(dst) = (__typeof__(*(dst)))BPF_CORE_READ(src, __VA_ARGS__))
+#define bpf_core_field_exists(field) has_bi_issue
+
+struct gendisk {
+	u32 major, minor;
+};
+struct block_device {
+	struct gendisk *bd_disk;
+};
+struct blkcg_gq {
+	void *blkcg;
+};
+struct bio {
+	/* Distinct offsets expose accidentally selecting the wrong field path. */
+	u64 issue_time_ns;
+	u64 bi_issue;
+	struct bio *bi_next;
+	struct blkcg_gq *bi_blkg;
+	struct gendisk *bi_disk;
+	u8 bi_partno;
+};
+struct request {
+	struct bio *bio;
+};
+struct request_queue {
+	struct blkcg_gq *root_blkg;
+};
+struct pt_regs {
+	u64 arg1, arg2;
+};
+
+static bool has_bi_issue;
+static int read_error;
+static const void *read_address;
+static bool start_present;
+static u64 start_value, start_key;
+static unsigned int deletes;
+
+static u64 bpf_ktime_get_ns(void);
+static long bpf_probe_read(void *dst, u32 size, const void *src);
+static void *bpf_map_lookup_elem(const void *map, const void *key);
+static long bpf_map_delete_elem(const void *map, const void *key);
+static long bpf_map_update_elem(const void *map, const void *key,
+			       const void *value, u64 flags);
+
+#include "../../bpf/iolatency_tracing.c"
+
+static u64 bpf_ktime_get_ns(void)
+{
+	return 0;
+}
+
+static long bpf_probe_read(void *dst, u32 size, const void *src)
+{
+	read_address = src;
+	if (read_error)
+		return read_error;
+	memcpy(dst, src, size);
+	return 0;
+}
+
+static void *bpf_map_lookup_elem(const void *map, const void *key)
+{
+	if (map == &bio_start_time && start_present &&
+	    *(const u64 *)key == start_key)
+		return &start_value;
+	return NULL;
+}
+
+static long bpf_map_delete_elem(const void *map, const void *key)
+{
+	if (map != &bio_start_time || *(const u64 *)key != start_key)
+		return -1;
+	deletes++;
+	start_present = false;
+	return 0;
+}
+
+static long bpf_map_update_elem(const void *map, const void *key,
+			       const void *value, u64 flags)
+{
+	(void)map;
+	(void)key;
+	(void)value;
+	(void)flags;
+	return 0;
+}
+
+static unsigned int failures;
+
+static void expect(const char *name, const char *path, int actual, int want)
+{
+	if (actual == want)
+		return;
+	fprintf(stderr, "%s (%s): got %d, want %d\n", name, path, actual, want);
+	failures++;
+}
+
+static void check_latency(const char *name, u64 start, u64 now, int want)
+{
+	struct bio bio = {};
+
+	for (int legacy = 0; legacy < 2; legacy++) {
+		has_bi_issue = legacy;
+		/* Old issue words pack flags; new kernels retain the full clock. */
+		bio.bi_issue = start | (5ULL << 51);
+		bio.issue_time_ns = start + 2 * (TIMESTAMP_MASK + 1);
+		expect(name, legacy ? "q2c packed issue" : "q2c plain issue",
+		       q2c_latency_index(&bio, now), want);
+		expect(name, "q2c field address",
+		       read_address == (legacy ? &bio.bi_issue : &bio.issue_time_ns), 1);
+	}
+	start_key = (u64)&bio;
+	start_value = start;
+	start_present = true;
+	deletes = 0;
+	expect(name, "d2c", d2c_latency_index(&bio, now), want);
+	expect(name, "d2c deletes timestamp once", deletes, 1);
+	expect(name, "d2c removes timestamp", start_present, 0);
+	expect(name, "d2c repeated completion", d2c_latency_index(&bio, now), -1);
+	expect(name, "d2c absent timestamp is not deleted", deletes, 1);
+}
+
+static void check_failures(void)
+{
+	struct bio bio = {};
+
+	read_error = -1;
+	for (int legacy = 0; legacy < 2; legacy++) {
+		has_bi_issue = legacy;
+		expect("read failure", legacy ? "q2c packed issue" : "q2c plain issue",
+		       q2c_latency_index(&bio, 5000000000ULL), -1);
+	}
+	read_error = 0;
+	for (int legacy = 0; legacy < 2; legacy++) {
+		has_bi_issue = legacy;
+		expect("zero issue timestamp", legacy ? "q2c packed issue" : "q2c plain issue",
+		       q2c_latency_index(&bio, 100000000ULL), 2);
+	}
+	start_present = false;
+	deletes = 0;
+	expect("map miss", "d2c", d2c_latency_index(&bio, 5000000000ULL), -1);
+	expect("map miss", "no delete", deletes, 0);
+}
+
+/* Runtime inputs prevent folding away the production arithmetic at -O2. */
+static volatile u64 benchmark_now = 5000000000ULL;
+static volatile u64 benchmark_delays[][2] = {
+	{100000000ULL, 500000000ULL},
+	{100000000ULL, 4400000000ULL},
+};
+static volatile int benchmark_sink;
+
+static __attribute__((noinline)) int benchmark_sample(struct bio *bio, u64 now)
+{
+	start_value = bio->bi_issue;
+	start_present = true;
+	return q2c_latency_index(bio, now) + d2c_latency_index(bio, now);
+}
+
+static void benchmark(void)
+{
+	const unsigned int iterations = 100000000;
+	const char *names[] = {"normal", "long-tail"};
+	struct bio bio = {};
+
+	start_key = (u64)&bio;
+	has_bi_issue = true;
+	for (unsigned int group = 0; group < 2; group++) {
+		clock_t begin = clock();
+		int sum = 0;
+
+		for (unsigned int i = 0; i < iterations; i++) {
+			u64 now = benchmark_now + i;
+
+			bio.bi_issue = now - benchmark_delays[group][i % 2];
+			sum += benchmark_sample(&bio, now);
+		}
+		benchmark_sink = sum;
+		printf("%s q2c+d2c: %.3f ns/pair (%u iterations; native helper stubs)\n",
+		       names[group],
+		       1e9 * (double)(clock() - begin) / CLOCKS_PER_SEC / iterations,
+		       iterations);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	static const struct {
+		u64 delta;
+		int zone;
+	} cases[] = {
+		{0, -1}, {19999999, -1}, {20000000, 0}, {20000001, 0},
+		{29999999, 0}, {30000000, 0}, {30000001, 1},
+		{49999999, 1}, {50000000, 1}, {50000001, 2},
+		{99999999, 2}, {100000000, 2}, {100000001, 3},
+		{199999999, 3}, {200000000, 3}, {200000001, 4},
+		{399999999, 4}, {400000000, 4},
+		{400000001, 5}, {2147483647ULL, 5}, {2147483648ULL, 5},
+		{2147483649ULL, 5}, {4294967295ULL, 5}, {4294967296ULL, 5},
+		{4294967297ULL, 5}, {4300000000ULL, 5},
+		{4314967296ULL, 5}, {4319967296ULL, 5}, {4394967296ULL, 5},
+		{4400000000ULL, 5}, {4694967296ULL, 5}, {8599934592ULL, 5},
+		{30000000000ULL, 5},
+	};
+	char name[80];
+
+	if (argc == 2 && strcmp(argv[1], "--benchmark") == 0) {
+		benchmark();
+		return 0;
+	}
+	if (argc != 1) {
+		fprintf(stderr, "usage: %s [--benchmark]\n", argv[0]);
+		return 2;
+	}
+	for (unsigned int i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		u64 start = TIMESTAMP_MASK - 9999999;
+
+		snprintf(name, sizeof(name), "delta=%llu ns",
+			 (unsigned long long)cases[i].delta);
+		check_latency(name, 0, cases[i].delta, cases[i].zone);
+		snprintf(name, sizeof(name), "wrapped delta=%llu ns",
+			 (unsigned long long)cases[i].delta);
+		check_latency(name, start,
+			      (start + cases[i].delta) & TIMESTAMP_MASK, cases[i].zone);
+	}
+	check_latency("nonzero start at 100 ms", 500000000, 600000000, 2);
+	check_latency("large start at 100 ms",
+		      1000000000000000ULL, 1000000100000000ULL, 2);
+	check_latency("51-bit wrap at now=0", TIMESTAMP_MASK - 19999999, 0, 0);
+	check_latency("51-bit wrap below 20 ms",
+		      TIMESTAMP_MASK - 9999999, 9999999, -1);
+	check_latency("51-bit wrap at 20 ms",
+		      TIMESTAMP_MASK - 9999999, 10000000, 0);
+	check_latency("51-bit wrap above 200 ms",
+		      TIMESTAMP_MASK - 100000000, 100000000, 4);
+	check_latency("51-bit wrap tail",
+		      TIMESTAMP_MASK - 3000000000ULL, 1400000000ULL, 5);
+	check_failures();
+	if (failures)
+		return 1;
+	puts("I/O latency production-function regression passed");
+	return 0;
+}


### PR DESCRIPTION
## Problem

Both q2c_latency_index and d2c_latency_index narrow a u64 nanosecond
difference to int before calling zone_index(u64). Slow I/O can disappear from
the tail counters or land in a much faster bucket.

The regression fixture directly executes the production C functions:

| Elapsed time | Original result | Expected result |
| --- | --- | --- |
| 4,294,967,296 ns | -1, excluded | zone 5 (>400 ms) |
| 4,300,000,000 ns | -1, excluded | zone 5 |
| 4,400,000,000 ns | zone 3 (100-200 ms) | zone 5 |

The first lost interval starts at 2^32 ns, not 2^31: the negative int values
above 2^31 become large u64 values and still enter the highest existing bucket.

## Design

Keep both differences as u64 and compute them modulo the existing 51-bit clock:

```c
u64 delta = (now - start) & TIMESTAMP_MASK;
```

Changing only int to u64 is insufficient. ktime_ns_mask and the stored start
timestamps share a wrapping clock. At its approximately 26-day boundary, an
unsigned subtraction without the mask would turn a short request into a huge
tail latency. A width-only mutation fails the wrapped 19,999,999 ns and
20,000,000 ns regression cases; the complete fix passes.

Keep read errors and missing map entries as -1, and preserve the existing
D2C timestamp deletion. A successfully read zero timestamp is not a missing
entry. Packed bio timestamps use their low 51 bits, while the plain field is
masked to the same existing domain. See the upstream
[packed timestamp initialization](https://github.com/torvalds/linux/blob/v6.17/block/blk.h)
and [plain bio timestamp field](https://github.com/torvalds/linux/blob/v6.18/include/linux/blk_types.h).
The nearby comment now describes field capabilities rather than an inaccurate
kernel-version cutoff.

This keeps the existing clock representation; it cannot distinguish elapsed
times separated by a complete 2^51 ns clock period.

## Scope

Only two production calculations and their comments change. No Go type,
map layout, metric name, bucket boundary, unit or transport changes.

Independent Q2C/D2C eligibility and first-disk-event accounting remain separate
issues; this patch does not change those counters' admission policy. It also
does not infer whether a kernel queue enabled timestamp recording from a zero
value. Related #788/#789 change userspace metric emission/container discovery,
not these calculations.

## Tests

New integration/test_iolatency_delta.sh is discovered by the existing
integration runner. Its C unit fixture includes bpf/iolatency_tracing.c
directly and stubs only the kernel/helper boundary, not the arithmetic.

Coverage includes:

- Every bucket boundary and +/-1 ns.
- 2^31 and 2^32 boundaries, 4.3/4.4 seconds, repeated 32-bit periods and 30 seconds.
- The same cases across the 51-bit wrap, nonzero/large starts and now=0.
- Packed and plain issue fields, including distinct offsets and read-address
  assertions, packed high bits and valid zero timestamps.
- Probe-read failures, missing start entries, and exactly one deletion of a
  valid D2C start entry.

The script also compiles the actual production BPF target. --benchmark is
optional and runs the regression checks before timing. These host-side tests
do not claim to validate real kernel field layouts or CO-RE relocation.

## Validation

Linux/arm64, kernel 6.10.14-linuxkit, Go 1.24.6, clang 14.0.6, libbpf 1.1.2.

Passed locally:

- Baseline regression fails; complete fix passes; width-only mutation fails
  the wrap cases.
- Standalone integration/test_iolatency_delta.sh, including production BPF
  compilation.
- Native fixture under GCC AddressSanitizer + UndefinedBehaviorSanitizer.
- BPF compilation for both arm64 and x86.
- Actual arm64 CO-RE relocation and verifier loading of all three production
  programs and all three maps against /sys/kernel/btf/vmlinux. The load-only
  verifier harness closes all handles and does not attach or pin anything.
- make gen-build, go build -p 2 ./..., make check.
- go test -p 2 -race -count=1 ./core/metrics ./core/autotracing ./cmd/iotracing ./pkg/types.

make check used golangci-lint v1.64.8 built with Go 1.24.6; repository files and
tool pins were not changed.

Full go test -p 2 -count=1 ./... was also attempted. It is not green in this
container: internal/bpf requires mounted tracefs/debugfs and additional
permissions for one perf-output test; internal/cgroups requires a systemd
socket. Other packages pass. The full VM integration/e2e matrix and delayed
block-device fault injection have not been run. No business disk was touched.

To run the checked-in regression directly from the repository root:

```sh
ROOT_DIR="$PWD" HUATUO_BAMAI_TEST_TMPDIR=/tmp \
  bash integration/test_iolatency_delta.sh

# In the project's full privileged integration environment:
bash integration/run.sh test_iolatency_delta.sh
```

## Hot-path check

No new helpers, loops or maps. All helper call-site counts are identical.
The loaded completion program changes from 292 to 284 encoded 8-byte eBPF
instruction slots (274 to 276 decoded cilium/ebpf instruction entries, which
count double-slot immediate loads once). The other two program tags are
unchanged. Map value sizes remain 8, 120 and 120 bytes.

Identical native fixtures built against the original and fixed production
functions, clang -O2, sequential runs, 100 million Q2C+D2C pairs x 5:

| Inputs | Before median ns/pair | After median ns/pair |
| --- | ---: | ---: |
| Alternating 100/500 ms | 2.774 | 2.856 |
| Alternating 100 ms/4.4 s | 2.564 | 2.788 |

These timings include native helper stubs, not real BPF map/probe-read costs.
They are a small arithmetic/control-flow microbenchmark, not a measurement of
whole-tracer overhead, application throughput, or I/O tail latency. The
original long-tail path also computes the wrong bucket, so no speedup is
claimed.
