### PR TITLE
fix(iolatency): count stages independently and retain first samples

### DIFF
--- a/bpf/iolatency_tracing.c
+++ b/bpf/iolatency_tracing.c
@@ -171,8 +171,10 @@ blkcg_latency_account(struct bio *bio, int q2c_index, int d2c_index)
 		entry->minor = disk_dev[1];
 	}
 
-	__sync_fetch_and_add(&entry->q2c_zone[q2c_index], 1);
-	__sync_fetch_and_add(&entry->d2c_zone[d2c_index], 1);
+	if (q2c_index >= 0 && q2c_index < LATENCY_ZONE_MAX)
+		__sync_fetch_and_add(&entry->q2c_zone[q2c_index], 1);
+	if (d2c_index >= 0 && d2c_index < LATENCY_ZONE_MAX)
+		__sync_fetch_and_add(&entry->d2c_zone[d2c_index], 1);
 }
 
 static __always_inline void
@@ -182,26 +184,32 @@ blkdisk_latency_account(struct bio *bio, int q2c_index, int d2c_index)
 	struct disk_entry *disk_entry;
 
 	disk_entry = bpf_map_lookup_elem(&blkdisk_map, &disk);
-	if (disk_entry) {
-		__sync_fetch_and_add(&disk_entry->q2c_zone[q2c_index], 1);
-		__sync_fetch_and_add(&disk_entry->d2c_zone[d2c_index], 1);
-		return;
+	if (!disk_entry) {
+		/* gendisk.major, gendisk.first_minor */
+		u32 disk_dev[2];
+
+		bio_major_minor_numbers(bio, disk_dev);
+
+		struct disk_entry new_entry = {
+			.disk	  = (u64)disk,
+			.major	  = disk_dev[0],
+			.minor	  = disk_dev[1],
+			.q2c_zone = {},
+			.d2c_zone = {},
+		};
+
+		/* A concurrent creator may already have counted samples. */
+		bpf_map_update_elem(&blkdisk_map, &disk, &new_entry,
+				    COMPAT_BPF_NOEXIST);
+		disk_entry = bpf_map_lookup_elem(&blkdisk_map, &disk);
+		if (!disk_entry)
+			return;
 	}
 
-	/* gendisk.major, gendisk.first_minor */
-	u32 disk_dev[2];
-
-	bio_major_minor_numbers(bio, disk_dev);
-
-	struct disk_entry new_entry = {
-		.disk	  = (u64)disk,
-		.major	  = disk_dev[0],
-		.minor	  = disk_dev[1],
-		.q2c_zone = {},
-		.d2c_zone = {},
-	};
-
-	bpf_map_update_elem(&blkdisk_map, &disk, &new_entry, COMPAT_BPF_ANY);
+	if (q2c_index >= 0 && q2c_index < LATENCY_ZONE_MAX)
+		__sync_fetch_and_add(&disk_entry->q2c_zone[q2c_index], 1);
+	if (d2c_index >= 0 && d2c_index < LATENCY_ZONE_MAX)
+		__sync_fetch_and_add(&disk_entry->d2c_zone[d2c_index], 1);
 }
 
 SEC("kprobe/__rq_qos_done_bio")
@@ -217,7 +225,8 @@ int kprobe_done_bio(struct pt_regs *ctx)
 	d2c_index = d2c_latency_index(bio, now);
 	q2c_index = q2c_latency_index(bio, now);
 
-	if (q2c_index < 0 || d2c_index < 0)
+	/* Each stage can be slow even when the other has no eligible sample. */
+	if (q2c_index < 0 && d2c_index < 0)
 		return 0;
 
 	blkcg_latency_account(bio, q2c_index, d2c_index);

--- a/docs/key-feature/kernel-wide-insight_en.md
+++ b/docs/key-feature/kernel-wide-insight_en.md
@@ -1111,6 +1111,13 @@ The current version exposes both host-level and container-level metrics.
 
 ### Queue
 
+Q2C and D2C count completed bio stages independently when their timestamps are
+available and their latency is at least 20 ms. A stage below this threshold or
+with a missing timestamp does not suppress the other stage, so the two totals
+can differ. Creating a disk map entry also counts the completion that triggered
+its creation; if the map is full and no entry exists, that disk sample cannot
+be recorded.
+
 These metrics always include the common labels `host` and `region`. Container
 metrics also always include `container_host`, `container_name`,
 `container_type`, `container_level`, and `container_hostnamespace`.

--- a/docs/key-feature/kernel-wide-insight_zh.md
+++ b/docs/key-feature/kernel-wide-insight_zh.md
@@ -1192,6 +1192,10 @@ huatuo_bamai_sockstat_sockets_used{host="hostname",region="dev"} 409
 
 ### 队列
 
+Q2C 和 D2C 分别统计已完成的 bio 阶段：本阶段时间戳可用且延迟至少为 20ms 即计数。
+另一阶段低于阈值或缺少时间戳不会抑制本阶段，因此两者总数可能不同。创建磁盘 map 项时，
+触发创建的当前完成事件也会计入；若 map 已满且该磁盘项不存在，则无法记录该磁盘样本。
+
 这些指标都会自动带上公共标签 `host` 和 `region`。其中容器维度指标还会固定带上
 `container_host`、`container_name`、`container_type`、`container_level`、`container_hostnamespace` 标签。
 

--- a/integration/test_iolatency_accounting.sh
+++ b/integration/test_iolatency_accounting.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+
+WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/iolatency-accounting.XXXXXX")
+FIXTURE="${ROOT_DIR}/integration/testdata/iolatency_accounting.c"
+
+# Native helper stubs exercise the production completion path and a forced
+# insertion race. Compiling the real BPF target separately is not a load test.
+command -v clang > /dev/null || fatal "clang not found in PATH"
+clang -O2 -pthread -Wall -Wextra -Werror -Wno-unknown-attributes \
+	-I "${ROOT_DIR}/bpf/include" "${FIXTURE}" -o "${WORK_DIR}/iolatency_accounting" \
+	2> "${WORK_DIR}/native.compile.log" \
+	|| fatal "clang failed compiling ${FIXTURE}:"$'\n'"$(< "${WORK_DIR}/native.compile.log")"
+"${WORK_DIR}/iolatency_accounting"
+"${WORK_DIR}/iolatency_accounting" --bounds
+if (($# > 0)); then
+	"${WORK_DIR}/iolatency_accounting" "$@"
+fi
+compile_bpf_fixture "${ROOT_DIR}/bpf/iolatency_tracing.c" "${WORK_DIR}/iolatency_tracing.o"
+log_info "I/O latency completion-path regression and BPF target compilation passed"

--- a/integration/testdata/iolatency_accounting.c
+++ b/integration/testdata/iolatency_accounting.c
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The HuaTuo Authors.
+
+#include <limits.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Replace the kernel/helper boundary; all accounting stays in production. */
+#define __BPF_HELPERS__
+#define __BPF_CORE_READ_H__
+#define __BPF_TRACING_H__
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint8_t u8;
+#ifndef __always_inline
+#define __always_inline inline __attribute__((always_inline))
+#endif
+#define SEC(name)
+#define __uint(name, value) int (*name)[value]
+#define __type(name, value) value *name
+#define BPF_MAP_TYPE_HASH 1
+#define PT_REGS_PARM1(ctx) ((ctx)->arg1)
+#define PT_REGS_PARM2(ctx) ((ctx)->arg2)
+#define READ_ONE(src, field) ((src)->field)
+#define READ_TWO(src, field, next) ((src)->field->next)
+#define READ_SELECT(_1, _2, NAME, ...) NAME
+#define BPF_CORE_READ(src, ...) \
+	READ_SELECT(__VA_ARGS__, READ_TWO, READ_ONE)(src, __VA_ARGS__)
+#define BPF_CORE_READ_INTO(dst, src, ...) \
+	(*(dst) = (__typeof__(*(dst)))BPF_CORE_READ(src, __VA_ARGS__))
+#define bpf_core_field_exists(field) true
+
+struct gendisk {
+	u32 major, minor;
+};
+struct block_device {
+	struct gendisk *bd_disk;
+};
+struct blkcg_gq {
+	void *blkcg;
+};
+struct bio {
+	u64 bi_issue;
+	struct bio *bi_next;
+	struct blkcg_gq *bi_blkg;
+	struct gendisk *bi_disk;
+	u8 bi_partno;
+};
+struct request {
+	struct bio *bio;
+};
+struct request_queue {
+	struct blkcg_gq *root_blkg;
+};
+struct pt_regs {
+	u64 arg1, arg2;
+};
+
+static u64 bpf_ktime_get_ns(void);
+static long bpf_probe_read(void *dst, u32 size, const void *src);
+static void *bpf_map_lookup_elem(const void *map, const void *key);
+static long bpf_map_delete_elem(const void *map, const void *key);
+static long bpf_map_update_elem(const void *map, const void *key,
+			       const void *value, u64 flags);
+
+#include "../../bpf/iolatency_tracing.c"
+
+static struct gendisk disk = {8, 16};
+static int css;
+static struct blkcg_gq blkg = {&css};
+static struct {
+	u64 before;
+	struct disk_entry value;
+	u64 after;
+} disk_slot;
+static struct {
+	u64 before;
+	struct blkgq_entry value;
+	u64 after;
+} cg_slot;
+static bool disk_present, cg_present, map_full;
+static unsigned int updates, rejected_inserts, failures;
+static pthread_mutex_t map_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_barrier_t race_missed, race_inserted;
+static _Thread_local struct bio current_bio;
+static _Thread_local u64 now, start;
+static _Thread_local bool start_present, issue_read_error, force_stale_miss;
+static _Thread_local unsigned int deletes;
+
+static u64 bpf_ktime_get_ns(void)
+{
+	return now;
+}
+
+static long bpf_probe_read(void *dst, u32 size, const void *src)
+{
+	if (issue_read_error && src == &current_bio.bi_issue)
+		return -1;
+	memcpy(dst, src, size);
+	return 0;
+}
+
+static void *bpf_map_lookup_elem(const void *map, const void *key)
+{
+	if (map == &bio_start_time)
+		return start_present && *(const u64 *)key == (u64)&current_bio
+			? &start : NULL;
+	if (map == &blkcg_map)
+		return cg_present && *(const u64 *)key == (u64)&css
+			? &cg_slot.value : NULL;
+	if (map == &blkdisk_map && *(const u64 *)key == (u64)&disk) {
+		pthread_mutex_lock(&map_lock);
+		void *entry = disk_present ? &disk_slot.value : NULL;
+		pthread_mutex_unlock(&map_lock);
+		if (!entry && force_stale_miss) {
+			force_stale_miss = false;
+			pthread_barrier_wait(&race_missed);
+			pthread_barrier_wait(&race_inserted);
+		}
+		return entry;
+	}
+	return NULL;
+}
+
+static long bpf_map_delete_elem(const void *map, const void *key)
+{
+	if (map != &bio_start_time || *(const u64 *)key != (u64)&current_bio)
+		return -1;
+	start_present = false;
+	deletes++;
+	return 0;
+}
+
+static long bpf_map_update_elem(const void *map, const void *key,
+			       const void *value, u64 flags)
+{
+	if (map != &blkdisk_map || *(const u64 *)key != (u64)&disk)
+		return -1;
+	pthread_mutex_lock(&map_lock);
+	updates++;
+	long result = 0;
+
+	if (disk_present && flags == COMPAT_BPF_NOEXIST) {
+		rejected_inserts++;
+		result = -17;
+	} else if (map_full) {
+		result = -12;
+	} else {
+		disk_slot.value = *(const struct disk_entry *)value;
+		disk_present = true;
+	}
+	pthread_mutex_unlock(&map_lock);
+	return result;
+}
+
+static void expect(const char *name, const char *field, u64 actual, u64 want)
+{
+	if (actual == want)
+		return;
+	fprintf(stderr, "%s (%s): got %llu, want %llu\n", name, field,
+		(unsigned long long)actual, (unsigned long long)want);
+	failures++;
+}
+
+static void reset(bool existing)
+{
+	memset(&disk_slot, 0, sizeof(disk_slot));
+	memset(&cg_slot, 0, sizeof(cg_slot));
+	disk_slot.before = cg_slot.before = 0x12345678;
+	disk_slot.after = cg_slot.after = 0x87654321;
+	disk_present = existing;
+	cg_present = true;
+	map_full = false;
+	updates = rejected_inserts = deletes = 0;
+	force_stale_miss = false;
+	cg_slot.value.blkgq = (u64)&blkg;
+	cg_slot.value.disk = (u64)&disk;
+	if (existing) {
+		disk_slot.value.disk = (u64)&disk;
+		disk_slot.value.major = 8;
+		disk_slot.value.minor = 19;
+		disk_slot.value.freeze_nr = 17;
+	}
+}
+
+static void complete(u64 q_delta, u64 d_delta, bool read_error, bool missing)
+{
+	now = 1000000000;
+	current_bio = (struct bio){
+		.bi_issue = now - q_delta,
+		.bi_blkg = &blkg,
+		.bi_disk = &disk,
+		.bi_partno = 3,
+	};
+	start = now - d_delta;
+	start_present = !missing;
+	issue_read_error = read_error;
+	struct pt_regs ctx = {.arg2 = (u64)&current_bio};
+
+	kprobe_done_bio(&ctx);
+}
+
+static void expect_state(const char *name, int q, int d, u64 count,
+			 bool present, u64 freeze)
+{
+	expect(name, "disk present", disk_present, present);
+	expect(name, "freeze preserved", disk_slot.value.freeze_nr, freeze);
+	expect(name, "disk prefix canary", disk_slot.before, 0x12345678);
+	expect(name, "disk suffix canary", disk_slot.after, 0x87654321);
+	expect(name, "cgroup prefix canary", cg_slot.before, 0x12345678);
+	expect(name, "cgroup suffix canary", cg_slot.after, 0x87654321);
+	expect(name, "cgroup identity", cg_slot.value.blkgq, (u64)&blkg);
+	expect(name, "cgroup disk identity", cg_slot.value.disk, (u64)&disk);
+	if (present) {
+		expect(name, "disk identity", disk_slot.value.disk, (u64)&disk);
+		expect(name, "disk major", disk_slot.value.major, 8);
+		expect(name, "disk minor", disk_slot.value.minor, 19);
+	}
+	if (cg_present && (q >= 0 || d >= 0)) {
+		expect(name, "cgroup major", cg_slot.value.major, 8);
+		expect(name, "cgroup minor", cg_slot.value.minor, 19);
+	}
+	for (int i = 0; i < LATENCY_ZONE_MAX; i++) {
+		char field[40];
+
+		snprintf(field, sizeof(field), "disk q2c[%d]", i);
+		expect(name, field, disk_slot.value.q2c_zone[i],
+		       present && i == q ? count : 0);
+		snprintf(field, sizeof(field), "disk d2c[%d]", i);
+		expect(name, field, disk_slot.value.d2c_zone[i],
+		       present && i == d ? count : 0);
+		snprintf(field, sizeof(field), "cgroup q2c[%d]", i);
+		expect(name, field, cg_slot.value.q2c_zone[i],
+		       cg_present && i == q ? count : 0);
+		snprintf(field, sizeof(field), "cgroup d2c[%d]", i);
+		expect(name, field, cg_slot.value.d2c_zone[i],
+		       cg_present && i == d ? count : 0);
+	}
+}
+
+static void completion_cases(void)
+{
+	static const struct {
+		const char *name;
+		u64 q, d;
+		bool read_error, missing;
+		int q_zone, d_zone;
+	} cases[] = {
+		{"queue slow, device fast", 100000000, 1000000, false, false, 2, -1},
+		{"queue read fails, device slow", 100000000, 50000000, true, false, -1, 1},
+		{"device missing, queue slow", 100000000, 50000000, false, true, 2, -1},
+		{"both slow", 100000000, 50000000, false, false, 2, 1},
+		{"both fast", 1000000, 1000000, false, false, -1, -1},
+		{"both unavailable", 100000000, 50000000, true, true, -1, -1},
+		{"first and last buckets", 500000000, 20000000, false, false, 5, 0},
+	};
+	for (int existing = 0; existing < 2; existing++) {
+		for (unsigned int i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+			bool slow = cases[i].q_zone >= 0 || cases[i].d_zone >= 0;
+			char name[100];
+
+			snprintf(name, sizeof(name), "%s (%s disk)", cases[i].name,
+				 existing ? "existing" : "new");
+			reset(existing);
+			complete(cases[i].q, cases[i].d,
+				 cases[i].read_error, cases[i].missing);
+			expect_state(name, cases[i].q_zone, cases[i].d_zone, 1,
+				     existing || slow, existing ? 17 : 0);
+			expect(name, "start timestamp consumed", start_present, 0);
+			expect(name, "timestamp deletes", deletes, !cases[i].missing);
+			expect(name, "disk insert attempts", updates, !existing && slow);
+		}
+	}
+	reset(false);
+	for (unsigned int i = 0; i < 32; i++)
+		complete(100000000, 50000000, false, false);
+	expect_state("32 completions", 2, 1, 32, true, 0);
+	expect("32 completions", "one insert", updates, 1);
+	reset(false);
+	map_full = true;
+	complete(100000000, 50000000, false, false);
+	expect_state("disk map full", 2, 1, 1, false, 0);
+	expect("disk map full", "one failed insert", updates, 1);
+	reset(false);
+	cg_present = false;
+	complete(100000000, 50000000, false, false);
+	expect_state("cgroup absent", 2, 1, 1, true, 0);
+}
+
+static void index_bounds(void)
+{
+	const int invalid[] = {-1, LATENCY_ZONE_MAX, INT_MIN, INT_MAX};
+	const int valid[] = {0, LATENCY_ZONE_MAX - 1};
+
+	for (unsigned int i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+		for (unsigned int j = 0; j < sizeof(valid) / sizeof(valid[0]); j++) {
+			for (int invalid_q = 0; invalid_q < 2; invalid_q++) {
+				int q = invalid_q ? invalid[i] : valid[j];
+				int d = invalid_q ? valid[j] : invalid[i];
+				char name[80];
+
+				snprintf(name, sizeof(name), "direct indices q=%d d=%d", q, d);
+				reset(true);
+				complete(1000000, 1000000, false, false);
+				blkcg_latency_account(&current_bio, q, d);
+				blkdisk_latency_account(&current_bio, q, d);
+				expect_state(name, invalid_q ? -1 : q, invalid_q ? d : -1,
+					     1, true, 17);
+			}
+		}
+	}
+}
+
+static void *competing_cpu(void *unused)
+{
+	(void)unused;
+	pthread_barrier_wait(&race_missed);
+	for (unsigned int i = 0; i < 3; i++)
+		complete(100000000, 50000000, false, false);
+	/* Existing freeze state must survive; freeze probe keying is out of scope. */
+	__sync_fetch_and_add(&disk_slot.value.freeze_nr, 17);
+	pthread_barrier_wait(&race_inserted);
+	return NULL;
+}
+
+static void check_thread(int error, const char *operation)
+{
+	if (!error)
+		return;
+	fprintf(stderr, "%s: %s\n", operation, strerror(error));
+	exit(2);
+}
+
+static void insertion_race(void)
+{
+	pthread_t thread;
+
+	reset(false);
+	check_thread(pthread_barrier_init(&race_missed, NULL, 2),
+		     "initialize missed-lookup barrier");
+	check_thread(pthread_barrier_init(&race_inserted, NULL, 2),
+		     "initialize completed-insert barrier");
+	check_thread(pthread_create(&thread, NULL, competing_cpu, NULL),
+		     "create competing insertion worker");
+	force_stale_miss = true;
+	complete(100000000, 50000000, false, false);
+	check_thread(pthread_join(thread, NULL), "join competing insertion worker");
+	pthread_barrier_destroy(&race_missed);
+	pthread_barrier_destroy(&race_inserted);
+	expect_state("concurrent first insertion", 2, 1, 4, true, 17);
+	expect("concurrent first insertion", "existing entry rejects insert",
+	       rejected_inserts, 1);
+}
+
+static void *parallel_cpu(void *unused)
+{
+	(void)unused;
+	pthread_barrier_wait(&race_missed);
+	for (unsigned int i = 0; i < 10000; i++)
+		complete(100000000, 50000000, false, false);
+	return NULL;
+}
+
+static void parallel_completions(void)
+{
+	pthread_t threads[4];
+
+	reset(true);
+	/* Metadata initialization is not the concurrent-counter contract under test. */
+	cg_slot.value.major = 8;
+	cg_slot.value.minor = 19;
+	check_thread(pthread_barrier_init(&race_missed, NULL, 5),
+		     "initialize concurrent completion barrier");
+	for (unsigned int i = 0; i < 4; i++)
+		check_thread(pthread_create(&threads[i], NULL, parallel_cpu, NULL),
+			     "create concurrent completion worker");
+	pthread_barrier_wait(&race_missed);
+	for (unsigned int i = 0; i < 4; i++)
+		check_thread(pthread_join(threads[i], NULL),
+			     "join concurrent completion worker");
+	pthread_barrier_destroy(&race_missed);
+	expect_state("four concurrent completion workers", 2, 1, 40000, true, 17);
+	expect("four concurrent completion workers", "no insert", updates, 0);
+}
+
+static volatile u64 benchmark_q = 100000000;
+
+static void benchmark(void)
+{
+	const unsigned int iterations = 50000000;
+	const char *names[] = {"both slow", "queue only", "device only", "both fast"};
+
+	for (unsigned int group = 0; group < 4; group++) {
+		reset(true);
+		clock_t begin = clock();
+
+		for (unsigned int i = 0; i < iterations; i++)
+			complete(group == 3 ? 1000000 : benchmark_q,
+				 group == 1 || group == 3 ? 1000000 : 50000000,
+				 group == 2, false);
+		printf("%s: %.3f ns/completion (%u iterations; native helper stubs)\n",
+		       names[group],
+		       1e9 * (double)(clock() - begin) / CLOCKS_PER_SEC / iterations,
+		       iterations);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	if (argc == 2 && strcmp(argv[1], "--benchmark") == 0) {
+		benchmark();
+		return 0;
+	}
+	if (argc == 2 && strcmp(argv[1], "--bounds") == 0) {
+		index_bounds();
+		if (failures)
+			return 1;
+		puts("I/O latency direct-accounting index bounds passed");
+		return 0;
+	}
+	if (argc != 1) {
+		fprintf(stderr, "usage: %s [--benchmark|--bounds]\n", argv[0]);
+		return 2;
+	}
+	/* A broken path must fail instead of leaving the barrier test hung in CI. */
+	alarm(10);
+	completion_cases();
+	insertion_race();
+	parallel_completions();
+	alarm(0);
+	if (failures)
+		return 1;
+	puts("I/O latency completion-path regression passed");
+	return 0;
+}


### PR DESCRIPTION
## Problem

Three paths currently lose eligible I/O latency samples:

- The completion hook returns when either stage is ineligible. For example,
  Q2C=100 ms and D2C=1 ms records neither stage, although Q2C belongs in zone 2.
  A missing D2C start also suppresses Q2C, and a Q2C read failure suppresses D2C.
- The first qualifying completion for a disk only inserts zero counters.
- Concurrent first completions can both observe a missing disk entry. The
  subsequent BPF_ANY insertion can replace another CPU's accumulated counters
  and freeze_nr with zeroes.

## Design

Each eligible stage of an observed bio completion contributes once to each
available accounting entry; an ineligible stage must not veto the other one.

1. Return early only when both stages are ineligible. Keep consuming the D2C
   start timestamp before this decision, including for fast completions.
2. Check both bounds of each stage's index before its own atomic increment,
   for both cgroup and disk entries. Negative indices must never reach an array.
3. On a disk lookup miss, insert a zero entry with COMPAT_BPF_NOEXIST, then
   look up again and use the common increment path. This counts the creator's
   completion exactly once. If another CPU won the insertion, use its entry
   without replacing its counters. If the lookup is still NULL, skip disk
   accounting without undoing the cgroup count.

The initialization pattern already exists in bpf/cpu_runqlat_tracing.c.
It follows the kernel's [hash map insertion and lookup semantics](https://docs.kernel.org/bpf/map_hash.html).
No new locks, maps, loops or userspace dependencies are introduced.

## Scope and compatibility

The two map values remain 120 bytes, with two arrays of six u64 counters.
Metric names, labels, bucket boundaries, timestamp calculation and Go ABI are
unchanged. The Go collectors and dashboards already consume the stages
independently. English and Chinese metric documentation now explain why their
totals may differ and what happens when the disk map cannot admit an entry.

This is independent of #811's elapsed-time width/wrap fix: neither its code nor
its tests are included. Its production patch applies cleanly on this branch;
the combined calculations and accounting also compile for arm64 and x86.

The guarantee concerns samples in the BPF counters, not application request
counts or Prometheus history before its first scrape. Map capacity failures,
untracked cgroups, missed kernel events, device attribution and freeze-probe
keying remain outside this patch.

## Regression coverage

integration/test_iolatency_accounting.sh compiles a native fixture that includes
the production C file and calls the actual completion/accounting functions.
Only the kernel structures and helper boundary are stubbed. It also compiles
the real production BPF target separately.

The fixture checks single-stage eligibility, both slow/fast, missing start
and read failures, first and repeated disk samples, map-full failure without
losing the cgroup count, absent cgroups, and index bounds. It checks all bucket
values, neighboring fields and canaries, including D2C timestamp cleanup.

A two-thread barrier test fixes the critical interleaving: one completion
observes a miss, another thread creates the entry and adds three completions
plus existing freeze state, then the first completion resumes its stale-miss
path. All four completions and freeze_nr must survive. A separate four-thread
test performs 40,000 completions against existing entries and checks both maps'
counter totals.

```sh
ROOT_DIR="$PWD" HUATUO_BAMAI_TEST_TMPDIR=/tmp \
  bash integration/test_iolatency_accounting.sh

# In the project's privileged integration environment:
bash integration/run.sh test_iolatency_accounting.sh
```

## Validation

Linux 6.10.14-linuxkit/arm64, clang 14.0.6, Go 1.24.6.

Passed:

- Original production completion-path regression fails; patched version passes.
- Standalone integration script, including direct index-bound checks and actual
  production BPF compilation.
- Native fixture under GCC AddressSanitizer + UndefinedBehaviorSanitizer.
- GCC ThreadSanitizer for the completion and concurrency regressions.
- Before/after BPF compilation for arm64 and x86 with -Wall -Werror.
- Actual arm64 CO-RE relocation and kernel verifier loading of all three
  production programs and all three maps, before and after the fix. The
  load-only harness closes all handles and never attaches, pins or test-runs
  the programs.
- `make gen-build`; `go build -p 2 ./...`.
- `make check` (golangci-lint v1.64.8 built with Go 1.24.6; no repository tool
  pins changed).
- go test -p 2 -race -count=1 ./core/metrics ./core/autotracing ./cmd/iotracing ./pkg/types.

Full go test -p 2 -count=1 ./... was attempted, not reported as green:
internal/bpf lacks mounted tracefs/debugfs and permission for one perf-output
test; internal/cgroups lacks the systemd socket. All other packages pass.
The full privileged integration/e2e matrix, live block-device workloads and
kernel-level multi-CPU I/O accounting have not been run. The pthread fixture
does not model real kernel layouts or replace that runtime validation.

## Hot-path cost

For completions with both stages eligible and an existing disk, helper calls
are unchanged; the extra map lookup is only on the cold creation path.
Loaded completion-program size changes from 292 to 320 encoded 8-byte eBPF
instruction slots; verifier stack depth stays 152 bytes.
The start and freeze programs, all map sizes and capacities are unchanged.

The optional --benchmark runs the actual production completion function with
native helper stubs. For identical fixtures built against the original and
patched functions (clang -O2, five sequential before/after pairs, 50 million
completions per run), the both-slow, existing-map median was 8.315 to 10.003
ns/completion (+1.688 ns, about 20%). This is a measured native cost, not a
zero-overhead claim. Full index protection and independent accounting are kept
for correctness; no new helpers execute on this existing-entry path.

Only that both-slow path is used for a like-for-like comparison. Single-stage
paths now perform accounting that the original skipped. Native timings are not
real BPF helper costs, application throughput, or storage-latency measurements.
