### PR TITLE
fix(exec): stop a command that exceeds its output limit

### DIFF
--- a/internal/exec/output.go
+++ b/internal/exec/output.go
@@ -26,6 +26,7 @@ type outputBuffer struct {
 	limit    int
 	data     []byte
 	exceeded bool
+	onExceed func()
 }
 
 func newOutputBuffer(limit int) outputBuffer {
@@ -34,21 +35,46 @@ func newOutputBuffer(limit int) outputBuffer {
 
 func (b *outputBuffer) Write(data []byte) (int, error) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
 
 	written := len(data)
 	remaining := b.limit - len(b.data)
 	if remaining <= 0 {
 		b.exceeded = b.exceeded || written > 0
-		return written, nil
-	}
-	if written > remaining {
+	} else if written > remaining {
 		b.data = append(b.data, data[:remaining]...)
 		b.exceeded = true
-		return written, nil
+	} else {
+		b.data = append(b.data, data...)
 	}
-	b.data = append(b.data, data...)
+
+	// The first write past the limit hands the callback to the caller. It runs
+	// outside the lock: Write is called by the os/exec copier goroutine, so the
+	// callback must never wait on this buffer.
+	var onExceed func()
+	if b.exceeded && b.onExceed != nil {
+		onExceed = b.onExceed
+		b.onExceed = nil
+	}
+	b.mu.Unlock()
+
+	if onExceed != nil {
+		onExceed()
+	}
 	return written, nil
+}
+
+// setOnExceed registers the callback that runs once a write passes the retained
+// limit. A buffer that has already passed it runs the callback immediately, so a
+// command cannot overflow before the registration and escape it.
+func (b *outputBuffer) setOnExceed(onExceed func()) {
+	b.mu.Lock()
+	if b.exceeded {
+		b.mu.Unlock()
+		onExceed()
+		return
+	}
+	b.onExceed = onExceed
+	b.mu.Unlock()
 }
 
 func (b *outputBuffer) Bytes() []byte {

--- a/internal/exec/process.go
+++ b/internal/exec/process.go
@@ -48,7 +48,8 @@ type Spec struct {
 	// StopGracePeriod controls when Run escalates from SIGTERM to SIGKILL.
 	// A zero value uses five seconds.
 	StopGracePeriod time.Duration
-	// MaxOutputBytes limits retained standard output. A zero value uses 64 KiB.
+	// MaxOutputBytes limits retained standard output and stops the command once
+	// it writes more than that. A zero value uses 64 KiB.
 	MaxOutputBytes int
 }
 
@@ -82,6 +83,7 @@ type Process struct {
 	start           lifecycleResult
 	wait            lifecycleResult
 	isStopRequested bool
+	isOutputLimit   bool
 	stopAttempt     *lifecycleResult
 	startCommand    func(*osexec.Cmd) error
 	forceStop       func(int) error
@@ -192,6 +194,7 @@ func (p *Process) Start(ctx context.Context) error {
 	p.mu.Unlock()
 
 	if launchErr == nil {
+		p.output.setOnExceed(func() { go p.stopOnOutputLimit() })
 		return nil
 	}
 	return p.finishCanceledStart(launchErr, cmd.Process.Pid)
@@ -241,7 +244,11 @@ func (p *Process) reap(cmd *osexec.Cmd) {
 	err := cmd.Wait()
 
 	p.mu.Lock()
-	if p.isStopRequested && isStoppedExit(err) {
+	if p.isOutputLimit && isStoppedExit(err) {
+		// The retained-output limit, not the child, explains why the command
+		// ended; outputError reports it to every waiter.
+		err = nil
+	} else if p.isStopRequested && isStoppedExit(err) {
 		err = fmt.Errorf("%w: command %q exited after a stop signal: %w", ErrStopped, p.spec.Path, err)
 	} else if err != nil {
 		err = fmt.Errorf("wait for command %q: %w", p.spec.Path, err)
@@ -358,6 +365,28 @@ func (p *Process) Stop(ctx context.Context) error {
 	close(attempt.done)
 	p.mu.Unlock()
 	return err
+}
+
+// stopOnOutputLimit stops a command that has written more than the retained
+// output limit. Overflow is not a reason to keep the command running: it can no
+// longer contribute retained output, and waiting for it to exit on its own would
+// hold the caller until the child decides to stop. The stop is best effort: the
+// limit error reaches every waiter through outputError even if the child cannot
+// be signaled.
+func (p *Process) stopOnOutputLimit() {
+	p.mu.Lock()
+	if p.isOutputLimit {
+		p.mu.Unlock()
+		return
+	}
+	p.isOutputLimit = true
+	gracePeriod := p.spec.StopGracePeriod
+	p.mu.Unlock()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+	defer cancel()
+
+	_ = p.Stop(stopCtx)
 }
 
 func (p *Process) waitForStopAttempt(ctx context.Context, attempt *lifecycleResult) error {

--- a/internal/exec/process_test.go
+++ b/internal/exec/process_test.go
@@ -322,6 +322,23 @@ func TestProcessReportsOutputOverflowAfterReaping(t *testing.T) {
 	}
 }
 
+func TestProcessStopsCommandThatExceedsOutputLimit(t *testing.T) {
+	process := newHelperProcessWithSpec(t, "noisy-then-sleep", &Spec{MaxOutputBytes: 1024})
+	startProcess(t, process)
+
+	waited := make(chan error, 1)
+	go func() { waited <- process.Wait() }()
+
+	select {
+	case err := <-waited:
+		if err == nil || !strings.Contains(err.Error(), "stdout exceeds 1024 bytes") {
+			t.Fatalf("Wait() error = %v, want stdout limit error", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait() did not return: the command kept running after passing the output limit")
+	}
+}
+
 func TestProcessRetainsFixedErrorTail(t *testing.T) {
 	process := newHelperProcess(t, "large-error")
 	startProcess(t, process)
@@ -643,6 +660,13 @@ func TestExecHelperProcess(t *testing.T) {
 		os.Exit(0)
 	case "large-error":
 		_, _ = fmt.Fprint(os.Stderr, largeOutputPayload())
+		os.Exit(0)
+	case "noisy-then-sleep":
+		// A command that overflows its output limit and then stops producing
+		// output while it stays alive. It only exits when it is stopped.
+		_, _ = fmt.Fprint(os.Stdout, largeOutputPayload())
+		_, _ = fmt.Fprintln(os.Stdout, "sleeping")
+		time.Sleep(time.Hour)
 		os.Exit(0)
 	case "split-output":
 		_, _ = fmt.Fprint(os.Stdout, "payload")


### PR DESCRIPTION
## Summary

- hand the first write that passes `Spec.MaxOutputBytes` to the process, and stop the command from there
- reuse the existing `Stop` escalation (SIGTERM, then SIGKILL after `StopGracePeriod`) instead of adding a new kill path
- keep reporting `command %q stdout exceeds N bytes` to every waiter, and stop wrapping the resulting kill as `ErrStopped`
- add a `noisy-then-sleep` helper command and a regression test behind the limit

## Why

Retained output was bounded, but the command's lifetime was not. `Write` capped the buffer and set `exceeded`, and the only reader of that flag was `outputError`, which `waitResult` calls after `reap` has already returned from `cmd.Wait`. Nothing signalled the child when the limit was passed, so a command that printed more than the limit and then stopped making progress kept its slot and left every waiter blocked in `Wait()`/`Run()` until the child exited on its own or an unrelated stop, context deadline or shutdown arrived. This is the `[P1]` contract question raised on #706 ("cancel or kill the child when the limit is reached"); the subsystem that PR patched (`pkg/tracing/task.go`) was replaced by `ccec9dda`, so the fix is carried here.

The buffer now hands the callback to `Process` on the transition — outside `b.mu`, because `Write` is called by the `os/exec` copier goroutine and the callback must never wait on the buffer it was called from — and `setOnExceed` runs the callback immediately when the limit was already passed before registration, so a fast child cannot escape it. `reap` treats an exit that follows the limit stop the way it treats a requested stop, but without the `ErrStopped` wrapper: no caller asked for that stop, and `outputError` is the only explanation the caller needs.

## Verification

`internal/exec` is `linux`-only (its test file is `//go:build linux` and `process_group.go` uses `Setpgid`/`Pdeathsig`), so on this Windows host I compiled and vetted for the real target and verified the behaviour with a throwaway, uncommitted stand-in for the four process-group primitives:

```
GOOS=linux GOARCH=amd64 go vet ./internal/exec/                      # clean
GOOS=linux GOARCH=amd64 go test -c -mod=vendor -o exec.test ./internal/exec/   # 4728273-byte ELF
gofmt -l internal/exec/output.go internal/exec/process.go internal/exec/process_test.go   # clean
```

Red first, with the unmodified sources and only the new test added:

```
--- FAIL: TestProcessStopsCommandThatExceedsOutputLimit (2.01s)
    process_test.go:338: Wait() did not return: the command kept running after passing the output limit
```

Green with the change:

```
--- PASS: TestProcessStopsCommandThatExceedsOutputLimit (0.01s)
--- PASS: TestProcessReportsOutputOverflowAfterReaping (0.01s)
```

I also ran the whole package both ways. The failures are identical in both runs (`TestProcessGracefulStopAndRepeatedStop`, `TestProcessStopTerminatesProcessGroup`, `TestProcessStartContextDoesNotOwnLifetime`, `TestProcessRunStopsAfterCancellation`, `TestProcessRunReturnsAfterStopFailureAndAllowsRetry`); they are artifacts of the local stand-in, which cannot deliver a real `SIGTERM` to a process group, and they are absent from the red/green delta. The delta is exactly one test: the new one.

The throwaway stand-in file, the temporary `//go:build` change and the two helper edits it needed are **not** part of this branch; the commit contains only `internal/exec/output.go`, `internal/exec/process.go` and `internal/exec/process_test.go`. GitHub CI is expected to run the tests on Linux itself.

Fixes #833

## AI disclosure
Prepared with AI assistance; contributor reviewed the final diff.