### PR TITLE
fix(pidfile): write the pid after the flock is held

### DIFF
--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"syscall"
@@ -41,11 +42,12 @@ type Handle struct {
 
 // Lock takes an exclusive, non-blocking flock on the pid file for name.
 // If another live process already holds the lock, the returned error
-// embeds its recorded pid.
+// embeds its recorded pid. The pid is written only after the flock is
+// held, so a rejected Lock leaves the running instance's record intact.
 func Lock(name string) (*Handle, error) {
 	p := path(name)
 
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +66,7 @@ func Lock(name string) (*Handle, error) {
 		return nil, err
 	}
 
-	if _, err := fmt.Fprintf(f, "%d", os.Getpid()); err != nil {
+	if err := writePID(f); err != nil {
 		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 		_ = f.Close()
 		_ = os.Remove(p)
@@ -73,6 +75,21 @@ func Lock(name string) (*Handle, error) {
 	}
 
 	return &Handle{file: f, path: p}, nil
+}
+
+// writePID replaces the pid file content with the current process id. It runs
+// with the flock already held: truncating before the flock would erase the pid
+// recorded by a running instance.
+func writePID(f *os.File) error {
+	if err := f.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
+	_, err := fmt.Fprintf(f, "%d", os.Getpid())
+	return err
 }
 
 // Unlock unlocks, closes, and removes the pid file. Calling Unlock more

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -174,3 +174,41 @@ func TestRead_NotExist(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, os.IsNotExist(err))
 }
+
+// TestLock_AlreadyLockedKeepsRecordedPID guards the regression where Lock
+// opened the pid file with O_TRUNC before taking the flock: starting a second
+// instance truncated the running instance's pid file, so the "already running"
+// diagnostic lost the pid and the on-disk record was destroyed.
+func TestLock_AlreadyLockedKeepsRecordedPID(t *testing.T) {
+	redirectPidDir(t)
+
+	name := "keep-pid"
+	lk, err := Lock(name)
+	require.NoError(t, err)
+	t.Cleanup(lk.Unlock)
+
+	_, err = Lock(name)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), strconv.Itoa(os.Getpid()))
+
+	data, err := os.ReadFile(path(name))
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(os.Getpid()), string(data))
+}
+
+// TestLock_ReplacesStaleRecord checks that an acquired lock still rewrites the
+// file it locked, without leaving bytes from the previous record behind.
+func TestLock_ReplacesStaleRecord(t *testing.T) {
+	redirectPidDir(t)
+
+	name := "stale-record"
+	require.NoError(t, os.WriteFile(path(name), []byte("999999999"), 0o600))
+
+	lk, err := Lock(name)
+	require.NoError(t, err)
+	t.Cleanup(lk.Unlock)
+
+	data, err := os.ReadFile(path(name))
+	require.NoError(t, err)
+	assert.Equal(t, strconv.Itoa(os.Getpid()), string(data))
+}


### PR DESCRIPTION
## Summary

- open the pid file without `O_TRUNC` and write the pid only after the flock is
  held
- keep the running instance's record intact when `Lock` rejects a second
  instance

## Why

`Lock` opened the pid file with `os.O_TRUNC` before attempting the flock, so a
second instance truncated the running instance's pid file on the way in, before
`flock` reported the conflict. The "already running" diagnostic then lost the
pid it is supposed to embed, and the on-disk record stayed empty:

    $ huatuo-bamai   # second instance, first one running
    already running: /var/run/huatuo-bamai.pid       # pid= is missing
    $ cat /var/run/huatuo-bamai.pid
    $                                                # the record is gone

Anything reading that file after the failed start (`pidfile.Read`, used by
`internal/pod/container_file.go`) now sees empty content instead of the live
pid.

## Validation

Before the fix, with the new test added:

    --- FAIL: TestLock_AlreadyLockedKeepsRecordedPID
        expected: "387469"
        actual  : ""

After the fix, on Linux, Go 1.24.5:

    ok  internal/pidfile  0.005s

- `GOOS=linux go build ./internal/pidfile/` and `go vet ./internal/pidfile/`
- `go test ./internal/pidfile/ -count=1` including the pre-existing lock,
  unlock, GC-survival and Read cases

`writePID` truncates and rewrites the file through the same locked descriptor,
so the released path (unlock, close, remove) is unchanged.
