### PR TITLE
fix(metrics): respect ancestor CPU limits and discard resize intervals

### DIFF
--- a/core/metrics/cpu_util.go
+++ b/core/metrics/cpu_util.go
@@ -15,9 +15,13 @@
 package collector
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math"
+	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,21 +37,48 @@ import (
 type cpuUtilStat struct {
 	lastUsage     stats.CpuUsage
 	lastTimestamp time.Time
-	totalUtil     float64
-	sysUtil       float64
-	usrUtil       float64
+	capacity      stats.CpuCapacity
+}
+
+type cpuUtilSample struct {
+	total float64
+	sys   float64
+	usr   float64
 }
 
 type cpuUtilCollector struct {
-	cgroup       cgroups.Cgroup
-	numCores     float64
-	cpuDataCache cpuUtilStat
-	mutex        sync.Mutex
+	cgroup         cgroups.Cgroup
+	cpuDataCache   cpuUtilStat
+	mutex          sync.Mutex
+	now            func() time.Time
+	readOnlineCPUs func() (string, error)
 }
 
 func init() {
 	tracing.RegisterEventTracing("cpu_util", newCpuCollector)
 	_ = pod.RegisterContainerLifeResources("collector_cpu_util", reflect.TypeOf(&cpuUtilStat{}))
+}
+
+func readSystemOnlineCPUs() (string, error) {
+	data, err := os.ReadFile(cpuutil.SystemCPUOnlinePath)
+	if err != nil {
+		return "", fmt.Errorf("read online CPUs: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func hostCPUCapacity(onlineCPUs string) (stats.CpuCapacity, error) {
+	numCores, err := cpuutil.ParseCPUListCount(onlineCPUs)
+	if err != nil {
+		return stats.CpuCapacity{}, fmt.Errorf("parse online CPUs: %w", err)
+	}
+	if numCores == 0 {
+		return stats.CpuCapacity{}, errors.New("no online CPU")
+	}
+	return stats.CpuCapacity{
+		Cores:    float64(numCores),
+		ConfigID: sha256.Sum256([]byte(onlineCPUs)),
+	}, nil
 }
 
 func newCpuCollector() (*tracing.EventTracingAttr, error) {
@@ -56,140 +87,194 @@ func newCpuCollector() (*tracing.EventTracingAttr, error) {
 		return nil, err
 	}
 
-	numCores, err := cpuutil.ParseOnlineCores(cpuutil.SystemCPUOnlinePath)
+	onlineCPUs, err := readSystemOnlineCPUs()
 	if err != nil {
-		return nil, fmt.Errorf("read online cpu: %w", err)
+		return nil, err
 	}
-	if numCores == 0 {
-		return nil, errors.New("no online cpu")
+	if _, err := hostCPUCapacity(onlineCPUs); err != nil {
+		return nil, err
 	}
 
 	return &tracing.EventTracingAttr{
 		TracingData: &cpuUtilCollector{
-			numCores: float64(numCores),
-			cgroup:   cgroup,
+			cgroup:         cgroup,
+			now:            time.Now,
+			readOnlineCPUs: readSystemOnlineCPUs,
 		},
 		Flag: tracing.FlagMetric,
 	}, nil
 }
 
-func (c *cpuUtilCollector) updateDataCache(cache *cpuUtilStat, container *pod.Container, numCores float64) error {
-	var (
-		usrUtil    float64
-		sysUtil    float64
-		totalUtil  float64
-		cgroupPath string
-	)
+func (c *cpuUtilCollector) sampleTime() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
 
+func (cache *cpuUtilStat) update(usage stats.CpuUsage, capacity stats.CpuCapacity, now time.Time) (cpuUtilSample, bool) {
+	next := cpuUtilStat{lastUsage: usage, lastTimestamp: now, capacity: capacity}
+
+	// A delta needs two samples from the same cgroup and capacity configuration.
+	// Reusing the old denominator across resize would invent utilization.
+	if cache.lastTimestamp.IsZero() || cache.capacity != capacity ||
+		now.Before(cache.lastTimestamp) ||
+		usage.Usage < cache.lastUsage.Usage ||
+		usage.User < cache.lastUsage.User ||
+		usage.System < cache.lastUsage.System {
+		*cache = next
+		return cpuUtilSample{}, false
+	}
+
+	elapsed := now.Sub(cache.lastTimestamp)
+	if elapsed < time.Second {
+		return cpuUtilSample{}, false
+	}
+
+	denominator := capacity.Cores * float64(elapsed.Microseconds())
+	sample := cpuUtilSample{
+		total: float64(usage.Usage-cache.lastUsage.Usage) * 100 / denominator,
+		usr:   float64(usage.User-cache.lastUsage.User) * 100 / denominator,
+		sys:   float64(usage.System-cache.lastUsage.System) * 100 / denominator,
+	}
+	// Quota is a bandwidth limit, not an instantaneous ceiling: CFS burst
+	// allowance and period boundaries can legitimately exceed 100%.
+	*cache = next
+	return sample, true
+}
+
+func (c *cpuUtilCollector) readCapacity(path, onlineCPUs string) (stats.CpuCapacity, error) {
+	capacity, err := c.cgroup.CpuCapacity(path, onlineCPUs)
+	if err != nil {
+		return stats.CpuCapacity{}, err
+	}
+	if capacity == nil {
+		return stats.CpuCapacity{}, errors.New("CPU capacity is unavailable")
+	}
+	if capacity.Cores <= 0 || math.IsNaN(capacity.Cores) || math.IsInf(capacity.Cores, 0) {
+		return stats.CpuCapacity{}, fmt.Errorf("CPU capacity must be positive and finite, got %v", capacity.Cores)
+	}
+	return *capacity, nil
+}
+
+func (c *cpuUtilCollector) updateContainerDataCache(cache *cpuUtilStat, container *pod.Container, onlineCPUs string) ([]*metric.Data, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	now := time.Now()
-	if now.Sub(cache.lastTimestamp).Nanoseconds() < 1000000000 {
-		return nil
-	}
-
-	if container != nil {
-		cgroupPath = container.CgroupPath
-	}
-
-	stat, err := c.cgroup.CpuUsage(cgroupPath)
+	before, err := c.readCapacity(container.CgroupPath, onlineCPUs)
 	if err != nil {
-		return err
+		*cache = cpuUtilStat{}
+		return nil, fmt.Errorf("read CPU capacity before usage: %w", err)
+	}
+	metrics := make([]*metric.Data, 1, 4)
+	metrics[0] = metric.NewContainerGaugeData(container, "cores", before.Cores, "cpu core number for the containers", nil)
+
+	usage, err := c.cgroup.CpuUsage(container.CgroupPath)
+	if err != nil || usage == nil {
+		*cache = cpuUtilStat{}
+		if err == nil {
+			err = errors.New("CPU usage is unavailable")
+		}
+		return metrics, fmt.Errorf("read CPU usage: %w", err)
+	}
+	sampledAt := c.sampleTime()
+
+	after, err := c.readCapacity(container.CgroupPath, onlineCPUs)
+	if err != nil {
+		*cache = cpuUtilStat{}
+		return metrics, fmt.Errorf("read CPU capacity after usage: %w", err)
+	}
+	metrics[0].Value = after.Cores
+	if before != after {
+		// The usage read cannot be assigned to either configuration reliably.
+		*cache = cpuUtilStat{}
+		return metrics, nil
 	}
 
-	// Usage, User, and System should increase monotonically. This defensive
-	// check prevents an unexpected reset from causing uint64 underflow.
-	if stat.Usage < cache.lastUsage.Usage ||
-		stat.User < cache.lastUsage.User ||
-		stat.System < cache.lastUsage.System {
-		cache.lastUsage = *stat
-		cache.lastTimestamp = now
-		return nil
+	sample, available := cache.update(*usage, after, sampledAt)
+	if available {
+		metrics = append(metrics,
+			metric.NewContainerGaugeData(container, "usr", sample.usr, "cpu usr for the containers", nil),
+			metric.NewContainerGaugeData(container, "sys", sample.sys, "cpu sys for the containers", nil),
+			metric.NewContainerGaugeData(container, "total", sample.total, "cpu total for the containers", nil),
+		)
 	}
-
-	deltaTotalTime := stat.Usage - cache.lastUsage.Usage
-	deltaUsrTime := stat.User - cache.lastUsage.User
-	deltaSysTime := stat.System - cache.lastUsage.System
-	deltaRealWorldTime := numCores * float64(now.Sub(cache.lastTimestamp).Microseconds())
-
-	if (float64(deltaTotalTime) > deltaRealWorldTime) || (float64(deltaUsrTime+deltaSysTime) > deltaRealWorldTime) {
-		cache.lastUsage = *stat
-		cache.lastTimestamp = now
-		return nil
-	}
-
-	totalUtil = float64(deltaTotalTime) * 100 / deltaRealWorldTime
-	usrUtil = float64(deltaUsrTime) * 100 / deltaRealWorldTime
-	sysUtil = float64(deltaSysTime) * 100 / deltaRealWorldTime
-
-	cache.lastUsage = *stat
-	cache.totalUtil = totalUtil
-	cache.usrUtil = usrUtil
-	cache.sysUtil = sysUtil
-	cache.lastTimestamp = now
-	return nil
+	return metrics, nil
 }
 
-func (c *cpuUtilCollector) updateHostDataCache() ([]*metric.Data, error) {
-	if err := c.updateDataCache(&c.cpuDataCache, nil, c.numCores); err != nil {
+func (c *cpuUtilCollector) updateHostDataCache(capacity stats.CpuCapacity) ([]*metric.Data, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	usage, err := c.cgroup.CpuUsage("")
+	if err != nil || usage == nil {
+		c.cpuDataCache = cpuUtilStat{}
+		if err == nil {
+			err = errors.New("CPU usage is unavailable")
+		}
 		return nil, err
+	}
+	sample, available := c.cpuDataCache.update(*usage, capacity, c.sampleTime())
+	if !available {
+		return nil, nil
 	}
 
 	return []*metric.Data{
-		metric.NewGaugeData("usr", c.cpuDataCache.usrUtil, "cpu usr for the host", nil),
-		metric.NewGaugeData("sys", c.cpuDataCache.sysUtil, "cpu sys for the host", nil),
-		metric.NewGaugeData("total", c.cpuDataCache.totalUtil, "cpu total for the host", nil),
+		metric.NewGaugeData("usr", sample.usr, "cpu usr for the host", nil),
+		metric.NewGaugeData("sys", sample.sys, "cpu sys for the host", nil),
+		metric.NewGaugeData("total", sample.total, "cpu total for the host", nil),
 	}, nil
 }
 
 func (c *cpuUtilCollector) Update() ([]*metric.Data, error) {
-	metrics := []*metric.Data{}
-
 	containers, err := pod.ContainersByType(pod.ContainerTypeNormal | pod.ContainerTypeSidecar)
 	if err != nil {
 		return nil, err
 	}
+	return c.updateMetrics(containers)
+}
 
+func (c *cpuUtilCollector) updateMetrics(containers map[string]*pod.Container) ([]*metric.Data, error) {
+	readOnline := c.readOnlineCPUs
+	if readOnline == nil {
+		readOnline = readSystemOnlineCPUs
+	}
+	onlineCPUs, err := readOnline()
+	var hostCapacity stats.CpuCapacity
+	if err == nil {
+		onlineCPUs = strings.TrimSpace(onlineCPUs)
+		hostCapacity, err = hostCPUCapacity(onlineCPUs)
+	}
+	if err != nil {
+		// No sample may bridge a scrape whose available CPU set is unknown.
+		c.mutex.Lock()
+		c.cpuDataCache = cpuUtilStat{}
+		for _, container := range containers {
+			if cache, ok := container.LifeResources("collector_cpu_util").(*cpuUtilStat); ok && cache != nil {
+				*cache = cpuUtilStat{}
+			}
+		}
+		c.mutex.Unlock()
+		return nil, err
+	}
+
+	metrics := make([]*metric.Data, 0, len(containers)*4+3)
 	for _, container := range containers {
-		cpuQuota, err := c.cgroup.CpuQuotaAndPeriod(container.CgroupPath)
-		if err != nil {
-			log.Infof("cpu quota: container=%s err=%v", container, err)
-			continue
-		}
-
-		numCores, err := cpuutil.BoundCores(
-			cpuQuota.Quota, cpuQuota.Period,
-			cpuQuota.EffectiveCPUCount, uint64(c.numCores),
-		)
-		if err != nil {
-			log.Infof("cpu capacity: container=%s err=%v", container, err)
-			continue
-		}
-
 		dataCache, ok := container.LifeResources("collector_cpu_util").(*cpuUtilStat)
 		if !ok || dataCache == nil {
 			log.Warnf("cpu cache: container=%s unavailable", container)
 			continue
 		}
-		if err := c.updateDataCache(dataCache, container, numCores); err != nil {
-			log.Infof("cpu usage: container=%s err=%v", container, err)
-			continue
+		data, err := c.updateContainerDataCache(dataCache, container, onlineCPUs)
+		metrics = append(metrics, data...)
+		if err != nil {
+			log.Infof("cpu utilization: container=%s err=%v", container, err)
 		}
-
-		metrics = append(
-			metrics,
-			metric.NewContainerGaugeData(container, "cores", numCores, "cpu core number for the containers", nil),
-			metric.NewContainerGaugeData(container, "usr", dataCache.usrUtil, "cpu usr for the containers", nil),
-			metric.NewContainerGaugeData(container, "sys", dataCache.sysUtil, "cpu sys for the containers", nil),
-			metric.NewContainerGaugeData(container, "total", dataCache.totalUtil, "cpu total for the containers", nil),
-		)
 	}
 
-	more, err := c.updateHostDataCache()
+	more, err := c.updateHostDataCache(hostCapacity)
 	if err != nil {
 		log.Warnf("host cpu usage: %v", err)
 	}
-
 	return append(metrics, more...), nil
 }

--- a/core/metrics/cpu_util_benchmark_test.go
+++ b/core/metrics/cpu_util_benchmark_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkCPUUtilState(b *testing.B) {
+	now := time.Unix(100, 0)
+	capacity := cpuUtilCapacity(2, 1)
+	cache := cpuUtilStat{lastTimestamp: now, capacity: capacity}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		now = now.Add(time.Second)
+		_, available := cache.update(cpuUtilUsage(uint64(i+1)*1_000_000), capacity, now)
+		if !available {
+			b.Fatal("stable sample unavailable")
+		}
+	}
+}
+
+// Isolate collector bookkeeping from the separately benchmarked cgroupfs reads.
+func BenchmarkCPUUtilCollectorStable(b *testing.B) {
+	now := time.Unix(100, 0)
+	stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1), onlineLists: make([]string, 0, 2)}
+	collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+	cache := cpuUtilStat{lastTimestamp: now, capacity: stub.capacity}
+	container := cpuUtilContainer()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		now = now.Add(time.Second)
+		stub.usage = cpuUtilUsage(uint64(i+1) * 1_000_000)
+		stub.onlineLists = stub.onlineLists[:0]
+		metrics, err := collector.updateContainerDataCache(&cache, container, "0-7")
+		if err != nil || len(metrics) != 4 {
+			b.Fatalf("stable sample metrics=%d error=%v", len(metrics), err)
+		}
+	}
+}

--- a/core/metrics/cpu_util_test.go
+++ b/core/metrics/cpu_util_test.go
@@ -15,72 +15,471 @@
 package collector
 
 import (
+	"errors"
+	"math"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"huatuo-bamai/internal/cgroups"
 	"huatuo-bamai/internal/cgroups/stats"
+	"huatuo-bamai/internal/pod"
+	"huatuo-bamai/pkg/metric"
 )
 
-type cpuUsageCgroup struct {
+type cpuUtilCgroupStub struct {
 	cgroups.Cgroup
-	usage stats.CpuUsage
+	capacity      stats.CpuCapacity
+	usage         stats.CpuUsage
+	hostUsage     stats.CpuUsage
+	capacityErr   error
+	usageErr      error
+	hostErr       error
+	capacityRead  func() (*stats.CpuCapacity, error)
+	duringUsage   func()
+	capacityCalls int
+	usageCalls    int
+	onlineLists   []string
 }
 
-func (c *cpuUsageCgroup) CpuUsage(string) (*stats.CpuUsage, error) {
-	return &c.usage, nil
-}
-
-func TestCPUUtilCollectorUpdateDataCacheCounterRegression(t *testing.T) {
-	tests := []struct {
-		name    string
-		current stats.CpuUsage
-	}{
-		{
-			name:    "total usage regresses",
-			current: stats.CpuUsage{Usage: 9, User: 6, System: 4},
-		},
-		{
-			name:    "user usage regresses",
-			current: stats.CpuUsage{Usage: 10, User: 5, System: 4},
-		},
-		{
-			name:    "system usage regresses",
-			current: stats.CpuUsage{Usage: 10, User: 6, System: 3},
-		},
+func (c *cpuUtilCgroupStub) CpuCapacity(path, onlineCPUs string) (*stats.CpuCapacity, error) {
+	if path == "" {
+		panic("host utilization must not read a cgroup quota")
 	}
+	c.capacityCalls++
+	c.onlineLists = append(c.onlineLists, onlineCPUs)
+	if c.capacityRead != nil {
+		return c.capacityRead()
+	}
+	capacity := c.capacity
+	return &capacity, c.capacityErr
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lastTimestamp := time.Now().Add(-2 * time.Second)
-			cache := cpuUtilStat{
-				lastUsage:     stats.CpuUsage{Usage: 10, User: 6, System: 4},
-				lastTimestamp: lastTimestamp,
-				totalUtil:     11,
-				usrUtil:       22,
-				sysUtil:       33,
-			}
-			collector := cpuUtilCollector{
-				cgroup: &cpuUsageCgroup{usage: tt.current},
-			}
+func (c *cpuUtilCgroupStub) CpuUsage(path string) (*stats.CpuUsage, error) {
+	c.usageCalls++
+	if path == "" {
+		usage := c.hostUsage
+		return &usage, c.hostErr
+	}
+	usage := c.usage
+	if c.duringUsage != nil {
+		c.duringUsage()
+	}
+	return &usage, c.usageErr
+}
 
-			if err := collector.updateDataCache(&cache, nil, 1); err != nil {
-				t.Fatalf("updateDataCache() error = %v", err)
-			}
-			if cache.lastUsage != tt.current {
-				t.Fatalf("last usage = %+v, want %+v", cache.lastUsage, tt.current)
-			}
-			if !cache.lastTimestamp.After(lastTimestamp) {
-				t.Fatalf("last timestamp = %v, want after %v", cache.lastTimestamp, lastTimestamp)
-			}
-			if cache.totalUtil != 11 || cache.usrUtil != 22 || cache.sysUtil != 33 {
-				t.Fatalf(
-					"utilization changed after counter regression: total=%v user=%v system=%v",
-					cache.totalUtil,
-					cache.usrUtil,
-					cache.sysUtil,
-				)
-			}
+func cpuUtilCapacity(cores float64, version byte) stats.CpuCapacity {
+	return stats.CpuCapacity{Cores: cores, ConfigID: [32]byte{version}}
+}
+
+func cpuUtilUsage(total uint64) stats.CpuUsage {
+	return stats.CpuUsage{Usage: total, User: total / 2, System: total / 4}
+}
+
+func cpuUtilContainer() *pod.Container {
+	return &pod.Container{
+		ID: "0123456789ab", CgroupPath: "/pod/container",
+		Name: "worker", Hostname: "test-pod", Type: pod.ContainerTypeNormal,
+		Labels: map[string]any{"HostNamespace": "test"},
+	}
+}
+
+func assertCPUUtilMetrics(t *testing.T, got []*metric.Data, want map[string]float64) {
+	t.Helper()
+	require.Len(t, got, len(want))
+	prefix := ""
+	if _, container := want["cores"]; container {
+		prefix = "container_"
+	}
+	expectedNames := make(map[string]float64, len(want))
+	for name, value := range want {
+		expectedNames[prefix+name] = value
+	}
+	for _, data := range got {
+		expected, ok := expectedNames[data.Name()]
+		require.True(t, ok, "unexpected metric %s", data.Name())
+		assert.InDelta(t, expected, data.Value, 1e-9, "metric %s", data.Name())
+		delete(expectedNames, data.Name())
+	}
+	assert.Empty(t, expectedNames)
+}
+
+func TestCPUUtilCollectorResizeAndBurst(t *testing.T) {
+	start := time.Unix(100, 0)
+	now := start
+	stub := &cpuUtilCgroupStub{}
+	collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+	var cache cpuUtilStat
+	container := cpuUtilContainer()
+	steps := []struct {
+		name    string
+		second  int
+		cores   float64
+		version byte
+		total   uint64
+		want    map[string]float64
+	}{
+		{"first sample", 0, 2, 1, 10_000_000, map[string]float64{"cores": 2}},
+		{"stable two cores", 1, 2, 1, 12_000_000, map[string]float64{"cores": 2, "total": 100, "usr": 50, "sys": 25}},
+		{"resize to four", 2, 4, 2, 15_000_000, map[string]float64{"cores": 4}},
+		{"stable four cores", 3, 4, 2, 17_000_000, map[string]float64{"cores": 4, "total": 50, "usr": 25, "sys": 12.5}},
+		{"resize to one", 4, 1, 3, 19_000_000, map[string]float64{"cores": 1}},
+		{"stable one core", 5, 1, 3, 19_500_000, map[string]float64{"cores": 1, "total": 50, "usr": 25, "sys": 12.5}},
+		{"quota burst", 6, 1, 3, 20_750_000, map[string]float64{"cores": 1, "total": 125, "usr": 62.5, "sys": 31.25}},
+	}
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			now = start.Add(time.Duration(step.second) * time.Second)
+			stub.capacity = cpuUtilCapacity(step.cores, step.version)
+			stub.usage = cpuUtilUsage(step.total)
+			data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, step.want)
 		})
 	}
+	require.Equal(t, len(steps)*2, stub.capacityCalls)
+	for _, online := range stub.onlineLists {
+		assert.Equal(t, "0-7", online)
+	}
+}
+
+func TestCPUUtilCollectorConfigurationChangeAtSameCapacity(t *testing.T) {
+	for _, name := range []string{"quota period", "cpuset membership", "ancestor limit", "cgroup identity"} {
+		t.Run(name, func(t *testing.T) {
+			now := time.Unix(100, 0)
+			stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1)}
+			collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+			var cache cpuUtilStat
+			container := cpuUtilContainer()
+			_, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			now = now.Add(time.Second)
+			stub.usage = cpuUtilUsage(1_000_000)
+			data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			require.Len(t, data, 4)
+
+			now = now.Add(time.Second)
+			stub.capacity.ConfigID[0]++
+			stub.usage = cpuUtilUsage(3_000_000)
+			data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2})
+
+			now = now.Add(time.Second)
+			stub.usage = cpuUtilUsage(4_000_000)
+			data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2, "total": 50, "usr": 25, "sys": 12.5})
+		})
+	}
+}
+
+func TestCPUUtilCollectorResizeDuringUsageRead(t *testing.T) {
+	now := time.Unix(100, 0)
+	stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1)}
+	collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+	var cache cpuUtilStat
+	container := cpuUtilContainer()
+	_, err := collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	now = now.Add(time.Second)
+	stub.usage = cpuUtilUsage(2_000_000)
+	stub.duringUsage = func() { stub.capacity = cpuUtilCapacity(4, 2) }
+	data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"cores": 4})
+	assert.True(t, cache.lastTimestamp.IsZero(), "mixed sample must not become a baseline")
+
+	stub.duringUsage = nil
+	now = now.Add(time.Second)
+	stub.usage = cpuUtilUsage(5_000_000)
+	data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"cores": 4})
+	now = now.Add(time.Second)
+	stub.usage = cpuUtilUsage(7_000_000)
+	data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"cores": 4, "total": 50, "usr": 25, "sys": 12.5})
+}
+
+func TestCPUUtilCollectorErrorsInvalidateBaseline(t *testing.T) {
+	failure := errors.New("cgroup read failed")
+	for _, source := range []string{"capacity before", "usage", "capacity after"} {
+		t.Run(source, func(t *testing.T) {
+			now := time.Unix(100, 0)
+			stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1)}
+			collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+			var cache cpuUtilStat
+			container := cpuUtilContainer()
+			_, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			now = now.Add(time.Second)
+			stub.usage = cpuUtilUsage(1_000_000)
+			_, err = collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+
+			now = now.Add(time.Second)
+			switch source {
+			case "capacity before":
+				stub.capacityErr = failure
+			case "usage":
+				stub.usageErr = failure
+			case "capacity after":
+				stub.duringUsage = func() { stub.capacityErr = failure }
+			}
+			data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.ErrorIs(t, err, failure)
+			if source == "capacity before" {
+				require.Empty(t, data)
+			} else {
+				assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2})
+			}
+			assert.True(t, cache.lastTimestamp.IsZero())
+
+			stub.capacityErr, stub.usageErr, stub.duringUsage = nil, nil, nil
+			now = now.Add(10 * time.Second)
+			stub.usage = cpuUtilUsage(30_000_000)
+			data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2})
+			now = now.Add(time.Second)
+			stub.usage = cpuUtilUsage(31_000_000)
+			data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2, "total": 50, "usr": 25, "sys": 12.5})
+		})
+	}
+}
+
+func TestCPUUtilCollectorCapacitySnapshotIsCopied(t *testing.T) {
+	now := time.Unix(100, 0)
+	stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1)}
+	stub.capacityRead = func() (*stats.CpuCapacity, error) { return &stub.capacity, nil }
+	collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+	var cache cpuUtilStat
+	container := cpuUtilContainer()
+	_, err := collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	now = now.Add(time.Second)
+	stub.usage = cpuUtilUsage(1_000_000)
+	stub.duringUsage = func() { stub.capacity.ConfigID[0]++ }
+	data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2})
+	assert.True(t, cache.lastTimestamp.IsZero(), "same cores with different configuration is still a mixed sample")
+}
+
+func TestCPUUtilCollectorShortIntervalsDoNotReuseUtilization(t *testing.T) {
+	start := time.Unix(100, 0)
+	now := start
+	stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1)}
+	collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+	var cache cpuUtilStat
+	container := cpuUtilContainer()
+	for _, step := range []struct {
+		elapsed  time.Duration
+		capacity stats.CpuCapacity
+		total    uint64
+		want     map[string]float64
+	}{
+		{0, cpuUtilCapacity(2, 1), 0, map[string]float64{"cores": 2}},
+		{100 * time.Millisecond, cpuUtilCapacity(4, 2), 100_000, map[string]float64{"cores": 4}},
+		{200 * time.Millisecond, cpuUtilCapacity(1, 3), 200_000, map[string]float64{"cores": 1}},
+		{1100 * time.Millisecond, cpuUtilCapacity(1, 3), 650_000, map[string]float64{"cores": 1}},
+		{1200 * time.Millisecond, cpuUtilCapacity(1, 3), 700_000, map[string]float64{"cores": 1, "total": 50, "usr": 25, "sys": 12.5}},
+		{1200 * time.Millisecond, cpuUtilCapacity(1, 3), 700_000, map[string]float64{"cores": 1}},
+		{1201 * time.Millisecond, cpuUtilCapacity(1, 3), 700_500, map[string]float64{"cores": 1}},
+	} {
+		now = start.Add(step.elapsed)
+		stub.capacity, stub.usage = step.capacity, cpuUtilUsage(step.total)
+		data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+		require.NoError(t, err)
+		assertCPUUtilMetrics(t, data, step.want)
+	}
+}
+
+func TestCPUUtilCollectorCounterRegression(t *testing.T) {
+	for _, field := range []string{"total", "user", "system"} {
+		t.Run(field, func(t *testing.T) {
+			now := time.Unix(100, 0)
+			previous := stats.CpuUsage{Usage: 10_000_000, User: 6_000_000, System: 4_000_000}
+			current := previous
+			switch field {
+			case "total":
+				current.Usage--
+			case "user":
+				current.User--
+			case "system":
+				current.System--
+			}
+			stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1), usage: previous}
+			collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+			var cache cpuUtilStat
+			container := cpuUtilContainer()
+			_, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			now = now.Add(time.Second)
+			stub.usage = current
+			data, err := collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2})
+			assert.Equal(t, current, cache.lastUsage)
+			assert.Equal(t, now, cache.lastTimestamp)
+
+			now = now.Add(time.Second)
+			stub.usage = stats.CpuUsage{Usage: current.Usage + 1_000_000, User: current.User + 500_000, System: current.System + 250_000}
+			data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+			require.NoError(t, err)
+			assertCPUUtilMetrics(t, data, map[string]float64{"cores": 2, "total": 50, "usr": 25, "sys": 12.5})
+		})
+	}
+}
+
+func TestCPUUtilCollectorHostAndContainerIsolation(t *testing.T) {
+	now := time.Unix(100, 0)
+	stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(2, 1)}
+	collector := &cpuUtilCollector{cgroup: stub, now: func() time.Time { return now }}
+	hostCapacity, err := hostCPUCapacity("0-7")
+	require.NoError(t, err)
+	var cache cpuUtilStat
+	container := cpuUtilContainer()
+	_, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	data, err := collector.updateHostDataCache(hostCapacity)
+	require.NoError(t, err)
+	require.Empty(t, data)
+
+	now = now.Add(time.Second)
+	stub.capacity = cpuUtilCapacity(4, 2)
+	stub.usage, stub.hostUsage = cpuUtilUsage(2_000_000), cpuUtilUsage(4_000_000)
+	data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"cores": 4})
+	data, err = collector.updateHostDataCache(hostCapacity)
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"total": 50, "usr": 25, "sys": 12.5})
+
+	now = now.Add(time.Second)
+	stub.capacityErr = errors.New("container disappeared")
+	stub.hostUsage = cpuUtilUsage(8_000_000)
+	_, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.Error(t, err)
+	data, err = collector.updateHostDataCache(hostCapacity)
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"total": 50, "usr": 25, "sys": 12.5})
+
+	stub.capacityErr = nil
+	_, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	now = now.Add(time.Second)
+	stub.usage = cpuUtilUsage(4_000_000)
+	stub.hostErr = errors.New("host read failed")
+	data, err = collector.updateContainerDataCache(&cache, container, "0-7")
+	require.NoError(t, err)
+	assertCPUUtilMetrics(t, data, map[string]float64{"cores": 4, "total": 50, "usr": 25, "sys": 12.5})
+	data, err = collector.updateHostDataCache(hostCapacity)
+	require.Error(t, err)
+	require.Empty(t, data)
+	assert.True(t, collector.cpuDataCache.lastTimestamp.IsZero())
+
+	stub.hostErr = nil
+	now = now.Add(time.Second)
+	stub.hostUsage = cpuUtilUsage(12_000_000)
+	data, err = collector.updateHostDataCache(hostCapacity)
+	require.NoError(t, err)
+	require.Empty(t, data)
+}
+
+func TestCPUUtilCollectorOnlineCPUChanges(t *testing.T) {
+	now := time.Unix(100, 0)
+	online, reads := "0-1", 0
+	var readErr error
+	stub := &cpuUtilCgroupStub{}
+	collector := &cpuUtilCollector{
+		cgroup: stub, now: func() time.Time { return now },
+		readOnlineCPUs: func() (string, error) { reads++; return online, readErr },
+	}
+	steps := []struct {
+		online string
+		total  uint64
+		want   map[string]float64
+	}{
+		{"0-1", 0, nil},
+		{"0-1", 1_000_000, map[string]float64{"total": 50, "usr": 25, "sys": 12.5}},
+		{"0-3", 3_000_000, nil},
+		{"0-3", 5_000_000, map[string]float64{"total": 50, "usr": 25, "sys": 12.5}},
+		{"4-7", 7_000_000, nil},
+		{"4-7", 9_000_000, map[string]float64{"total": 50, "usr": 25, "sys": 12.5}},
+	}
+	for _, step := range steps {
+		online, stub.hostUsage = step.online, cpuUtilUsage(step.total)
+		data, err := collector.updateMetrics(nil)
+		require.NoError(t, err)
+		assertCPUUtilMetrics(t, data, step.want)
+		now = now.Add(time.Second)
+	}
+	assert.Equal(t, len(steps), reads, "online CPUs should be read once per update")
+
+	readErr = errors.New("online CPUs unavailable")
+	data, err := collector.updateMetrics(nil)
+	require.ErrorIs(t, err, readErr)
+	require.Empty(t, data)
+	assert.True(t, collector.cpuDataCache.lastTimestamp.IsZero())
+	readErr = nil
+	now = now.Add(time.Second)
+	stub.hostUsage = cpuUtilUsage(12_000_000)
+	data, err = collector.updateMetrics(nil)
+	require.NoError(t, err)
+	require.Empty(t, data)
+}
+
+func TestCPUUtilCollectorInvalidCapacity(t *testing.T) {
+	for _, cores := range []float64{0, -1, math.NaN(), math.Inf(1)} {
+		stub := &cpuUtilCgroupStub{capacity: cpuUtilCapacity(cores, 1)}
+		collector := &cpuUtilCollector{cgroup: stub}
+		cache := cpuUtilStat{lastTimestamp: time.Unix(100, 0)}
+		data, err := collector.updateContainerDataCache(&cache, cpuUtilContainer(), "0-7")
+		require.Error(t, err)
+		require.Empty(t, data)
+		assert.True(t, cache.lastTimestamp.IsZero())
+	}
+}
+
+func TestCPUUtilCollectorInvalidOnlineCPUList(t *testing.T) {
+	for _, online := range []string{"", "invalid", "3-1"} {
+		t.Run(online, func(t *testing.T) {
+			stub := &cpuUtilCgroupStub{}
+			collector := &cpuUtilCollector{
+				cgroup:         stub,
+				cpuDataCache:   cpuUtilStat{lastTimestamp: time.Unix(100, 0)},
+				readOnlineCPUs: func() (string, error) { return online, nil },
+			}
+			data, err := collector.updateMetrics(nil)
+			require.Error(t, err)
+			require.Empty(t, data)
+			assert.Zero(t, stub.usageCalls)
+			assert.True(t, collector.cpuDataCache.lastTimestamp.IsZero())
+		})
+	}
+}
+
+func TestCPUUtilStateClockRegressionAndLargeCounters(t *testing.T) {
+	start := time.Unix(100, 0)
+	capacity := cpuUtilCapacity(1, 1)
+	cache := cpuUtilStat{lastTimestamp: start, capacity: capacity}
+	_, available := cache.update(cpuUtilUsage(100), capacity, start.Add(-time.Second))
+	require.False(t, available)
+	assert.Equal(t, start.Add(-time.Second), cache.lastTimestamp)
+
+	cache = cpuUtilStat{lastTimestamp: start, capacity: capacity}
+	sample, available := cache.update(stats.CpuUsage{Usage: math.MaxUint64, User: math.MaxUint64, System: math.MaxUint64}, capacity, start.Add(time.Second))
+	require.True(t, available)
+	assert.Greater(t, sample.total, float64(100))
+	assert.Equal(t, sample.total, sample.usr)
+	assert.Equal(t, sample.total, sample.sys)
+	assert.False(t, math.IsInf(sample.total, 0))
 }

--- a/docs/development/integration_en.md
+++ b/docs/development/integration_en.md
@@ -81,3 +81,23 @@ New *.txt files are automatically picked up by the test.
 bash integration/run.sh
 ```
 The test fails if any expected metric is missing or mismatched.
+
+### Real cgroup CPU Capacity
+
+`test_cpu_capacity.sh` checks ancestor and leaf quotas, different periods,
+cpuset inheritance, resize configuration changes, and the CPU budget shared by
+two sibling cgroups. It requires Linux cgroup v2, Go, and an explicitly delegated
+writable directory with `cpu` and `cpuset` enabled in `cgroup.subtree_control`:
+
+```bash
+HUATUO_CPU_CAPACITY_CGROUP_ROOT=/path/to/delegated/test-cgroup \
+  bash integration/run.sh test_cpu_capacity.sh
+```
+
+Use a dedicated test environment, not a production hierarchy. The test does not
+enable controllers or change limits on the supplied directory. It creates an
+exclusive subtree capped at one CPU, runs two two-second workers under a shared
+half-CPU parent, then removes only its own processes and cgroups. Missing
+prerequisites produce an explicit `SKIP`, not a verified result. A single-CPU
+cpuset skips only the cpuset-resize assertion. Collector interval invalidation
+is covered separately by the fake-clock CPU utilization unit tests.

--- a/docs/development/integration_zh.md
+++ b/docs/development/integration_zh.md
@@ -72,3 +72,20 @@ integration/fixtures/expected_metrics/
 bash integration/run.sh
 ```
 当任意一个预期指标缺失或不匹配时，测试将失败。
+
+### 真实 cgroup CPU 容量测试
+
+`test_cpu_capacity.sh` 验证祖先与叶级配额、不同 period、cpuset 继承、resize
+配置变化以及两个兄弟 cgroup 共享的 CPU 预算。运行需要 Linux cgroup v2、Go，
+以及显式委派的可写目录，其 `cgroup.subtree_control` 已启用 `cpu` 和 `cpuset`：
+
+```bash
+HUATUO_CPU_CAPACITY_CGROUP_ROOT=/path/to/delegated/test-cgroup \
+  bash integration/run.sh test_cpu_capacity.sh
+```
+
+请使用专用测试环境，不要使用生产层级。测试不会替所传目录启用控制器或修改其
+限额，只在其下创建独占子树：总上限为 1 CPU，两个运行两秒的工作进程共享父级
+0.5 CPU 配额，结束后仅清理自建进程和 cgroup。前置条件不足会明确输出 `SKIP`，
+不代表验证通过；cpuset 只有一个 CPU 时仅跳过 cpuset resize 断言。collector
+跨配置区间的弃样行为由独立的假时钟 CPU 利用率单元测试验证。

--- a/docs/key-feature/kernel-wide-insight_en.md
+++ b/docs/key-feature/kernel-wide-insight_en.md
@@ -69,6 +69,13 @@ huatuo_bamai_softirq_latency{cpuid="1",host="hostname",region="dev",type="NET_TX
 
 Metrics showing CPU usage on hosts and containers (Prometheus format):
 
+Container utilization is normalized by the effective CPU capacity described
+below. The first observation only establishes a baseline. After an observed
+quota, period, CPU-set or cgroup identity change, a counter reset, or a read
+failure, utilization is omitted until a new stable interval of at least one
+second is available. The collector does not replay the previous percentage or
+substitute zero for an invalid interval. Valid quota bursts can exceed 100%.
+
 ```bash
 # HELP huatuo_bamai_cpu_util_sys cpu sys for the host
 # TYPE huatuo_bamai_cpu_util_sys gauge
@@ -104,6 +111,20 @@ huatuo_bamai_cpu_util_container_usr{container_host="coredns-855c4dd65d-8v5kg",co
 
 Container CPU resource configuration:
 
+`cpu_util_container_cores` is the visible CPU capacity ceiling, not the raw
+leaf quota: it is bounded by online CPUs, the effective CPU set, and every
+visible ancestor's quota divided by that ancestor's own period. For example,
+an unlimited leaf with 32 allowed CPUs under a two-CPU parent reports two
+cores. The parent's quota is shared with siblings, not reserved for each leaf.
+
+The existing metric name and labels are retained; installations with tighter
+ancestor limits will observe smaller `cores` and correspondingly higher
+normalized utilization. Raw cgroup quota/period reads are unchanged. Ancestors
+hidden by the cgroup mount or namespace cannot be included. Polling can detect
+changes between observed configurations, but not a change and reversal entirely
+between observations. The legacy v1 reader retains the existing assumption
+that CPU, CPU accounting and cpuset controllers use the same relative path.
+
 ```bash
 # HELP huatuo_bamai_cpu_util_container_cores cpu core number for the containers
 # TYPE huatuo_bamai_cpu_util_container_cores gauge
@@ -112,7 +133,7 @@ huatuo_bamai_cpu_util_container_cores{container_host="coredns-855c4dd65d-8v5kg",
 
 |Metric|Description|Unit|Target|Labels|
 |---|---|---|---|---|
-|cpu_util_container_cores| Number of CPU cores|cores| Container | (same as above) |
+|cpu_util_container_cores| Visible CPU capacity ceiling after ancestor quota and CPU-set limits|cores| Container | (same as above) |
 
 ### Contention
 

--- a/docs/key-feature/kernel-wide-insight_zh.md
+++ b/docs/key-feature/kernel-wide-insight_zh.md
@@ -68,6 +68,11 @@ huatuo_bamai_softirq_latency{cpuid="1",host="hostname",region="dev",type="NET_TX
 ### 资源利用率
 
 通过如下指标可以观测，物理机，容器的 CPU 资源使用情况，prometheus 指标格式：
+
+容器利用率按下文的有效 CPU 容量归一化。首次观测只建立基线；观测到 quota、period、
+CPU 集合或 cgroup 身份变化，以及计数器回退、读取失败后，需重新取得至少一秒的稳定区间，
+才输出利用率。无效区间不会重发旧百分比，也不会用零代替。合法的配额突发使用可能超过 100%。
+
 ```bash
 # HELP huatuo_bamai_cpu_util_sys cpu sys for the host
 # TYPE huatuo_bamai_cpu_util_sys gauge
@@ -102,6 +107,17 @@ huatuo_bamai_cpu_util_container_usr{container_host="coredns-855c4dd65d-8v5kg",co
 ### 资源配置
 
 通过如下指标可以了解容器 CPU 资源配置情况，prometheus 指标格式：
+
+`cpu_util_container_cores` 表示可见 CPU 容量上限，不是原始叶级 quota：它同时受在线 CPU、
+有效 CPU 集合，以及所有可见祖先各自的 quota/period 比值约束。例如，叶级 unlimited、
+允许使用 32 个 CPU，但父级只有两核预算时，报告两核。父级配额由兄弟 cgroup 共享，
+不代表为每个叶级独占预留的资源。
+
+指标名称和标签不变；祖先限制更紧的部署会看到更小的 `cores` 和相应提高的归一化利用率。
+原始 cgroup quota/period 读取接口不变。挂载或命名空间之外不可见的祖先无法计入；
+轮询也无法发现两次观测之间完整发生的“变更后又恢复”。v1 读取仍沿用原有约定：
+CPU、CPU accounting 和 cpuset 控制器使用相同的相对路径。
+
 ```bash
 # HELP huatuo_bamai_cpu_util_container_cores cpu core number for the containers
 # TYPE huatuo_bamai_cpu_util_container_cores gauge
@@ -110,7 +126,7 @@ huatuo_bamai_cpu_util_container_cores{container_host="coredns-855c4dd65d-8v5kg",
 
 |指标|意义|单位|对象| 标签 |
 |---|---|---|---|---|
-|cpu_util_container_cores| CPU 核心数|个| 容器 | container_host, container_hostnamespace, container_level, container_name, container_type, host, region |
+|cpu_util_container_cores| 计入祖先配额和 CPU 集合限制后的可见 CPU 容量上限|个| 容器 | container_host, container_hostnamespace, container_level, container_name, container_type, host, region |
 
 ### 资源争抢
 

--- a/integration/test_cpu_capacity.sh
+++ b/integration/test_cpu_capacity.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The HuaTuo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "${ROOT_DIR}/integration/lib.sh"
+
+readonly DELEGATED_ROOT=${HUATUO_CPU_CAPACITY_CGROUP_ROOT:-}
+[[ -n "${DELEGATED_ROOT}" ]] \
+	|| skip "set HUATUO_CPU_CAPACITY_CGROUP_ROOT to an explicitly delegated cgroup v2 directory"
+[[ -d "${DELEGATED_ROOT}" ]] \
+	|| skip "delegated cgroup directory does not exist: ${DELEGATED_ROOT}"
+[[ -w "${DELEGATED_ROOT}" ]] \
+	|| skip "delegated cgroup directory is not writable: ${DELEGATED_ROOT}"
+command -v go > /dev/null || skip "go command is not installed"
+
+readonly WORK_DIR=$(mktemp -d "${HUATUO_BAMAI_TEST_TMPDIR}/cpu-capacity.XXXXXX")
+readonly PROBE_BIN="${WORK_DIR}/cpu-capacity"
+readonly PROBE_LOG="${WORK_DIR}/cpu-capacity.log"
+
+go build -mod=vendor -tags=integration -o "${PROBE_BIN}" \
+	"${ROOT_DIR}/integration/testdata/cpu_capacity.go" \
+	> "${WORK_DIR}/build.log" 2>&1 \
+	|| fatal "failed to build CPU capacity probe:"$'\n'"$(< "${WORK_DIR}/build.log")"
+
+# The probe verifies cgroup2 mount/delegation before creating an owned subtree.
+# It never remounts cgroupfs or modifies the supplied root's controller settings.
+if "${PROBE_BIN}" "${DELEGATED_ROOT}" > "${PROBE_LOG}" 2>&1; then
+	log_info "$(< "${PROBE_LOG}")"
+	log_info "real cgroup v2 CPU capacity integration test passed"
+else
+	probe_status=$?
+	[[ ${probe_status} -ne 77 ]] || skip "$(< "${PROBE_LOG}")"
+	fatal "CPU capacity probe failed (${probe_status}):"$'\n'"$(< "${PROBE_LOG}")"
+fi

--- a/integration/testdata/cpu_capacity.go
+++ b/integration/testdata/cpu_capacity.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"huatuo-bamai/internal/cgroups/paths"
+	"huatuo-bamai/internal/cgroups/stats"
+	v2 "huatuo-bamai/internal/cgroups/v2"
+	"huatuo-bamai/internal/utils/cpuutil"
+
+	"golang.org/x/sys/unix"
+)
+
+type skipError string
+
+func (e skipError) Error() string { return string(e) }
+
+func main() {
+	var err error
+	if len(os.Args) == 2 && os.Args[1] == "--burn" {
+		err = burn()
+	} else {
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		err = runCPUCapacity(ctx)
+		stop()
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		var skipped skipError
+		if errors.As(err, &skipped) {
+			os.Exit(77)
+		}
+		os.Exit(1)
+	}
+}
+
+func runCPUCapacity(ctx context.Context) (retErr error) {
+	if len(os.Args) != 2 || !filepath.IsAbs(os.Args[1]) {
+		return errors.New("usage: cpu-capacity ABSOLUTE_DELEGATED_CGROUP_ROOT")
+	}
+	root, err := filepath.EvalSymlinks(os.Args[1])
+	if err != nil {
+		return skipError(fmt.Sprintf("resolve delegated cgroup root: %v", err))
+	}
+	var filesystem unix.Statfs_t
+	if err := unix.Statfs(root, &filesystem); err != nil {
+		return fmt.Errorf("inspect delegated cgroup filesystem: %w", err)
+	}
+	if filesystem.Type != unix.CGROUP2_SUPER_MAGIC {
+		return skipError("delegated root is not on a real cgroup v2 filesystem")
+	}
+	if filesystem.Flags&unix.ST_RDONLY != 0 {
+		return skipError("delegated cgroup v2 mount is read-only")
+	}
+	controllers, err := os.ReadFile(filepath.Join(root, "cgroup.subtree_control"))
+	if err != nil {
+		return skipError(fmt.Sprintf("read delegated controllers: %v", err))
+	}
+	for _, controller := range []string{"cpu", "cpuset"} {
+		if !slices.Contains(strings.Fields(string(controllers)), controller) {
+			return skipError("delegated root must already enable cpu and cpuset in cgroup.subtree_control")
+		}
+	}
+	online, err := os.ReadFile(cpuutil.SystemCPUOnlinePath)
+	if err != nil {
+		return fmt.Errorf("read online CPUs: %w", err)
+	}
+	// This is a real delegated mount subtree, not a regular-file fixture.
+	paths.RootfsDefaultPath = root
+	manager := &v2.CgroupV2{}
+	capacity, err := manager.CpuCapacity("", string(online))
+	if err != nil {
+		return fmt.Errorf("read delegated root capacity: %w", err)
+	}
+	if capacity.Cores < 1 {
+		return skipError("delegated root needs at least one visible CPU of capacity")
+	}
+	owned, err := os.MkdirTemp(root, "huatuo-cpu-capacity-")
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) || errors.Is(err, unix.EROFS) {
+			return skipError(fmt.Sprintf("create owned subtree in delegated root: %v", err))
+		}
+		return fmt.Errorf("create owned cgroup subtree: %w", err)
+	}
+	directories := []string{owned}
+	defer func() {
+		for i := len(directories) - 1; i >= 0; i-- {
+			if err := os.Remove(directories[i]); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("remove owned cgroup %q: %w", directories[i], err))
+			}
+		}
+	}()
+	if err := writeControl(owned, "cpu.max", "100000 100000"); err != nil {
+		return err
+	}
+	if err := writeControl(owned, "cgroup.subtree_control", "+cpu +cpuset"); err != nil {
+		return err
+	}
+	parent := filepath.Join(owned, "parent")
+	child := filepath.Join(parent, "child")
+	sibling := filepath.Join(parent, "sibling")
+	for _, dir := range []string{parent, child, sibling} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			return fmt.Errorf("create owned cgroup %q: %w", dir, err)
+		}
+		directories = append(directories, dir)
+		if dir == parent {
+			if err := writeControl(parent, "cpu.max", "50000 100000"); err != nil {
+				return err
+			}
+			if err := writeControl(parent, "cgroup.subtree_control", "+cpu +cpuset"); err != nil {
+				return err
+			}
+		}
+	}
+	check := func(path string, want float64) (*stats.CpuCapacity, error) {
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil, err
+		}
+		got, err := manager.CpuCapacity(relative, string(online))
+		if err != nil {
+			return nil, fmt.Errorf("read capacity of %q: %w", relative, err)
+		}
+		if math.Abs(got.Cores-want) > 1e-9 {
+			return nil, fmt.Errorf("capacity of %q: got %g CPUs, want %g", relative, got.Cores, want)
+		}
+		return got, nil
+	}
+	initial, err := check(child, 0.5)
+	if err != nil {
+		return err
+	}
+	if _, err := check(sibling, 0.5); err != nil {
+		return err
+	}
+	for _, limit := range []struct {
+		path, value string
+		want        float64
+	}{{child, "25000 100000", 0.25}, {sibling, "20000 50000", 0.4}} {
+		if err := writeControl(limit.path, "cpu.max", limit.value); err != nil {
+			return err
+		}
+		if _, err := check(limit.path, limit.want); err != nil {
+			return err
+		}
+		if err := writeControl(limit.path, "cpu.max", "max 100000"); err != nil {
+			return err
+		}
+	}
+	for _, limit := range []struct {
+		value string
+		want  float64
+	}{{"25000 100000", 0.25}, {"50000 100000", 0.5}, {"25000 50000", 0.5}} {
+		if err := writeControl(parent, "cpu.max", limit.value); err != nil {
+			return err
+		}
+		resized, err := check(child, limit.want)
+		if err != nil {
+			return err
+		}
+		if resized.ConfigID == initial.ConfigID {
+			return fmt.Errorf("parent resize to %q did not change child ConfigID", limit.value)
+		}
+		if _, err := check(sibling, limit.want); err != nil {
+			return err
+		}
+		initial = resized
+	}
+	if err := writeControl(parent, "cpu.max", "50000 100000"); err != nil {
+		return err
+	}
+	initial, err = check(child, 0.5)
+	if err != nil {
+		return err
+	}
+	effective, err := os.ReadFile(filepath.Join(parent, "cpuset.cpus.effective"))
+	if err != nil {
+		return fmt.Errorf("read inherited effective cpuset: %w", err)
+	}
+	ids := strings.FieldsFunc(strings.TrimSpace(string(effective)), func(r rune) bool { return r == ',' || r == '-' })
+	if len(ids) == 0 {
+		return errors.New("owned parent has no effective CPUs")
+	}
+	if strings.TrimSpace(string(effective)) != ids[0] {
+		if err := writeControl(parent, "cpuset.cpus", ids[0]); err != nil {
+			return err
+		}
+		resized, err := check(child, 0.5)
+		if err != nil {
+			return err
+		}
+		if resized.ConfigID == initial.ConfigID {
+			return errors.New("ancestor cpuset resize did not change child ConfigID")
+		}
+	} else {
+		fmt.Println("[SKIP] cpuset resize: delegated tree has only one effective CPU")
+	}
+	fmt.Println("real hierarchy: shared ancestor ceiling, leaf limits, periods and resize ConfigID verified")
+	return verifySharedBudget(ctx, root, parent, []string{child, sibling}, manager)
+}
+
+func writeControl(group, name, value string) error {
+	path := filepath.Join(group, name)
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open owned cgroup control %q: %w", path, err)
+	}
+	_, writeErr := io.WriteString(file, value+"\n")
+	if err := errors.Join(writeErr, file.Close()); err != nil {
+		return fmt.Errorf("write owned cgroup control %q: %w", path, err)
+	}
+	return nil
+}
+
+func verifySharedBudget(ctx context.Context, root, parent string, leaves []string, manager *v2.CgroupV2) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	var commands []*exec.Cmd
+	var gates []*os.File
+	defer func() {
+		for _, cmd := range commands {
+			if cmd.ProcessState == nil {
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			}
+		}
+		for _, gate := range gates {
+			_ = gate.Close()
+		}
+	}()
+	for _, leaf := range leaves {
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			return fmt.Errorf("create CPU worker gate: %w", err)
+		}
+		gates = append(gates, writer)
+		cmd := exec.CommandContext(ctx, os.Args[0], "--burn")
+		cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+		cmd.Stdin = reader
+		cmd.Stderr = os.Stderr
+		err = cmd.Start()
+		_ = reader.Close()
+		if err != nil {
+			return fmt.Errorf("start bounded CPU worker: %w", err)
+		}
+		commands = append(commands, cmd)
+		if err := writeControl(leaf, "cgroup.procs", strconv.Itoa(cmd.Process.Pid)); err != nil {
+			return err
+		}
+	}
+	parentPath, err := filepath.Rel(root, parent)
+	if err != nil {
+		return err
+	}
+	before, err := manager.CpuStatRaw(parentPath)
+	if err != nil {
+		return fmt.Errorf("read parent CPU counters before workload: %w", err)
+	}
+	started := time.Now()
+	for _, gate := range gates {
+		if _, err := gate.Write([]byte{1}); err != nil {
+			return fmt.Errorf("release bounded CPU worker: %w", err)
+		}
+	}
+	for _, cmd := range commands {
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("bounded CPU worker: %w", err)
+		}
+	}
+	elapsed := time.Since(started)
+	var childrenUsage uint64
+	for _, leaf := range leaves {
+		path, err := filepath.Rel(root, leaf)
+		if err != nil {
+			return err
+		}
+		usage, err := manager.CpuUsage(path)
+		if err != nil {
+			return fmt.Errorf("read worker CPU usage: %w", err)
+		}
+		if usage.Usage == 0 {
+			return fmt.Errorf("worker cgroup %q accumulated no CPU usage", path)
+		}
+		childrenUsage += usage.Usage
+	}
+	after, err := manager.CpuStatRaw(parentPath)
+	if err != nil {
+		return fmt.Errorf("read parent CPU counters after workload: %w", err)
+	}
+	if after["usage_usec"] < before["usage_usec"] || after["nr_throttled"] <= before["nr_throttled"] {
+		return errors.New("shared parent did not accumulate monotonic usage and throttling; check external CPU restrictions")
+	}
+	// Allow period-boundary runtime; do not assert equal shares for siblings.
+	budgetUS := float64(elapsed.Microseconds())*0.5 + 150000
+	if float64(after["usage_usec"]-before["usage_usec"]) > budgetUS {
+		return fmt.Errorf("parent consumed %d us over %s, exceeding 0.5 CPU budget plus period tolerance",
+			after["usage_usec"]-before["usage_usec"], elapsed)
+	}
+	if childrenUsage > after["usage_usec"] {
+		return errors.New("children CPU usage exceeds hierarchical parent usage")
+	}
+	fmt.Printf("real shared budget: child usage=%d us, parent usage=%d us, throttled periods=%d, elapsed=%s\n",
+		childrenUsage, after["usage_usec"]-before["usage_usec"], after["nr_throttled"]-before["nr_throttled"], elapsed)
+	return nil
+}
+
+var burnSink uint64
+
+func burn() error {
+	if _, err := io.ReadFull(os.Stdin, make([]byte, 1)); err != nil {
+		return fmt.Errorf("wait for owned-cgroup placement: %w", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	value := uint64(1)
+	for time.Now().Before(deadline) {
+		for i := 0; i < 16384; i++ {
+			value = value*2862933555777941757 + 3037000493
+		}
+	}
+	burnSink = value
+	return nil
+}

--- a/internal/cgroups/capacity/cpu.go
+++ b/internal/cgroups/capacity/cpu.go
@@ -1,0 +1,304 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package capacity reads CPU ceilings without changing raw leaf quota APIs.
+package capacity
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"huatuo-bamai/internal/cgroups/stats"
+	"huatuo-bamai/internal/utils/cpuutil"
+)
+
+// ReadV1 uses the same relative path in the cpu, cpuacct and cpuset controllers.
+func ReadV1(root, path, onlineCPUs string) (*stats.CpuCapacity, error) {
+	return read(root, path, onlineCPUs, false)
+}
+
+// ReadV2 stops at the visible root; limits above that mount are not observable.
+func ReadV2(root, path, onlineCPUs string) (*stats.CpuCapacity, error) {
+	return read(root, path, onlineCPUs, true)
+}
+
+type reader struct {
+	cores    float64
+	config   strings.Builder
+	cpuLists []string
+}
+
+type hierarchy struct {
+	root *os.Root
+	dirs []string
+}
+
+func read(root, path, onlineCPUs string, unified bool) (*stats.CpuCapacity, error) {
+	count, err := cpuutil.ParseCPUListCount(onlineCPUs)
+	if err != nil {
+		return nil, fmt.Errorf("parse online CPUs: %w", err)
+	}
+	if count == 0 {
+		return nil, errors.New("online CPU list is empty")
+	}
+	r := reader{cores: float64(count), cpuLists: []string{onlineCPUs}}
+	r.record("online", strings.TrimSpace(onlineCPUs), path, strconv.FormatBool(unified))
+	cpuRoot := root
+	if !unified {
+		cpuRoot = filepath.Join(root, "cpu")
+	}
+	cpu, err := r.openHierarchy(cpuRoot, path)
+	if err != nil {
+		return nil, err
+	}
+	defer cpu.root.Close()
+
+	for _, dir := range cpu.dirs {
+		if unified {
+			err = r.quotaV2(cpu, dir)
+		} else {
+			err = r.quotaV1(cpu, dir)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if unified {
+		err = r.cpuset(cpu, true)
+	} else {
+		// cpuacct can be a separate hierarchy: its generation owns usage deltas.
+		usage, usageErr := r.openHierarchy(filepath.Join(root, "cpuacct"), path)
+		if usageErr != nil {
+			return nil, usageErr
+		}
+		_ = usage.root.Close()
+		cpusetRoot := filepath.Join(root, "cpuset")
+		var cpuset *hierarchy
+		cpuset, err = r.openHierarchy(cpusetRoot, path)
+		if err != nil {
+			// An absent controller is different from a missing container in it.
+			if _, rootErr := os.Lstat(cpusetRoot); errors.Is(rootErr, fs.ErrNotExist) {
+				r.record("cpuset controller absent", cpusetRoot)
+				err = nil
+			}
+		} else {
+			defer cpuset.root.Close()
+			err = r.cpuset(cpuset, false)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	available, err := cpuutil.CPUListIntersectionCount(r.cpuLists...)
+	if err != nil {
+		return nil, fmt.Errorf("intersect online and cpuset CPUs: %w", err)
+	}
+	if available == 0 {
+		return nil, errors.New("cpuset has no online CPUs")
+	}
+	r.cores = min(r.cores, float64(available))
+	return &stats.CpuCapacity{
+		Cores:    r.cores,
+		ConfigID: sha256.Sum256([]byte(r.config.String())),
+	}, nil
+}
+
+func (r *reader) record(parts ...string) {
+	for _, part := range parts {
+		r.config.WriteString(part)
+		r.config.WriteByte(0)
+	}
+}
+
+func (r *reader) openHierarchy(root, path string) (*hierarchy, error) {
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
+		if part == ".." {
+			return nil, fmt.Errorf("cgroup path %q contains a parent traversal", path)
+		}
+	}
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve cgroup root %q: %w", root, err)
+	}
+	realRoot, err = filepath.Abs(realRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve absolute cgroup root %q: %w", realRoot, err)
+	}
+	leaf, err := filepath.EvalSymlinks(filepath.Join(realRoot, strings.TrimPrefix(path, "/")))
+	if err != nil {
+		return nil, fmt.Errorf("resolve cgroup %q in %q: %w", path, root, err)
+	}
+	relative, err := filepath.Rel(realRoot, leaf)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("cgroup path %q escapes root %q", path, root)
+	}
+	// Root also confines individual control-file symlinks during the read.
+	directory, err := os.OpenRoot(realRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open cgroup root %q: %w", realRoot, err)
+	}
+	h := &hierarchy{root: directory}
+	r.record("hierarchy", root, realRoot)
+	for dir := relative; ; dir = filepath.Dir(dir) {
+		info, err := directory.Stat(dir)
+		if err != nil || !info.IsDir() {
+			_ = directory.Close()
+			if err != nil {
+				return nil, fmt.Errorf("stat cgroup %q in %q: %w", dir, realRoot, err)
+			}
+			return nil, fmt.Errorf("cgroup %q in %q is not a directory", dir, realRoot)
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			_ = directory.Close()
+			return nil, fmt.Errorf("cgroup %q in %q has no filesystem identity", dir, realRoot)
+		}
+		r.record(dir, strconv.FormatUint(stat.Dev, 10), strconv.FormatUint(stat.Ino, 10))
+		h.dirs = append(h.dirs, dir)
+		if dir == "." {
+			return h, nil
+		}
+	}
+}
+
+func (r *reader) readFile(h *hierarchy, dir, name string) (string, error) {
+	file := filepath.Join(dir, name)
+	data, err := fs.ReadFile(h.root.FS(), file)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			r.record(file, "absent")
+		}
+		return "", fmt.Errorf("read CPU configuration %q in %q: %w", file, h.root.Name(), err)
+	}
+	value := strings.TrimSpace(string(data))
+	r.record(file, value)
+	return value, nil
+}
+
+func (r *reader) quotaV2(h *hierarchy, dir string) error {
+	value, err := r.readFile(h, dir, "cpu.max")
+	if err != nil {
+		if dir == "." && errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	fields := strings.Fields(value)
+	if len(fields) != 2 {
+		return fmt.Errorf("invalid cpu.max %q at %q: expected quota and period", value, dir)
+	}
+	period, err := positive(fields[1], "cpu.max period", dir)
+	if err != nil {
+		return err
+	}
+	if fields[0] == "max" {
+		return nil
+	}
+	quota, err := positive(fields[0], "cpu.max quota", dir)
+	if err != nil {
+		return err
+	}
+	r.cores = min(r.cores, float64(quota)/float64(period))
+	return nil
+}
+
+func (r *reader) quotaV1(h *hierarchy, dir string) error {
+	quota, err := r.readFile(h, dir, "cpu.cfs_quota_us")
+	if err != nil {
+		return err
+	}
+	periodText, err := r.readFile(h, dir, "cpu.cfs_period_us")
+	if err != nil {
+		return err
+	}
+	period, err := positive(periodText, "cpu.cfs_period_us", dir)
+	if err != nil {
+		return err
+	}
+	if quota == "-1" {
+		return nil
+	}
+	value, err := positive(quota, "cpu.cfs_quota_us", dir)
+	if err != nil {
+		return err
+	}
+	if value > math.MaxInt64 {
+		return fmt.Errorf("cpu.cfs_quota_us exceeds int64 at %q", dir)
+	}
+	r.cores = min(r.cores, float64(value)/float64(period))
+	return nil
+}
+
+func positive(value, name, dir string) (uint64, error) {
+	number, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s %q at %q: %w", name, value, dir, err)
+	}
+	if number == 0 {
+		return 0, fmt.Errorf("%s is zero at %q", name, dir)
+	}
+	return number, nil
+}
+
+func (r *reader) cpuset(h *hierarchy, unified bool) error {
+	found := false
+	for _, dir := range h.dirs {
+		name := "cpuset.cpus.effective"
+		if !unified {
+			name = "cpuset.effective_cpus"
+		}
+		value, err := r.readFile(h, dir, name)
+		if errors.Is(err, fs.ErrNotExist) && !unified {
+			name = "cpuset.cpus"
+			value, err = r.readFile(h, dir, name)
+		}
+		if err != nil {
+			if unified && errors.Is(err, fs.ErrNotExist) {
+				// A controller not enabled here still constrains descendants
+				// through the nearest ancestor where it is enabled.
+				continue
+			}
+			return err
+		}
+		count, err := cpuutil.ParseCPUListCount(value)
+		if err != nil {
+			return fmt.Errorf("invalid %s at %q: %w", name, dir, err)
+		}
+		if unified && found {
+			// The nearest effective set already includes kernel constraints.
+			// Ancestor partitions can retain disjoint CPUs, or none at all.
+			continue
+		}
+		if count == 0 {
+			if name == "cpuset.cpus" && dir != "." {
+				continue
+			}
+			return fmt.Errorf("%s is empty at %q", name, dir)
+		}
+		found = true
+		r.cpuLists = append(r.cpuLists, value)
+	}
+	if !found {
+		r.record("cpuset controller unavailable")
+	}
+	return nil
+}

--- a/internal/cgroups/capacity/cpu_test.go
+++ b/internal/cgroups/capacity/cpu_test.go
@@ -1,0 +1,402 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package capacity
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t testing.TB, root, name, value string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func removeFile(t *testing.T, root, name string) {
+	t.Helper()
+	if err := os.Remove(filepath.Join(root, name)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fixture(t testing.TB, unified bool) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, dir := range []string{".", "parent", "parent/leaf"} {
+		if unified {
+			if dir != "." {
+				writeFile(t, root, filepath.Join(dir, "cpu.max"), "max 100000")
+			}
+			writeFile(t, root, filepath.Join(dir, "cpuset.cpus.effective"), "0-7")
+		} else {
+			writeFile(t, root, filepath.Join("cpu", dir, "cpu.cfs_quota_us"), "-1")
+			writeFile(t, root, filepath.Join("cpu", dir, "cpu.cfs_period_us"), "100000")
+			writeFile(t, root, filepath.Join("cpuacct", dir, "cpuacct.usage"), "1000000000")
+			writeFile(t, root, filepath.Join("cpuset", dir, "cpuset.cpus"), "0-7")
+		}
+	}
+	return root
+}
+
+func TestCapacityHierarchy(t *testing.T) {
+	for _, unified := range []bool{false, true} {
+		t.Run(fmt.Sprintf("v2=%v", unified), func(t *testing.T) {
+			root := fixture(t, unified)
+			if unified {
+				writeFile(t, root, "parent/cpu.max", "150000 100000")
+				writeFile(t, root, "parent/leaf/cpu.max", "400000 100000")
+			} else {
+				writeFile(t, root, "cpu/parent/cpu.cfs_quota_us", "150000")
+				writeFile(t, root, "cpu/parent/leaf/cpu.cfs_quota_us", "400000")
+			}
+			got, err := read(root, "/parent/leaf", "0-7\n", unified)
+			if err != nil || got.Cores != 1.5 {
+				t.Fatalf("read() = %v, %v, want 1.5 cores", got, err)
+			}
+			again, err := read(root, "/parent/leaf", "0-7\n", unified)
+			if err != nil || *again != *got {
+				t.Fatalf("unchanged configuration = %v, %v, want %v", again, err, got)
+			}
+		})
+	}
+}
+
+func TestCapacityCpuset(t *testing.T) {
+	tests := []struct {
+		name    string
+		unified bool
+		files   map[string]string
+		remove  []string
+		online  string
+		want    float64
+		wantErr bool
+	}{
+		{name: "v1 online intersection", files: map[string]string{"cpuset/parent/leaf/cpuset.cpus": "2-5"}, online: "0-3", want: 2},
+		{name: "v1 disjoint", files: map[string]string{"cpuset/parent/leaf/cpuset.cpus": "4-7"}, online: "0-3", wantErr: true},
+		{name: "v1 effective preferred", files: map[string]string{"cpuset/parent/leaf/cpuset.effective_cpus": "1-2"}, want: 2},
+		{name: "v1 empty requested inherits", files: map[string]string{"cpuset/parent/leaf/cpuset.cpus": "\n", "cpuset/parent/cpuset.cpus": "0-2"}, want: 3},
+		{name: "v1 empty effective does not inherit", files: map[string]string{"cpuset/parent/leaf/cpuset.effective_cpus": ""}, wantErr: true},
+		{name: "v1 empty root", files: map[string]string{"cpuset/cpuset.cpus": ""}, wantErr: true},
+		{name: "v1 missing configured file", remove: []string{"cpuset/parent/leaf/cpuset.cpus"}, wantErr: true},
+		{name: "v2 effective intersection", unified: true, files: map[string]string{"parent/leaf/cpuset.cpus.effective": "2-5"}, online: "0-3", want: 2},
+		{name: "v2 disjoint partitions", unified: true, files: map[string]string{"parent/leaf/cpuset.cpus.effective": "2-3", "parent/cpuset.cpus.effective": "0-1"}, want: 2},
+		{name: "v2 empty parent partition", unified: true, files: map[string]string{"parent/leaf/cpuset.cpus.effective": "2-3", "parent/cpuset.cpus.effective": ""}, want: 2},
+		{name: "v2 empty root with child CPUs", unified: true, files: map[string]string{"parent/leaf/cpuset.cpus.effective": "2-3", "cpuset.cpus.effective": ""}, want: 2},
+		{name: "v2 nearest available ancestor", unified: true, files: map[string]string{"parent/cpuset.cpus.effective": "0-2"}, remove: []string{"parent/leaf/cpuset.cpus.effective"}, want: 3},
+		{name: "v2 inherits partition CPUs", unified: true, files: map[string]string{"parent/cpuset.cpus.effective": "2-3", "cpuset.cpus.effective": "0-1"}, remove: []string{"parent/leaf/cpuset.cpus.effective"}, want: 2},
+		{name: "v2 empty nearest available ancestor", unified: true, files: map[string]string{"parent/cpuset.cpus.effective": ""}, remove: []string{"parent/leaf/cpuset.cpus.effective"}, wantErr: true},
+		{name: "v2 root only", unified: true, files: map[string]string{"cpuset.cpus.effective": "0-1"}, remove: []string{"parent/leaf/cpuset.cpus.effective", "parent/cpuset.cpus.effective"}, want: 2},
+		{name: "v2 unavailable controller", unified: true, remove: []string{"parent/leaf/cpuset.cpus.effective", "parent/cpuset.cpus.effective", "cpuset.cpus.effective"}, want: 8},
+		{name: "v2 empty effective", unified: true, files: map[string]string{"parent/leaf/cpuset.cpus.effective": ""}, wantErr: true},
+		{name: "invalid cpuset", unified: true, files: map[string]string{"parent/leaf/cpuset.cpus.effective": "3-1"}, wantErr: true},
+		{name: "invalid online", unified: true, online: "bad", wantErr: true},
+		{name: "empty online", unified: true, online: "\n", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := fixture(t, tt.unified)
+			for name, value := range tt.files {
+				writeFile(t, root, name, value)
+			}
+			for _, name := range tt.remove {
+				removeFile(t, root, name)
+			}
+			online := tt.online
+			if online == "" {
+				online = "0-7"
+			}
+			got, err := read(root, "parent/leaf", online, tt.unified)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("read() = %v, %v, want error %v", got, err, tt.wantErr)
+			}
+			if err == nil && got.Cores != tt.want {
+				t.Fatalf("read() cores = %v, want %v", got.Cores, tt.want)
+			}
+		})
+	}
+}
+
+func TestCapacityInvalidQuota(t *testing.T) {
+	tests := []struct {
+		name    string
+		unified bool
+		file    string
+		value   string
+		remove  bool
+	}{
+		{name: "v2 missing leaf", unified: true, file: "parent/leaf/cpu.max", remove: true},
+		{name: "v2 missing ancestor", unified: true, file: "parent/cpu.max", remove: true},
+		{name: "v2 incomplete", unified: true, file: "parent/cpu.max", value: "max"},
+		{name: "v2 extra field", unified: true, file: "parent/cpu.max", value: "max 100000 extra"},
+		{name: "v2 zero quota", unified: true, file: "parent/cpu.max", value: "0 100000"},
+		{name: "v2 zero period", unified: true, file: "parent/cpu.max", value: "max 0"},
+		{name: "v2 invalid period", unified: true, file: "parent/cpu.max", value: "max bad"},
+		{name: "v2 negative", unified: true, file: "parent/cpu.max", value: "-1 100000"},
+		{name: "v2 overflow", unified: true, file: "parent/cpu.max", value: "18446744073709551616 100000"},
+		{name: "v1 missing quota", file: "cpu/parent/cpu.cfs_quota_us", remove: true},
+		{name: "v1 missing period", file: "cpu/parent/cpu.cfs_period_us", remove: true},
+		{name: "v1 zero quota", file: "cpu/parent/cpu.cfs_quota_us", value: "0"},
+		{name: "v1 invalid unlimited", file: "cpu/parent/cpu.cfs_quota_us", value: "-2"},
+		{name: "v1 signed overflow", file: "cpu/parent/cpu.cfs_quota_us", value: "9223372036854775808"},
+		{name: "v1 invalid period", file: "cpu/parent/cpu.cfs_period_us", value: "bad"},
+		{name: "v1 zero period", file: "cpu/parent/cpu.cfs_period_us", value: "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := fixture(t, tt.unified)
+			if tt.remove {
+				removeFile(t, root, tt.file)
+			} else {
+				writeFile(t, root, tt.file, tt.value)
+			}
+			if got, err := read(root, "parent/leaf", "0-7", tt.unified); err == nil {
+				t.Fatalf("read() = %v, want error for %s", got, tt.file)
+			}
+		})
+	}
+}
+
+func TestCapacityIdentityChanges(t *testing.T) {
+	changes := map[string]func(*testing.T, string){
+		"disjoint ancestor cpuset":      func(t *testing.T, root string) { writeFile(t, root, "parent/cpuset.cpus.effective", "4-7") },
+		"ancestor cpuset becomes empty": func(t *testing.T, root string) { writeFile(t, root, "parent/cpuset.cpus.effective", "") },
+		"equal ratio":                   func(t *testing.T, root string) { writeFile(t, root, "parent/cpu.max", "400000 200000") },
+		"nonbinding quota":              func(t *testing.T, root string) { writeFile(t, root, "parent/leaf/cpu.max", "600000 100000") },
+		"equal count cpuset swap":       func(t *testing.T, root string) { writeFile(t, root, "parent/leaf/cpuset.cpus.effective", "2-5") },
+		"root max appears":              func(t *testing.T, root string) { writeFile(t, root, "cpu.max", "max 100000") },
+		"cpuset becomes inherited":      func(t *testing.T, root string) { removeFile(t, root, "parent/leaf/cpuset.cpus.effective") },
+		"directory recreated": func(t *testing.T, root string) {
+			if err := os.Rename(filepath.Join(root, "parent/leaf"), filepath.Join(root, "parent/previous")); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, root, "parent/leaf/cpu.max", "max 100000")
+			writeFile(t, root, "parent/leaf/cpuset.cpus.effective", "0-3")
+		},
+	}
+	for name, change := range changes {
+		t.Run(name, func(t *testing.T) {
+			root := fixture(t, true)
+			writeFile(t, root, "parent/cpu.max", "200000 100000")
+			writeFile(t, root, "parent/leaf/cpuset.cpus.effective", "0-3")
+			before, err := ReadV2(root, "parent/leaf", "0-7")
+			if err != nil {
+				t.Fatal(err)
+			}
+			change(t, root)
+			after, err := ReadV2(root, "parent/leaf", "0-7")
+			if err != nil || after.Cores != before.Cores || after.ConfigID == before.ConfigID {
+				t.Fatalf("before = %v, after = %v, error = %v; want equal cores, different identity", before, after, err)
+			}
+		})
+	}
+	t.Run("equal count online swap", func(t *testing.T) {
+		root := fixture(t, true)
+		before, err := ReadV2(root, "parent/leaf", "0-3")
+		if err != nil {
+			t.Fatal(err)
+		}
+		after, err := ReadV2(root, "parent/leaf", "4-7")
+		if err != nil || after.Cores != before.Cores || after.ConfigID == before.ConfigID {
+			t.Fatalf("before = %v, after = %v, error = %v", before, after, err)
+		}
+	})
+}
+
+func TestCapacityRootBoundary(t *testing.T) {
+	t.Run("visible root does not include parent limits", func(t *testing.T) {
+		root := fixture(t, true)
+		writeFile(t, root, "parent/cpu.max", "100000 100000")
+		got, err := ReadV2(filepath.Join(root, "parent/leaf"), "", "0-7")
+		if err != nil || got.Cores != 8 {
+			t.Fatalf("ReadV2() = %v, %v, want 8 cores", got, err)
+		}
+	})
+	t.Run("v1 controller alias", func(t *testing.T) {
+		root := fixture(t, false)
+		if err := os.Rename(filepath.Join(root, "cpu"), filepath.Join(root, "cpu,cpuacct")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("cpu,cpuacct", filepath.Join(root, "cpu")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Rename(filepath.Join(root, "cpuacct"), filepath.Join(root, "cpuacct-saved")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink("cpu,cpuacct", filepath.Join(root, "cpuacct")); err != nil {
+			t.Fatal(err)
+		}
+		got, err := ReadV1(root, "parent/leaf", "0-7")
+		if err != nil || got.Cores != 8 {
+			t.Fatalf("ReadV1() = %v, %v, want 8 cores", got, err)
+		}
+	})
+	for _, state := range []string{"absent", "missing leaf", "broken alias"} {
+		t.Run("v1 cpuset "+state, func(t *testing.T) {
+			root := fixture(t, false)
+			old := filepath.Join(root, "cpuset")
+			if state == "missing leaf" {
+				old = filepath.Join(old, "parent/leaf")
+			}
+			if err := os.Rename(old, old+"-saved"); err != nil {
+				t.Fatal(err)
+			}
+			if state == "broken alias" {
+				if err := os.Symlink("missing", old); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := ReadV1(root, "parent/leaf", "0-7")
+			if state == "absent" {
+				if err != nil || got.Cores != 8 {
+					t.Fatalf("ReadV1() = %v, %v, want 8 cores", got, err)
+				}
+			} else if err == nil {
+				t.Fatalf("ReadV1() = %v, want error", got)
+			}
+		})
+	}
+	for _, path := range []string{"../parent/leaf", "parent/../parent/leaf", "missing", "parent/cpu.max"} {
+		t.Run(path, func(t *testing.T) {
+			if got, err := ReadV2(fixture(t, true), path, "0-7"); err == nil {
+				t.Fatalf("ReadV2() = %v, want invalid path error", got)
+			}
+		})
+	}
+	for _, target := range []string{"directory", "control file"} {
+		t.Run("escaping "+target, func(t *testing.T) {
+			root := fixture(t, true)
+			outside := fixture(t, true)
+			link := filepath.Join(root, "parent/leaf")
+			destination := filepath.Join(outside, "parent/leaf")
+			if target == "control file" {
+				link = filepath.Join(link, "cpu.max")
+				destination = filepath.Join(destination, "cpu.max")
+			}
+			if err := os.Rename(link, link+"-saved"); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(destination, link); err != nil {
+				t.Fatal(err)
+			}
+			if got, err := ReadV2(root, "parent/leaf", "0-7"); err == nil {
+				t.Fatalf("ReadV2() = %v, want symlink escape error", got)
+			}
+		})
+	}
+}
+
+func TestCapacityCPUAcctGeneration(t *testing.T) {
+	root := fixture(t, false)
+	before, err := ReadV1(root, "parent/leaf", "0-7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf := filepath.Join(root, "cpuacct/parent/leaf")
+	if err := os.Rename(leaf, leaf+"-saved"); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := ReadV1(root, "parent/leaf", "0-7"); err == nil {
+		t.Fatalf("ReadV1() = %v, want missing cpuacct error", got)
+	}
+	writeFile(t, root, "cpuacct/parent/leaf/cpuacct.usage", "2000000000")
+	after, err := ReadV1(root, "parent/leaf", "0-7")
+	if err != nil || after.Cores != before.Cores || after.ConfigID == before.ConfigID {
+		t.Fatalf("before = %v, after = %v, error = %v; want new cpuacct generation", before, after, err)
+	}
+	writeFile(t, root, "cpuacct/parent/leaf/cpuacct.usage", "3000000000")
+	again, err := ReadV1(root, "parent/leaf", "0-7")
+	if err != nil || *again != *after {
+		t.Fatalf("usage-only change = %v, %v; want unchanged identity %v", again, err, after)
+	}
+}
+
+func TestCapacityReadErrors(t *testing.T) {
+	for _, name := range []string{"parent/cpu.max", "parent/cpuset.cpus.effective"} {
+		t.Run(name, func(t *testing.T) {
+			root := fixture(t, true)
+			removeFile(t, root, name)
+			if err := os.Mkdir(filepath.Join(root, name), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if got, err := ReadV2(root, "parent/leaf", "0-7"); err == nil {
+				t.Fatalf("ReadV2() = %v, want read error", got)
+			}
+		})
+	}
+	t.Run("permission denied", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root can read mode-000 files")
+		}
+		root := fixture(t, true)
+		if err := os.Chmod(filepath.Join(root, "parent/cpuset.cpus.effective"), 0); err != nil {
+			t.Fatal(err)
+		}
+		if got, err := ReadV2(root, "parent/leaf", "0-7"); err == nil {
+			t.Fatalf("ReadV2() = %v, want permission error", got)
+		}
+	})
+}
+
+func BenchmarkCapacity(b *testing.B) {
+	for _, unified := range []bool{false, true} {
+		for _, count := range []int{100, 1000} {
+			for _, depth := range []int{2, 5} {
+				b.Run(fmt.Sprintf("v2=%v/containers=%d/depth=%d", unified, count, depth), func(b *testing.B) {
+					root := b.TempDir()
+					paths := make([]string, count)
+					for index := range paths {
+						paths[index] = strings.Repeat("parent/", depth-1) + fmt.Sprintf("leaf%d", index)
+						for dir := paths[index]; ; dir = filepath.Dir(dir) {
+							if unified {
+								if dir != "." {
+									writeFile(b, root, filepath.Join(dir, "cpu.max"), "200000 100000")
+								}
+								writeFile(b, root, filepath.Join(dir, "cpuset.cpus.effective"), "0-7")
+							} else {
+								writeFile(b, root, filepath.Join("cpu", dir, "cpu.cfs_quota_us"), "200000")
+								writeFile(b, root, filepath.Join("cpu", dir, "cpu.cfs_period_us"), "100000")
+								writeFile(b, root, filepath.Join("cpuacct", dir, "cpuacct.usage"), "1000000000")
+								writeFile(b, root, filepath.Join("cpuset", dir, "cpuset.cpus"), "0-7")
+							}
+							if dir == "." {
+								break
+							}
+						}
+					}
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						for _, path := range paths {
+							if _, err := read(root, path, "0-7", unified); err != nil {
+								b.Fatal(err)
+							}
+						}
+					}
+					b.StopTimer()
+					b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*count), "ns/container")
+				})
+			}
+		}
+	}
+}

--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The HuaTuo Authors
+// Copyright 2025, 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,6 +64,8 @@ type Cgroup interface {
 	CpuStatRaw(path string) (map[string]uint64, error)
 	// CpuQuotaAndPeriod cgroup quota and period
 	CpuQuotaAndPeriod(path string) (*stats.CpuQuota, error)
+	// CpuCapacity bounds online CPUs by cpuset and visible ancestor quotas.
+	CpuCapacity(path, onlineCPUs string) (*stats.CpuCapacity, error)
 	// MemoryStatRaw memory.stat
 	MemoryStatRaw(path string) (map[string]uint64, error)
 	// MemoryEventRaw memory.stat

--- a/internal/cgroups/v1/cpu_capacity.go
+++ b/internal/cgroups/v1/cpu_capacity.go
@@ -1,4 +1,4 @@
-// Copyright 2025, 2026 The HuaTuo Authors
+// Copyright 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package stats
+package v1
 
-// All members are measured in microseconds
-type CpuUsage struct {
-	Usage  uint64
-	User   uint64
-	System uint64
-}
+import (
+	"huatuo-bamai/internal/cgroups/capacity"
+	"huatuo-bamai/internal/cgroups/paths"
+	"huatuo-bamai/internal/cgroups/stats"
+)
 
-type CpuQuota struct {
-	Quota             uint64
-	Period            uint64
-	EffectiveCPUCount uint64
-}
-
-// CpuCapacity is the CPU ceiling observable within the mounted hierarchy.
-// ConfigID identifies its configuration, not an exclusive CPU allocation.
-type CpuCapacity struct {
-	Cores    float64
-	ConfigID [32]byte
-}
-
-type MemoryUsage struct {
-	Usage      uint64
-	MaxLimited uint64
+func (c *CgroupV1) CpuCapacity(path, onlineCPUs string) (*stats.CpuCapacity, error) {
+	return capacity.ReadV1(paths.RootfsDefaultPath, path, onlineCPUs)
 }

--- a/internal/cgroups/v2/cpu_capacity.go
+++ b/internal/cgroups/v2/cpu_capacity.go
@@ -1,4 +1,4 @@
-// Copyright 2025, 2026 The HuaTuo Authors
+// Copyright 2026 The HuaTuo Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package stats
+package v2
 
-// All members are measured in microseconds
-type CpuUsage struct {
-	Usage  uint64
-	User   uint64
-	System uint64
-}
+import (
+	"huatuo-bamai/internal/cgroups/capacity"
+	"huatuo-bamai/internal/cgroups/paths"
+	"huatuo-bamai/internal/cgroups/stats"
+)
 
-type CpuQuota struct {
-	Quota             uint64
-	Period            uint64
-	EffectiveCPUCount uint64
-}
-
-// CpuCapacity is the CPU ceiling observable within the mounted hierarchy.
-// ConfigID identifies its configuration, not an exclusive CPU allocation.
-type CpuCapacity struct {
-	Cores    float64
-	ConfigID [32]byte
-}
-
-type MemoryUsage struct {
-	Usage      uint64
-	MaxLimited uint64
+func (c *CgroupV2) CpuCapacity(path, onlineCPUs string) (*stats.CpuCapacity, error) {
+	return capacity.ReadV2(paths.RootfsDefaultPath, path, onlineCPUs)
 }

--- a/internal/utils/cpuutil/cpuset.go
+++ b/internal/utils/cpuutil/cpuset.go
@@ -15,10 +15,12 @@
 package cpuutil
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -33,7 +35,12 @@ func ParseOnlineCores(path string) (uint64, error) {
 		return 0, err
 	}
 
-	list := strings.TrimSpace(string(v))
+	return ParseCPUListCount(string(v))
+}
+
+// ParseCPUListCount returns the number of CPUs in a Linux CPU list.
+func ParseCPUListCount(list string) (uint64, error) {
+	list = strings.TrimSpace(list)
 	if list == "" {
 		return 0, nil
 	}
@@ -44,27 +51,15 @@ func ParseOnlineCores(path string) (uint64, error) {
 			return 0, fmt.Errorf("invalid CPU list %q", list)
 		}
 
-		firstText, lastText, isRange := strings.Cut(item, "-")
-		first, err := strconv.ParseUint(firstText, 10, 64)
+		first, last, err := parseCPURange(item)
 		if err != nil {
-			return 0, fmt.Errorf("parse CPU %q: %w", item, err)
+			return 0, err
 		}
-
-		size := uint64(1)
-		if isRange {
-			last, err := strconv.ParseUint(lastText, 10, 64)
-			if err != nil {
-				return 0, fmt.Errorf("parse CPU range %q: %w", item, err)
-			}
-			if last < first {
-				return 0, fmt.Errorf("invalid CPU range %q", item)
-			}
-			width := last - first
-			if width == math.MaxUint64 {
-				return 0, errors.New("cpu count overflow")
-			}
-			size = width + 1
+		width := last - first
+		if width == math.MaxUint64 {
+			return 0, errors.New("cpu count overflow")
 		}
+		size := width + 1
 		if count > math.MaxUint64-size {
 			return 0, errors.New("cpu count overflow")
 		}
@@ -72,6 +67,98 @@ func ParseOnlineCores(path string) (uint64, error) {
 	}
 
 	return count, nil
+}
+
+func parseCPURange(item string) (uint64, uint64, error) {
+	firstText, lastText, isRange := strings.Cut(item, "-")
+	first, err := strconv.ParseUint(firstText, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse CPU %q: %w", item, err)
+	}
+	if !isRange {
+		return first, first, nil
+	}
+	last, err := strconv.ParseUint(lastText, 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse CPU range %q: %w", item, err)
+	}
+	if last < first {
+		return 0, 0, fmt.Errorf("invalid CPU range %q", item)
+	}
+	return first, last, nil
+}
+
+type cpuRange struct {
+	first uint64
+	last  uint64
+}
+
+// CPUListIntersectionCount counts CPUs common to all lists without expanding ranges.
+func CPUListIntersectionCount(lists ...string) (uint64, error) {
+	var common []cpuRange
+	for index, list := range lists {
+		ranges, err := parseCPURanges(list)
+		if err != nil {
+			return 0, err
+		}
+		if index == 0 {
+			common = ranges
+			continue
+		}
+		intersection := make([]cpuRange, 0, len(common)+len(ranges))
+		for left, right := 0, 0; left < len(common) && right < len(ranges); {
+			first := max(common[left].first, ranges[right].first)
+			last := min(common[left].last, ranges[right].last)
+			if first <= last {
+				intersection = append(intersection, cpuRange{first: first, last: last})
+			}
+			if common[left].last < ranges[right].last {
+				left++
+			} else {
+				right++
+			}
+		}
+		common = intersection
+	}
+	var count uint64
+	for _, interval := range common {
+		width := interval.last - interval.first
+		if width == math.MaxUint64 || count > math.MaxUint64-(width+1) {
+			return 0, errors.New("cpu count overflow")
+		}
+		count += width + 1
+	}
+	return count, nil
+}
+
+func parseCPURanges(list string) ([]cpuRange, error) {
+	list = strings.TrimSpace(list)
+	if list == "" {
+		return nil, nil
+	}
+	items := strings.Split(list, ",")
+	ranges := make([]cpuRange, 0, len(items))
+	for _, item := range items {
+		if item == "" {
+			return nil, fmt.Errorf("invalid CPU list %q", list)
+		}
+		first, last, err := parseCPURange(item)
+		if err != nil {
+			return nil, err
+		}
+		ranges = append(ranges, cpuRange{first: first, last: last})
+	}
+	slices.SortFunc(ranges, func(a, b cpuRange) int { return cmp.Compare(a.first, b.first) })
+	merged := ranges[:1]
+	for _, interval := range ranges[1:] {
+		previous := &merged[len(merged)-1]
+		if interval.first <= previous.last || (previous.last != math.MaxUint64 && interval.first == previous.last+1) {
+			previous.last = max(previous.last, interval.last)
+		} else {
+			merged = append(merged, interval)
+		}
+	}
+	return merged, nil
 }
 
 // MaxOnlineCPU returns the highest CPU ID in a Linux online CPU list.

--- a/internal/utils/cpuutil/cpuset_test.go
+++ b/internal/utils/cpuutil/cpuset_test.go
@@ -105,3 +105,44 @@ func TestBoundCoresFallback(t *testing.T) {
 		t.Errorf("BoundCores() = %v, want 4", got)
 	}
 }
+
+func TestCPUListIntersectionCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		lists   []string
+		want    uint64
+		wantErr bool
+	}{
+		{name: "no lists"},
+		{name: "offline members", lists: []string{"0-3", "2-5"}, want: 2},
+		{name: "disjoint", lists: []string{"0-3", "4-7"}},
+		{name: "sparse hierarchy", lists: []string{"0-7", "1-4,6", "2-3,6-7"}, want: 3},
+		{name: "unsorted overlapping", lists: []string{"3-5,0-3,2,7", "0-7"}, want: 7},
+		{name: "empty list", lists: []string{"0-3", "\n"}},
+		{name: "invalid after empty intersection", lists: []string{"0", "1", "bad"}, wantErr: true},
+		{name: "empty item", lists: []string{"0,,1"}, wantErr: true},
+		{name: "reverse range", lists: []string{"4-2"}, wantErr: true},
+		{name: "invalid end", lists: []string{"0-1-2"}, wantErr: true},
+		{name: "huge range stays compact", lists: []string{"0-18446744073709551615", "7-9"}, want: 3},
+		{name: "max endpoint", lists: []string{"18446744073709551614-18446744073709551615,18446744073709551615"}, want: 2},
+		{name: "unrepresentable count", lists: []string{"0-18446744073709551615"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CPUListIntersectionCount(tt.lists...)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CPUListIntersectionCount() error = %v, want error %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("CPUListIntersectionCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCPUListCount(t *testing.T) {
+	got, err := ParseCPUListCount("0-3,8,10-11\n")
+	if err != nil || got != 7 {
+		t.Fatalf("ParseCPUListCount() = %d, %v, want 7, nil", got, err)
+	}
+}


### PR DESCRIPTION
## Problem

CPU utilization needs both a correct capacity denominator and two usage
observations belonging to the same capacity configuration.

The current collector reads only the leaf quota. An unlimited leaf with eight
allowed CPUs below a two-CPU parent is consequently normalized by eight cores.
It also applies the latest capacity to the entire previous interval after a
resize. That interval cannot be reconstructed from two usage counters alone.

Reproduced against unmodified `bb6e1a7` collector code in an isolated test:

- A real temporary v2 file tree (parent `200000 100000`, unlimited leaf,
  `cpuset=0-7`) returns **8 cores instead of 2** through the old call path.
- The first observation exports three utilization gauges without a baseline.
- The shared old state machine exports a **25% mixed-window result** across
  a simulated 2-to-4-core resize instead of withholding utilization.

The legacy reproducer uses explicit Go file arguments and in-memory usage
stubs; it is not claimed as a live collector resize experiment.

## Design

- Add a separate `CpuCapacity` API for cgroup v1/v2. Keep the existing raw
  `CpuQuotaAndPeriod` and `BoundCores` contracts unchanged.
- Bound capacity by the intersection of online/effective cpuset CPU IDs and
  every visible ancestor's quota divided by its **own** period, including the
  visible root when it exposes a limit. A parent's ceiling is shared with
  siblings, not an exclusive allocation or an equal-share guarantee.
- Identify configuration with quota/period, CPU membership, absence/inheritance
  state, and hierarchy directory identity. Equal-capacity changes still reset
  the baseline; v1's separate cpuacct generation is included.
- Read `capacity -> usage -> capacity`. Discard a sample if the surrounding
  configurations differ. On an observed between-sample change, keep only a new
  baseline. First samples, counter regressions, backward time, and read failures
  cannot replay old utilization or manufacture zero. Require a stable interval
  of at least one second before exporting usr/sys/total again.
- Preserve valid CFS bursts above 100%; exceeding the nominal bandwidth ceiling
  is not by itself proof of a corrupt usage delta.
- Retain metric names/labels and document the corrected denominator and missing
  samples. Host baseline/error handling is independent of container results;
  existing pod-enumeration error handling is unchanged.

CPU-set intersection uses intervals rather than expanding individual CPU IDs.
For v2, the nearest available effective set already incorporates kernel
placement constraints. Higher ancestor effective sets are fingerprinted, not
intersected again: a parent partition may have no local CPUs after assigning
them to child partitions. Regression tests cover disjoint and empty parents.
Controller aliases are supported; directory traversal and control-file symlink
escapes are rejected. Missing/invalid quotas fail closed, except the legal
absence of root v2 `cpu.max`. Unavailable cpuset controllers inherit visible
ancestor/online constraints; an actual empty effective set is an error.

## Verification

- Generated artifacts rebuilt with `make gen-build`.
- `make check` (dependency verification, generated-file consistency, format,
  full-repository lint and clean worktree diff): PASS.
- `go build -p 2 ./...`: PASS.
- Full-repository Go tests pass with four existing environment-dependent test
  groups excluded: `TestDefaultBPF_Attach`, `TestDefaultBPF_EventPipe_Flow`,
  `TestPerfEventReader_ReadInto_And_Close_ProgTest`, `TestCgroupInterfaces`.
  An unrestricted run was also attempted: the environment lacks tracefs,
  the required BPF permission, and a systemd private socket for those tests.
- CPU-utilization regression tests: 20 runs with the race detector. Tests assert
  exact exported metric presence/values using a fake clock, including 2->4->1
  resize, equal-capacity membership/identity changes, resize during usage reads,
  errors/recovery, short intervals, counter resets, and >100% bursts.
- Capacity/cpuset/v1/v2 tests and race checks pass; capacity statement coverage
  is 96.3%. The permission-denied case was separately run as UID 65534.
- The new opt-in integration test **ran successfully on real cgroup v2** in a
  dedicated Docker private cgroup namespace. It checks ancestor/leaf limits,
  different periods, configuration identity after resize, cpuset inheritance,
  and siblings sharing a half-CPU parent. The final run took about 2.013 seconds,
  with 1,016,536 us parent CPU usage and 20 throttled periods. Collector interval
  invalidation is tested separately, not inferred from this kernel experiment.
- Missing delegation/read-only cgroup mounts explicitly SKIP. The integration
  test changes only its own subtree and workers, never the supplied root's
  controller settings or existing processes.

## Cost and boundaries

Linux arm64, Go 1.24.6, GOMAXPROCS=2, warm temporary-file fixtures (not cgroupfs):

| One capacity scan | 100 containers, depth 2 / 5 | 1000 containers, depth 2 / 5 |
| --- | --- | --- |
| v1 | 8.3 / 16.7 ms | 67.7 / 156.3 ms |
| v2 | 2.6 / 6.8 ms | 27.2 / 65.8 ms |

Commands: `go test -run '^$' -bench BenchmarkCapacity -benchtime=1x -count=1
./internal/cgroups/capacity` and `go test -run '^$' -bench BenchmarkCPUUtil
-benchmem ./core/metrics`.

The collector performs **two** capacity scans per container, so the table is
not full-scrape cost. At 1000 containers/depth 5, one v1/v2 scan allocates about
58/24 MB respectively; double-read consistency doubles that cost. The pure
baseline state machine measures about 15 ns with zero allocations; the fake
reader plus four metric constructions measures about 1.43 us, 1624 B/28 allocs.
No persistent quota cache is introduced because it would hide live changes.
There is no BPF event-processing change.

Only the visible hierarchy can be observed. Polling cannot detect A->B->A
changes wholly between observations. Online CPUs are refreshed once per scrape,
not atomically with every usage read, so this does not promise atomic hotplug
detection. v1 retains the existing same-relative-path assumption across cpu,
cpuacct and cpuset controllers; general membership remapping is out of scope.
The separate cpuidle tracing consumer remains unchanged.

Semantics are based on the Linux kernel's
[cgroup v2 CPU and cpuset interfaces](https://docs.kernel.org/admin-guide/cgroup-v2.html)
and [CFS bandwidth hierarchy/burst documentation](https://docs.kernel.org/scheduler/sched-bwc.html).
