### PR TITLE
fix(procfs): reject arp cache rows wider than the header

### DIFF
--- a/internal/procfs/net_arpcache.go
+++ b/internal/procfs/net_arpcache.go
@@ -16,6 +16,7 @@ package procfs
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -39,16 +40,34 @@ func NetArpCache() (*ArpCacheStats, error) {
 
 	scanner := bufio.NewScanner(file)
 	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 
 	// First string is always a header for stats
-	var headers []string
-	headers = append(headers, strings.Fields(scanner.Text())...)
+	headers := strings.Fields(scanner.Text())
 
 	// Fast path ...
 	cache := &ArpCacheStats{Stats: make(map[string]uint64)}
 
 	scanner.Scan()
-	for num, counter := range strings.Fields(scanner.Text()) {
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	fields := strings.Fields(scanner.Text())
+	if len(fields) > len(headers) {
+		// Counters are keyed by header position, so a wider row would either
+		// panic on the header lookup or report unnamed counters. Reject the
+		// row instead of guessing the layout.
+		return nil, fmt.Errorf(
+			"arp cache data row has %d fields, header has %d fields",
+			len(fields),
+			len(headers),
+		)
+	}
+
+	for num, counter := range fields {
 		value, err := strconv.ParseUint(counter, 16, 64)
 		if err != nil {
 			return nil, err

--- a/internal/procfs/net_arpcache_test.go
+++ b/internal/procfs/net_arpcache_test.go
@@ -114,3 +114,22 @@ func TestNetArpCache(t *testing.T) {
 		require.Equal(t, uint64(11), stats.Stats["allocs"])
 	})
 }
+
+func TestNetArpCacheRejectsWiderRowThanHeader(t *testing.T) {
+	tempDir := t.TempDir()
+	arpDir := filepath.Join(tempDir, "proc/net/stat")
+	require.NoError(t, os.MkdirAll(arpDir, 0o755))
+
+	RootPrefix(tempDir)
+	defer RootPrefix("/")
+
+	// Counters are keyed by header position: a data row with more fields than
+	// the header must be rejected instead of indexed with the header length.
+	content := "entries allocs\n0a 0b 0c\n"
+	require.NoError(t, os.WriteFile(filepath.Join(arpDir, "arp_cache"), []byte(content), 0o600))
+
+	stats, err := NetArpCache()
+	require.Error(t, err)
+	require.Nil(t, stats)
+	require.Contains(t, err.Error(), "header has 2 fields")
+}


### PR DESCRIPTION
## Summary

- reject a `/proc/net/stat/arp_cache` data row that is wider than its header
- propagate buffered scanner errors instead of returning a partial map

## Why

`NetArpCache` keys counters by header position:

    for num, counter := range strings.Fields(scanner.Text()) {
        cache.Stats[headers[num]] = value
    }

A row with more fields than the header line indexes past `headers` and panics
the collector goroutine instead of reporting the layout mismatch:

    panic: runtime error: index out of range [2] with length 2
    huatuo/internal/procfs.NetArpCache()

The package already treats mismatched input as supported: the existing
`MismatchedFieldsFewerValues` case parses a hand-written file whose row is
narrower than the header. Only the wider direction panics.

## Validation

Before the fix, with the new case added:

    --- FAIL: TestNetArpCacheRejectsWiderRowThanHeader
    panic: runtime error: index out of range [2] with length 2

After the fix, on Linux, Go 1.24.5:

    ok  internal/procfs  0.003s

- `GOOS=linux go build ./internal/procfs/` and `go vet ./internal/procfs/`
- `go test ./internal/procfs/ -count=1` including the pre-existing cases
  (missing file, invalid hex, missing second line, empty file, narrower row)

Parsing only the first data row and per-CPU aggregation are unchanged; this
change only replaces the panic with an error.
