### PR TITLE
fix(metrics): withhold cpu_util until a baseline sample exists

### DIFF
--- a/core/metrics/cpu_util.go
+++ b/core/metrics/cpu_util.go
@@ -36,6 +36,11 @@ type cpuUtilStat struct {
 	totalUtil     float64
 	sysUtil       float64
 	usrUtil       float64
+	// utilValid reports whether totalUtil/usrUtil/sysUtil describe the interval
+	// that ended at lastTimestamp. It is false until a second sample has been
+	// observed, so the first scrape after a baseline (or after a re-baseline)
+	// does not publish a lifetime average as if it were an interval rate.
+	utilValid bool
 }
 
 type cpuUtilCollector struct {
@@ -74,18 +79,18 @@ func newCpuCollector() (*tracing.EventTracingAttr, error) {
 }
 
 func (c *cpuUtilCollector) updateDataCache(cache *cpuUtilStat, container *pod.Container, numCores float64) error {
-	var (
-		usrUtil    float64
-		sysUtil    float64
-		totalUtil  float64
-		cgroupPath string
-	)
+	var cgroupPath string
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	now := time.Now()
-	if now.Sub(cache.lastTimestamp).Nanoseconds() < 1000000000 {
+
+	// A zero lastTimestamp means "no baseline yet", not "sampled in year 1":
+	// now.Sub(time.Time{}) saturates at the maximum Duration (~292 years), so the
+	// interval check below cannot detect the first sample on its own.
+	firstSample := cache.lastTimestamp.IsZero()
+	if !firstSample && now.Sub(cache.lastTimestamp) < time.Second {
 		return nil
 	}
 
@@ -98,42 +103,85 @@ func (c *cpuUtilCollector) updateDataCache(cache *cpuUtilStat, container *pod.Co
 		return err
 	}
 
-	// Usage, User, and System should increase monotonically. This defensive
-	// check prevents an unexpected reset from causing uint64 underflow.
-	if stat.Usage < cache.lastUsage.Usage ||
-		stat.User < cache.lastUsage.User ||
-		stat.System < cache.lastUsage.System {
+	// The counters are lifetime totals. On the first sample there is no previous
+	// observation to subtract, so record the baseline and publish nothing. The
+	// alternative is to divide a whole-lifetime total by the whole-lifetime
+	// interval that a zero timestamp implies and report it as an interval rate.
+	if firstSample {
 		cache.lastUsage = *stat
 		cache.lastTimestamp = now
+		cache.utilValid = false
 		return nil
 	}
 
-	deltaTotalTime := stat.Usage - cache.lastUsage.Usage
-	deltaUsrTime := stat.User - cache.lastUsage.User
-	deltaSysTime := stat.System - cache.lastUsage.System
-	deltaRealWorldTime := numCores * float64(now.Sub(cache.lastTimestamp).Microseconds())
-
-	if (float64(deltaTotalTime) > deltaRealWorldTime) || (float64(deltaUsrTime+deltaSysTime) > deltaRealWorldTime) {
+	totalUtil, usrUtil, sysUtil, ok := computeCPUUtil(cache.lastUsage, *stat, now.Sub(cache.lastTimestamp), numCores)
+	if !ok {
+		// A counter that ran backwards, or that advanced faster than the elapsed
+		// wall clock and the core count can deliver, cannot be normalized: the
+		// cgroup was recreated or the clock stepped. Re-baseline, publish nothing.
 		cache.lastUsage = *stat
 		cache.lastTimestamp = now
+		cache.utilValid = false
 		return nil
 	}
-
-	totalUtil = float64(deltaTotalTime) * 100 / deltaRealWorldTime
-	usrUtil = float64(deltaUsrTime) * 100 / deltaRealWorldTime
-	sysUtil = float64(deltaSysTime) * 100 / deltaRealWorldTime
 
 	cache.lastUsage = *stat
+	cache.lastTimestamp = now
 	cache.totalUtil = totalUtil
 	cache.usrUtil = usrUtil
 	cache.sysUtil = sysUtil
-	cache.lastTimestamp = now
+	cache.utilValid = true
 	return nil
+}
+
+// computeCPUUtil normalizes the CPU counter delta between two consecutive
+// samples into a percentage of the capacity the workload could have used over
+// the elapsed interval.
+//
+// It reports ok=false, rather than a number, whenever the delta cannot be
+// normalized:
+//
+//   - a non-positive interval or core count, which leaves nothing to divide by;
+//   - a counter that moved backwards, which is a reset rather than usage;
+//   - a delta larger than the interval and the core count could physically
+//     deliver, which is the signature of a stale or missing baseline.
+func computeCPUUtil(prev, curr stats.CpuUsage, elapsed time.Duration, numCores float64) (total, usr, sys float64, ok bool) {
+	if elapsed <= 0 || numCores <= 0 {
+		return 0, 0, 0, false
+	}
+
+	// Usage, User, and System should increase monotonically. Checking before the
+	// subtraction also keeps an unexpected reset from underflowing uint64.
+	if curr.Usage < prev.Usage || curr.User < prev.User || curr.System < prev.System {
+		return 0, 0, 0, false
+	}
+
+	capacity := numCores * float64(elapsed.Microseconds())
+	if capacity <= 0 {
+		return 0, 0, 0, false
+	}
+
+	deltaTotal := curr.Usage - prev.Usage
+	deltaUsr := curr.User - prev.User
+	deltaSys := curr.System - prev.System
+
+	if float64(deltaTotal) > capacity || float64(deltaUsr+deltaSys) > capacity {
+		return 0, 0, 0, false
+	}
+
+	return float64(deltaTotal) * 100 / capacity,
+		float64(deltaUsr) * 100 / capacity,
+		float64(deltaSys) * 100 / capacity,
+		true
 }
 
 func (c *cpuUtilCollector) updateHostDataCache() ([]*metric.Data, error) {
 	if err := c.updateDataCache(&c.cpuDataCache, nil, c.numCores); err != nil {
 		return nil, err
+	}
+
+	if !c.cpuDataCache.utilValid {
+		return nil, nil
 	}
 
 	return []*metric.Data{
@@ -180,10 +228,19 @@ func (c *cpuUtilCollector) Update() ([]*metric.Data, error) {
 		metrics = append(
 			metrics,
 			metric.NewContainerGaugeData(container, "cores", numCores, "cpu core number for the containers", nil),
-			metric.NewContainerGaugeData(container, "usr", dataCache.usrUtil, "cpu usr for the containers", nil),
-			metric.NewContainerGaugeData(container, "sys", dataCache.sysUtil, "cpu sys for the containers", nil),
-			metric.NewContainerGaugeData(container, "total", dataCache.totalUtil, "cpu total for the containers", nil),
 		)
+
+		// Without a baseline there is no rate to report. The core count is still
+		// meaningful, but publishing usr/sys/total here would export a lifetime
+		// average as though it were the current scrape interval's rate.
+		if dataCache.utilValid {
+			metrics = append(
+				metrics,
+				metric.NewContainerGaugeData(container, "usr", dataCache.usrUtil, "cpu usr for the containers", nil),
+				metric.NewContainerGaugeData(container, "sys", dataCache.sysUtil, "cpu sys for the containers", nil),
+				metric.NewContainerGaugeData(container, "total", dataCache.totalUtil, "cpu total for the containers", nil),
+			)
+		}
 	}
 
 	more, err := c.updateHostDataCache()

--- a/core/metrics/cpu_util_test.go
+++ b/core/metrics/cpu_util_test.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -82,5 +83,167 @@ func TestCPUUtilCollectorUpdateDataCacheCounterRegression(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestComputeCPUUtil(t *testing.T) {
+	const usagePerCorePerSecond = uint64(time.Second / time.Microsecond)
+
+	tests := []struct {
+		name     string
+		prev     stats.CpuUsage
+		curr     stats.CpuUsage
+		elapsed  time.Duration
+		numCores float64
+		wantTot  float64
+		wantUsr  float64
+		wantSys  float64
+		wantOK   bool
+	}{
+		{
+			name:     "one core fully busy",
+			prev:     stats.CpuUsage{Usage: usagePerCorePerSecond, User: 600000, System: 400000},
+			curr:     stats.CpuUsage{Usage: 2 * usagePerCorePerSecond, User: 1200000, System: 800000},
+			elapsed:  time.Second,
+			numCores: 1,
+			wantTot:  100,
+			wantUsr:  60,
+			wantSys:  40,
+			wantOK:   true,
+		},
+		{
+			name:     "four cores half busy",
+			prev:     stats.CpuUsage{},
+			curr:     stats.CpuUsage{Usage: 2 * usagePerCorePerSecond, User: usagePerCorePerSecond, System: usagePerCorePerSecond},
+			elapsed:  time.Second,
+			numCores: 4,
+			wantTot:  50,
+			wantUsr:  25,
+			wantSys:  25,
+			wantOK:   true,
+		},
+		{
+			name:     "idle core",
+			prev:     stats.CpuUsage{Usage: 5 * usagePerCorePerSecond, User: 3 * usagePerCorePerSecond, System: 2 * usagePerCorePerSecond},
+			curr:     stats.CpuUsage{Usage: 5 * usagePerCorePerSecond, User: 3 * usagePerCorePerSecond, System: 2 * usagePerCorePerSecond},
+			elapsed:  time.Second,
+			numCores: 2,
+			wantOK:   true,
+		},
+		{
+			name:     "counter moved backwards",
+			prev:     stats.CpuUsage{Usage: 2 * usagePerCorePerSecond, User: usagePerCorePerSecond, System: usagePerCorePerSecond},
+			curr:     stats.CpuUsage{Usage: usagePerCorePerSecond, User: usagePerCorePerSecond / 2, System: usagePerCorePerSecond / 2},
+			elapsed:  time.Second,
+			numCores: 1,
+			wantOK:   false,
+		},
+		{
+			name:     "delta exceeds the interval and the core count",
+			prev:     stats.CpuUsage{},
+			curr:     stats.CpuUsage{Usage: 2 * usagePerCorePerSecond, User: usagePerCorePerSecond, System: usagePerCorePerSecond},
+			elapsed:  time.Second,
+			numCores: 1,
+			wantOK:   false,
+		},
+		{
+			name:     "no elapsed time",
+			prev:     stats.CpuUsage{},
+			curr:     stats.CpuUsage{Usage: usagePerCorePerSecond},
+			numCores: 1,
+			wantOK:   false,
+		},
+		{
+			name:     "no cores",
+			prev:     stats.CpuUsage{},
+			curr:     stats.CpuUsage{Usage: usagePerCorePerSecond},
+			elapsed:  time.Second,
+			numCores: 0,
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total, usr, sys, ok := computeCPUUtil(tt.prev, tt.curr, tt.elapsed, tt.numCores)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (total=%v usr=%v sys=%v)", ok, tt.wantOK, total, usr, sys)
+			}
+			if !tt.wantOK {
+				if total != 0 || usr != 0 || sys != 0 {
+					t.Fatalf("rejected sample returned total=%v usr=%v sys=%v, want all zero", total, usr, sys)
+				}
+				return
+			}
+			for _, c := range []struct {
+				name string
+				got  float64
+				want float64
+			}{
+				{name: "total", got: total, want: tt.wantTot},
+				{name: "usr", got: usr, want: tt.wantUsr},
+				{name: "sys", got: sys, want: tt.wantSys},
+			} {
+				if math.Abs(c.got-c.want) > 1e-9 {
+					t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCPUUtilCollectorFirstSamplePublishesNoUtilization(t *testing.T) {
+	// A container that has been busy since it started: the cgroup counters are
+	// lifetime totals, so they are already large on the very first scrape.
+	const lifetimeUsage = uint64(time.Hour / time.Microsecond)
+
+	usage := &cpuUsageCgroup{
+		usage: stats.CpuUsage{
+			Usage:  lifetimeUsage,
+			User:   lifetimeUsage / 2,
+			System: lifetimeUsage / 2,
+		},
+	}
+	collector := cpuUtilCollector{cgroup: usage, numCores: 1}
+
+	// First scrape: there is no previous sample, so no rate can be derived. The
+	// zero lastTimestamp used to slip past the interval guard, because
+	// now.Sub(time.Time{}) saturates at roughly 292 years, and the lifetime total
+	// was then divided by that interval, publishing a total of a few 1e-5 percent.
+	data, err := collector.updateHostDataCache()
+	if err != nil {
+		t.Fatalf("updateHostDataCache() error = %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("first sample published %d series, want 0", len(data))
+	}
+	if collector.cpuDataCache.lastUsage.Usage != lifetimeUsage {
+		t.Fatalf("baseline usage = %d, want %d", collector.cpuDataCache.lastUsage.Usage, lifetimeUsage)
+	}
+	if collector.cpuDataCache.lastTimestamp.IsZero() {
+		t.Fatal("first sample did not record a baseline timestamp")
+	}
+
+	// Second scrape, one second of wall clock later, with one core saturated.
+	const oneSecond = uint64(time.Second / time.Microsecond)
+	usage.usage = stats.CpuUsage{
+		Usage:  lifetimeUsage + oneSecond,
+		User:   lifetimeUsage/2 + oneSecond/2,
+		System: lifetimeUsage/2 + oneSecond/2,
+	}
+	collector.cpuDataCache.lastTimestamp = time.Now().Add(-time.Second)
+
+	data, err = collector.updateHostDataCache()
+	if err != nil {
+		t.Fatalf("updateHostDataCache() error = %v", err)
+	}
+	if len(data) != 3 {
+		t.Fatalf("second sample published %d series, want 3", len(data))
+	}
+	if !collector.cpuDataCache.utilValid {
+		t.Fatal("second sample did not mark the utilization valid")
+	}
+	if got := collector.cpuDataCache.totalUtil; got < 90 || got > 100.01 {
+		t.Fatalf("total utilization = %v, want about 100", got)
 	}
 }


### PR DESCRIPTION
## Summary

- treat a zero `lastTimestamp` as "no baseline yet" instead of as a very old sample
- move the rate arithmetic into `computeCPUUtil`, which declines to produce a number when the delta cannot be normalized
- withhold `usr`/`sys`/`total` until a real interval exists, while still exporting `cores`
- add a first-sample regression test and table coverage for the pure function

## Why

`updateDataCache` used `lastTimestamp` for two meanings at once: when the previous sample was taken, and whether there was a previous sample at all. A zero `time.Time` cannot express the second one, because `now.Sub(time.Time{})` saturates at the maximum `time.Duration` (~292 years). The interval guard

    now.Sub(cache.lastTimestamp).Nanoseconds() < 1000000000

therefore let the very first scrape through instead of skipping it.

That first scrape had no previous counter values to subtract, so the lifetime totals became the deltas and the saturated interval became the divisor. For a container that had been busy for an hour:

    total = 3600e6 * 100 / (1 * 9223372036854775) = 3.9e-05 %

I confirmed the saturation directly instead of deriving it: `time.Now().Sub(time.Time{}).Nanoseconds()` returns `9223372036854775807`, which is `math.MaxInt64`.

The value was written to the time series, so a container pinning a core is reported as idle from the moment the collector starts until its second scrape. The host path has the same defect, and a container whose `LifeResources` entry is rebuilt repeats it. `disk_io.collectIOWait` skips its first sample on `previous.total == 0` and `cpu_stat` guards on `lastUpdate.IsZero()`; `cpu_util` was the one that did not.

## Validation

```
gofmt -l core/metrics/cpu_util.go core/metrics/cpu_util_test.go     # clean
GOOS=linux GOARCH=amd64 go vet ./core/metrics/                       # clean
GOOS=linux GOARCH=amd64 go test -c -mod=vendor -o /dev/null ./core/metrics/   # builds
```

The Linux test binary cannot execute on this Windows host: `core/metrics` imports procfs and cgroups, so `go test` fails here at the build constraints, and there is no WSL distro or container runtime available. Rather than guess at the outcome, I replayed the pre-fix and post-fix arithmetic in a standalone harness using the same assertions as the added test:

| scrape | before | after |
| --- | --- | --- |
| first | 3 series published, `total=3.9e-05` | 0 series published, baseline recorded |
| second, 1s later, 1 core saturated | — | 3 series, `total=100`, `usr=50`, `sys=50` |

`computeCPUUtil` also reports `ok=false` for a counter that moved backwards, a delta larger than the interval and the core count could deliver, a zero interval and a zero core count. GitHub CI is expected to run the tests themselves.

Fixes #827

## AI disclosure
Prepared with AI assistance; contributor reviewed the final diff.