### PR TITLE
fix(events): guard net_rx_latency stage table indexes

### DIFF
--- a/core/events/net_rx_latency.go
+++ b/core/events/net_rx_latency.go
@@ -67,6 +67,16 @@ var latencyStageNames = []string{
 	"RX_STAGE_USERCOPY",
 }
 
+// latencyStageInfo maps a kernel-provided stage index to its name and
+// configured threshold. Unknown stages (struct drift, corrupted samples)
+// must not panic the agent.
+func latencyStageInfo(stage int, thresholds []uint64) (string, uint64, bool) {
+	if stage < 0 || stage >= len(latencyStageNames) || stage >= len(thresholds) {
+		return "", 0, false
+	}
+	return latencyStageNames[stage], thresholds[stage], true
+}
+
 func init() {
 	tracing.RegisterEventTracing("net_rx_latency", newNetRcvLat)
 }
@@ -162,9 +172,13 @@ func (c *netRecvLatTracing) Start(ctx context.Context) error {
 				continue
 			}
 
-			latencyStage := latencyStageNames[pd.LatencyStage]
+			latencyStage, latencyThresholdMS, okStage :=
+				latencyStageInfo(int(pd.LatencyStage), latencyThresholds)
+			if !okStage {
+				log.Warnf("net_rx_latency: unknown latency stage %d, skip event", pd.LatencyStage)
+				continue
+			}
 			latencyMS := float64(pd.LatencyNS) / 1000 / 1000
-			latencyThresholdMS := latencyThresholds[pd.LatencyStage]
 			state := packet.TCPStateName(pd.TCPState)
 			saddr, daddr := netutil.Inetv4Ntop(pd.TCPSaddr).String(), netutil.Inetv4Ntop(pd.TCPDaddr).String()
 			sport, dport := netutil.Ntohs(pd.TCPSport), netutil.Ntohs(pd.TCPDport)

--- a/core/events/net_rx_latency.go
+++ b/core/events/net_rx_latency.go
@@ -172,8 +172,7 @@ func (c *netRecvLatTracing) Start(ctx context.Context) error {
 				continue
 			}
 
-			latencyStage, latencyThresholdMS, okStage :=
-				latencyStageInfo(int(pd.LatencyStage), latencyThresholds)
+			latencyStage, latencyThresholdMS, okStage := latencyStageInfo(int(pd.LatencyStage), latencyThresholds)
 			if !okStage {
 				log.Warnf("net_rx_latency: unknown latency stage %d, skip event", pd.LatencyStage)
 				continue

--- a/core/events/net_rx_latency_test.go
+++ b/core/events/net_rx_latency_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The HuaTuo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import "testing"
+
+func TestLatencyStageInfo(t *testing.T) {
+	thresholds := []uint64{10, 20, 30}
+
+	name, threshold, ok := latencyStageInfo(0, thresholds)
+	if !ok || name != "RX_STAGE_NETIF" || threshold != 10 {
+		t.Fatalf("stage 0 = (%q, %d, %v)", name, threshold, ok)
+	}
+
+	name, threshold, ok = latencyStageInfo(2, thresholds)
+	if !ok || name != "RX_STAGE_USERCOPY" || threshold != 30 {
+		t.Fatalf("stage 2 = (%q, %d, %v)", name, threshold, ok)
+	}
+
+	if _, _, ok = latencyStageInfo(3, thresholds); ok {
+		t.Fatal("out-of-range stage should be rejected")
+	}
+	if _, _, ok = latencyStageInfo(-1, thresholds); ok {
+		t.Fatal("negative stage should be rejected")
+	}
+	if _, _, ok = latencyStageInfo(0, nil); ok {
+		t.Fatal("empty thresholds should be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- Guard `latencyStageNames` / `latencyThresholds` indexes with a bounds check.
- Skip unknown BPF latency stages with a warning instead of panicking the agent.

## Issue
Fixes #822

## Testing
- Added `TestLatencyStageInfo` covering valid, out-of-range, negative, and empty-threshold cases.
- Go toolchain is not available in this environment, so `make check` / `make unit` were not run. Please run them locally.

## Notes
Draft while unit/lint evidence is pending. Ready after local `make check` and `make unit` pass.
