### PR TITLE
fix(storage): aggregate distinct values on the keyword subfield

### DIFF
--- a/internal/storage/elasticsearch/dsl.go
+++ b/internal/storage/elasticsearch/dsl.go
@@ -147,9 +147,21 @@ func buildValuesRequest(field string, q driver.Query, size int) ([]byte, error) 
 	body := valuesBody{
 		Size:  0,
 		Query: query,
-		Aggs:  map[string]termsAggBody{"terms": {Terms: termsAgg{Field: field, Size: size}}},
+		Aggs: map[string]termsAggBody{
+			"terms": {Terms: termsAgg{Field: aggregationField(field), Size: size}},
+		},
 	}
 	return json.Marshal(body)
+}
+
+// aggregationField targets the dynamic keyword subfield so terms
+// aggregations work on dynamically mapped text fields, mirroring the
+// exact-term query fallback; explicit .keyword names pass through.
+func aggregationField(field string) string {
+	if strings.HasSuffix(field, ".keyword") {
+		return field
+	}
+	return field + ".keyword"
 }
 
 func buildQuery(filters []driver.Filter) (*types.Query, error) {

--- a/internal/storage/elasticsearch/elasticsearch_test.go
+++ b/internal/storage/elasticsearch/elasticsearch_test.go
@@ -319,6 +319,9 @@ func (m *mockElasticsearchServer) handleTermsSearch(w http.ResponseWriter, body 
 	termsAggregation, _ := aggs["terms"].(map[string]any)
 	termsConfig, _ := termsAggregation["terms"].(map[string]any)
 	fieldName := stringValue(termsConfig["field"])
+	// Dynamic text mappings expose values under the .keyword subfield, so
+	// aggregate on the base field like real Elasticsearch would.
+	fieldName = strings.TrimSuffix(fieldName, ".keyword")
 
 	counts := make(map[string]int)
 	for _, doc := range docs {
@@ -1349,6 +1352,61 @@ func TestElasticsearchBackendTerms(t *testing.T) {
 		if terms[index] != expectedTerm {
 			t.Errorf("Terms()[%d]=%q, want %q", index, terms[index], expectedTerm)
 		}
+	}
+}
+
+// TestBuildValuesRequestAggregatesKeywordSubfield pins the terms aggregation
+// to the dynamic keyword subfield: stock Elasticsearch maps document string
+// fields as text plus a keyword subfield and rejects terms aggregations on
+// the text field itself with "Fielddata is disabled".
+func TestBuildValuesRequestAggregatesKeywordSubfield(t *testing.T) {
+	testCases := []struct {
+		name     string
+		field    string
+		wantAgg  string
+		wantSize int
+	}{
+		{
+			name:     "document field gets keyword subfield",
+			field:    "profile_data.profile_type",
+			wantAgg:  "profile_data.profile_type.keyword",
+			wantSize: 10,
+		},
+		{
+			name:     "explicit keyword name passes through",
+			field:    "tracer_id.keyword",
+			wantAgg:  "tracer_id.keyword",
+			wantSize: 7,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			body, err := buildValuesRequest(testCase.field, driver.Query{}, testCase.wantSize)
+			if err != nil {
+				t.Fatalf("buildValuesRequest() error = %v", err)
+			}
+
+			var payload struct {
+				Aggs map[string]struct {
+					Terms struct {
+						Field string `json:"field"`
+						Size  int    `json:"size"`
+					} `json:"terms"`
+				} `json:"aggs"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			terms := payload.Aggs["terms"].Terms
+			if terms.Field != testCase.wantAgg {
+				t.Fatalf("aggregation field = %q, want %q", terms.Field, testCase.wantAgg)
+			}
+			if terms.Size != testCase.wantSize {
+				t.Fatalf("aggregation size = %d, want %d", terms.Size, testCase.wantSize)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #838.

## Problem / Evidence

`Store.Values` (distinct-value terms aggregation) builds its aggregation on the raw field name (`internal/storage/elasticsearch/dsl.go:150` pre-fix): `{"terms":{"field":<field>}}`. Stock Elasticsearch — including the exact version this repo ships (`build/docker/docker-compose.yml`, `elasticsearch:8.15.5`; the integration harness pins the same image at `integration/lib_storage.sh:24`) — maps document string fields dynamically as `text` plus a `keyword` subfield, and rejects terms aggregations on a `text` field with HTTP 400.

Both production callers go through this path:

- `internal/profiling/query/service.go:247` — `ProfileTypes` (flamegraph profile-type discovery, field `profile_data.profile_type`)
- `internal/profiling/query/service.go:324` — `LabelValues` (flamegraph label-value discovery, fields `region`, `hostname`, `container_id`, …)

So with Elasticsearch enabled (the intended flamegraph deployment), **both endpoints always fail**: the driver returns the ES 400 and the API surfaces a 500. The unit tests pass only because the test mock reads the aggregation field name and serves values from the raw document fields — it does not emulate real mapping semantics.

End-to-end reproduction against the shipped Elasticsearch 8.15.5, through the real code path (`storage.NewFromConfig` → `Store.Values`), after indexing three documents with dynamic mapping. Pre-fix, verbatim:

```
Values(profile_data.profile_type) = [], err = elasticsearch terms aggregation huatuo-repro-tracing: status 400:
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Fielddata is disabled on
[profile_data.profile_type] in [huatuo-repro-tracing]. Text fields are not optimised for operations that
require per-document field data like aggregations and sorting, so these operations are disabled by default.
Please use a keyword field instead. ..."}]},"status":400}
```

The query side of the same DSL already falls back to the `.keyword` subfield for exactly this reason (`buildExactTermClause` `dsl.go:220`, `buildExactTermsClause` `dsl.go:234`, `exactFieldFallback` `dsl.go:247`, introduced by commit `3ea5b8aa` "fix(storage): match dynamic keyword fields" — "Also query dynamic keyword subfields created by Elasticsearch … without requiring a mapping migration"); the aggregation side never received the same treatment.

## Root cause / Fix

Root cause: `buildValuesRequest` aggregates on the raw field name, which for dynamically mapped string fields is a `text` field — not aggregatable by default.

Fix (mirrors the established query-side convention): aggregate on the dynamic keyword subfield, passing through names that already end in `.keyword`. The actual diff (`internal/storage/elasticsearch/dsl.go`):

```diff
 	body := valuesBody{
 		Size:  0,
 		Query: query,
-		Aggs:  map[string]termsAggBody{"terms": {Terms: termsAgg{Field: field, Size: size}}},
+		Aggs: map[string]termsAggBody{
+			"terms": {Terms: termsAgg{Field: aggregationField(field), Size: size}},
+		},
 	}
 	return json.Marshal(body)
 }
 
+// aggregationField targets the dynamic keyword subfield so terms
+// aggregations work on dynamically mapped text fields, mirroring the
+// exact-term query fallback; explicit .keyword names pass through.
+func aggregationField(field string) string {
+	if strings.HasSuffix(field, ".keyword") {
+		return field
+	}
+	return field + ".keyword"
+}
```

The test mock (`internal/storage/elasticsearch/elasticsearch_test.go`, `handleTermsSearch`) now resolves the `.keyword` subfield like real Elasticsearch:

```diff
 	fieldName := stringValue(termsConfig["field"])
+	// Dynamic text mappings expose values under the .keyword subfield, so
+	// aggregate on the base field like real Elasticsearch would.
+	fieldName = strings.TrimSuffix(fieldName, ".keyword")
```

Same fix run against the same live ES instance:

```
Values(profile_data.profile_type) = [process_cpu:cpu:nanoseconds:cpu:nanoseconds], err = <nil>
```

Compatibility note: deployments that natively map the allowlisted fields as `keyword` (the repo ships no index template, so dynamic text+keyword is the shipped reality; the ES integration harness likewise starts a bare 8.15.5 node) would find no `<field>.keyword` subfield; those are outside the configurations this repository ships or tests.

## Priority and confidence

- PRIORITY 78/100: impact 34/40 (flamegraph ProfileTypes and LabelValues always fail in the default ES deployment — a core query surface is broken), scope 14/20 (generic driver `Values` path; all current and future consumers), reproducibility 16/20 (reproduced end-to-end against the shipped ES version through the real code path), maintenance value 14/20 (aligns the aggregation path with the query-side keyword-subfield convention).
- FIX_CONFIDENCE 85/100: convention already established in the same file for term queries; live before/after evidence through the real code path; tradeoff documented above.

## Tests

- New regression test `TestBuildValuesRequestAggregatesKeywordSubfield` (`internal/storage/elasticsearch/elasticsearch_test.go`): pins `profile_data.profile_type` → `profile_data.profile_type.keyword` and `.keyword`-suffixed passthrough, plus size preservation.
  - Pre-fix (red): `go test ./internal/storage/elasticsearch/ -run TestBuildValuesRequestAggregatesKeywordSubfield -count=1` →
    ```
    --- FAIL: TestBuildValuesRequestAggregatesKeywordSubfield (0.00s)
        --- FAIL: TestBuildValuesRequestAggregatesKeywordSubfield/document_field_gets_keyword_subfield (0.00s)
            elasticsearch_test.go:1404: aggregation field = "profile_data.profile_type", want "profile_data.profile_type.keyword"
    FAIL	github.com/ccfos/huatuo/internal/storage/elasticsearch	0.004s
    ```
  - Post-fix (green): `ok github.com/ccfos/huatuo/internal/storage/elasticsearch 0.060s`.
- Mock update: `handleTermsSearch` now resolves the `.keyword` subfield like real Elasticsearch, so the two existing `Values` mock tests (`TestElasticsearchBackendTerms`, `TestElasticsearchBackendMissingIndexIsEmpty`) exercise the new request shape.
- Related modules: `go test ./internal/storage/... ./pkg/profiling/store/... ./internal/profiling/... ./pkg/tracing/... -count=1` — all `ok`.
- Full suite on this branch: `go test ./... -count=1` → **100 packages `ok`, 0 FAIL, exit 0**.
- `gofumpt -extra -l` on both changed files: clean.
- Live end-to-end (Elasticsearch 8.15.5 container, dynamic mapping, real `storage.NewFromConfig` → `Store.Values` path): pre-fix 400 error quoted above; post-fix returns `[process_cpu:cpu:nanoseconds:cpu:nanoseconds]` with no error. Container removed after the run.
- Integration coverage enumeration: the continuous-profiling integration scripts (`test_continuous_profiling_api.sh`, `test_continuous_profiling_control.sh`, `test_continuous_profiling_multi.sh`, `test_apiserver_job_recovery.sh`) start a real ES 8.15.5 node via `lib_storage.sh` but exercise only ingestion and the `/v1/profiling` list API — no script on main calls the flamegraph query endpoints or the `Values` aggregation, which is why this bug survived CI. Those scripts are unaffected by this change (their requests never carry a terms aggregation) and CI runs them: pass. The VM-based suite requires the repo's qemu infra (not executable in this environment).

## CI

All checks pass on this branch (job IDs for reference):

| Check | Result | Duration | Job |
|---|---|---|---|
| pr_name_lint | pass | 19s | 103704479515 |
| Build, Lint and Vendor | pass | 7m35s | 103704479536 |
| Test in VM (amd64 ubuntu20.04) | pass | 15m27s | 103704479669 |
| Test in VM (amd64 ubuntu22.04) | pass | 15m54s | 103704479663 |
| Test in VM (amd64 ubuntu24.04) | pass | 15m10s | 103704479836 |
| Test in VM (amd64 ubuntu26.04) | pass | 16m29s | 103704479575 |

## Risk

Low. The aggregation now targets `<field>.keyword`, which exists on every dynamically mapped string field (all fields in `normalizeAggregationField`'s allowlist are document strings). Explicit `.keyword` names behave unchanged. Queries other than `Values` are untouched.
