### PR TITLE
fix(apiserver): treat a disabled profile query service as unavailable

### DIFF
--- a/cmd/huatuo-apiserver/handlers/api.go
+++ b/cmd/huatuo-apiserver/handlers/api.go
@@ -77,7 +77,7 @@ var _ serverapi.StrictServerInterface = (*APIHandler)(nil)
 func NewAPIHandler(
 	profilingService *profilinghandler.Service,
 	tracingService *tracehandler.Service,
-	profileQuery profileQueryService,
+	profileQuery *profilequery.ProfileQueryService,
 ) (*APIHandler, error) {
 	if profilingService == nil {
 		return nil, errors.New("create Server API handler: Profiling service is required")
@@ -89,10 +89,17 @@ func NewAPIHandler(
 	if err := json.Unmarshal(serverapi.OpenAPIJSON(), &specification); err != nil {
 		return nil, fmt.Errorf("create Server API handler: decode bundled OpenAPI: %w", err)
 	}
+	// A nil *ProfileQueryService assigned to the profileQueryService field
+	// yields a non-nil interface value, so compare the concrete pointer
+	// before storing; otherwise the availability guard never fires.
+	var query profileQueryService
+	if profileQuery != nil {
+		query = profileQuery
+	}
 	return &APIHandler{
 		profiling:    profilingService,
 		tracing:      tracingService,
-		profileQuery: profileQuery,
+		profileQuery: query,
 		openAPI:      specification,
 	}, nil
 }

--- a/cmd/huatuo-apiserver/handlers/profile_query_test.go
+++ b/cmd/huatuo-apiserver/handlers/profile_query_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	serverapi "github.com/ccfos/huatuo/apis/v1/server"
+	"github.com/ccfos/huatuo/cmd/huatuo-apiserver/handlers/profiling"
+	"github.com/ccfos/huatuo/cmd/huatuo-apiserver/handlers/trace"
 	"github.com/ccfos/huatuo/internal/auth"
 	profilequery "github.com/ccfos/huatuo/internal/profiling/query"
 	"github.com/ccfos/huatuo/internal/server/response"
@@ -118,5 +120,29 @@ func TestSelectMergeStacktracesMapsProfileAbsence(t *testing.T) {
 	var apiErr *response.APIError
 	if !errors.As(err, &apiErr) || apiErr.Code != "not_found" {
 		t.Fatalf("SelectMergeStacktraces() error = %v", err)
+	}
+}
+
+func TestNewAPIHandlerTreatsTypedNilProfileQueryAsUnavailable(t *testing.T) {
+	handler, err := NewAPIHandler(
+		&profiling.Service{},
+		&trace.Service{},
+		(*profilequery.ProfileQueryService)(nil),
+	)
+	if err != nil {
+		t.Fatalf("NewAPIHandler() error = %v", err)
+	}
+
+	_, err = handler.GetProfileTypes(
+		profileQueryContext(t, true),
+		serverapi.GetProfileTypesRequestObject{Body: bytes.NewReader(nil)},
+	)
+	var apiErr *response.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != "service_unavailable" {
+		t.Fatalf("GetProfileTypes() error = %v", err)
+	}
+
+	if handler.profileQuery != nil {
+		t.Fatal("typed-nil profile query service must be stored as unavailable")
 	}
 }


### PR DESCRIPTION
Fixes #837.

## Problem / Evidence

With Elasticsearch disabled, `setupProfileQueryService` (`cmd/huatuo-apiserver/profiling.go:30-34`) logs "profile storage disabled" and returns `(nil, nil)` without ever setting `d.profileQueryService`, so the `Daemon` field stays the zero value — a nil `*profilequery.ProfileQueryService` (`cmd/huatuo-apiserver/main.go:86`).

`handlers.Start` then passes that concrete nil pointer into `NewAPIHandler`'s `profileQueryService` **interface** parameter (`cmd/huatuo-apiserver/handlers/server.go:76-80` → `cmd/huatuo-apiserver/handlers/api.go:80` pre-fix). A typed nil pointer converted to an interface yields a **non-nil interface value**, so the availability guard

```go
if h.profileQuery == nil {   // api.go:603 — dead code in exactly the deployment that needs it
    return response.NewAPIError(apiv1.ErrorCodeServiceUnavailable,
        "Profiling query service is unavailable")
}
```

never fires. The four flamegraph endpoints (wrappers at `api.go:186` `SelectMergeStacktraces`, `api.go:208` `GetProfileTypes`, `api.go:230` `GetProfileLabelNames`, `api.go:252` `GetProfileLabelValues`; all guarded by `authorizeProfileQuery` at `api.go:595-609`) then behave wrong in a supported configuration (storage disabled):

| Endpoint | Observed | Expected |
|---|---|---|
| `SelectMergeStacktraces` | nil-pointer panic in `(*ProfileQueryService).SelectMergeStacktraces` at `internal/profiling/query/service.go:96` (`s.profileStorage.Search` on nil receiver) → gin recovery → **500** | 503 `service_unavailable` |
| `ProfileTypes` | panic at `internal/profiling/query/service.go:247` (`s.profileStorage.Values`) → **500** | 503 |
| `LabelValues` | panic at `internal/profiling/query/service.go:324` → **500** | 503 |
| `LabelNames` | touches nothing on the receiver (`service.go:281`, returns a static list) → **misleading 200** with static data | 503 |

Deterministic repro (unit level): call `NewAPIHandler` with `(*profilequery.ProfileQueryService)(nil)` and issue `GetProfileTypes` as an admin — pre-fix code panics; captured verbatim from `go test ./cmd/huatuo-apiserver/handlers/ -run TestNewAPIHandlerTreatsTypedNilProfileQueryAsUnavailable -count=1` on pre-fix code:

```
--- FAIL: TestNewAPIHandlerTreatsTypedNilProfileQueryAsUnavailable (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
panic({0x1d77640?, 0x3329050?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
FAIL	github.com/ccfos/huatuo/cmd/huatuo-apiserver/handlers	0.012s
```

The 503 branch's existence shows the intended behavior; this change makes it reachable.

## Root cause / Fix

Root cause: the concrete nil pointer is converted to the `profileQueryService` interface at the `NewAPIHandler` call boundary (`handlers/server.go:76-80`), defeating the `== nil` guard downstream.

Fix: `NewAPIHandler` now takes the concrete `*profilequery.ProfileQueryService` and normalizes it to an untyped nil before storing. The actual diff (`cmd/huatuo-apiserver/handlers/api.go`; `handlers.Start` compiles unchanged, no other caller exists):

```diff
 func NewAPIHandler(
 	profilingService *profilinghandler.Service,
 	tracingService *tracehandler.Service,
-	profileQuery profileQueryService,
+	profileQuery *profilequery.ProfileQueryService,
 ) (*APIHandler, error) {
 	if profilingService == nil {
 		return nil, errors.New("create Server API handler: Profiling service is required")
@@
 	if err := json.Unmarshal(serverapi.OpenAPIJSON(), &specification); err != nil {
 		return nil, fmt.Errorf("create Server API handler: decode bundled OpenAPI: %w", err)
 	}
+	// A nil *ProfileQueryService assigned to the profileQueryService field
+	// yields a non-nil interface value, so compare the concrete pointer
+	// before storing; otherwise the availability guard never fires.
+	var query profileQueryService
+	if profileQuery != nil {
+		query = profileQuery
+	}
 	return &APIHandler{
 		profiling:    profilingService,
 		tracing:      tracingService,
-		profileQuery: profileQuery,
+		profileQuery: query,
 		openAPI:      specification,
 	}, nil
 }
```

## Priority and confidence

- PRIORITY 74/100: impact 28/40 (admin flamegraph API panics or lies in a supported ES-disabled deployment; no data loss), scope 12/20 (all four flamegraph query endpoints), reproducibility 20/20 (deterministic unit-level repro), maintenance value 14/20 (removes a silent typed-nil hazard at an interface conversion boundary and revives dead code).
- FIX_CONFIDENCE 90/100: boundary normalization matching the guard's evident intent; no API change for existing callers.

## Tests

- New regression test `TestNewAPIHandlerTreatsTypedNilProfileQueryAsUnavailable` (`cmd/huatuo-apiserver/handlers/profile_query_test.go`): issues the flamegraph request as an admin and asserts the 503 `service_unavailable` mapping plus the nil normalization.
  - Pre-fix (red): `go test ./cmd/huatuo-apiserver/handlers/ -run TestNewAPIHandlerTreatsTypedNilProfileQueryAsUnavailable -count=1` → the nil-pointer panic quoted above, `FAIL`.
  - Post-fix (green): same command → `ok github.com/ccfos/huatuo/cmd/huatuo-apiserver/handlers 0.010s`.
- Related modules: `go test ./cmd/huatuo-apiserver/... ./internal/server/... ./internal/profiling/... -count=1` — all `ok` (handlers, handlers/profiling, handlers/trace, server, server/pprof, server/response, profiling, profiling/publication, profiling/query).
- Full suite on this branch: `go test ./... -count=1` → **100 packages `ok`, 0 FAIL, exit 0**.
- `gofumpt -extra -l` on both changed files: clean.
- Integration coverage enumeration: `integration/test_apiserver_profile_disabled.sh` starts the apiserver in exactly the affected configuration (`write_apiserver_without_profile_storage_config`) but only probes `/v1/profiling`, `/v1/profiling/capabilities`, `/v1/profiles` and auth — it never calls the flamegraph endpoints, which is why this bug survived CI. The script's existing assertions are unaffected by this change (startup behavior unchanged), and CI runs it: pass. The 503 mapping itself is covered by the unit regression test above; the VM-based suite requires the repo's qemu infra (not executable in this environment).

## CI

All checks pass on this branch (job IDs for reference):

| Check | Result | Duration | Job |
|---|---|---|---|
| pr_name_lint | pass | 15s | 103703562203 |
| Build, Lint and Vendor | pass | 8m17s | 103703561756 |
| Test in VM (amd64 ubuntu20.04) | pass | 15m3s | 103703561263 |
| Test in VM (amd64 ubuntu22.04) | pass | 17m6s | 103703561737 |
| Test in VM (amd64 ubuntu24.04) | pass | 14m53s | 103703561708 |
| Test in VM (amd64 ubuntu26.04) | pass | 16m14s | 103703562315 |

## Risk

Low. The only behavior change is for `ProfileQueryService == nil`: previously a panic/500 (or false 200 on `LabelNames`), now the designed 503 `service_unavailable`. Callers with a real service are untouched.
