### PR TITLE
fix(kmsgutil): report sysrq capture failures instead of returning nothing

### DIFF
--- a/internal/utils/kmsgutil/kmsgutil.go
+++ b/internal/utils/kmsgutil/kmsgutil.go
@@ -23,6 +23,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/ccfos/huatuo/internal/log"
 )
 
@@ -34,6 +36,26 @@ func GetAllCPUsBT() (string, error) {
 // GetBlockedProcessesBT gets backtrace of blocked processes
 func GetBlockedProcessesBT() (string, error) {
 	return GetSysrqMsg("w")
+}
+
+// setNonblock switches fd to non-blocking mode.
+//
+// /dev/kmsg blocks once the record buffer has been drained, so the read loop in
+// GetSysrqMsg relies on EAGAIN to stop. A descriptor that cannot be switched
+// would block there instead, so the failure has to reach the caller: discarding
+// it returns an empty backtrace together with a nil error, and neither the
+// caller nor the operator has anything to investigate.
+func setNonblock(fd uintptr) error {
+	flags, err := unix.FcntlInt(fd, unix.F_GETFL, 0)
+	if err != nil {
+		return fmt.Errorf("read kmsg descriptor flags: %w", err)
+	}
+
+	if _, err := unix.FcntlInt(fd, unix.F_SETFL, flags|unix.O_NONBLOCK); err != nil {
+		return fmt.Errorf("set kmsg descriptor non-blocking: %w", err)
+	}
+
+	return nil
 }
 
 // GetSysrqMsg reads sysrq triggered demsg
@@ -64,13 +86,7 @@ func GetSysrqMsg(command string) (string, error) {
 	}
 
 	fd := kmsgFile.Fd()
-	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_GETFL, 0)
-	if errno != 0 {
-		return "", err
-	}
-
-	_, _, errno = syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_SETFL, flags|syscall.O_NONBLOCK)
-	if errno != 0 {
+	if err := setNonblock(fd); err != nil {
 		return "", err
 	}
 
@@ -100,7 +116,7 @@ func formatKmsgs(kmsgs string) string {
 		if line != "" {
 			formattedLine, err := formatKmsgEntry(line)
 			if err != nil {
-				fmt.Printf("Error formatting kmsg line: %v\n", err)
+				log.Errorf("Error formatting kmsg line: %v", err)
 				continue
 			}
 			formattedMsgs.WriteString(formattedLine)

--- a/internal/utils/kmsgutil/kmsgutil_test.go
+++ b/internal/utils/kmsgutil/kmsgutil_test.go
@@ -15,10 +15,14 @@
 package kmsgutil
 
 import (
+	"bytes"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ccfos/huatuo/internal/log"
 )
 
 func parseFormattedKmsgLine(line string) (time.Time, string, error) {
@@ -191,7 +195,35 @@ func TestGetBootTime(t *testing.T) {
 	}
 }
 
-// Note: GetSysrqMsg, GetAllCPUsBT, and GetBlockedProcessesBT involve system I/O (/dev/kmsg, /proc/sysrq-trigger)
-// and are better suited for integration tests with mocked file systems (e.g., using afero or test containers).
-// Unit tests for these would require dependency injection for os.Open, syscall.Read, etc., to isolate logic.
-// For brevity, they are omitted here; focus on pure functions above.
+// TestSetNonblockRejectsInvalidDescriptor verifies that a descriptor whose flags
+// cannot be read is reported. GetSysrqMsg used to discard the fcntl errno and
+// return the stale nil error left by the earlier write, so a failure here gave
+// the caller an empty backtrace together with a nil error.
+func TestSetNonblockRejectsInvalidDescriptor(t *testing.T) {
+	if err := setNonblock(^uintptr(0)); err == nil {
+		t.Fatal("setNonblock() error = nil, want the fcntl failure to surface")
+	}
+}
+
+// TestFormatKmsgsReportsInvalidEntryToLogger verifies that a record the parser
+// cannot read is reported through the logger. It previously went to
+// fmt.Printf, which writes to the process stdout and bypasses the logger's
+// configured output, so the diagnostic never reached the agent's log.
+func TestFormatKmsgsReportsInvalidEntryToLogger(t *testing.T) {
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(os.Stdout) })
+
+	if got := formatKmsgs("invalid\n"); got != "" {
+		t.Fatalf("formatKmsgs() = %q, want empty output", got)
+	}
+
+	if output := logged.String(); !strings.Contains(output, "Error formatting kmsg line") {
+		t.Fatalf("logger output = %q, want it to report the unparsable record", output)
+	}
+}
+
+// Note: GetAllCPUsBT and GetBlockedProcessesBT read /dev/kmsg and write
+// /proc/sysrq-trigger, which needs a real kernel. They remain integration-test
+// territory; setNonblock is covered above because the flag handling is where the
+// error was lost.


### PR DESCRIPTION
## Summary

- move the `/dev/kmsg` flag handling into `setNonblock`, which returns the error from each `fcntl` step
- stop returning the stale, provably-nil `err` left over from `sysrqFile.WriteString` when the descriptor cannot be switched
- replace the deprecated `syscall.Syscall(syscall.SYS_FCNTL, ...)` with `unix.FcntlInt`, which the repository already vendors
- route the unparsable-record diagnostic through the logger instead of `fmt.Printf`
- add a regression test for each path

## Why

`GetSysrqMsg` writes the sysrq command, then switches `/dev/kmsg` to non-blocking mode so that the read loop can stop on `EAGAIN`. Both `fcntl` steps were written as

```go
flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_GETFL, 0)
if errno != 0 {
	return "", err
}
```

`err` at that point is the one returned by `sysrqFile.WriteString(command)`, which was already checked for nil three statements earlier, so the branch can only ever return `nil`. The `errno` was bound and then discarded, and the bare `errno` variable the second block had declared was shadowed by the assignment above it. A descriptor that cannot be switched therefore produced an empty backtrace with a **nil error**: `GetAllCPUsBT` and `GetBlockedProcessesBT` handed their caller an empty string that was indistinguishable from a sysrq trigger that simply produced no output, and nothing was logged. The sysrq output is exactly what an operator reads when the machine is already misbehaving, so the failure has to be attributable.

The read loop in the same function relies on that mode: without it a drained `/dev/kmsg` blocks instead of reporting `EAGAIN`, so the failure mode is a hung collection rather than a wrong one.

The second defect is in `formatKmsgs`, which reports a record it cannot parse with

```go
fmt.Printf("Error formatting kmsg line: %v\n", err)
```

That writes to the process stdout and bypasses the logger, so on an agent whose log is configured to a file the diagnostic went to the console and the operator lost the very line that explained the truncated backtrace. The rest of the file already uses `log.Errorf`.

`setNonblock` now wraps each step, so the caller sees `read kmsg descriptor flags: ...` or `set kmsg descriptor non-blocking: ...`, and the dropped records are logged through the same logger as the other diagnostics.

## Validation

```
gofmt -l internal/utils/kmsgutil/kmsgutil.go internal/utils/kmsgutil/kmsgutil_test.go   # clean
GOOS=linux GOARCH=amd64 go vet ./internal/utils/kmsgutil/                                 # clean
GOOS=linux GOARCH=amd64 go test -c -mod=vendor -o kmsgutil.test ./internal/utils/kmsgutil/
file kmsgutil.test                                                                        # ELF 64-bit LSB executable, x86-64, 4640587 bytes
```

The Linux test binary cannot execute on this Windows host: `internal/utils/kmsgutil` pulls in `internal/timeutil`, which uses `golang.org/x/sys/unix`, so the package does not build under the windows target here and there is no WSL distro or container runtime available. Rather than assert an outcome I cannot observe, I drove the patched and unpatched code in a throwaway `_test`-style probe package that imports the real `internal/log` and calls the real functions, and captured what each version emits:

| scenario | before | after |
| --- | --- | --- |
| `fcntl(fd, F_GETFL)` fails with `EBADF` | returned error `<nil>` | returned error `read kmsg descriptor flags: bad file descriptor` |
| unparsable kmsg record | stdout: `Error formatting kmsg line: invalid entry format`, logger empty | stdout empty, logger: `level=error msg="Error formatting kmsg line: invalid entry format"` |

The probe package and the throwaway `//go:build windows` shim used to type-check the package on this host are not part of this pull request; the branch contains only the two files in the diff. `TestSetNonblockRejectsInvalidDescriptor` and `TestFormatKmsgsReportsInvalidEntryToLogger` encode the two rows above. GitHub CI is expected to run the tests themselves.

Fixes #831

## AI disclosure
Prepared with AI assistance; contributor reviewed the final diff.