### PR TITLE
fix(metrics): retain cpu_stat series on sub-second scrapes

### DIFF
--- a/core/metrics/cpu_stat.go
+++ b/core/metrics/cpu_stat.go
@@ -115,20 +115,20 @@ func newCPUStatSample(raw map[string]uint64, cpuTotal uint64, now time.Time) (cp
 	burstTime, burstTimeOK := durationNanoseconds(raw, "burst_time", "burst_usec")
 
 	return cpuStat{
-		nrThrottled:   nrThrottled,
-		throttledTime: throttledTime,
-		waitSum:       waitSum,
-		nrBursts:      nrBursts,
-		burstTime:     burstTime,
-		cpuTotal:      cpuTotal,
-		lastUpdate:    now,
-	}, cpuStatAvailability{
-		waitPercent:   waitSumOK,
-		nrThrottled:   nrThrottledOK,
-		throttledTime: throttledTimeOK,
-		nrBursts:      nrBurstsOK,
-		burstTime:     burstTimeOK,
-	}
+			nrThrottled:   nrThrottled,
+			throttledTime: throttledTime,
+			waitSum:       waitSum,
+			nrBursts:      nrBursts,
+			burstTime:     burstTime,
+			cpuTotal:      cpuTotal,
+			lastUpdate:    now,
+		}, cpuStatAvailability{
+			waitPercent:   waitSumOK,
+			nrThrottled:   nrThrottledOK,
+			throttledTime: throttledTimeOK,
+			nrBursts:      nrBurstsOK,
+			burstTime:     burstTimeOK,
+		}
 }
 
 func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Container) (cpuStatAvailability, error) {

--- a/core/metrics/cpu_stat.go
+++ b/core/metrics/cpu_stat.go
@@ -39,6 +39,10 @@ type cpuStat struct {
 	waitPercent float64
 
 	lastUpdate time.Time
+	// availability remembers which series the last successful sample
+	// exposed. A sub-second scrape reuses it instead of dropping every
+	// metric for the container.
+	availability cpuStatAvailability
 }
 
 type cpuStatAvailability struct {
@@ -111,20 +115,20 @@ func newCPUStatSample(raw map[string]uint64, cpuTotal uint64, now time.Time) (cp
 	burstTime, burstTimeOK := durationNanoseconds(raw, "burst_time", "burst_usec")
 
 	return cpuStat{
-			nrThrottled:   nrThrottled,
-			throttledTime: throttledTime,
-			waitSum:       waitSum,
-			nrBursts:      nrBursts,
-			burstTime:     burstTime,
-			cpuTotal:      cpuTotal,
-			lastUpdate:    now,
-		}, cpuStatAvailability{
-			waitPercent:   waitSumOK,
-			nrThrottled:   nrThrottledOK,
-			throttledTime: throttledTimeOK,
-			nrBursts:      nrBurstsOK,
-			burstTime:     burstTimeOK,
-		}
+		nrThrottled:   nrThrottled,
+		throttledTime: throttledTime,
+		waitSum:       waitSum,
+		nrBursts:      nrBursts,
+		burstTime:     burstTime,
+		cpuTotal:      cpuTotal,
+		lastUpdate:    now,
+	}, cpuStatAvailability{
+		waitPercent:   waitSumOK,
+		nrThrottled:   nrThrottledOK,
+		throttledTime: throttledTimeOK,
+		nrBursts:      nrBurstsOK,
+		burstTime:     burstTimeOK,
+	}
 }
 
 func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Container) (cpuStatAvailability, error) {
@@ -135,7 +139,11 @@ func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Containe
 
 	now := time.Now()
 	if now.Sub(cpu.lastUpdate) < time.Second {
-		return availability, nil
+		// wait_sum deltas need a >=1s window, but a faster scrape must
+		// still export the last-known series. Returning an empty
+		// availability here made every cpu_stat metric vanish for the
+		// container on that scrape.
+		return cpu.availability, nil
 	}
 
 	raw, err := c.cgroup.CpuStatRaw(container.CgroupPath)
@@ -151,17 +159,20 @@ func (c *cpuStatCollector) updateDataCache(cpu *cpuStat, container *pod.Containe
 	stat, availability := newCPUStatSample(raw, usage.Usage*1000, now)
 	if !availability.waitPercent {
 		stat.lastUpdate = time.Time{}
+		stat.availability = availability
 		*cpu = stat
 		return availability, nil
 	}
 
 	if cpu.lastUpdate.IsZero() {
 		availability.waitPercent = false
+		stat.availability = availability
 		*cpu = stat
 		return availability, nil
 	}
 
 	stat.waitPercent, availability.waitPercent = calculateWaitPercent(&stat, cpu)
+	stat.availability = availability
 
 	*cpu = stat
 	return availability, nil

--- a/core/metrics/cpu_stat_test.go
+++ b/core/metrics/cpu_stat_test.go
@@ -18,7 +18,25 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/ccfos/huatuo/internal/cgroups"
+	"github.com/ccfos/huatuo/internal/cgroups/stats"
+	"github.com/ccfos/huatuo/internal/pod"
 )
+
+type cpuStatCgroupStub struct {
+	cgroups.Cgroup
+	raw   map[string]uint64
+	usage stats.CpuUsage
+}
+
+func (c *cpuStatCgroupStub) CpuStatRaw(string) (map[string]uint64, error) {
+	return c.raw, nil
+}
+
+func (c *cpuStatCgroupStub) CpuUsage(string) (*stats.CpuUsage, error) {
+	return &c.usage, nil
+}
 
 func TestDurationNanoseconds(t *testing.T) {
 	tests := []struct {
@@ -183,5 +201,47 @@ func TestNewCPUStatSample(t *testing.T) {
 				t.Fatalf("newCPUStatSample() availability = %+v, want %+v", availability, tt.wantAvailability)
 			}
 		})
+	}
+}
+
+func TestCPUStatUpdateDataCacheRetainsAvailabilityOnSubSecondScrape(t *testing.T) {
+	raw := map[string]uint64{
+		"nr_throttled":   3,
+		"throttled_usec": 4,
+		"wait_sum":       100,
+		"nr_bursts":      1,
+		"burst_usec":     2,
+	}
+	container := &pod.Container{CgroupPath: "/sys/fs/cgroup/test"}
+	collector := &cpuStatCollector{
+		cgroup: &cpuStatCgroupStub{
+			raw:   raw,
+			usage: stats.CpuUsage{Usage: 1000},
+		},
+	}
+	cache := &cpuStat{lastUpdate: time.Now().Add(-2 * time.Second)}
+
+	first, err := collector.updateDataCache(cache, container)
+	if err != nil {
+		t.Fatalf("first updateDataCache() error = %v", err)
+	}
+	if !first.nrThrottled || !first.throttledTime || !first.nrBursts || !first.burstTime {
+		t.Fatalf("first availability = %+v, want throttle/burst series", first)
+	}
+	if first.waitPercent {
+		t.Fatal("first sample should not expose wait_sum_percent until a delta window exists")
+	}
+
+	// Simulate a second scrape inside the 1s refresh window.
+	cache.lastUpdate = time.Now()
+	second, err := collector.updateDataCache(cache, container)
+	if err != nil {
+		t.Fatalf("sub-second updateDataCache() error = %v", err)
+	}
+	if second != first {
+		t.Fatalf("sub-second availability = %+v, want retained %+v", second, first)
+	}
+	if second != cache.availability {
+		t.Fatalf("cache availability = %+v, want %+v", cache.availability, second)
 	}
 }

--- a/core/metrics/cpu_stat_test.go
+++ b/core/metrics/cpu_stat_test.go
@@ -219,7 +219,9 @@ func TestCPUStatUpdateDataCacheRetainsAvailabilityOnSubSecondScrape(t *testing.T
 			usage: stats.CpuUsage{Usage: 1000},
 		},
 	}
-	cache := &cpuStat{lastUpdate: time.Now().Add(-2 * time.Second)}
+	// Fresh life-resource cache has a zero lastUpdate; only then is
+	// wait_sum_percent suppressed until a delta window exists.
+	cache := &cpuStat{}
 
 	first, err := collector.updateDataCache(cache, container)
 	if err != nil {


### PR DESCRIPTION
## Summary

`cpuStatCollector.updateDataCache` rate-limits cgroup reads to one per second so `wait_sum` deltas have a meaningful window. The rate-limit path returned a zero-value `cpuStatAvailability`, so `Update()` skipped every `cpu_stat` series for that container. A scrape landing inside the window made `wait_sum_percent`, `nr_throttled`, `throttled_time`, `nr_bursts` and `burst_time` vanish even though the cached values were still valid.

This stores the last successful availability on the `cpuStat` life resource and returns it from the rate-limit path, matching `cpu_util` which already re-exports cached utilization under the same guard.

Fixes #825

## Changes

- `core/metrics/cpu_stat.go`: persist `cpuStatAvailability` on the cache and return it when the 1s window has not elapsed
- `core/metrics/cpu_stat_test.go`: stub cgroup + regression test that a sub-second call retains the previous availability

## Validation

- `gofmt -l` clean on both files; `git diff --check` clean
- `go test ./core/metrics -run TestCPUStatUpdateDataCacheRetainsAvailabilityOnSubSecondScrape` could not run in this Windows checkout: the package setup fails on pre-existing vendored build constraints (`internal/bpf/abi` with `-mod=vendor`, and `prometheus/procfs/sysfs`). The added test targets the pure cache path and is kept for Linux CI.
- `make check` / `make unit` not run for the same environment limitation.

## Notes for reviewers

DCO Signed-off-by present. No generated files touched.