### PR TITLE
fix(storage): bound Elasticsearch response bodies

### DIFF
--- a/internal/storage/elasticsearch/elasticsearch.go
+++ b/internal/storage/elasticsearch/elasticsearch.go
@@ -41,6 +41,22 @@ import (
 const (
 	defaultQuerySize = 10000
 
+	// maxResponseBodyBytes bounds a successful response body before it is
+	// decoded. A query returns at most defaultQuerySize hits, so this leaves
+	// roughly 6.5 KiB per hit and no legitimate response reaches it, while an
+	// endpoint that streams without end is rejected instead of growing the
+	// agent's heap without bound. HTTP timeouts bound elapsed time, not bytes.
+	maxResponseBodyBytes = 64 << 20
+
+	// maxErrorPreviewBytes bounds the response body retained for diagnostics.
+	// Elasticsearch error documents are small JSON objects, so a longer body is
+	// truncated and marked rather than copied into the error's text in full.
+	maxErrorPreviewBytes = 4 << 10
+
+	// truncatedMarker is appended to a preview that hit maxErrorPreviewBytes, so
+	// a partial diagnostic is never mistaken for the whole response.
+	truncatedMarker = " ... (truncated)"
+
 	// Bulk indexer tuning. 5MB / 1s matches the upstream defaults and is a
 	// safe starting point for ES/OpenSearch single-node and small clusters.
 	// Adjust if write rate or per-event size drifts significantly.
@@ -214,7 +230,7 @@ func (s *Storage) Get(ctx context.Context, id string) (rec driver.Record, err er
 	}
 
 	var payload esget.Response
-	if err = json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err = decodeBounded(res.Body, &payload); err != nil {
 		return rec, fmt.Errorf("elasticsearch backend get %s/%s: decode: %w", s.index, id, err)
 	}
 	if !payload.Found {
@@ -277,7 +293,7 @@ func (s *Storage) DeleteByQuery(ctx context.Context, query driver.DeleteQuery) (
 	}
 
 	var payload esdeletebyquery.Response
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeBounded(res.Body, &payload); err != nil {
 		return 0, fmt.Errorf(
 			"elasticsearch backend delete by query %s: decode: %w",
 			s.index,
@@ -322,7 +338,7 @@ func (s *Storage) Query(ctx context.Context, q driver.Query) ([]driver.Record, e
 	}
 
 	var payload essearch.Response
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeBounded(res.Body, &payload); err != nil {
 		return nil, fmt.Errorf("elasticsearch backend query %s: decode: %w", s.index, err)
 	}
 	records := make([]driver.Record, 0, len(payload.Hits.Hits))
@@ -358,7 +374,7 @@ func (s *Storage) Count(ctx context.Context, q driver.Query) (int64, error) {
 	}
 
 	var payload escount.Response
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeBounded(res.Body, &payload); err != nil {
 		return 0, fmt.Errorf("elasticsearch backend count %s: decode: %w", s.index, err)
 	}
 	return payload.Count, nil
@@ -385,7 +401,7 @@ func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size
 	}
 
 	var payload valuesResponse
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+	if err := decodeBounded(res.Body, &payload); err != nil {
 		return nil, fmt.Errorf("elasticsearch backend terms %s/%s: decode: %w", s.index, field, err)
 	}
 	result := make([]string, 0, len(payload.Aggregations.Terms.Buckets))
@@ -395,10 +411,40 @@ func (s *Storage) Values(ctx context.Context, field string, q driver.Query, size
 	return result, nil
 }
 
+// readBounded reads at most limit bytes of body. It reports truncated when the
+// body was longer, in which case the returned data is the first limit bytes and
+// the remainder is left unread, so an oversized body is never held in memory.
+func readBounded(body io.Reader, limit int64) (data []byte, truncated bool, err error) {
+	data, err = io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(data)) > limit {
+		return data[:limit], true, nil
+	}
+	return data, false, nil
+}
+
+// decodeBounded decodes a successful response body under maxResponseBodyBytes.
+func decodeBounded(body io.Reader, target any) error {
+	data, truncated, err := readBounded(body, maxResponseBodyBytes)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	if truncated {
+		return fmt.Errorf("response body exceeds %d bytes", maxResponseBodyBytes)
+	}
+	return json.Unmarshal(data, target)
+}
+
 func responseError(action, target string, res *esapi.Response) error {
-	body, err := io.ReadAll(res.Body)
+	body, truncated, err := readBounded(res.Body, maxErrorPreviewBytes)
 	if err != nil {
 		return fmt.Errorf("elasticsearch %s %s: status %d: read body: %w", action, target, res.StatusCode, err)
 	}
-	return fmt.Errorf("elasticsearch %s %s: status %d: %s", action, target, res.StatusCode, strings.TrimSpace(string(body)))
+	preview := strings.TrimSpace(string(body))
+	if truncated {
+		preview += truncatedMarker
+	}
+	return fmt.Errorf("elasticsearch %s %s: status %d: %s", action, target, res.StatusCode, preview)
 }

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+
 	"github.com/ccfos/huatuo/internal/storage/driver"
 )
 
@@ -1406,5 +1408,175 @@ func TestNewBackendRequiresIndex(t *testing.T) {
 	_, err := NewBackend(&Config{})
 	if err == nil || err.Error() != "elasticsearch backend: index is required" {
 		t.Fatalf("NewBackend() error = %v", err)
+	}
+}
+
+// failingReader returns a fixed error from Read, standing in for a response
+// body that fails part-way through.
+type failingReader struct{ err error }
+
+func (r failingReader) Read([]byte) (int, error) { return 0, r.err }
+
+func newResponseForTest(status int, body string) *esapi.Response {
+	return &esapi.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// TestReadBounded covers the helper that keeps an oversized body out of memory:
+// a body at the limit is returned whole, and a body past it is cut at the limit
+// and reported as truncated rather than read to the end.
+func TestReadBounded(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		limit         int64
+		wantData      string
+		wantTruncated bool
+	}{
+		{name: "below limit", body: "abc", limit: 8, wantData: "abc"},
+		{name: "exactly at limit", body: "abcdefgh", limit: 8, wantData: "abcdefgh"},
+		{name: "one byte over limit", body: "abcdefghi", limit: 8, wantData: "abcdefgh", wantTruncated: true},
+		{name: "far over limit", body: strings.Repeat("x", 4096), limit: 8, wantData: "xxxxxxxx", wantTruncated: true},
+		{name: "empty body", body: "", limit: 8, wantData: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, truncated, err := readBounded(strings.NewReader(tt.body), tt.limit)
+			if err != nil {
+				t.Fatalf("readBounded() error = %v", err)
+			}
+			if truncated != tt.wantTruncated {
+				t.Fatalf("truncated = %v, want %v", truncated, tt.wantTruncated)
+			}
+			if string(data) != tt.wantData {
+				t.Fatalf("data = %q, want %q", data, tt.wantData)
+			}
+		})
+	}
+}
+
+func TestReadBoundedPropagatesReadError(t *testing.T) {
+	wantErr := errors.New("connection reset")
+	if _, _, err := readBounded(failingReader{err: wantErr}, 8); !errors.Is(err, wantErr) {
+		t.Fatalf("readBounded() error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestDecodeBoundedPropagatesReadError(t *testing.T) {
+	wantErr := errors.New("connection reset")
+
+	var payload map[string]any
+	if err := decodeBounded(failingReader{err: wantErr}, &payload); !errors.Is(err, wantErr) {
+		t.Fatalf("decodeBounded() error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+// TestResponseErrorBoundsPreview verifies that diagnostics keep a short error
+// body verbatim, truncate and mark a long one, and still surface a body read
+// failure.
+func TestResponseErrorBoundsPreview(t *testing.T) {
+	const (
+		action = "query documents"
+		target = "huatuo_bamai"
+	)
+
+	t.Run("short body is reported verbatim", func(t *testing.T) {
+		body := `{"error":"index_not_found_exception"}`
+		err := responseError(action, target, newResponseForTest(http.StatusInternalServerError, body))
+		want := "elasticsearch " + action + " " + target + ": status 500: " + body
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("oversized body is truncated and marked", func(t *testing.T) {
+		body := strings.Repeat("!", int(maxErrorPreviewBytes)*4)
+		err := responseError(action, target, newResponseForTest(http.StatusInternalServerError, body))
+
+		if !strings.HasSuffix(err.Error(), truncatedMarker) {
+			t.Fatalf("error = %q, want suffix %q", err.Error(), truncatedMarker)
+		}
+		if got := strings.Count(err.Error(), "!"); got != int(maxErrorPreviewBytes) {
+			t.Fatalf("error retained %d body bytes, want %d", got, maxErrorPreviewBytes)
+		}
+	})
+
+	t.Run("read failure is preserved", func(t *testing.T) {
+		wantErr := errors.New("connection reset")
+		res := &esapi.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(failingReader{err: wantErr}),
+		}
+		if err := responseError(action, target, res); !errors.Is(err, wantErr) {
+			t.Fatalf("error = %v, want it to wrap %v", err, wantErr)
+		}
+	})
+}
+
+// TestElasticsearchBackendRejectsOversizedResponse verifies that a successful
+// response larger than maxResponseBodyBytes is refused instead of decoded, so a
+// misrouted or malfunctioning endpoint cannot grow the agent's heap.
+func TestElasticsearchBackendRejectsOversizedResponse(t *testing.T) {
+	// The body is valid JSON that simply carries an oversized padding field. It
+	// therefore decodes without error when the whole body is read, which is what
+	// makes this a regression test: before the limit existed the response was
+	// accepted and materialized in full, and only afterwards is it refused.
+	const (
+		prefix = `{"hits":{"hits":[],"padding":"`
+		suffix = `"}}`
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+
+		if strings.Trim(r.URL.Path, "/") == "" {
+			_, _ = w.Write([]byte(`{"name":"mock-es","version":{"number":"7.17.0"}}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		written, err := w.Write([]byte(prefix))
+		if err != nil {
+			return
+		}
+
+		chunk := strings.Repeat("x", 4096)
+		for int64(written) <= maxResponseBodyBytes {
+			n, err := w.Write([]byte(chunk))
+			written += n
+			if err != nil {
+				// The client stopped reading once it had enough to reject the
+				// response, which is the behavior under test.
+				return
+			}
+		}
+
+		_, _ = w.Write([]byte(suffix))
+	}))
+	defer server.Close()
+
+	backend, err := NewBackend(&Config{
+		Addresses: []string{server.URL},
+		Index:     "huatuo_bamai",
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() returned error: %v", err)
+	}
+	defer func() {
+		if err := backend.Close(t.Context()); err != nil {
+			t.Errorf("Close() returned error: %v", err)
+		}
+	}()
+
+	_, err = backend.Query(t.Context(), driver.Query{Limit: 1})
+	if err == nil {
+		t.Fatal("Query() error = nil, want a response body limit error")
+	}
+	if !strings.Contains(err.Error(), "response body exceeds") {
+		t.Fatalf("Query() error = %v, want it to mention the response body limit", err)
 	}
 }


### PR DESCRIPTION
## Summary

- read Elasticsearch/OpenSearch responses through a byte-bounded reader
- reject a successful response that exceeds `maxResponseBodyBytes` (64 MiB)
- cap the error preview at `maxErrorPreviewBytes` (4 KiB) and mark it when truncated
- keep body read failures on both paths, with the existing error text unchanged

## Why

Responses were read without a byte limit. Every successful reply went straight to `json.NewDecoder(res.Body)`, and an error reply was pulled in with `io.ReadAll(res.Body)` before being formatted into the error text. The HTTP client timeouts bound how long a request may take, not how many bytes it may return, so a misrouted address, a proxy serving an unrelated body, or a misbehaving endpoint could make the agent allocate an arbitrarily large response.

`readBounded` now draws at most `limit+1` bytes and reports whether the body was longer, leaving the remainder unread — so the oversized body is never held in memory, and an unbounded stream is cut after a fixed amount rather than after an OOM. Both paths use it.

The 64 MiB limit is derived from the existing `defaultQuerySize` of 10000: it leaves roughly 6.5 KiB per hit, above any real event document, so a legitimate query cannot trip it.

## Verification

```
gofmt -l internal/storage/elasticsearch/elasticsearch.go internal/storage/elasticsearch/elasticsearch_test.go   # clean
go vet ./internal/storage/elasticsearch/                                                                        # clean
go test -count=1 ./internal/storage/elasticsearch/
ok  	github.com/ccfos/huatuo/internal/storage/elasticsearch	0.342s
```

New coverage: a body below the limit, exactly at the limit, one byte over, far over, an empty body, read errors on both the decode and the error-preview path, a short error preview reported verbatim, an oversized error preview truncated and marked, and an end-to-end oversized successful response.

The end-to-end case is a real regression test rather than a compile-only one: it serves **valid** JSON carrying an oversized padding field, so it decodes cleanly when read in full. Run against the pre-change code:

```
--- FAIL: TestZzProbeOriginalAcceptsOversizedResponse
    BEFORE FIX: Query() accepted an oversized response body without error
```

and it passes with the change.

One environment note. `internal/timeutil` calls `golang.org/x/sys/unix`, which has no Windows implementation, so this repository cannot be built here without help. To execute the tests I added a throwaway `//go:build windows` shim for the five `unix` symbols `timeutil` uses. **It is not part of this PR** — the branch contains only the two files above. With the shim in place, `go test ./internal/storage/...` passes for every package except `internal/storage/localfile`, which fails on Windows-only `TempDir` cleanup (`The process cannot access the file because it is being used by another process`) independently of this change.

Fixes #701

## AI disclosure
Prepared with AI assistance; contributor reviewed the final diff.